### PR TITLE
Refactor data generation methods to helper object 

### DIFF
--- a/src/test/java/com/google/cloud/anviltop/hbase/AbstractTest.java
+++ b/src/test/java/com/google/cloud/anviltop/hbase/AbstractTest.java
@@ -31,7 +31,7 @@ public abstract class AbstractTest {
   protected HConnection connection;
   protected static final byte[] TABLE_NAME = Bytes.toBytes("test_table");
   protected static final byte[] COLUMN_FAMILY = Bytes.toBytes("test_family");
-  protected DataGenerationHelper dataGenerationHelper = new DataGenerationHelper();
+  protected DataGenerationHelper dataHelper = new DataGenerationHelper();
 
   @BeforeClass
   public static void setUpBeforeClass() throws Exception {

--- a/src/test/java/com/google/cloud/anviltop/hbase/DataGenerationHelper.java
+++ b/src/test/java/com/google/cloud/anviltop/hbase/DataGenerationHelper.java
@@ -22,11 +22,11 @@ import org.apache.hadoop.hbase.util.Bytes;
  */
 public class DataGenerationHelper {
 
-  protected byte[] randomData(String prefix) {
+  public byte[] randomData(String prefix) {
     return Bytes.toBytes(prefix + RandomStringUtils.randomAlphanumeric(8));
   }
 
-  protected byte[][] randomData(String prefix, int count) {
+  public byte[][] randomData(String prefix, int count) {
     byte[][] result = new byte[count][];
     for (int i = 0; i < count; ++i) {
       result[i] = Bytes.toBytes(prefix + RandomStringUtils.randomAlphanumeric(8));
@@ -34,11 +34,11 @@ public class DataGenerationHelper {
     return result;
   }
 
-  protected long[] sequentialTimestamps(int count) {
+  public long[] sequentialTimestamps(int count) {
     return sequentialTimestamps(count, System.currentTimeMillis());
   }
 
-  protected long[] sequentialTimestamps(int count, long firstValue) {
+  public long[] sequentialTimestamps(int count, long firstValue) {
     assert count > 0;
     long[] timestamps = new long[count];
     timestamps[0] = firstValue;

--- a/src/test/java/com/google/cloud/anviltop/hbase/TestAutoFlush.java
+++ b/src/test/java/com/google/cloud/anviltop/hbase/TestAutoFlush.java
@@ -13,12 +13,10 @@
  */
 package com.google.cloud.anviltop.hbase;
 
-import org.apache.commons.lang.RandomStringUtils;
 import org.apache.hadoop.hbase.client.Get;
 import org.apache.hadoop.hbase.client.HTableInterface;
 import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.Result;
-import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -65,9 +63,9 @@ public class TestAutoFlush extends AbstractTest {
 
   private Get quickPutThenGet(HTableInterface tableForWrite) throws IOException {
     // Set up the tiny write and read
-    byte[] rowKey = dataGenerationHelper.randomData("testrow-");
-    byte[] qualifier = dataGenerationHelper.randomData("testQualifier-");
-    byte[] value = dataGenerationHelper.randomData("testValue-");
+    byte[] rowKey = dataHelper.randomData("testrow-");
+    byte[] qualifier = dataHelper.randomData("testQualifier-");
+    byte[] value = dataHelper.randomData("testValue-");
     Put put = new Put(rowKey);
     put.add(COLUMN_FAMILY, qualifier, value);
     Get get = new Get(rowKey);

--- a/src/test/java/com/google/cloud/anviltop/hbase/TestBasicOps.java
+++ b/src/test/java/com/google/cloud/anviltop/hbase/TestBasicOps.java
@@ -13,7 +13,6 @@
  */
 package com.google.cloud.anviltop.hbase;
 
-import org.apache.commons.lang.RandomStringUtils;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellUtil;
 import org.apache.hadoop.hbase.client.Delete;
@@ -23,7 +22,6 @@ import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -37,9 +35,9 @@ public class TestBasicOps extends AbstractTest {
   @Test
   public void testPutGetDelete() throws IOException {
     // Initialize
-    byte[] rowKey = dataGenerationHelper.randomData("testrow-");
-    byte[] testQualifier = dataGenerationHelper.randomData("testQualifier-");
-    byte[] testValue = dataGenerationHelper.randomData("testValue-");
+    byte[] rowKey = dataHelper.randomData("testrow-");
+    byte[] testQualifier = dataHelper.randomData("testQualifier-");
+    byte[] testValue = dataHelper.randomData("testValue-");
     putGetDeleteExists(rowKey, testQualifier, testValue);
   }
 
@@ -70,8 +68,8 @@ public class TestBasicOps extends AbstractTest {
   public void testNullQualifier() throws IOException {
     // Initialize values
     HTableInterface table = connection.getTable(TABLE_NAME);
-    byte[] rowKey = dataGenerationHelper.randomData("testrow-");
-    byte[] testValue = dataGenerationHelper.randomData("testValue-");
+    byte[] rowKey = dataHelper.randomData("testrow-");
+    byte[] testValue = dataHelper.randomData("testValue-");
 
     // Insert value with null qualifier
     Put put = new Put(rowKey);
@@ -125,8 +123,8 @@ public class TestBasicOps extends AbstractTest {
   public void testPutBigValue() throws IOException {
     // Initialize variables
     HTableInterface table = connection.getTable(TABLE_NAME);
-    byte[] testRowKey = dataGenerationHelper.randomData("testrow-");
-    byte[] testQualifier = dataGenerationHelper.randomData("testQualifier-");
+    byte[] testRowKey = dataHelper.randomData("testrow-");
+    byte[] testQualifier = dataHelper.randomData("testQualifier-");
     byte[] testValue = new byte[(10 << 20) - 1024];  // 10 MB - 1kB
     new Random().nextBytes(testValue);
     putGetDeleteExists(testRowKey, testQualifier, testValue);
@@ -142,8 +140,8 @@ public class TestBasicOps extends AbstractTest {
   public void testPutTooBigValue() throws IOException {
     // Initialize variables
     HTableInterface table = connection.getTable(TABLE_NAME);
-    byte[] testRowKey = dataGenerationHelper.randomData("testrow-");
-    byte[] testQualifier = dataGenerationHelper.randomData("testQualifier-");
+    byte[] testRowKey = dataHelper.randomData("testrow-");
+    byte[] testQualifier = dataHelper.randomData("testQualifier-");
     byte[] testValue = new byte[10 << 20];  // 10 MB
     new Random().nextBytes(testValue);
     System.out.println(testValue.length);

--- a/src/test/java/com/google/cloud/anviltop/hbase/TestDelete.java
+++ b/src/test/java/com/google/cloud/anviltop/hbase/TestDelete.java
@@ -17,7 +17,6 @@ import org.apache.hadoop.hbase.client.Delete;
 import org.apache.hadoop.hbase.client.Get;
 import org.apache.hadoop.hbase.client.HTableInterface;
 import org.apache.hadoop.hbase.client.Put;
-import org.apache.hadoop.hbase.client.Result;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -31,9 +30,9 @@ public class TestDelete extends AbstractTest {
     public void testDeleteRow() throws IOException {
         // Initialize data
         HTableInterface table = connection.getTable(TABLE_NAME);
-        byte[] rowKey = dataGenerationHelper.randomData("testrow-");
-        byte[] qual = dataGenerationHelper.randomData("qual-");
-        byte[] value = dataGenerationHelper.randomData("value-");
+        byte[] rowKey = dataHelper.randomData("testrow-");
+        byte[] qual = dataHelper.randomData("qual-");
+        byte[] value = dataHelper.randomData("value-");
 
         // Insert empty values.  Null and byte[0] are interchangeable for puts (but not gets).
         Put put = new Put(rowKey);

--- a/src/test/java/com/google/cloud/anviltop/hbase/TestDurability.java
+++ b/src/test/java/com/google/cloud/anviltop/hbase/TestDurability.java
@@ -13,7 +13,6 @@
  */
 package com.google.cloud.anviltop.hbase;
 
-import org.apache.commons.lang.RandomStringUtils;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellUtil;
 import org.apache.hadoop.hbase.client.Delete;
@@ -22,9 +21,7 @@ import org.apache.hadoop.hbase.client.Get;
 import org.apache.hadoop.hbase.client.HTableInterface;
 import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.Result;
-import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -47,9 +44,9 @@ public class TestDurability extends AbstractTest {
 
   private void testDurability(Durability durability) throws IOException {
     // Initialize
-    byte[] rowKey = dataGenerationHelper.randomData("testrow-");
-    byte[] testQualifier = dataGenerationHelper.randomData("testQualifier-");
-    byte[] testValue = dataGenerationHelper.randomData("testValue-");
+    byte[] rowKey = dataHelper.randomData("testrow-");
+    byte[] testQualifier = dataHelper.randomData("testQualifier-");
+    byte[] testValue = dataHelper.randomData("testValue-");
 
     // Put
     Put put = new Put(rowKey);

--- a/src/test/java/com/google/cloud/anviltop/hbase/TestGet.java
+++ b/src/test/java/com/google/cloud/anviltop/hbase/TestGet.java
@@ -39,10 +39,10 @@ public class TestGet extends AbstractTest {
   public void testNoQualifier() throws IOException {
     // Initialize variables
     HTableInterface table = connection.getTable(TABLE_NAME);
-    byte[] rowKey = dataGenerationHelper.randomData("testrow-");
+    byte[] rowKey = dataHelper.randomData("testrow-");
     int numValues = 3;
-    byte[][] quals = dataGenerationHelper.randomData("qual-", numValues);
-    byte[][] values = dataGenerationHelper.randomData("value-", numValues);
+    byte[][] quals = dataHelper.randomData("qual-", numValues);
+    byte[][] values = dataHelper.randomData("value-", numValues);
 
     // Insert some columns
     Put put = new Put(rowKey);
@@ -75,10 +75,10 @@ public class TestGet extends AbstractTest {
   public void testMultipleQualifiers() throws IOException {
     // Initialize variables
     HTableInterface table = connection.getTable(TABLE_NAME);
-    byte[] rowKey = dataGenerationHelper.randomData("testrow-");
+    byte[] rowKey = dataHelper.randomData("testrow-");
     int numValues = 3;
-    byte[][] quals = dataGenerationHelper.randomData("qual-", numValues);
-    byte[][] values = dataGenerationHelper.randomData("value-", numValues);
+    byte[][] quals = dataHelper.randomData("qual-", numValues);
+    byte[][] values = dataHelper.randomData("value-", numValues);
 
     // Insert a few columns
     Put put = new Put(rowKey);
@@ -115,13 +115,13 @@ public class TestGet extends AbstractTest {
   public void testTimeRange() throws IOException {
     // Initialize variables
     HTableInterface table = connection.getTable(TABLE_NAME);
-    byte[] rowKey = dataGenerationHelper.randomData("testrow-");
-    byte[] qual = dataGenerationHelper.randomData("qual-");
+    byte[] rowKey = dataHelper.randomData("testrow-");
+    byte[] qual = dataHelper.randomData("qual-");
     int numVersions = 5;
     int minVersion = 1;
     int maxVersion = 4;
-    long timestamps[] = dataGenerationHelper.sequentialTimestamps(numVersions);
-    byte[][] values = dataGenerationHelper.randomData("value-", numVersions);
+    long timestamps[] = dataHelper.sequentialTimestamps(numVersions);
+    byte[][] values = dataHelper.randomData("value-", numVersions);
 
     // Insert values with different timestamps at the same column.
     Put put = new Put(rowKey);
@@ -160,12 +160,12 @@ public class TestGet extends AbstractTest {
   public void testSingleTimestamp() throws IOException {
     // Initialize variables
     HTableInterface table = connection.getTable(TABLE_NAME);
-    byte[] rowKey = dataGenerationHelper.randomData("testrow-");
-    byte[] qual = dataGenerationHelper.randomData("qual-");
+    byte[] rowKey = dataHelper.randomData("testrow-");
+    byte[] qual = dataHelper.randomData("qual-");
     int numVersions = 5;
     int particularTimestamp = 3;
-    long timestamps[] = dataGenerationHelper.sequentialTimestamps(numVersions);
-    byte[][] values = dataGenerationHelper.randomData("value-", numVersions);
+    long timestamps[] = dataHelper.sequentialTimestamps(numVersions);
+    byte[][] values = dataHelper.randomData("value-", numVersions);
 
     // Insert several timestamps for a single row/column.
     Put put = new Put(rowKey);
@@ -200,12 +200,12 @@ public class TestGet extends AbstractTest {
   public void testMaxVersions() throws IOException {
     // Initialize data
     HTableInterface table = connection.getTable(TABLE_NAME);
-    byte[] rowKey = dataGenerationHelper.randomData("testrow-");
-    byte[] qual = dataGenerationHelper.randomData("qual-");
+    byte[] rowKey = dataHelper.randomData("testrow-");
+    byte[] qual = dataHelper.randomData("qual-");
     int totalVersions = 5;
     int maxVersions = 3;
-    long timestamps[] = dataGenerationHelper.sequentialTimestamps(totalVersions);
-    byte[][] values = dataGenerationHelper.randomData("value-", totalVersions);
+    long timestamps[] = dataHelper.sequentialTimestamps(totalVersions);
+    byte[][] values = dataHelper.randomData("value-", totalVersions);
 
     // Insert several versions into the same row/col
     Put put = new Put(rowKey);
@@ -245,13 +245,13 @@ public class TestGet extends AbstractTest {
   public void testMaxResultsPerColumnFamily() throws IOException {
     // Initialize data
     HTableInterface table = connection.getTable(TABLE_NAME);
-    byte[] rowKey = dataGenerationHelper.randomData("testrow-");
+    byte[] rowKey = dataHelper.randomData("testrow-");
     int totalColumns = 10;
     int offsetColumn = 3;
     int maxColumns = 5;
-    byte[][] quals = dataGenerationHelper.randomData("qual-", totalColumns);
-    byte[][] values = dataGenerationHelper.randomData("value-", totalColumns);
-    long[] timestamps = dataGenerationHelper.sequentialTimestamps(totalColumns);
+    byte[][] quals = dataHelper.randomData("qual-", totalColumns);
+    byte[][] values = dataHelper.randomData("value-", totalColumns);
+    long[] timestamps = dataHelper.sequentialTimestamps(totalColumns);
 
     // Insert a bunch of columns.
     Put put = new Put(rowKey);
@@ -296,8 +296,8 @@ public class TestGet extends AbstractTest {
     // Initialize data
     HTableInterface table = connection.getTable(TABLE_NAME);
     int numValues = 10;
-    byte[] rowKey = dataGenerationHelper.randomData("testrow-");
-    byte[][] quals = dataGenerationHelper.randomData("qual-", numValues);
+    byte[] rowKey = dataHelper.randomData("testrow-");
+    byte[][] quals = dataHelper.randomData("qual-", numValues);
 
     // Insert empty values.  Null and byte[0] are interchangeable for puts (but not gets).
     Put put = new Put(rowKey);
@@ -332,9 +332,9 @@ public class TestGet extends AbstractTest {
     // Initialize data
     HTableInterface table = connection.getTable(TABLE_NAME);
     int numValues = 10;
-    byte[][] rowKeys = dataGenerationHelper.randomData("testrow-", numValues);
-    byte[][] quals = dataGenerationHelper.randomData("qual-", numValues);
-    byte[][] values = dataGenerationHelper.randomData("value-", numValues);
+    byte[][] rowKeys = dataHelper.randomData("testrow-", numValues);
+    byte[][] quals = dataHelper.randomData("qual-", numValues);
+    byte[][] values = dataHelper.randomData("value-", numValues);
 
     // Insert a bunch of data
     List<Put> puts = new ArrayList<Put>(numValues);
@@ -389,7 +389,7 @@ public class TestGet extends AbstractTest {
     // Test bad rows, both individually and as batch
     gets.clear();
     for(int i = 0; i < numValues; ++i) {
-      Get get = new Get(dataGenerationHelper.randomData("badRow-"));
+      Get get = new Get(dataHelper.randomData("badRow-"));
       Assert.assertFalse(table.exists(get));
       gets.add(get);
     }
@@ -403,7 +403,7 @@ public class TestGet extends AbstractTest {
     gets.clear();
     for(int i = 0; i < numValues; ++i) {
       Get get = new Get(rowKeys[i]);
-      get.addFamily(dataGenerationHelper.randomData("badFamily-"));
+      get.addFamily(dataHelper.randomData("badFamily-"));
       boolean throwsException = false;
       try {
         table.exists(get);
@@ -426,7 +426,7 @@ public class TestGet extends AbstractTest {
     gets.clear();
     for (int i = 0; i < numValues; ++i) {
       Get get = new Get(rowKeys[i]);
-      get.addColumn(COLUMN_FAMILY, dataGenerationHelper.randomData("badColumn-"));
+      get.addColumn(COLUMN_FAMILY, dataHelper.randomData("badColumn-"));
       Assert.assertFalse(table.exists(get));
       gets.add(get);
     }
@@ -441,7 +441,7 @@ public class TestGet extends AbstractTest {
     for (int i = 0; i < numValues; ++i) {
       Get get = new Get(rowKeys[i]);
       get.addColumn(COLUMN_FAMILY, quals[i]);
-      get.addColumn(COLUMN_FAMILY, dataGenerationHelper.randomData("badColumn-"));
+      get.addColumn(COLUMN_FAMILY, dataHelper.randomData("badColumn-"));
       Assert.assertTrue(table.exists(get));
       gets.add(get);
     }
@@ -464,17 +464,17 @@ public class TestGet extends AbstractTest {
     // Run a control test.
     List<Get> gets = new ArrayList<Get>(numValues + 1);
     for (int i = 0; i < numValues; ++i) {
-      Get get = new Get(dataGenerationHelper.randomData("key-"));
-      get.addColumn(COLUMN_FAMILY, dataGenerationHelper.randomData("qual-"));
+      Get get = new Get(dataHelper.randomData("key-"));
+      get.addColumn(COLUMN_FAMILY, dataHelper.randomData("qual-"));
       gets.add(get);
     }
     table.get(gets);
 
     // Now add a poison get.
-    Get get = new Get(dataGenerationHelper.randomData("testRow-"));
+    Get get = new Get(dataHelper.randomData("testRow-"));
     get.addColumn(
-        dataGenerationHelper.randomData("badFamily-"),
-        dataGenerationHelper.randomData("qual-"));
+        dataHelper.randomData("badFamily-"),
+        dataHelper.randomData("qual-"));
     gets.add(get);
 
     boolean throwsException = false;

--- a/src/test/java/com/google/cloud/anviltop/hbase/TestPut.java
+++ b/src/test/java/com/google/cloud/anviltop/hbase/TestPut.java
@@ -48,9 +48,9 @@ public class TestPut extends AbstractTest {
   public void testPutMultipleCellsOneRow() throws IOException {
     // Initialize variables
     HTableInterface table = connection.getTable(TABLE_NAME);
-    byte[] rowKey = dataGenerationHelper.randomData("testrow-");
-    byte[][] quals = dataGenerationHelper.randomData("testQualifier-", NUM_CELLS);
-    byte[][] values = dataGenerationHelper.randomData("testValue-", NUM_CELLS);
+    byte[] rowKey = dataHelper.randomData("testrow-");
+    byte[][] quals = dataHelper.randomData("testQualifier-", NUM_CELLS);
+    byte[][] values = dataHelper.randomData("testValue-", NUM_CELLS);
 
     // Construct put with NUM_CELL random qualifier/value combos
     Put put = new Put(rowKey);
@@ -91,9 +91,9 @@ public class TestPut extends AbstractTest {
   public void testPutGetDeleteMultipleRows() throws IOException {
     // Initialize interface
     HTableInterface table = connection.getTable(TABLE_NAME);
-    byte[][] rowKeys = dataGenerationHelper.randomData("testrow-", NUM_ROWS);
-    byte[][] qualifiers = dataGenerationHelper.randomData("testQualifier-", NUM_ROWS);
-    byte[][] values = dataGenerationHelper.randomData("testValue-", NUM_ROWS);
+    byte[][] rowKeys = dataHelper.randomData("testrow-", NUM_ROWS);
+    byte[][] qualifiers = dataHelper.randomData("testQualifier-", NUM_ROWS);
+    byte[][] values = dataHelper.randomData("testValue-", NUM_ROWS);
 
     // Do puts
     List<Put> puts = new ArrayList<Put>(NUM_ROWS);

--- a/src/test/java/com/google/cloud/anviltop/hbase/TestTimestamp.java
+++ b/src/test/java/com/google/cloud/anviltop/hbase/TestTimestamp.java
@@ -13,7 +13,6 @@
  */
 package com.google.cloud.anviltop.hbase;
 
-import org.apache.commons.lang.RandomStringUtils;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellUtil;
 import org.apache.hadoop.hbase.client.Delete;
@@ -21,9 +20,7 @@ import org.apache.hadoop.hbase.client.Get;
 import org.apache.hadoop.hbase.client.HTableInterface;
 import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.Result;
-import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -39,12 +36,12 @@ public class TestTimestamp extends AbstractTest {
   public void testArbitraryTimestamp() throws IOException {
     // Initialize
     HTableInterface table = connection.getTable(TABLE_NAME);
-    byte[] rowKey = dataGenerationHelper.randomData("testrow-");
-    byte[] testQualifier = dataGenerationHelper.randomData("testQual-");
+    byte[] rowKey = dataHelper.randomData("testrow-");
+    byte[] testQualifier = dataHelper.randomData("testQual-");
     int numVersions = 4;
     assert numVersions > 2;
-    byte[][] values = dataGenerationHelper.randomData("testValue-", numVersions);
-    long[] versions = dataGenerationHelper.sequentialTimestamps(numVersions, 1L);
+    byte[][] values = dataHelper.randomData("testValue-", numVersions);
+    long[] versions = dataHelper.sequentialTimestamps(numVersions, 1L);
 
     // Put several versions in the same row/column.
     Put put = new Put(rowKey);


### PR DESCRIPTION
Refactor data generation methods to helper object so they can be reused in tests not deriving from AbstractTest.
