### PR TITLE
Added rowfilter tests

### DIFF
--- a/src/test/java/com/google/cloud/anviltop/hbase/TestFilters.java
+++ b/src/test/java/com/google/cloud/anviltop/hbase/TestFilters.java
@@ -22,15 +22,25 @@ import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.ResultScanner;
 import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.filter.BinaryComparator;
+import org.apache.hadoop.hbase.filter.BinaryPrefixComparator;
+import org.apache.hadoop.hbase.filter.BitComparator;
+import org.apache.hadoop.hbase.filter.ByteArrayComparable;
 import org.apache.hadoop.hbase.filter.ColumnCountGetFilter;
 import org.apache.hadoop.hbase.filter.ColumnPaginationFilter;
 import org.apache.hadoop.hbase.filter.ColumnPrefixFilter;
 import org.apache.hadoop.hbase.filter.ColumnRangeFilter;
+import org.apache.hadoop.hbase.filter.CompareFilter;
 import org.apache.hadoop.hbase.filter.Filter;
+import org.apache.hadoop.hbase.filter.NullComparator;
+import org.apache.hadoop.hbase.filter.RegexStringComparator;
+import org.apache.hadoop.hbase.filter.RowFilter;
+import org.apache.hadoop.hbase.filter.SubstringComparator;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.util.List;
 
 public class TestFilters extends AbstractTest {
@@ -278,5 +288,642 @@ public class TestFilters extends AbstractTest {
     Assert.assertEquals("C", Bytes.toString(CellUtil.cloneQualifier(result.rawCells()[2])));
 
     table.close();
+  }
+
+  /**
+   * Requirement 9.5 - RowFilter - filter by rowkey against a given Comparable
+   *
+   * Test the BinaryComparator against EQUAL, GREATER, GREATER_OR_EQUAL, LESS, LESS_OR_EQUAL,
+   * NOT_EQUAL, and NO_OP.  BinaryComparator compares two byte arrays lexicographically using
+   * Bytes.compareTo(byte[], byte[]).
+   */
+  @Test
+  public void testRowFilterBinaryComparator() throws Exception {
+    // Initialize data
+    HTableInterface table = connection.getTable(TABLE_NAME);
+    String rowKeyPrefix = "testRowFilter-" + RandomStringUtils.randomAlphabetic(10);
+    byte[] rowKey1 = Bytes.toBytes(rowKeyPrefix + "A");
+    byte[] rowKey2 = Bytes.toBytes(rowKeyPrefix + "AA");
+    byte[] rowKey3 = Bytes.toBytes(rowKeyPrefix + "B");
+    byte[] rowKey4 = Bytes.toBytes(rowKeyPrefix + "BB");
+    byte[] qual = Bytes.toBytes("testqual");
+    byte[] value = Bytes.toBytes("testvalue");
+    for (byte[] rowKey : new byte[][] { rowKey1, rowKey2, rowKey3, rowKey4}) {
+      Put put = new Put(rowKey).add(COLUMN_FAMILY, qual, value);
+      table.put(put);
+    }
+
+    // Test BinaryComparator - EQUAL
+    ByteArrayComparable rowKey2Comparable = new BinaryComparator(rowKey2);
+    Filter filter = new RowFilter(CompareFilter.CompareOp.EQUAL, rowKey2Comparable);
+    Result[] results = scanWithFilter(table, rowKey1, rowKey4, qual, filter);
+    Assert.assertEquals("# results", 1, results.length);
+    Assert.assertArrayEquals(rowKey2, results[0].getRow());
+
+    // Test BinaryComparator - GREATER
+    filter = new RowFilter(CompareFilter.CompareOp.GREATER, rowKey2Comparable);
+    results = scanWithFilter(table, rowKey1, rowKey4, qual, filter);
+    Assert.assertEquals("# results", 1, results.length);
+    Assert.assertArrayEquals(rowKey3, results[0].getRow());
+
+    // Test BinaryComparator - GREATER_OR_EQUAL
+    filter = new RowFilter(CompareFilter.CompareOp.GREATER_OR_EQUAL, rowKey2Comparable);
+    results = scanWithFilter(table, rowKey1, rowKey4, qual, filter);
+    Assert.assertEquals("# results", 2, results.length);
+    Assert.assertArrayEquals(rowKey2, results[0].getRow());
+    Assert.assertArrayEquals(rowKey3, results[1].getRow());
+
+    // Test BinaryComparator - LESS
+    filter = new RowFilter(CompareFilter.CompareOp.LESS, rowKey2Comparable);
+    results = scanWithFilter(table, rowKey1, rowKey4, qual, filter);
+    Assert.assertEquals("# results", 1, results.length);
+    Assert.assertArrayEquals(rowKey1, results[0].getRow());
+
+    // Test BinaryComparator - LESS_OR_EQUAL
+    filter = new RowFilter(CompareFilter.CompareOp.LESS_OR_EQUAL, rowKey2Comparable);
+    results = scanWithFilter(table, rowKey1, rowKey4, qual, filter);
+    Assert.assertEquals("# results", 2, results.length);
+    Assert.assertArrayEquals(rowKey1, results[0].getRow());
+    Assert.assertArrayEquals(rowKey2, results[1].getRow());
+
+    // Test BinaryComparator - NOT_EQUAL
+    filter = new RowFilter(CompareFilter.CompareOp.NOT_EQUAL, rowKey2Comparable);
+    results = scanWithFilter(table, rowKey1, rowKey4, qual, filter);
+    Assert.assertEquals("# results", 2, results.length);
+    Assert.assertArrayEquals(rowKey1, results[0].getRow());
+    Assert.assertArrayEquals(rowKey3, results[1].getRow());
+
+    // Test BinaryComparator - NO_OP
+    filter = new RowFilter(CompareFilter.CompareOp.NO_OP, rowKey2Comparable);
+    results = scanWithFilter(table, rowKey1, rowKey4, qual, filter);
+    Assert.assertEquals("# results", 0, results.length);
+
+    table.close();
+  }
+
+  /**
+   * Requirement 9.5
+   *
+   * Test the BinaryPrefixComparator against EQUAL, GREATER, GREATER_OR_EQUAL, LESS, LESS_OR_EQUAL,
+   * NOT_EQUAL, and NO_OP.  BinaryPrefixComparator compares against a specified byte array, up to
+   * the length of this byte array.
+   */
+  @Test
+  public void testRowFilterBinaryPrefixComparator() throws Exception {
+    // Initialize data
+    HTableInterface table = connection.getTable(TABLE_NAME);
+    String rowKeyPrefix = "testRowFilter-" + RandomStringUtils.randomAlphabetic(10);
+    byte[] rowA = Bytes.toBytes(rowKeyPrefix + "A");
+    byte[] rowAA = Bytes.toBytes(rowKeyPrefix + "AA");
+    byte[] rowB = Bytes.toBytes(rowKeyPrefix + "B");
+    byte[] rowBB = Bytes.toBytes(rowKeyPrefix + "BB");
+    byte[] rowC = Bytes.toBytes(rowKeyPrefix + "C");
+    byte[] rowCC = Bytes.toBytes(rowKeyPrefix + "CC");
+    byte[] rowD = Bytes.toBytes(rowKeyPrefix + "D");
+    byte[] qual = Bytes.toBytes("testqual");
+    byte[] value = Bytes.toBytes("testvalue");
+    for (byte[] rowKey : new byte[][] { rowA, rowAA, rowB, rowBB, rowC, rowCC, rowD }) {
+      Put put = new Put(rowKey).add(COLUMN_FAMILY, qual, value);
+      table.put(put);
+    }
+
+    // Test BinaryPrefixComparator - EQUAL
+    ByteArrayComparable rowBComparable = new BinaryPrefixComparator(rowB);
+    Filter filter = new RowFilter(CompareFilter.CompareOp.EQUAL, rowBComparable);
+    Result[] results = scanWithFilter(table, rowA, rowD, qual, filter);
+    Assert.assertEquals("# results", 2, results.length);
+    Assert.assertArrayEquals(rowB, results[0].getRow());
+    Assert.assertArrayEquals(rowBB, results[1].getRow());
+
+    // Test BinaryPrefixComparator - GREATER
+    filter = new RowFilter(CompareFilter.CompareOp.GREATER, rowBComparable);
+    results = scanWithFilter(table, rowA, rowD, qual, filter);
+    Assert.assertEquals("# results", 2, results.length);
+    Assert.assertArrayEquals(rowC, results[0].getRow());
+    Assert.assertArrayEquals(rowCC, results[1].getRow());
+
+    // Test BinaryPrefixComparator - GREATER_OR_EQUAL
+    filter = new RowFilter(CompareFilter.CompareOp.GREATER_OR_EQUAL, rowBComparable);
+    results = scanWithFilter(table, rowA, rowD, qual, filter);
+    Assert.assertEquals("# results", 4, results.length);
+    Assert.assertArrayEquals(rowB, results[0].getRow());
+    Assert.assertArrayEquals(rowBB, results[1].getRow());
+    Assert.assertArrayEquals(rowC, results[2].getRow());
+    Assert.assertArrayEquals(rowCC, results[3].getRow());
+
+    // Test BinaryPrefixComparator - LESS
+    filter = new RowFilter(CompareFilter.CompareOp.LESS, rowBComparable);
+    results = scanWithFilter(table, rowA, rowD, qual, filter);
+    Assert.assertEquals("# results", 2, results.length);
+    Assert.assertArrayEquals(rowA, results[0].getRow());
+    Assert.assertArrayEquals(rowAA, results[1].getRow());
+
+    // Test BinaryPrefixComparator - LESS_OR_EQUAL
+    filter = new RowFilter(CompareFilter.CompareOp.LESS_OR_EQUAL, rowBComparable);
+    results = scanWithFilter(table, rowA, rowD, qual, filter);
+    Assert.assertEquals("# results", 4, results.length);
+    Assert.assertArrayEquals(rowA, results[0].getRow());
+    Assert.assertArrayEquals(rowAA, results[1].getRow());
+    Assert.assertArrayEquals(rowB, results[2].getRow());
+    Assert.assertArrayEquals(rowBB, results[3].getRow());
+
+    // Test BinaryPrefixComparator - NOT_EQUAL
+    filter = new RowFilter(CompareFilter.CompareOp.NOT_EQUAL, rowBComparable);
+    results = scanWithFilter(table, rowA, rowD, qual, filter);
+    Assert.assertEquals("# results", 4, results.length);
+    Assert.assertArrayEquals(rowA, results[0].getRow());
+    Assert.assertArrayEquals(rowAA, results[1].getRow());
+    Assert.assertArrayEquals(rowC, results[2].getRow());
+    Assert.assertArrayEquals(rowCC, results[3].getRow());
+
+    // Test BinaryPrefixComparator - NO_OP
+    filter = new RowFilter(CompareFilter.CompareOp.NO_OP, rowBComparable);
+    results = scanWithFilter(table, rowA, rowD, qual, filter);
+    Assert.assertEquals("# results", 0, results.length);
+
+    table.close();
+  }
+
+  /**
+   * Requirement 9.5
+   *
+   * Test the BitComparator with XOR against EQUAL, GREATER, GREATER_OR_EQUAL, LESS, LESS_OR_EQUAL,
+   * NOT_EQUAL, and NO_OP.  Perform XOR bit operation on the specified array and returns whether the
+   * result is non-zero.  When comparing arrays of different length, the comparison fails regardless
+   * of the operation.  If the comparison fails, it is returned as LESS THAN by the comparator.
+   */
+  @Test
+  public void testRowFilterBitComparatorXOR() throws Exception {
+    // Initialize data
+    HTableInterface table = connection.getTable(TABLE_NAME);
+    String rowKeyPrefix = "testRowFilter-" + RandomStringUtils.randomAlphabetic(10);
+    byte[] row0000 = Bytes.fromHex("00");
+    byte[] row0101 = Bytes.fromHex("55");
+    byte[] row1010 = Bytes.fromHex("aa");
+    byte[] row1111 = Bytes.fromHex("ff");
+    byte[] rowDiffLength = Bytes.fromHex("abcd");
+    byte[] rowMax = Bytes.fromHex("ffffff");
+    byte[] qual = dataHelper.randomData("testqual");
+    byte[] value = Bytes.toBytes("testvalue");
+    for (byte[] rowKey : new byte[][] { row0000, row0101, row1010, row1111, rowDiffLength}) {
+      Put put = new Put(rowKey).add(COLUMN_FAMILY, qual, value);
+      table.put(put);
+    }
+
+    // Test BitComparator - XOR - EQUAL
+    ByteArrayComparable rowBComparable = new BitComparator(row0101, BitComparator.BitwiseOp.XOR);
+    Filter filter = new RowFilter(CompareFilter.CompareOp.EQUAL, rowBComparable);
+    Result[] results = scanWithFilter(table, row0000, rowMax, qual, filter);
+    Assert.assertEquals("# results", 3, results.length);
+    Assert.assertArrayEquals(Bytes.toHex(results[0].getRow()), row0000, results[0].getRow());
+    Assert.assertArrayEquals(Bytes.toHex(results[1].getRow()), row1010, results[1].getRow());
+    Assert.assertArrayEquals(Bytes.toHex(results[2].getRow()), row1111, results[2].getRow());
+
+    // Test BitComparator - XOR - GREATER (effectively no values)
+    filter = new RowFilter(CompareFilter.CompareOp.GREATER, rowBComparable);
+    results = scanWithFilter(table, row0000, rowMax, qual, filter);
+    Assert.assertEquals("# results", 0, results.length);
+
+    // Test BitComparator - XOR - GREATER_OR_EQUAL (same effect as EQUAL)
+    filter = new RowFilter(CompareFilter.CompareOp.GREATER_OR_EQUAL, rowBComparable);
+    results = scanWithFilter(table, row0000, rowMax, qual, filter);
+    Assert.assertEquals("# results", 3, results.length);
+    Assert.assertArrayEquals(Bytes.toHex(results[0].getRow()), row0000, results[0].getRow());
+    Assert.assertArrayEquals(Bytes.toHex(results[1].getRow()), row1010, results[1].getRow());
+    Assert.assertArrayEquals(Bytes.toHex(results[2].getRow()), row1111, results[2].getRow());
+
+    // Test BitComparator - XOR - LESS (same effect as NOT_EQUAL)
+    filter = new RowFilter(CompareFilter.CompareOp.LESS, rowBComparable);
+    results = scanWithFilter(table, row0000, rowMax, qual, filter);
+    Assert.assertEquals("# results", 2, results.length);
+    Assert.assertArrayEquals(Bytes.toHex(results[0].getRow()), row0101, results[0].getRow());
+    Assert.assertArrayEquals(Bytes.toHex(results[1].getRow()), rowDiffLength, results[1].getRow());
+
+    // Test BitComparator - XOR - LESS_OR_EQUAL (effectively all values)
+    filter = new RowFilter(CompareFilter.CompareOp.LESS_OR_EQUAL, rowBComparable);
+    results = scanWithFilter(table, row0000, rowMax, qual, filter);
+    Assert.assertEquals("# results", 5, results.length);
+    Assert.assertArrayEquals(Bytes.toHex(results[0].getRow()), row0000, results[0].getRow());
+    Assert.assertArrayEquals(Bytes.toHex(results[1].getRow()), row0101, results[1].getRow());
+    Assert.assertArrayEquals(Bytes.toHex(results[2].getRow()), row1010, results[2].getRow());
+    Assert.assertArrayEquals(Bytes.toHex(results[3].getRow()), rowDiffLength, results[3].getRow());
+    Assert.assertArrayEquals(Bytes.toHex(results[4].getRow()), row1111, results[4].getRow());
+
+    // Test BitComparator - XOR - NOT_EQUAL (same effect as LESS)
+    filter = new RowFilter(CompareFilter.CompareOp.NOT_EQUAL, rowBComparable);
+    results = scanWithFilter(table, row0000, rowMax, qual, filter);
+    Assert.assertEquals("# results", 2, results.length);
+    Assert.assertArrayEquals(Bytes.toHex(results[0].getRow()), row0101, results[0].getRow());
+    Assert.assertArrayEquals(Bytes.toHex(results[1].getRow()), rowDiffLength, results[1].getRow());
+
+    // Test BitComparator - XOR - NO_OP (no values)
+    filter = new RowFilter(CompareFilter.CompareOp.NO_OP, rowBComparable);
+    results = scanWithFilter(table, row0000, rowMax, qual, filter);
+    Assert.assertEquals("# results", 0, results.length);
+
+    table.close();
+  }
+
+  /**
+   * Requirement 9.5
+   *
+   * Test the BitComparator with AND against EQUAL, GREATER, GREATER_OR_EQUAL, LESS, LESS_OR_EQUAL,
+   * NOT_EQUAL, and NO_OP.  Perform AND bit operation on the specified array and returns whether the
+   * result is non-zero.  When comparing arrays of different length, the comparison fails regardless
+   * of the operation.  If the comparison fails, it is returned as LESS THAN by the comparator.
+   */
+  @Test
+  public void testRowFilterBitComparatorAND() throws Exception {
+    // Initialize data
+    HTableInterface table = connection.getTable(TABLE_NAME);
+    String rowKeyPrefix = "testRowFilter-" + RandomStringUtils.randomAlphabetic(10);
+    byte[] row0000 = Bytes.fromHex("00");
+    byte[] row0101 = Bytes.fromHex("55");
+    byte[] row1010 = Bytes.fromHex("aa");
+    byte[] row1111 = Bytes.fromHex("ff");
+    byte[] rowDiffLength = Bytes.fromHex("abcd");
+    byte[] rowMax = Bytes.fromHex("ffffff");
+    byte[] qual = dataHelper.randomData("testqual");
+    byte[] value = Bytes.toBytes("testvalue");
+    for (byte[] rowKey : new byte[][] { row0000, row0101, row1010, row1111, rowDiffLength}) {
+      Put put = new Put(rowKey).add(COLUMN_FAMILY, qual, value);
+      table.put(put);
+    }
+
+    // Test BitComparator - AND - EQUAL
+    ByteArrayComparable rowBComparable = new BitComparator(row0101, BitComparator.BitwiseOp.AND);
+    Filter filter = new RowFilter(CompareFilter.CompareOp.EQUAL, rowBComparable);
+    Result[] results = scanWithFilter(table, row0000, rowMax, qual, filter);
+    Assert.assertEquals("# results", 2, results.length);
+    Assert.assertArrayEquals(Bytes.toHex(results[0].getRow()), row0101, results[0].getRow());
+    Assert.assertArrayEquals(Bytes.toHex(results[1].getRow()), row1111, results[1].getRow());
+
+    // Test BitComparator - AND - GREATER (effectively no values)
+    filter = new RowFilter(CompareFilter.CompareOp.GREATER, rowBComparable);
+    results = scanWithFilter(table, row0000, rowMax, qual, filter);
+    Assert.assertEquals("# results", 0, results.length);
+
+    // Test BitComparator - AND - GREATER_OR_EQUAL (same effect as EQUAL)
+    filter = new RowFilter(CompareFilter.CompareOp.GREATER_OR_EQUAL, rowBComparable);
+    results = scanWithFilter(table, row0000, rowMax, qual, filter);
+    Assert.assertEquals("# results", 2, results.length);
+    Assert.assertArrayEquals(Bytes.toHex(results[0].getRow()), row0101, results[0].getRow());
+    Assert.assertArrayEquals(Bytes.toHex(results[1].getRow()), row1111, results[1].getRow());
+
+    // Test BitComparator - AND - LESS (same effect as NOT_EQUAL)
+    filter = new RowFilter(CompareFilter.CompareOp.LESS, rowBComparable);
+    results = scanWithFilter(table, row0000, rowMax, qual, filter);
+    Assert.assertEquals("# results", 3, results.length);
+    Assert.assertArrayEquals(Bytes.toHex(results[0].getRow()), row0000, results[0].getRow());
+    Assert.assertArrayEquals(Bytes.toHex(results[1].getRow()), row1010, results[1].getRow());
+    Assert.assertArrayEquals(Bytes.toHex(results[2].getRow()), rowDiffLength, results[2].getRow());
+
+    // Test BitComparator - AND - LESS_OR_EQUAL (effectively all values)
+    filter = new RowFilter(CompareFilter.CompareOp.LESS_OR_EQUAL, rowBComparable);
+    results = scanWithFilter(table, row0000, rowMax, qual, filter);
+    Assert.assertEquals("# results", 5, results.length);
+    Assert.assertArrayEquals(Bytes.toHex(results[0].getRow()), row0000, results[0].getRow());
+    Assert.assertArrayEquals(Bytes.toHex(results[1].getRow()), row0101, results[1].getRow());
+    Assert.assertArrayEquals(Bytes.toHex(results[2].getRow()), row1010, results[2].getRow());
+    Assert.assertArrayEquals(Bytes.toHex(results[3].getRow()), rowDiffLength, results[3].getRow());
+    Assert.assertArrayEquals(Bytes.toHex(results[4].getRow()), row1111, results[4].getRow());
+
+    // Test BitComparator - AND - NOT_EQUAL (same effect as LESS)
+    filter = new RowFilter(CompareFilter.CompareOp.NOT_EQUAL, rowBComparable);
+    results = scanWithFilter(table, row0000, rowMax, qual, filter);
+    Assert.assertEquals("# results", 3, results.length);
+    Assert.assertArrayEquals(Bytes.toHex(results[0].getRow()), row0000, results[0].getRow());
+    Assert.assertArrayEquals(Bytes.toHex(results[1].getRow()), row1010, results[1].getRow());
+    Assert.assertArrayEquals(Bytes.toHex(results[2].getRow()), rowDiffLength, results[2].getRow());
+
+    // Test BitComparator - AND - NO_OP (no values)
+    filter = new RowFilter(CompareFilter.CompareOp.NO_OP, rowBComparable);
+    results = scanWithFilter(table, row0000, rowMax, qual, filter);
+    Assert.assertEquals("# results", 0, results.length);
+
+    table.close();
+  }
+
+  /**
+   * Requirement 9.5
+   *
+   * Test the BitComparator with AND against EQUAL, GREATER, GREATER_OR_EQUAL, LESS, LESS_OR_EQUAL,
+   * NOT_EQUAL, and NO_OP.  Perform AND bit operation on the specified array and returns whether the
+   * result is non-zero.  When comparing arrays of different length, the comparison fails regardless
+   * of the operation.  If the comparison fails, it is returned as LESS THAN by the comparator.
+   */
+  @Test
+  public void testRowFilterBitComparatorOR() throws Exception {
+    // Initialize data
+    HTableInterface table = connection.getTable(TABLE_NAME);
+    String rowKeyPrefix = "testRowFilter-" + RandomStringUtils.randomAlphabetic(10);
+    byte[] row0000 = Bytes.fromHex("00");
+    byte[] row0101 = Bytes.fromHex("55");
+    byte[] row1010 = Bytes.fromHex("aa");
+    byte[] row1111 = Bytes.fromHex("ff");
+    byte[] rowDiffLength = Bytes.fromHex("abcd");
+    byte[] rowMax = Bytes.fromHex("ffffff");
+    byte[] qual = dataHelper.randomData("testqual");
+    byte[] value = Bytes.toBytes("testvalue");
+    for (byte[] rowKey : new byte[][] { row0000, row0101, row1010, row1111, rowDiffLength}) {
+      Put put = new Put(rowKey).add(COLUMN_FAMILY, qual, value);
+      table.put(put);
+    }
+
+    // Test BitComparator - OR - EQUAL
+    ByteArrayComparable rowBComparable = new BitComparator(row0101, BitComparator.BitwiseOp.OR);
+    Filter filter = new RowFilter(CompareFilter.CompareOp.EQUAL, rowBComparable);
+    Result[] results = scanWithFilter(table, row0000, rowMax, qual, filter);
+    Assert.assertEquals("# results", 4, results.length);
+    Assert.assertArrayEquals(Bytes.toHex(results[0].getRow()), row0000, results[0].getRow());
+    Assert.assertArrayEquals(Bytes.toHex(results[1].getRow()), row0101, results[1].getRow());
+    Assert.assertArrayEquals(Bytes.toHex(results[2].getRow()), row1010, results[2].getRow());
+    Assert.assertArrayEquals(Bytes.toHex(results[3].getRow()), row1111, results[3].getRow());
+
+    // Test BitComparator - OR - GREATER (effectively no values)
+    filter = new RowFilter(CompareFilter.CompareOp.GREATER, rowBComparable);
+    results = scanWithFilter(table, row0000, rowMax, qual, filter);
+    Assert.assertEquals("# results", 0, results.length);
+
+    // Test BitComparator - OR - GREATER_OR_EQUAL (same effect as EQUAL)
+    filter = new RowFilter(CompareFilter.CompareOp.GREATER_OR_EQUAL, rowBComparable);
+    results = scanWithFilter(table, row0000, rowMax, qual, filter);
+    Assert.assertEquals("# results", 4, results.length);
+    Assert.assertArrayEquals(Bytes.toHex(results[0].getRow()), row0000, results[0].getRow());
+    Assert.assertArrayEquals(Bytes.toHex(results[1].getRow()), row0101, results[1].getRow());
+    Assert.assertArrayEquals(Bytes.toHex(results[2].getRow()), row1010, results[2].getRow());
+    Assert.assertArrayEquals(Bytes.toHex(results[3].getRow()), row1111, results[3].getRow());
+
+    // Test BitComparator - OR - LESS (same effect as NOT_EQUAL)
+    filter = new RowFilter(CompareFilter.CompareOp.LESS, rowBComparable);
+    results = scanWithFilter(table, row0000, rowMax, qual, filter);
+    Assert.assertEquals("# results", 1, results.length);
+    Assert.assertArrayEquals(Bytes.toHex(results[0].getRow()), rowDiffLength, results[0].getRow());
+
+    // Test BitComparator - OR - LESS_OR_EQUAL (effectively all values)
+    filter = new RowFilter(CompareFilter.CompareOp.LESS_OR_EQUAL, rowBComparable);
+    results = scanWithFilter(table, row0000, rowMax, qual, filter);
+    Assert.assertEquals("# results", 5, results.length);
+    Assert.assertArrayEquals(Bytes.toHex(results[0].getRow()), row0000, results[0].getRow());
+    Assert.assertArrayEquals(Bytes.toHex(results[1].getRow()), row0101, results[1].getRow());
+    Assert.assertArrayEquals(Bytes.toHex(results[2].getRow()), row1010, results[2].getRow());
+    Assert.assertArrayEquals(Bytes.toHex(results[3].getRow()), rowDiffLength, results[3].getRow());
+    Assert.assertArrayEquals(Bytes.toHex(results[4].getRow()), row1111, results[4].getRow());
+
+    // Test BitComparator - OR - NOT_EQUAL (same effect as LESS)
+    filter = new RowFilter(CompareFilter.CompareOp.NOT_EQUAL, rowBComparable);
+    results = scanWithFilter(table, row0000, rowMax, qual, filter);
+    Assert.assertEquals("# results", 1, results.length);
+    Assert.assertArrayEquals(Bytes.toHex(results[0].getRow()), rowDiffLength, results[0].getRow());
+
+    // Test BitComparator - OR - NO_OP (no values)
+    filter = new RowFilter(CompareFilter.CompareOp.NO_OP, rowBComparable);
+    results = scanWithFilter(table, row0000, rowMax, qual, filter);
+    Assert.assertEquals("# results", 0, results.length);
+
+    table.close();
+  }
+
+  /**
+   * Requirement 9.5
+   *
+   * Test the NullComparator against EQUAL, GREATER, GREATER_OR_EQUAL, LESS, LESS_OR_EQUAL,
+   * NOT_EQUAL, and NO_OP.  It behaves the same as constructing a BinaryComparator with an empty
+   * byte array.
+   */
+  @Test
+  public void testRowFilterNullComparator() throws Exception {
+    // Initialize data
+    HTableInterface table = connection.getTable(TABLE_NAME);
+    String rowKeyPrefix = "testRowFilter-" + RandomStringUtils.randomAlphabetic(10);
+    byte[] rowKeyA = Bytes.toBytes(rowKeyPrefix + "A");
+    byte[] rowKeyB = Bytes.toBytes(rowKeyPrefix + "B");
+    byte[] qual = dataHelper.randomData("testqual");
+    byte[] value = Bytes.toBytes("testvalue");
+    Put put = new Put(rowKeyA).add(COLUMN_FAMILY, qual, value);
+    table.put(put);
+
+    // Test BinaryComparator - EQUAL
+    ByteArrayComparable nullComparator = new NullComparator();
+    Filter filter = new RowFilter(CompareFilter.CompareOp.EQUAL, nullComparator);
+    Result[] results = scanWithFilter(table, rowKeyA, rowKeyB, qual, filter);
+    Assert.assertEquals("# results", 0, results.length);
+
+    // Test BinaryComparator - GREATER
+    filter = new RowFilter(CompareFilter.CompareOp.GREATER, nullComparator);
+    results = scanWithFilter(table, rowKeyA, rowKeyB, qual, filter);
+    Assert.assertEquals("# results", 0, results.length);
+
+    // Test BinaryComparator - GREATER_OR_EQUAL
+    filter = new RowFilter(CompareFilter.CompareOp.GREATER_OR_EQUAL, nullComparator);
+    results = scanWithFilter(table, rowKeyA, rowKeyB, qual, filter);
+    Assert.assertEquals("# results", 0, results.length);
+
+    // Test BinaryComparator - LESS
+    filter = new RowFilter(CompareFilter.CompareOp.LESS, nullComparator);
+    results = scanWithFilter(table, rowKeyA, rowKeyB, qual, filter);
+    Assert.assertEquals("# results", 1, results.length);
+    Assert.assertArrayEquals(rowKeyA, results[0].getRow());
+
+    // Test BinaryComparator - LESS_OR_EQUAL
+    filter = new RowFilter(CompareFilter.CompareOp.LESS_OR_EQUAL, nullComparator);
+    results = scanWithFilter(table, rowKeyA, rowKeyB, qual, filter);
+    Assert.assertEquals("# results", 1, results.length);
+    Assert.assertArrayEquals(rowKeyA, results[0].getRow());
+
+    // Test BinaryComparator - NOT_EQUAL
+    filter = new RowFilter(CompareFilter.CompareOp.NOT_EQUAL, nullComparator);
+    results = scanWithFilter(table, rowKeyA, rowKeyB, qual, filter);
+    Assert.assertEquals("# results", 1, results.length);
+    Assert.assertArrayEquals(rowKeyA, results[0].getRow());
+
+    // Test BinaryComparator - NO_OP
+    filter = new RowFilter(CompareFilter.CompareOp.NO_OP, nullComparator);
+    results = scanWithFilter(table, rowKeyA, rowKeyB, qual, filter);
+    Assert.assertEquals("# results", 0, results.length);
+
+    table.close();
+  }
+
+  /**
+   * Requirement 9.5
+   *
+   * Test the SubstringComparator.  Case-insensitive check for values containing the given
+   * substring. Only EQUAL and NOT_EQUAL tests are valid with this comparator, but the other
+   * operators can still return deterministic results in HBase.
+   */
+  @Test
+  public void testRowFilterSubstringComparator() throws Exception {
+    // Initialize data
+    HTableInterface table = connection.getTable(TABLE_NAME);
+    byte[] rowab = Bytes.toBytes("ab");  // Substring match, but out of row range
+    byte[] rowA = Bytes.toBytes("A");
+    byte[] rowAB= Bytes.toBytes("AB");
+    byte[] rowAbC = Bytes.toBytes("AbC");
+    byte[] rowDaB = Bytes.toBytes("DaB");
+    byte[] rowDabE = Bytes.toBytes("DabE");
+    byte[] rowZ = Bytes.toBytes("Z");
+    byte[] qual = dataHelper.randomData("testqual");
+    byte[] value = Bytes.toBytes("testvalue");
+    for (byte[] rowKey : new byte[][] { rowab, rowA, rowAB, rowAbC, rowDaB, rowDabE}) {
+      Put put = new Put(rowKey).add(COLUMN_FAMILY, qual, value);
+      table.put(put);
+    }
+
+    // Test SubstringComparator - EQUAL
+    ByteArrayComparable rowKey2Comparable = new SubstringComparator("AB");
+    Filter filter = new RowFilter(CompareFilter.CompareOp.EQUAL, rowKey2Comparable);
+    Result[] results = scanWithFilter(table, rowA, rowZ, qual, filter);
+    Assert.assertEquals("# results", 4, results.length);
+    Assert.assertArrayEquals(rowAB, results[0].getRow());
+    Assert.assertArrayEquals(rowAbC, results[1].getRow());
+    Assert.assertArrayEquals(rowDaB, results[2].getRow());
+    Assert.assertArrayEquals(rowDabE, results[3].getRow());
+
+    // Test SubstringComparator - GREATER
+    filter = new RowFilter(CompareFilter.CompareOp.GREATER, rowKey2Comparable);
+    results = scanWithFilter(table, rowA, rowZ, qual, filter);
+    Assert.assertEquals("# results", 0, results.length);
+
+    // Test SubstringComparator - GREATER_OR_EQUAL
+    filter = new RowFilter(CompareFilter.CompareOp.GREATER_OR_EQUAL, rowKey2Comparable);
+    results = scanWithFilter(table, rowA, rowZ, qual, filter);
+    Assert.assertEquals("# results", 4, results.length);
+    Assert.assertArrayEquals(rowAB, results[0].getRow());
+    Assert.assertArrayEquals(rowAbC, results[1].getRow());
+    Assert.assertArrayEquals(rowDaB, results[2].getRow());
+    Assert.assertArrayEquals(rowDabE, results[3].getRow());
+
+    // Test SubstringComparator - LESS
+    filter = new RowFilter(CompareFilter.CompareOp.LESS, rowKey2Comparable);
+    results = scanWithFilter(table, rowA, rowZ, qual, filter);
+    Assert.assertEquals("# results", 1, results.length);
+    Assert.assertArrayEquals(rowA, results[0].getRow());
+
+    // Test SubstringComparator - LESS_OR_EQUAL
+    filter = new RowFilter(CompareFilter.CompareOp.LESS_OR_EQUAL, rowKey2Comparable);
+    results = scanWithFilter(table, rowA, rowZ, qual, filter);
+    Assert.assertEquals("# results", 5, results.length);
+    Assert.assertArrayEquals(rowA, results[0].getRow());
+    Assert.assertArrayEquals(rowAB, results[1].getRow());
+    Assert.assertArrayEquals(rowAbC, results[2].getRow());
+    Assert.assertArrayEquals(rowDaB, results[3].getRow());
+    Assert.assertArrayEquals(rowDabE, results[4].getRow());
+
+    // Test SubstringComparator - NOT_EQUAL
+    filter = new RowFilter(CompareFilter.CompareOp.NOT_EQUAL, rowKey2Comparable);
+    results = scanWithFilter(table, rowA, rowZ, qual, filter);
+    Assert.assertEquals("# results", 1, results.length);
+    Assert.assertArrayEquals(rowA, results[0].getRow());
+
+    // Test SubstringComparator - NO_OP
+    filter = new RowFilter(CompareFilter.CompareOp.NO_OP, rowKey2Comparable);
+    results = scanWithFilter(table, rowA, rowZ, qual, filter);
+    Assert.assertEquals("# results", 0, results.length);
+
+    table.close();
+  }
+
+  /**
+   * Requirement 9.5
+   *
+   * Test the SubstringComparator.  Case-insensitive check for values containing the given
+   * substring. Only EQUAL and NOT_EQUAL tests are valid with this comparator, but the other
+   * operators can still return deterministic results in HBase.
+   */
+  @Test
+  public void testRowFilterRegexStringComparator() throws Exception {
+    // Initialize data
+    HTableInterface table = connection.getTable(TABLE_NAME);
+    byte[] row0 = Bytes.toBytes("0");  // Substring match, but out of row range
+    byte[] rowGoodIP1 = Bytes.toBytes("192.168.2.13");
+    byte[] rowGoodIP2 = Bytes.toBytes("8.8.8.8");
+    byte[] rowGoodIPv6 = Bytes.toBytes("FE80:0000:0000:0000:0202:B3FF:FE1E:8329");
+    byte[] rowBadIP = Bytes.toBytes("1.2.278.0");
+    byte[] rowTelephone = Bytes.toBytes("1-212-867-5309");
+    byte[] rowRandom = dataHelper.randomData("9-rowkey");
+    byte[] endRow = Bytes.fromHex("ffffff");
+    byte[] qual = dataHelper.randomData("testqual");
+    byte[] value = Bytes.toBytes("testvalue");
+    for (byte[] rowKey : new byte[][] { row0, rowGoodIP1, rowGoodIP2, rowGoodIPv6, rowBadIP,
+        rowTelephone, rowRandom }) {
+      Put put = new Put(rowKey).add(COLUMN_FAMILY, qual, value);
+      table.put(put);
+    }
+    String regexIPAddr =
+      // v4 IP address
+      "(((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3,3}" +
+        "(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?))(\\/[0-9]+)?" +
+        "|" +
+        // v6 IP address
+        "((([\\dA-Fa-f]{1,4}:){7}[\\dA-Fa-f]{1,4})(:([\\d]{1,3}.)" +
+        "{3}[\\d]{1,3})?)(\\/[0-9]+)?";
+
+    // Test RegexStringComparator - EQUAL
+    ByteArrayComparable rowKey2Comparable = new RegexStringComparator(regexIPAddr);
+    Filter filter = new RowFilter(CompareFilter.CompareOp.EQUAL, rowKey2Comparable);
+    Result[] results = scanWithFilter(table, row0, endRow, qual, filter);
+    Assert.assertEquals("# results", 3, results.length);
+    Assert.assertArrayEquals(rowGoodIP1, results[0].getRow());
+    Assert.assertArrayEquals(rowGoodIP2, results[1].getRow());
+    Assert.assertArrayEquals(rowGoodIPv6, results[2].getRow());
+
+    // Test RegexStringComparator - NOT_EQUAL
+    filter = new RowFilter(CompareFilter.CompareOp.NOT_EQUAL, rowKey2Comparable);
+    results = scanWithFilter(table, row0, endRow, qual, filter);
+    Assert.assertEquals("# results", 4, results.length);
+    Assert.assertArrayEquals(row0, results[0].getRow());
+    Assert.assertArrayEquals(rowTelephone, results[1].getRow());
+    Assert.assertArrayEquals(rowBadIP, results[2].getRow());
+    Assert.assertArrayEquals(rowRandom, results[3].getRow());
+
+    // Test RegexStringComparator - GREATER
+    filter = new RowFilter(CompareFilter.CompareOp.GREATER, rowKey2Comparable);
+    results = scanWithFilter(table, row0, endRow, qual, filter);
+    Assert.assertEquals("# results", 0, results.length);
+
+    // Test RegexStringComparator - GREATER_OR_EQUAL
+    filter = new RowFilter(CompareFilter.CompareOp.GREATER_OR_EQUAL, rowKey2Comparable);
+    results = scanWithFilter(table, row0, endRow, qual, filter);
+    Assert.assertEquals("# results", 3, results.length);
+    Assert.assertArrayEquals(rowGoodIP1, results[0].getRow());
+    Assert.assertArrayEquals(rowGoodIP2, results[1].getRow());
+    Assert.assertArrayEquals(rowGoodIPv6, results[2].getRow());
+
+    // Test RegexStringComparator - LESS
+    filter = new RowFilter(CompareFilter.CompareOp.LESS, rowKey2Comparable);
+    results = scanWithFilter(table, row0, endRow, qual, filter);
+    Assert.assertEquals("# results", 4, results.length);
+    Assert.assertArrayEquals(row0, results[0].getRow());
+    Assert.assertArrayEquals(rowTelephone, results[1].getRow());
+    Assert.assertArrayEquals(rowBadIP, results[2].getRow());
+    Assert.assertArrayEquals(rowRandom, results[3].getRow());
+
+    // Test RegexStringComparator - LESS_OR_EQUAL
+    filter = new RowFilter(CompareFilter.CompareOp.LESS_OR_EQUAL, rowKey2Comparable);
+    results = scanWithFilter(table, row0, endRow, qual, filter);
+    Assert.assertEquals("# results", 7, results.length);
+    Assert.assertArrayEquals(row0, results[0].getRow());
+    Assert.assertArrayEquals(rowTelephone, results[1].getRow());
+    Assert.assertArrayEquals(rowBadIP, results[2].getRow());
+    Assert.assertArrayEquals(rowGoodIP1, results[3].getRow());
+    Assert.assertArrayEquals(rowGoodIP2, results[4].getRow());
+    Assert.assertArrayEquals(rowRandom, results[5].getRow());
+    Assert.assertArrayEquals(rowGoodIPv6, results[6].getRow());
+
+    // Test RegexStringComparator - NO_OP
+    filter = new RowFilter(CompareFilter.CompareOp.NO_OP, rowKey2Comparable);
+    results = scanWithFilter(table, row0, endRow, qual, filter);
+    Assert.assertEquals("# results", 0, results.length);
+
+    table.close();
+  }
+
+  private Result[] scanWithFilter(HTableInterface t, byte[] startRow, byte[] endRow, byte[] qual,
+      Filter f) throws IOException {
+    Scan scan = new Scan(startRow, endRow).setFilter(f).addColumn(COLUMN_FAMILY, qual);
+    ResultScanner scanner = t.getScanner(scan);
+    Result[] results = scanner.next(10);
+    return results;
   }
 }


### PR DESCRIPTION
- Test BinaryPrefixComparator row filter
- Working XOR and AND bitwise filter tests
- Implemented OR bitwise filter test
- Implement nullcomparator test
- Implemented substring comparator filter test
- Add RegexStringComparator test

Some of these tests retrieve results for comparator operations that won't be supported in the future (e.g. GREATER means nothing for a regex comparison.).  When we catch up to the latest version, these tests will be updated to ensure they throw IllegalArgumentExceptions.
