### PR TITLE
Anviltop interfaces to full messages

### DIFF
--- a/src/main/java/org/apache/hadoop/hbase/client/AnviltopAdmin.java
+++ b/src/main/java/org/apache/hadoop/hbase/client/AnviltopAdmin.java
@@ -1,9 +1,11 @@
 package org.apache.hadoop.hbase.client;
 
 
+import com.google.bigtable.anviltop.AnviltopAdminServices;
 import com.google.cloud.anviltop.hbase.AnviltopOptions;
 import com.google.cloud.anviltop.hbase.adapters.ColumnDescriptorAdapter;
 import com.google.cloud.hadoop.hbase.AnviltopAdminClient;
+import com.google.protobuf.ByteString;
 import com.google.protobuf.ServiceException;
 
 import org.apache.hadoop.conf.Configuration;
@@ -113,7 +115,11 @@ public class AnviltopAdmin implements Admin {
 
   @Override
   public void createTable(HTableDescriptor desc) throws IOException {
-    anviltopAdminClient.createTable(options.getProjectId(), Bytes.toString(desc.getName()));
+    anviltopAdminClient.createTable(
+        AnviltopAdminServices.CreateTableRequest.newBuilder()
+            .setProjectId(options.getProjectId())
+            .setTableNameBytes(ByteString.copyFrom(desc.getName()))
+            .build());
   }
 
   @Override
@@ -134,7 +140,10 @@ public class AnviltopAdmin implements Admin {
 
   @Override
   public void deleteTable(TableName tableName) throws IOException {
-    anviltopAdminClient.deleteTable(options.getProjectId(), tableName.getQualifierAsString());
+    anviltopAdminClient.deleteTable(AnviltopAdminServices.DeleteTableRequest.newBuilder()
+        .setProjectId(options.getProjectId())
+        .setTableNameBytes(ByteString.copyFrom(tableName.getQualifier()))
+        .build());
   }
 
   @Override
@@ -225,17 +234,20 @@ public class AnviltopAdmin implements Admin {
   @Override
   public void addColumn(TableName tableName, HColumnDescriptor column) throws IOException {
     anviltopAdminClient.createFamily(
-        options.getProjectId(),
-        tableName.getQualifierAsString(),
-        columnDescriptorAdapter.adapt(column).build());
+        AnviltopAdminServices.CreateFamilyRequest.newBuilder()
+            .setProjectId(options.getProjectId())
+            .setTableName(tableName.getQualifierAsString())
+            .setFamily(columnDescriptorAdapter.adapt(column))
+            .build());
   }
 
   @Override
   public void deleteColumn(TableName tableName, byte[] columnName) throws IOException {
     anviltopAdminClient.deleteFamily(
-        options.getProjectId(),
-        tableName.getQualifierAsString(),
-        Bytes.toString(columnName));
+        AnviltopAdminServices.DeleteFamilyRequest.newBuilder()
+            .setProjectId(options.getProjectId())
+            .setTableName(tableName.getQualifierAsString())
+            .setFamilyNameBytes(ByteString.copyFrom(columnName)).build());
   }
 
   @Override

--- a/src/test/java/com/google/cloud/anviltop/hbase/TestAnviltopTable.java
+++ b/src/test/java/com/google/cloud/anviltop/hbase/TestAnviltopTable.java
@@ -1,0 +1,109 @@
+package com.google.cloud.anviltop.hbase;
+
+import com.google.bigtable.anviltop.AnviltopServices;
+import com.google.cloud.hadoop.hbase.AnviltopBlockingClient;
+import com.google.protobuf.ServiceException;
+
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Delete;
+import org.apache.hadoop.hbase.client.Get;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import java.io.IOException;
+
+/**
+ * Unit tests for
+ */
+@RunWith(JUnit4.class)
+public class TestAnviltopTable {
+
+  public static final String TEST_PROJECT = "testproject";
+  public static final String TEST_TABLE = "testtable";
+
+  @Mock
+  public AnviltopBlockingClient mockClient;
+  public AnvilTopTable table;
+
+  @Before
+  public void setup() {
+    MockitoAnnotations.initMocks(this);
+    AnviltopOptions options = new AnviltopOptions("testhost", 0, null, TEST_PROJECT);
+    table = new AnvilTopTable(
+        TableName.valueOf(TEST_TABLE), options, new Configuration(), mockClient);
+  }
+
+  @Test
+  public void projectIsPopulatedInMutationRequests() throws ServiceException, IOException {
+    table.delete(new Delete(Bytes.toBytes("rowKey1")));
+
+    ArgumentCaptor<AnviltopServices.MutateRowRequest> argument =
+        ArgumentCaptor.forClass(AnviltopServices.MutateRowRequest.class);
+    Mockito.verify(mockClient).mutateAtomic(argument.capture());
+    Assert.assertEquals(TEST_PROJECT, argument.getValue().getProjectId());
+  }
+
+  @Test
+  public void tableNameIsPopulatedInMutationRequests() throws ServiceException, IOException {
+    table.delete(new Delete(Bytes.toBytes("rowKey1")));
+
+    ArgumentCaptor<AnviltopServices.MutateRowRequest> argument =
+        ArgumentCaptor.forClass(AnviltopServices.MutateRowRequest.class);
+    Mockito.verify(mockClient).mutateAtomic(argument.capture());
+    Assert.assertEquals(TEST_TABLE, argument.getValue().getTableName());
+  }
+
+  @Test
+  public void projectIsPopulatedInGetRequests() throws ServiceException, IOException {
+    Mockito.when(mockClient.getRow(Mockito.any(AnviltopServices.GetRowRequest.class)))
+        .thenReturn(AnviltopServices.GetRowResponse.getDefaultInstance());
+
+    table.get(new Get(Bytes.toBytes("rowKey1")));
+
+    ArgumentCaptor<AnviltopServices.GetRowRequest> argument =
+        ArgumentCaptor.forClass(AnviltopServices.GetRowRequest.class);
+    Mockito.verify(mockClient).getRow(argument.capture());
+    Assert.assertEquals(TEST_PROJECT, argument.getValue().getProjectId());
+  }
+
+  @Test
+  public void tableNameIsPopulatedInGetRequests() throws ServiceException, IOException {
+    Mockito.when(mockClient.getRow(Mockito.any(AnviltopServices.GetRowRequest.class)))
+        .thenReturn(AnviltopServices.GetRowResponse.getDefaultInstance());
+
+    table.get(new Get(Bytes.toBytes("rowKey1")));
+
+    ArgumentCaptor<AnviltopServices.GetRowRequest> argument =
+        ArgumentCaptor.forClass(AnviltopServices.GetRowRequest.class);
+    Mockito.verify(mockClient).getRow(argument.capture());
+    Assert.assertEquals(TEST_TABLE, argument.getValue().getTableName());
+  }
+
+  @Test
+  public void filterIsPopulatedInGetRequests() throws ServiceException, IOException {
+    Mockito.when(mockClient.getRow(Mockito.any(AnviltopServices.GetRowRequest.class)))
+        .thenReturn(AnviltopServices.GetRowResponse.getDefaultInstance());
+
+    String expectedFilter = "(col(family:qualifier, 1))";
+    table.get(
+        new Get(Bytes.toBytes("rowKey1"))
+            .addColumn(
+                Bytes.toBytes("family"),
+                Bytes.toBytes("qualifier")));
+
+    ArgumentCaptor<AnviltopServices.GetRowRequest> argument =
+        ArgumentCaptor.forClass(AnviltopServices.GetRowRequest.class);
+    Mockito.verify(mockClient).getRow(argument.capture());
+    Assert.assertEquals(expectedFilter, argument.getValue().getFilter());
+  }
+}


### PR DESCRIPTION
This is a companion to cl/75223150. The main motivator is to make adding new optional fields to messages not require interface updates.

This is based off of PR #45 for (my) convenience.
