### PR TITLE
Get a few integration tests passing

### DIFF
--- a/src/main/java/com/google/cloud/anviltop/hbase/AnvilTopTable.java
+++ b/src/main/java/com/google/cloud/anviltop/hbase/AnvilTopTable.java
@@ -110,12 +110,19 @@ public class AnvilTopTable implements HTableInterface {
 
   @Override
   public boolean exists(Get get) throws IOException {
-    throw new UnsupportedOperationException();  // TODO
+    // TODO: make use of strip_value() or count to hopefully return no extra data
+    Result result = get(get);
+    return !result.isEmpty();
   }
 
   @Override
   public Boolean[] exists(List<Get> gets) throws IOException {
-    throw new UnsupportedOperationException();  // TODO
+    Boolean[] results = new Boolean[gets.size()];
+    for (int i = 0; i < gets.size(); i++) {
+      Get get = gets.get(i);
+      results[i] = exists(get);
+    }
+    return results;
   }
 
   @Override
@@ -165,7 +172,12 @@ public class AnvilTopTable implements HTableInterface {
 
   @Override
   public Result[] get(List<Get> gets) throws IOException {
-    throw new UnsupportedOperationException();  // TODO
+    Result[] results = new Result[gets.size()];
+    for (int i = 0; i < gets.size(); i++) {
+      Get get = gets.get(i);
+      results[i] = get(get);
+    }
+    return results;
   }
 
   @Override
@@ -208,7 +220,9 @@ public class AnvilTopTable implements HTableInterface {
 
   @Override
   public void put(List<Put> puts) throws IOException {
-    throw new UnsupportedOperationException();  // TODO
+    for (Put put : puts) {
+      put(put);
+    }
   }
 
   @Override
@@ -243,7 +257,9 @@ public class AnvilTopTable implements HTableInterface {
 
   @Override
   public void delete(List<Delete> deletes) throws IOException {
-    throw new UnsupportedOperationException();  // TODO
+    for (Delete delete : deletes) {
+      delete(delete);
+    }
   }
 
   @Override
@@ -300,7 +316,7 @@ public class AnvilTopTable implements HTableInterface {
 
   @Override
   public boolean isAutoFlush() {
-    throw new UnsupportedOperationException();  // TODO
+    return true;
   }
 
   @Override
@@ -310,7 +326,6 @@ public class AnvilTopTable implements HTableInterface {
 
   @Override
   public void close() throws IOException {
-    throw new UnsupportedOperationException();  // TODO
   }
 
   @Override
@@ -333,17 +348,14 @@ public class AnvilTopTable implements HTableInterface {
 
   @Override
   public void setAutoFlush(boolean autoFlush) {
-    throw new UnsupportedOperationException();  // TODO
   }
 
   @Override
   public void setAutoFlush(boolean autoFlush, boolean clearBufferOnFail) {
-    throw new UnsupportedOperationException();  // TODO
   }
 
   @Override
   public void setAutoFlushTo(boolean autoFlush) {
-    throw new UnsupportedOperationException();  // TODO
   }
 
   @Override

--- a/src/main/java/com/google/cloud/anviltop/hbase/adapters/ScanAdapter.java
+++ b/src/main/java/com/google/cloud/anviltop/hbase/adapters/ScanAdapter.java
@@ -31,7 +31,7 @@ public class ScanAdapter
     implements OperationAdapter<Scan, AnviltopData.ReadOptions.Builder> {
 
   private final static byte[] NULL_CHARACTER_BYTES = Bytes.toBytes("\\x00");
-  public static final String ALL_QUALIFIERS = "\\\\C*";
+  public static final String ALL_QUALIFIERS = "\\C*";
   public static final String ALL_FAMILIES = ".*";
   public static final String ALL_VERSIONS = "ALL";
   public static final char INTERLEAVE_CHARACTER = '+';
@@ -101,10 +101,11 @@ public class ScanAdapter
           scan.getMaxVersions() == Integer.MAX_VALUE ?
               ALL_VERSIONS : Integer.toString(scan.getMaxVersions());
 
-      outputStream.write(Bytes.toBytes("col("));
+      outputStream.write(Bytes.toBytes("col({"));
       outputStream.write(family);
       outputStream.write(':');
       outputStream.write(qualifier);
+      outputStream.write('}');
       outputStream.write(',');
       outputStream.write(' ');
       outputStream.write(Bytes.toBytes(versionPart));

--- a/src/test/java/com/google/cloud/anviltop/hbase/TestAnviltopTable.java
+++ b/src/test/java/com/google/cloud/anviltop/hbase/TestAnviltopTable.java
@@ -94,7 +94,7 @@ public class TestAnviltopTable {
     Mockito.when(mockClient.getRow(Mockito.any(AnviltopServices.GetRowRequest.class)))
         .thenReturn(AnviltopServices.GetRowResponse.getDefaultInstance());
 
-    String expectedFilter = "(col(family:qualifier, 1))";
+    String expectedFilter = "(col({family:qualifier}, 1))";
     table.get(
         new Get(Bytes.toBytes("rowKey1"))
             .addColumn(

--- a/src/test/java/com/google/cloud/anviltop/hbase/TestBasicOps.java
+++ b/src/test/java/com/google/cloud/anviltop/hbase/TestBasicOps.java
@@ -174,7 +174,7 @@ public class TestBasicOps extends AbstractTest {
 
     // Delete
     Delete delete = new Delete(rowKey);
-    delete.deleteColumn(COLUMN_FAMILY, testQualifier);
+    delete.deleteColumns(COLUMN_FAMILY, testQualifier);
     table.delete(delete);
 
     // Confirm deleted

--- a/src/test/java/com/google/cloud/anviltop/hbase/adapters/TestGetAdapter.java
+++ b/src/test/java/com/google/cloud/anviltop/hbase/adapters/TestGetAdapter.java
@@ -63,7 +63,7 @@ public class TestGetAdapter {
 
     GetRowRequest.Builder rowRequestBuilder = getAdapter.adapt(get);
 
-    Assert.assertEquals("(col(family1:\\\\C*, ALL))", rowRequestBuilder.getFilter());
+    Assert.assertEquals("(col({family1:\\C*}, ALL))", rowRequestBuilder.getFilter());
   }
 
   @Test
@@ -77,7 +77,7 @@ public class TestGetAdapter {
 
     GetRowRequest.Builder rowRequestBuilder = getAdapter.adapt(get);
 
-    Assert.assertEquals("(col(family1:\\\\C*, ALL))+(col(family2:\\\\C*, ALL))",
+    Assert.assertEquals("(col({family1:\\C*}, ALL))+(col({family2:\\C*}, ALL))",
         rowRequestBuilder.getFilter());
   }
 
@@ -94,8 +94,8 @@ public class TestGetAdapter {
     GetRowRequest.Builder rowRequestBuilder = getAdapter.adapt(get);
 
     Assert.assertEquals(
-        "(col(family1:\\\\C*, ALL) | ts(1000000, 1999000))" +
-            "+(col(family2:\\\\C*, ALL) | ts(1000000, 1999000))",
+        "(col({family1:\\C*}, ALL) | ts(1000000, 1999000))" +
+            "+(col({family2:\\C*}, ALL) | ts(1000000, 1999000))",
         rowRequestBuilder.getFilter());
   }
 
@@ -111,7 +111,7 @@ public class TestGetAdapter {
     GetRowRequest.Builder rowRequestBuilder = getAdapter.adapt(get);
 
     Assert.assertEquals(
-        "(col(family1:\\\\C*, 1))+(col(family2:\\\\C*, 1))",
+        "(col({family1:\\C*}, 1))+(col({family2:\\C*}, 1))",
         rowRequestBuilder.getFilter());
   }
 
@@ -125,7 +125,7 @@ public class TestGetAdapter {
     GetRowRequest.Builder rowRequestBuilder = getAdapter.adapt(get);
 
     Assert.assertEquals(
-        "(col(family1:\\\\C*, 1))+(col(family2:qualifier1, 1))",
+        "(col({family1:\\C*}, 1))+(col({family2:qualifier1}, 1))",
         rowRequestBuilder.getFilter());
   }
 
@@ -146,13 +146,13 @@ public class TestGetAdapter {
     GetRowRequest.Builder rowRequestBuilder = getAdapter.adapt(get);
 
     ByteArrayOutputStream expectedFilterBuilder = new ByteArrayOutputStream();
-    expectedFilterBuilder.write(Bytes.toBytes("(col(f1:"));
+    expectedFilterBuilder.write(Bytes.toBytes("(col({f1:"));
     expectedFilterBuilder.write(Bytes.toBytes(utf8Part)); // Only ASCII characters need escaping
     expectedFilterBuilder.write(Bytes.toBytes(asciiPart)); // Leave a-z intact
     expectedFilterBuilder.write(Bytes.toBytes("\\x00")); // null byte
     expectedFilterBuilder.write(
         Bytes.toBytes("\\\\\\[\\]\\(\\)\\.\\*")); // Escape each in special characters
-    expectedFilterBuilder.write(Bytes.toBytes(", ALL))"));
+    expectedFilterBuilder.write(Bytes.toBytes("}, ALL))"));
     Assert.assertArrayEquals(
         expectedFilterBuilder.toByteArray(),
         rowRequestBuilder.getFilterBytes().toByteArray());


### PR DESCRIPTION
For filter expressions, escape regular expressions with {}. 
Fix handling of all characters \C\* expression.
Basic implementations of a few multi-operation (get(List<Get>)) methods with simple implementations to get first round tests passing.
