### PR TITLE
Exclude proto 2.5 from HBase dependencies. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,8 +30,9 @@
                     <artifactId>hbase-client</artifactId>
                     <version>${hbase.version}</version>
                     <exclusions>
-                        <!-- Stubby requires netty5 and a newer version of guava. When available, we can
-                        repackage netty5, guava and stubby into our client and remove these exclusions  -->
+                        <!-- Stubby requires netty5 and a newer version of guava. When available,
+                        we can repackage netty5, guava, stubby, and protobuf into our client and
+                        remove these exclusions  -->
                         <exclusion>
                             <groupId>io.netty</groupId>
                             <artifactId>netty-all</artifactId>
@@ -43,6 +44,13 @@
                         <exclusion>
                             <groupId>com.google.guava</groupId>
                             <artifactId>guava</artifactId>
+                        </exclusion>
+                        <!-- The generated messages in the anviltop driver depend on an unreleased
+                         version of protobuf-java. We can shade our references into the client
+                         when grpc is opened. -->
+                        <exclusion>
+                            <groupId>com.google.protobuf</groupId>
+                            <artifactId>protobuf-java</artifactId>
                         </exclusion>
                     </exclusions>
                 </dependency>
@@ -52,8 +60,9 @@
                     <version>${hbase.version}</version>
                     <scope>test</scope>
                     <exclusions>
-                        <!-- Stubby requires netty5 and a newer version of guava. When available, we can
-                       repackage netty5, guava and stubby into our client and remove these exclusions  -->
+                        <!-- Stubby requires netty5 and a newer version of guava. When available,
+                        we can repackage netty5, guava, stubby, and protobuf into our client and
+                        remove these exclusions  -->
                         <exclusion>
                             <groupId>io.netty</groupId>
                             <artifactId>netty-all</artifactId>
@@ -65,6 +74,13 @@
                         <exclusion>
                             <groupId>com.google.guava</groupId>
                             <artifactId>guava</artifactId>
+                        </exclusion>
+                        <!-- The generated messages in the anviltop driver depend on an unreleased
+                         version of protobuf-java. We can shade our references into the client
+                         when grpc is opened. -->
+                        <exclusion>
+                            <groupId>com.google.protobuf</groupId>
+                            <artifactId>protobuf-java</artifactId>
                         </exclusion>
                     </exclusions>
                 </dependency>
@@ -78,6 +94,13 @@
                             <groupId>com.google.guava</groupId>
                             <artifactId>guava</artifactId>
                         </exclusion>
+                        <!-- The generated messages in the anviltop driver depend on an unreleased
+                         version of protobuf-java. We can shade our references into the client
+                         when grpc is opened. -->
+                        <exclusion>
+                            <groupId>com.google.protobuf</groupId>
+                            <artifactId>protobuf-java</artifactId>
+                        </exclusion>
                     </exclusions>
                 </dependency>
                 <dependency>
@@ -87,8 +110,9 @@
                     <type>test-jar</type>
                     <scope>test</scope>
                     <exclusions>
-                        <!-- Stubby requires netty5 and a newer version of guava. When available, we can
-                        repackage netty5, guava and stubby into our client and remove these exclusions  -->
+                        <!-- Stubby requires netty5 and a newer version of guava. When available,
+                        we can repackage netty5, guava, stubby, and protobuf into our client and
+                        remove these exclusions  -->
                         <exclusion>
                             <groupId>io.netty</groupId>
                             <artifactId>netty-all</artifactId>
@@ -100,6 +124,13 @@
                         <exclusion>
                             <groupId>com.google.guava</groupId>
                             <artifactId>guava</artifactId>
+                        </exclusion>
+                        <!-- The generated messages in the anviltop driver depend on an unreleased
+                         version of protobuf-java. We can shade our references into the client
+                         when grpc is opened. -->
+                        <exclusion>
+                            <groupId>com.google.protobuf</groupId>
+                            <artifactId>protobuf-java</artifactId>
                         </exclusion>
                     </exclusions>
                 </dependency>
@@ -114,6 +145,13 @@
                             <groupId>com.google.guava</groupId>
                             <artifactId>guava</artifactId>
                         </exclusion>
+                        <!-- The generated messages in the anviltop driver depend on an unreleased
+                         version of protobuf-java. We can shade our references into the client
+                         when grpc is opened. -->
+                        <exclusion>
+                            <groupId>com.google.protobuf</groupId>
+                            <artifactId>protobuf-java</artifactId>
+                        </exclusion>
                     </exclusions>
                 </dependency>
                 <dependency>
@@ -123,8 +161,9 @@
                     <version>${hadoop.version}</version>
                     <scope>test</scope>
                     <exclusions>
-                        <!-- Stubby requires netty5 and a newer version of guava. When available, we can
-                        repackage netty5, guava and stubby into our client and remove these exclusions  -->
+                        <!-- Stubby requires netty5 and a newer version of guava. When available,
+                        we can repackage netty5, guava, stubby, and protobuf into our client and
+                        remove these exclusions  -->
                         <exclusion>
                             <groupId>io.netty</groupId>
                             <artifactId>netty-all</artifactId>
@@ -137,6 +176,13 @@
                             <groupId>com.google.guava</groupId>
                             <artifactId>guava</artifactId>
                         </exclusion>
+                        <!-- The generated messages in the anviltop driver depend on an unreleased
+                         version of protobuf-java. We can shade our references into the client
+                         when grpc is opened. -->
+                        <exclusion>
+                            <groupId>com.google.protobuf</groupId>
+                            <artifactId>protobuf-java</artifactId>
+                        </exclusion>
                     </exclusions>
                 </dependency>
                 <dependency>
@@ -146,9 +192,19 @@
                     <type>test-jar</type>
                     <scope>test</scope>
                     <exclusions>
+                        <!-- Stubby requires netty5 and a newer version of guava. When available,
+                        we can repackage netty5, guava, stubby, and protobuf into our client and
+                        remove these exclusions  -->
                         <exclusion>
                             <groupId>com.google.guava</groupId>
                             <artifactId>guava</artifactId>
+                        </exclusion>
+                        <!-- The generated messages in the anviltop driver depend on an unreleased
+                         version of protobuf-java. We can shade our references into the client
+                         when grpc is opened. -->
+                        <exclusion>
+                            <groupId>com.google.protobuf</groupId>
+                            <artifactId>protobuf-java</artifactId>
                         </exclusion>
                     </exclusions>
                 </dependency>
@@ -163,6 +219,13 @@
                             <groupId>com.google.guava</groupId>
                             <artifactId>guava</artifactId>
                         </exclusion>
+                        <!-- The generated messages in the anviltop driver depend on an unreleased
+                         version of protobuf-java. We can shade our references into the client
+                         when grpc is opened. -->
+                        <exclusion>
+                            <groupId>com.google.protobuf</groupId>
+                            <artifactId>protobuf-java</artifactId>
+                        </exclusion>
                     </exclusions>
                 </dependency>
                 <dependency>
@@ -175,6 +238,13 @@
                         <exclusion>
                             <groupId>com.google.guava</groupId>
                             <artifactId>guava</artifactId>
+                        </exclusion>
+                        <!-- The generated messages in the anviltop driver depend on an unreleased
+                         version of protobuf-java. We can shade our references into the client
+                         when grpc is opened. -->
+                        <exclusion>
+                            <groupId>com.google.protobuf</groupId>
+                            <artifactId>protobuf-java</artifactId>
                         </exclusion>
                     </exclusions>
                 </dependency>
@@ -225,6 +295,15 @@
             <groupId>org.apache.hbase</groupId>
             <artifactId>hbase-client</artifactId>
             <version>${hbase.version}</version>
+            <exclusions>
+                <!-- The generated messages in the anviltop driver depend on an unreleased
+                 version of protobuf-java. We can shade our references into the client
+                 when grpc is opened. -->
+                <exclusion>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protobuf-java</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>javax.validation</groupId>
@@ -254,12 +333,30 @@
             <artifactId>hbase-server</artifactId>
             <version>${hbase.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <!-- The generated messages in the anviltop driver depend on an unreleased
+                 version of protobuf-java. We can shade our references into the client
+                 when grpc is opened. -->
+                <exclusion>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protobuf-java</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.hbase</groupId>
             <artifactId>hbase-hadoop-compat</artifactId>
             <version>${hbase.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <!-- The generated messages in the anviltop driver depend on an unreleased
+                 version of protobuf-java. We can shade our references into the client
+                 when grpc is opened. -->
+                <exclusion>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protobuf-java</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.hbase</groupId>
@@ -267,6 +364,15 @@
             <version>${hbase.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
+            <exclusions>
+                <!-- The generated messages in the anviltop driver depend on an unreleased
+                 version of protobuf-java. We can shade our references into the client
+                 when grpc is opened. -->
+                <exclusion>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protobuf-java</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.hbase</groupId>
@@ -274,6 +380,15 @@
             <version>${hbase.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
+            <exclusions>
+                <!-- The generated messages in the anviltop driver depend on an unreleased
+                 version of protobuf-java. We can shade our references into the client
+                 when grpc is opened. -->
+                <exclusion>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protobuf-java</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>
@@ -281,6 +396,15 @@
             <artifactId>hadoop-minicluster</artifactId>
             <version>${hadoop.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <!-- The generated messages in the anviltop driver depend on an unreleased
+                 version of protobuf-java. We can shade our references into the client
+                 when grpc is opened. -->
+                <exclusion>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protobuf-java</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.hbase</groupId>
@@ -288,6 +412,15 @@
             <version>${hbase.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
+            <exclusions>
+                <!-- The generated messages in the anviltop driver depend on an unreleased
+                 version of protobuf-java. We can shade our references into the client
+                 when grpc is opened. -->
+                <exclusion>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protobuf-java</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.hbase</groupId>
@@ -295,6 +428,15 @@
             <version>${hbase.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
+            <exclusions>
+                <!-- The generated messages in the anviltop driver depend on an unreleased
+                 version of protobuf-java. We can shade our references into the client
+                 when grpc is opened. -->
+                <exclusion>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protobuf-java</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>
@@ -302,6 +444,15 @@
             <version>${hadoop.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
+            <exclusions>
+                <!-- The generated messages in the anviltop driver depend on an unreleased
+                 version of protobuf-java. We can shade our references into the client
+                 when grpc is opened. -->
+                <exclusion>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protobuf-java</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.mortbay.jetty.alpn</groupId>


### PR DESCRIPTION
A recent change at HEAD makes the inclusion of GeneratedMessage from 2.5 break usages
