### PR TITLE
Fix quoting for binary put, get, delete

### DIFF
--- a/src/test/java/com/google/cloud/anviltop/hbase/adapters/TestGetAdapter.java
+++ b/src/test/java/com/google/cloud/anviltop/hbase/adapters/TestGetAdapter.java
@@ -159,6 +159,17 @@ public class TestGetAdapter {
   }
 
   @Test
+  public void testBigtableReaderSpecialCharactersAreQuoted() throws IOException {
+    String family = "f1";
+    String qualifier = "foo }{ @";
+
+    Get get = makeValidGet(dataHelper.randomData("special"));
+    get.addColumn(Bytes.toBytes(family), Bytes.toBytes(qualifier));
+    GetRowRequest.Builder rowRequestBuilder = getAdapter.adapt(get);
+    Assert.assertEquals("(col({f1:foo\\ \\@}\\@{\\ \\@@}, ALL))", rowRequestBuilder.getFilter());
+  }
+
+  @Test
   public void testMaxCellsPerColumnFamilyIsNotSupported() throws IOException {
     Get get = makeValidGet(dataHelper.randomData("rk1-"));
     get.setMaxResultsPerColumnFamily(10);
@@ -184,5 +195,4 @@ public class TestGetAdapter {
 
     getAdapter.adapt(get);
   }
-
 }


### PR DESCRIPTION
Looking through RPC analyzer, it looks like many of the failed GetRow operations are failing with:
Malformed filter expression: : Error while parsing filter: offset 81: Did not find closing brace '}'

This is an attempt at resolving that.  re-run the integration tests a few times after applying this and haven't had any errors of that sort.
