### PR TITLE
Add credential loading based on Configuration (either metadata server or...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,8 @@
         <compileSource>1.7</compileSource>
         <!-- For Netty HTTP2/TLS negotiation -->
         <alpn.version>7.0.0.v20140317</alpn.version>
+        <google.api.client.version>1.19.0</google.api.client.version>
+        <google.anviltop.auth.service.account.enable>false</google.anviltop.auth.service.account.enable>
     </properties>
     <profiles>
         <profile>
@@ -388,8 +390,42 @@
             <systemPath>${stubby.driver.path}</systemPath>
             <scope>system</scope>
         </dependency>
+        <dependency>
+            <groupId>com.google.api-client</groupId>
+            <artifactId>google-api-client-jackson2</artifactId>
+            <version>${google.api.client.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.api-client</groupId>
+            <artifactId>google-api-client-java6</artifactId>
+            <version>${google.api.client.version}</version>
+            <exclusions>
+                <exclusion>
+                    <!-- this version hides too many things -->
+                    <artifactId>guava-jdk5</artifactId>
+                    <groupId>com.google.guava</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.google.oauth-client</groupId>
+            <artifactId>google-oauth-client</artifactId>
+            <version>${google.api.client.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.oauth-client</groupId>
+            <artifactId>google-oauth-client-java6</artifactId>
+            <version>${google.api.client.version}</version>
+        </dependency>
     </dependencies>
     <build>
+        <testResources>
+            <testResource>
+                <directory>src/test/resources</directory>
+                <!-- enable system property substitution. -->
+                <filtering>true</filtering>
+            </testResource>
+        </testResources>
         <pluginManagement>
             <plugins>
                 <plugin>

--- a/src/main/java/com/google/cloud/anviltop/hbase/CredentialFactory.java
+++ b/src/main/java/com/google/cloud/anviltop/hbase/CredentialFactory.java
@@ -1,0 +1,127 @@
+package com.google.cloud.anviltop.hbase;
+
+import com.google.api.client.auth.oauth2.Credential;
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.googleapis.compute.ComputeCredential;
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.common.collect.ImmutableList;
+
+import java.io.File;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.List;
+
+/**
+ * Simple factory for creating OAuth Credential objects for use with anviltop.
+ */
+public class CredentialFactory {
+
+  /**
+   * The OAuth scope required to perform administrator actions such as creating tables.
+   */
+  public static final String CLOUD_BIGTABLE_ADMIN_SCOPE =
+      "https://www.googleapis.com/auth/cloud-bigtable.admin";
+  /**
+   * The OAuth scope required to read data from tables.
+   */
+  public static final String CLOUD_BIGTABLE_READER_SCOPE =
+      "https://www.googleapis.com/auth/cloud-bigtable.data.readonly";
+  /**
+   * The OAuth scope required to write data to tables.
+   */
+  public static final String CLOUD_BIGTABLE_WRITER_SCOPE =
+      "https://www.googleapis.com/auth/cloud-bigtable.data";
+
+  /**
+   * Scopes required to read and write data from tables.
+   */
+  public static final List<String> CLOUD_BIGTABLE_READ_WRITE_SCOPES =
+      ImmutableList.of(
+          CLOUD_BIGTABLE_READER_SCOPE,
+          CLOUD_BIGTABLE_WRITER_SCOPE);
+
+  /**
+   * Scopes required for full access to cloud bigtable.
+   */
+  public static final List<String> CLOUD_BIGTABLE_ALL_SCOPES =
+      ImmutableList.of(
+          CLOUD_BIGTABLE_READER_SCOPE,
+          CLOUD_BIGTABLE_WRITER_SCOPE,
+          CLOUD_BIGTABLE_ADMIN_SCOPE);
+
+  // JSON factory used for formatting credential-handling payloads.
+  private static final JsonFactory JSON_FACTORY = new JacksonFactory();
+
+  // HTTP transport used for created credentials to perform token-refresh handshakes with remote
+  // credential servers. Initialized lazily to move the possibility of throwing
+  // GeneralSecurityException to the time a caller actually tries to get a credential.
+  private static HttpTransport httpTransport = null;
+
+  /**
+   * Returns shared httpTransport instance; initializes httpTransport if it hasn't already been
+   * initialized.
+   */
+  private static synchronized HttpTransport getHttpTransport()
+      throws IOException, GeneralSecurityException {
+    if (httpTransport == null) {
+      httpTransport = GoogleNetHttpTransport.newTrustedTransport();
+    }
+    return httpTransport;
+  }
+
+  /**
+   * Initializes OAuth2 credential using preconfigured ServiceAccount settings on the local
+   * GCE VM. See: <a href="https://developers.google.com/compute/docs/authentication"
+   * >Authenticating from Google Compute Engine</a>.
+   */
+  public static Credential getCredentialFromMetadataServiceAccount()
+      throws IOException, GeneralSecurityException {
+    Credential cred = new ComputeCredential(getHttpTransport(), JSON_FACTORY);
+    try {
+      cred.refreshToken();
+    } catch (IOException e) {
+      throw new IOException("Error getting access token from metadata server at: " +
+          ComputeCredential.TOKEN_SERVER_ENCODED_URL, e);
+    }
+    return cred;
+  }
+
+  /**
+   * Initializes OAuth2 credential from a private keyfile, as described in
+   * <a href="https://code.google.com/p/google-api-java-client/wiki/OAuth2#Service_Accounts"
+   * > OAuth2 Service Accounts</a>.
+   *
+   * @param serviceAccountEmail Email address of the service account associated with the keyfile.
+   * @param privateKeyFile Full local path to private keyfile.
+   */
+  public static Credential getCredentialFromPrivateKeyServiceAccount(
+      String serviceAccountEmail, String privateKeyFile)
+      throws IOException, GeneralSecurityException {
+    return getCredentialFromPrivateKeyServiceAccount(
+        serviceAccountEmail, privateKeyFile, CLOUD_BIGTABLE_ALL_SCOPES);
+  }
+
+  /**
+   * Initializes OAuth2 credential from a private keyfile, as described in
+   * <a href="https://code.google.com/p/google-api-java-client/wiki/OAuth2#Service_Accounts"
+   * > OAuth2 Service Accounts</a>.
+   *
+   * @param serviceAccountEmail Email address of the service account associated with the keyfile.
+   * @param privateKeyFile Full local path to private keyfile.
+   * @param scopes List of well-formed desired scopes to use with the credential.
+   */
+  public static Credential getCredentialFromPrivateKeyServiceAccount(
+      String serviceAccountEmail, String privateKeyFile, List<String> scopes)
+      throws IOException, GeneralSecurityException {
+    return new GoogleCredential.Builder()
+        .setTransport(getHttpTransport())
+        .setJsonFactory(JSON_FACTORY)
+        .setServiceAccountId(serviceAccountEmail)
+        .setServiceAccountScopes(scopes)
+        .setServiceAccountPrivateKeyFromP12File(new File(privateKeyFile))
+        .build();
+  }
+}

--- a/src/test/java/com/google/cloud/anviltop/hbase/TestAnviltopOptionsFactory.java
+++ b/src/test/java/com/google/cloud/anviltop/hbase/TestAnviltopOptionsFactory.java
@@ -9,6 +9,8 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import java.io.IOException;
+
 @RunWith(JUnit4.class)
 public class TestAnviltopOptionsFactory {
 
@@ -20,7 +22,7 @@ public class TestAnviltopOptionsFactory {
   public ExpectedException expectedException = ExpectedException.none();
 
   @Test
-  public void testProjectIdIsRequired() {
+  public void testProjectIdIsRequired() throws IOException {
     Configuration configuration = new Configuration();
     configuration.set(AnvilTopOptionsFactory.ANVILTOP_HOST_KEY, TEST_HOST);
 
@@ -29,7 +31,7 @@ public class TestAnviltopOptionsFactory {
   }
 
   @Test
-  public void testHostIsRequired() {
+  public void testHostIsRequired() throws IOException {
     Configuration configuration = new Configuration();
     configuration.set(AnvilTopOptionsFactory.PROJECT_ID_KEY, TEST_PROJECT_ID);
 
@@ -38,10 +40,12 @@ public class TestAnviltopOptionsFactory {
   }
 
   @Test
-  public void testOptionsAreConstructedWithValidInput() {
+  public void testOptionsAreConstructedWithValidInput() throws IOException {
     Configuration configuration = new Configuration();
     configuration.set(AnvilTopOptionsFactory.PROJECT_ID_KEY, TEST_PROJECT_ID);
     configuration.set(AnvilTopOptionsFactory.ANVILTOP_HOST_KEY, TEST_HOST);
+    configuration.setBoolean(AnvilTopOptionsFactory.ANVILTOP_USE_SERVICE_ACCOUNTS_KEY, false);
+    configuration.setBoolean(AnvilTopOptionsFactory.ANVILTOP_NULL_CREDENTIAL_ENABLE_KEY, true);
     AnviltopOptions options = AnvilTopOptionsFactory.fromConfiguration(configuration);
     Assert.assertEquals(TEST_HOST, options.getTransportOptions().getHost());
     Assert.assertEquals(TEST_PROJECT_ID, options.getProjectId());

--- a/src/test/resources/anviltop-test.xml
+++ b/src/test/resources/anviltop-test.xml
@@ -18,4 +18,12 @@
         <name>google.anviltop.project.id</name>
         <value>testproject</value>
     </property>
+    <property>
+        <name>google.anviltop.auth.service.account.enable</name>
+        <value>${google.anviltop.auth.service.account.enable}</value>
+    </property>
+    <property>
+        <name>google.anviltop.auth.null.credential.enable</name>
+        <value>true</value>
+    </property>
 </configuration>


### PR DESCRIPTION
... P12 keyfiles).

By default, integration tests will not use any credentials. The jenkins
instance has already been updated with new OAuth scopes and the system
property -Dgoogle.anviltop.auth.service.account.enable can be set to
true to get metadata server based credentials.
