### PR TITLE
Wire out a second host for admin connections

### DIFF
--- a/anviltop-client-core/pom.xml
+++ b/anviltop-client-core/pom.xml
@@ -28,6 +28,8 @@
         <alpn.version>7.0.0.v20140317</alpn.version>
         <google.api.client.version>1.19.0</google.api.client.version>
         <google.anviltop.auth.service.account.enable>false</google.anviltop.auth.service.account.enable>
+        <google.anviltop.admin.endpoint.host>9f135f0537b12b4b.sandbox.google.com</google.anviltop.admin.endpoint.host>
+        <google.anviltop.endpoint.host>9f135f0537b12b4b.sandbox.google.com</google.anviltop.endpoint.host>
     </properties>
     <profiles>
         <profile>

--- a/anviltop-client-core/src/main/java/com/google/cloud/anviltop/hbase/AnvilTopOptionsFactory.java
+++ b/anviltop-client-core/src/main/java/com/google/cloud/anviltop/hbase/AnvilTopOptionsFactory.java
@@ -29,9 +29,10 @@ public class AnvilTopOptionsFactory {
 
   public static final String ANVILTOP_PORT_KEY = "google.anviltop.endpoint.port";
   public static final int DEFAULT_ANVILTOP_PORT = 443;
-
+  public static final String ANVILTOP_ADMIN_HOST_KEY = "google.anviltop.admin.endpoint.host";
   public static final String ANVILTOP_HOST_KEY = "google.anviltop.endpoint.host";
   public static final String PROJECT_ID_KEY = "google.anviltop.project.id";
+
 
   /**
    * Key to set to enable service accounts to be used, either metadata server-based or P12-based.
@@ -78,6 +79,13 @@ public class AnvilTopOptionsFactory {
         !Strings.isNullOrEmpty(host),
         String.format("API endpoint host must be supplied via %s", ANVILTOP_HOST_KEY));
     optionsBuilder.setHost(host);
+
+    String adminHost = configuration.get(ANVILTOP_ADMIN_HOST_KEY);
+    if (!Strings.isNullOrEmpty(adminHost)) {
+      optionsBuilder.setAdminHost(adminHost);
+    } else {
+      optionsBuilder.setAdminHost(host);
+    }
 
     int port = configuration.getInt(ANVILTOP_PORT_KEY, DEFAULT_ANVILTOP_PORT);
     optionsBuilder.setPort(port);

--- a/anviltop-client-core/src/main/java/com/google/cloud/anviltop/hbase/AnviltopOptions.java
+++ b/anviltop-client-core/src/main/java/com/google/cloud/anviltop/hbase/AnviltopOptions.java
@@ -31,7 +31,13 @@ public class AnviltopOptions {
     private String projectId = "";
     private Credential credential;
     private String host;
+    private String adminHost;
     private int port;
+
+    public Builder setAdminHost(String host) {
+      this.adminHost = host;
+      return this;
+    }
 
     public Builder setHost(String host) {
       this.host = host;
@@ -54,20 +60,28 @@ public class AnviltopOptions {
     }
 
     public AnviltopOptions build() {
-      return new AnviltopOptions(host, port, credential, projectId);
+      if (Strings.isNullOrEmpty(adminHost)) {
+        adminHost = host;
+      }
+
+      return new AnviltopOptions(adminHost, host, port, credential, projectId);
     }
   }
 
+  private final String adminHost;
   private final String host;
   private final int port;
   private final Credential credential;
   private final String projectId;
 
-  public AnviltopOptions(String host, int port, Credential credential, String projectId) {
+  public AnviltopOptions(String adminHost, String host, int port, Credential credential, String projectId) {
     Preconditions.checkArgument(
         !Strings.isNullOrEmpty(host), "Host must not be empty or null.");
     Preconditions.checkArgument(
+        !Strings.isNullOrEmpty(adminHost), "Admin host must not be empty or null.");
+    Preconditions.checkArgument(
         !Strings.isNullOrEmpty(projectId), "ProjectId must not be empty or null.");
+    this.adminHost = adminHost;
     this.host = host;
     this.port = port;
     this.credential = credential;
@@ -89,6 +103,13 @@ public class AnviltopOptions {
     return new TransportOptions(
         TransportOptions.AnviltopTransports.HTTP2_NETTY_TLS,
         host,
+        port);
+  }
+
+  public TransportOptions getAdminTransportOptions() {
+    return new TransportOptions(
+        TransportOptions.AnviltopTransports.HTTP2_NETTY_TLS,
+        adminHost,
         port);
   }
 }

--- a/anviltop-client-core/src/main/java/org/apache/hadoop/hbase/client/AnvilTopConnection.java
+++ b/anviltop-client-core/src/main/java/org/apache/hadoop/hbase/client/AnvilTopConnection.java
@@ -102,13 +102,14 @@ public class AnvilTopConnection implements ClusterConnection, Closeable {
     this.options = AnvilTopOptionsFactory.fromConfiguration(conf);
     TransportOptions transportOptions = options.getTransportOptions();
     ChannelOptions channelOptions = options.getChannelOptions();
+    TransportOptions adminTransportOptions = options.getAdminTransportOptions();
 
     this.client = getAnviltopClient(
         transportOptions,
         channelOptions,
         batchPool);
     this.anviltopAdminClient = getAdminClient(
-        transportOptions,
+        adminTransportOptions,
         channelOptions,
         batchPool);
   }

--- a/anviltop-client-core/src/test/java/com/google/cloud/anviltop/hbase/TestAnviltopOptionsFactory.java
+++ b/anviltop-client-core/src/test/java/com/google/cloud/anviltop/hbase/TestAnviltopOptionsFactory.java
@@ -40,6 +40,18 @@ public class TestAnviltopOptionsFactory {
   }
 
   @Test
+  public void testAdminHostKeyIsUsed() throws IOException {
+    Configuration configuration = new Configuration();
+    configuration.set(AnvilTopOptionsFactory.PROJECT_ID_KEY, TEST_PROJECT_ID);
+    configuration.set(AnvilTopOptionsFactory.ANVILTOP_HOST_KEY, TEST_HOST);
+    configuration.set(AnvilTopOptionsFactory.ANVILTOP_ADMIN_HOST_KEY, TEST_HOST + "-admin");
+    configuration.setBoolean(AnvilTopOptionsFactory.ANVILTOP_USE_SERVICE_ACCOUNTS_KEY, false);
+    configuration.setBoolean(AnvilTopOptionsFactory.ANVILTOP_NULL_CREDENTIAL_ENABLE_KEY, true);
+    AnviltopOptions options = AnvilTopOptionsFactory.fromConfiguration(configuration);
+    Assert.assertEquals(TEST_HOST + "-admin", options.getAdminTransportOptions().getHost());
+  }
+
+  @Test
   public void testOptionsAreConstructedWithValidInput() throws IOException {
     Configuration configuration = new Configuration();
     configuration.set(AnvilTopOptionsFactory.PROJECT_ID_KEY, TEST_PROJECT_ID);

--- a/anviltop-client-core/src/test/java/com/google/cloud/anviltop/hbase/TestAnviltopTable.java
+++ b/anviltop-client-core/src/test/java/com/google/cloud/anviltop/hbase/TestAnviltopTable.java
@@ -39,7 +39,7 @@ public class TestAnviltopTable {
   @Before
   public void setup() {
     MockitoAnnotations.initMocks(this);
-    AnviltopOptions options = new AnviltopOptions("testhost", 0, null, TEST_PROJECT);
+    AnviltopOptions options = new AnviltopOptions("testhost-admin", "testhost", 0, null, TEST_PROJECT);
     table = new AnvilTopTable(
         TableName.valueOf(TEST_TABLE),
         options,

--- a/anviltop-client-core/src/test/resources/anviltop-test.xml
+++ b/anviltop-client-core/src/test/resources/anviltop-test.xml
@@ -8,11 +8,15 @@
     </property>
     <property>
         <name>google.anviltop.endpoint.host</name>
-        <value>9f135f0537b12b4b.sandbox.google.com</value>
+        <value>${google.anviltop.endpoint.host}</value>
     </property>
     <property>
         <name>google.anviltop.endpoint.port</name>
         <value>443</value>
+    </property>
+    <property>
+        <name>google.anviltop.admin.endpoint.host</name>
+        <value>${google.anviltop.admin.endpoint.host}</value>
     </property>
     <property>
         <name>google.anviltop.project.id</name>


### PR DESCRIPTION
Wire out a second host for admin connections
Parameterize hosts in the integration tests for easy switching between sandbox and test.
