### PR TITLE
Shade the anviltop-client-core so it includes the anviltop grpc interfaces

### DIFF
--- a/anviltop-client-core/pom.xml
+++ b/anviltop-client-core/pom.xml
@@ -15,9 +15,15 @@
     <version>0.1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
+    <repositories>
+        <repository>
+            <id>repo</id>
+            <url>file://${anviltop.grpc.repo.fullpath}</url>
+        </repository>
+    </repositories>
+
     <properties>
-        <!-- As soon as stubby is public, this goes away -->
-        <stubby.driver.path>/google/data/ro/teams/cloud-bigtable/driver_mpm/live/driver_with_deps.jar</stubby.driver.path>
+        <anviltop.grpc.repo.fullpath>${project.basedir}/../${anviltop.grpc.repo.dir}</anviltop.grpc.repo.fullpath>
         <hbase.version>0.99.0</hbase.version>
         <hadoop.version>2.4.0</hadoop.version>
         <compat.module>hbase-hadoop2-compat</compat.module>
@@ -32,193 +38,11 @@
         <google.anviltop.endpoint.host>9f135f0537b12b4b.sandbox.google.com</google.anviltop.endpoint.host>
         <google.anviltop.call.report.directory>target/call_reports</google.anviltop.call.report.directory>
         <google.anviltop.endpoint.ip.address.override></google.anviltop.endpoint.ip.address.override>
+        <google.anviltop.enable.grpc.v2>false</google.anviltop.enable.grpc.v2>
     </properties>
     <profiles>
         <profile>
             <id>anviltopIntegrationTest</id>
-            <dependencies>
-                <dependency>
-                    <groupId>org.apache.hbase</groupId>
-                    <artifactId>hbase-client</artifactId>
-                    <version>${hbase.version}</version>
-                    <exclusions>
-                        <!-- Stubby requires netty5 and a newer version of guava. When available,
-                        we can repackage netty5, guava, stubby, and protobuf into our client and
-                        remove these exclusions  -->
-                        <exclusion>
-                            <groupId>io.netty</groupId>
-                            <artifactId>netty-all</artifactId>
-                        </exclusion>
-                        <exclusion>
-                            <groupId>io.netty</groupId>
-                            <artifactId>netty</artifactId>
-                        </exclusion>
-                        <exclusion>
-                            <groupId>com.google.guava</groupId>
-                            <artifactId>guava</artifactId>
-                        </exclusion>
-                    </exclusions>
-                </dependency>
-                <dependency>
-                    <groupId>org.apache.hbase</groupId>
-                    <artifactId>hbase-server</artifactId>
-                    <version>${hbase.version}</version>
-                    <scope>test</scope>
-                    <exclusions>
-                        <!-- Stubby requires netty5 and a newer version of guava. When available,
-                        we can repackage netty5, guava, stubby, and protobuf into our client and
-                        remove these exclusions  -->
-                        <exclusion>
-                            <groupId>io.netty</groupId>
-                            <artifactId>netty-all</artifactId>
-                        </exclusion>
-                        <exclusion>
-                            <groupId>io.netty</groupId>
-                            <artifactId>netty</artifactId>
-                        </exclusion>
-                        <exclusion>
-                            <groupId>com.google.guava</groupId>
-                            <artifactId>guava</artifactId>
-                        </exclusion>
-                    </exclusions>
-                </dependency>
-                <dependency>
-                    <groupId>org.apache.hbase</groupId>
-                    <artifactId>hbase-hadoop-compat</artifactId>
-                    <version>${hbase.version}</version>
-                    <scope>test</scope>
-                    <exclusions>
-                        <exclusion>
-                            <groupId>com.google.guava</groupId>
-                            <artifactId>guava</artifactId>
-                        </exclusion>
-                        <!-- The generated messages in the anviltop driver depend on an unreleased
-                         version of protobuf-java. We can shade our references into the client
-                         when grpc is opened. -->
-                    </exclusions>
-                </dependency>
-                <dependency>
-                    <groupId>org.apache.hbase</groupId>
-                    <artifactId>hbase-server</artifactId>
-                    <version>${hbase.version}</version>
-                    <type>test-jar</type>
-                    <scope>test</scope>
-                    <exclusions>
-                        <!-- Stubby requires netty5 and a newer version of guava. When available,
-                        we can repackage netty5, guava, stubby, and protobuf into our client and
-                        remove these exclusions  -->
-                        <exclusion>
-                            <groupId>io.netty</groupId>
-                            <artifactId>netty-all</artifactId>
-                        </exclusion>
-                        <exclusion>
-                            <groupId>io.netty</groupId>
-                            <artifactId>netty</artifactId>
-                        </exclusion>
-                        <exclusion>
-                            <groupId>com.google.guava</groupId>
-                            <artifactId>guava</artifactId>
-                        </exclusion>
-                        <!-- The generated messages in the anviltop driver depend on an unreleased
-                         version of protobuf-java. We can shade our references into the client
-                         when grpc is opened. -->
-                    </exclusions>
-                </dependency>
-                <dependency>
-                    <groupId>org.apache.hbase</groupId>
-                    <artifactId>hbase-common</artifactId>
-                    <version>${hbase.version}</version>
-                    <type>test-jar</type>
-                    <scope>test</scope>
-                    <exclusions>
-                        <exclusion>
-                            <groupId>com.google.guava</groupId>
-                            <artifactId>guava</artifactId>
-                        </exclusion>
-                        <!-- The generated messages in the anviltop driver depend on an unreleased
-                         version of protobuf-java. We can shade our references into the client
-                         when grpc is opened. -->
-                    </exclusions>
-                </dependency>
-                <dependency>
-                    <groupId>org.apache.hadoop</groupId>
-                    <!--In hadoop1 this is hadoop-test-->
-                    <artifactId>hadoop-minicluster</artifactId>
-                    <version>${hadoop.version}</version>
-                    <scope>test</scope>
-                    <exclusions>
-                        <!-- Stubby requires netty5 and a newer version of guava. When available,
-                        we can repackage netty5, guava, stubby, and protobuf into our client and
-                        remove these exclusions  -->
-                        <exclusion>
-                            <groupId>io.netty</groupId>
-                            <artifactId>netty-all</artifactId>
-                        </exclusion>
-                        <exclusion>
-                            <groupId>io.netty</groupId>
-                            <artifactId>netty</artifactId>
-                        </exclusion>
-                        <exclusion>
-                            <groupId>com.google.guava</groupId>
-                            <artifactId>guava</artifactId>
-                        </exclusion>
-                        <!-- The generated messages in the anviltop driver depend on an unreleased
-                         version of protobuf-java. We can shade our references into the client
-                         when grpc is opened. -->
-                    </exclusions>
-                </dependency>
-                <dependency>
-                    <groupId>org.apache.hbase</groupId>
-                    <artifactId>hbase-hadoop-compat</artifactId>
-                    <version>${hbase.version}</version>
-                    <type>test-jar</type>
-                    <scope>test</scope>
-                    <exclusions>
-                        <!-- Stubby requires netty5 and a newer version of guava. When available,
-                        we can repackage netty5, guava, stubby, and protobuf into our client and
-                        remove these exclusions  -->
-                        <exclusion>
-                            <groupId>com.google.guava</groupId>
-                            <artifactId>guava</artifactId>
-                        </exclusion>
-                        <!-- The generated messages in the anviltop driver depend on an unreleased
-                         version of protobuf-java. We can shade our references into the client
-                         when grpc is opened. -->
-                    </exclusions>
-                </dependency>
-                <dependency>
-                    <groupId>org.apache.hbase</groupId>
-                    <artifactId>${compat.module}</artifactId>
-                    <version>${hbase.version}</version>
-                    <type>test-jar</type>
-                    <scope>test</scope>
-                    <exclusions>
-                        <exclusion>
-                            <groupId>com.google.guava</groupId>
-                            <artifactId>guava</artifactId>
-                        </exclusion>
-                        <!-- The generated messages in the anviltop driver depend on an unreleased
-                         version of protobuf-java. We can shade our references into the client
-                         when grpc is opened. -->
-                    </exclusions>
-                </dependency>
-                <dependency>
-                    <groupId>org.apache.hadoop</groupId>
-                    <artifactId>hadoop-common</artifactId>
-                    <version>${hadoop.version}</version>
-                    <type>test-jar</type>
-                    <scope>test</scope>
-                    <exclusions>
-                        <exclusion>
-                            <groupId>com.google.guava</groupId>
-                            <artifactId>guava</artifactId>
-                        </exclusion>
-                        <!-- The generated messages in the anviltop driver depend on an unreleased
-                         version of protobuf-java. We can shade our references into the client
-                         when grpc is opened. -->
-                    </exclusions>
-                </dependency>
-            </dependencies>
             <build>
                 <plugins>
                     <plugin>
@@ -240,6 +64,9 @@
                                 <phase>integration-test</phase>
                                 <configuration>
                                     <!-- ALPN is needed for SSL engine rewrites and the stubby driver for its version of guava -->
+                                    <!-- to enable netty logging, include:
+                                    -Djava.util.logging.config.file=src/test/resources/logging.properties
+                                    -->
                                     <argLine>
                                         -Xbootclasspath/p:${settings.localRepository}/org/mortbay/jetty/alpn/alpn-boot/${alpn.version}/alpn-boot-${alpn.version}.jar:${stubby.driver.path}
                                     </argLine>
@@ -249,8 +76,7 @@
                                     </includes>
                                     <reportNameSuffix>anviltop-server</reportNameSuffix>
                                     <systemPropertyVariables>
-                                        <anviltop.test.extra.resources>anviltop-test.xml
-                                        </anviltop.test.extra.resources>
+                                        <anviltop.test.extra.resources>anviltop-test.xml</anviltop.test.extra.resources>
                                     </systemPropertyVariables>
                                 </configuration>
                             </execution>
@@ -265,11 +91,6 @@
             <groupId>org.apache.hbase</groupId>
             <artifactId>hbase-client</artifactId>
             <version>${hbase.version}</version>
-            <exclusions>
-                <!-- The generated messages in the anviltop driver depend on an unreleased
-                 version of protobuf-java. We can shade our references into the client
-                 when grpc is opened. -->
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>javax.validation</groupId>
@@ -299,22 +120,12 @@
             <artifactId>hbase-server</artifactId>
             <version>${hbase.version}</version>
             <scope>test</scope>
-            <exclusions>
-                <!-- The generated messages in the anviltop driver depend on an unreleased
-                 version of protobuf-java. We can shade our references into the client
-                 when grpc is opened. -->
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.hbase</groupId>
             <artifactId>hbase-hadoop-compat</artifactId>
             <version>${hbase.version}</version>
             <scope>test</scope>
-            <exclusions>
-                <!-- The generated messages in the anviltop driver depend on an unreleased
-                 version of protobuf-java. We can shade our references into the client
-                 when grpc is opened. -->
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.hbase</groupId>
@@ -322,11 +133,6 @@
             <version>${hbase.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
-            <exclusions>
-                <!-- The generated messages in the anviltop driver depend on an unreleased
-                 version of protobuf-java. We can shade our references into the client
-                 when grpc is opened. -->
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.hbase</groupId>
@@ -334,11 +140,6 @@
             <version>${hbase.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
-            <exclusions>
-                <!-- The generated messages in the anviltop driver depend on an unreleased
-                 version of protobuf-java. We can shade our references into the client
-                 when grpc is opened. -->
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>
@@ -346,11 +147,6 @@
             <artifactId>hadoop-minicluster</artifactId>
             <version>${hadoop.version}</version>
             <scope>test</scope>
-            <exclusions>
-                <!-- The generated messages in the anviltop driver depend on an unreleased
-                 version of protobuf-java. We can shade our references into the client
-                 when grpc is opened. -->
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.hbase</groupId>
@@ -358,11 +154,6 @@
             <version>${hbase.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
-            <exclusions>
-                <!-- The generated messages in the anviltop driver depend on an unreleased
-                 version of protobuf-java. We can shade our references into the client
-                 when grpc is opened. -->
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.hbase</groupId>
@@ -370,11 +161,6 @@
             <version>${hbase.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
-            <exclusions>
-                <!-- The generated messages in the anviltop driver depend on an unreleased
-                 version of protobuf-java. We can shade our references into the client
-                 when grpc is opened. -->
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>
@@ -382,11 +168,6 @@
             <version>${hadoop.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
-            <exclusions>
-                <!-- The generated messages in the anviltop driver depend on an unreleased
-                 version of protobuf-java. We can shade our references into the client
-                 when grpc is opened. -->
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.mortbay.jetty.alpn</groupId>
@@ -394,11 +175,9 @@
             <version>${alpn.version}</version>
         </dependency>
         <dependency>
-            <groupId>anviltop-client</groupId>
-            <artifactId>anviltop-client-interface</artifactId>
-            <version>0.1</version>
-            <systemPath>${stubby.driver.path}</systemPath>
-            <scope>system</scope>
+            <groupId>${stubby.driver.group}</groupId>
+            <artifactId>${stubby.driver.artifact}</artifactId>
+            <version>${stubby.driver.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.api-client</groupId>
@@ -505,7 +284,46 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>2.3</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <artifactSet>
+                                <includes>
+                                    <include>com.google.bigtable.anviltop:*</include>
+                                </includes>
+                            </artifactSet>
+                            <relocations>
+                                <relocation>
+                                    <pattern>com.google.common</pattern>
+                                    <shadedPattern>com.google.bigtable.anviltop.repackaged.com.google.common</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.fasterxml</pattern>
+                                    <shadedPattern>com.google.bigtable.anviltop.repackaged.com.fasterxml</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.commons.codec</pattern>
+                                    <shadedPattern>com.google.bigtable.anviltop.repackaged.org.apache.commons.codec</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>io.netty</pattern>
+                                    <shadedPattern>com.google.bigtable.anviltop.repackaged.io.netty</shadedPattern>
+                                </relocation>
+                            </relocations>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
-
 </project>

--- a/anviltop-client-core/src/main/java/com/google/cloud/anviltop/hbase/AnvilTopOptionsFactory.java
+++ b/anviltop-client-core/src/main/java/com/google/cloud/anviltop/hbase/AnvilTopOptionsFactory.java
@@ -15,6 +15,7 @@ package com.google.cloud.anviltop.hbase;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import com.google.net.stubby.transport.AbstractClientStream;
 
 import org.apache.hadoop.conf.Configuration;
 
@@ -38,6 +39,7 @@ public class AnvilTopOptionsFactory {
   public static final String ANVILTOP_HOST_KEY = "google.anviltop.endpoint.host";
   public static final String PROJECT_ID_KEY = "google.anviltop.project.id";
   public static final String CALL_REPORT_DIRECTORY_KEY = "google.anviltop.call.report.directory";
+  public static final String ENABLE_GRPC_V2_KEY = "google.anviltop.enable.grpc.v2";
 
   /**
    * If set, bypass DNS host lookup and use the given IP address.
@@ -189,6 +191,8 @@ public class AnvilTopOptionsFactory {
         ENABLE_GRPC_RETRIES_KEY, ENABLE_GRPC_RETRIES_DEFAULT);
     LOG.debug("gRPC retries enabled: %s", enableRetries);
     optionsBuilder.setRetriesEnabled(enableRetries);
+
+    AbstractClientStream.GRPC_V2_PROTOCOL = configuration.getBoolean(ENABLE_GRPC_V2_KEY, false);
 
     return optionsBuilder.build();
   }

--- a/anviltop-client-core/src/test/resources/anviltop-test.xml
+++ b/anviltop-client-core/src/test/resources/anviltop-test.xml
@@ -38,4 +38,8 @@
         <name>google.anviltop.endpoint.ip.address.override</name>
         <value>${google.anviltop.endpoint.ip.address.override}</value>
     </property>
+    <property>
+        <name>google.anviltop.enable.grpc.v2</name>
+        <value>${google.anviltop.enable.grpc.v2}</value>
+    </property>
 </configuration>

--- a/anviltop-client-core/src/test/resources/logging.properties
+++ b/anviltop-client-core/src/test/resources/logging.properties
@@ -1,0 +1,5 @@
+handlers = java.util.logging.ConsoleHandler
+java.util.logging.ConsoleHandler.level = ALL
+.level = ALL
+io.netty.handler.codec.http2.Http2FrameLogger.level = FINE
+io.level = INFO

--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,16 @@
     <version>0.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
+    <properties>
+        <!-- As soon as stubby is public, this goes away -->
+        <stubby.driver.path>/google/data/ro/teams/cloud-bigtable/driver_mpm/live/driver_with_deps.jar</stubby.driver.path>
+        <stubby.driver.group>com.google.bigtable.anviltop</stubby.driver.group>
+        <stubby.driver.artifact>anviltop-grpc-interface</stubby.driver.artifact>
+        <stubby.driver.version>0.1</stubby.driver.version>
+        <anviltop.grpc.repo.dir>anviltop-grpc-repo</anviltop.grpc.repo.dir>
+        <anviltop.grpc.repo.fullpath>${project.basedir}/${anviltop.grpc.repo.dir}</anviltop.grpc.repo.fullpath>
+    </properties>
+
     <modules>
         <module>anviltop-client-core</module>
     </modules>
@@ -19,4 +29,35 @@
             <url>https://repository.apache.org/content/repositories/snapshots/</url>
         </repository>
     </repositories>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>exec-maven-plugin</artifactId>
+                <groupId>org.codehaus.mojo</groupId>
+                <version>1.3.2</version>
+                <executions>
+                    <execution>
+                        <id>install-grpc-client</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>mvn</executable>
+                            <arguments>
+                                <argument>org.apache.maven.plugins:maven-install-plugin:2.3.1:install-file</argument>
+                                <argument>-Dfile=${stubby.driver.path}</argument>
+                                <argument>-DgroupId=${stubby.driver.group}</argument>
+                                <argument>-DartifactId=${stubby.driver.artifact}</argument>
+                                <argument>-Dversion=${stubby.driver.version}</argument>
+                                <argument>-Dpackaging=jar</argument>
+                                <argument>-DlocalRepositoryPath=${anviltop.grpc.repo.fullpath}</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
Shade the anviltop-client-core so it includes the anviltop grpc interfaces and a repackaged version of guava
Stop excluding conflicting library versions.

The method of achieving the shading is rather hacky. Shade will not pull in system jars so I need the anviltop grpc interfaces installed in a repository. At the same time, I don't want current processes to change to include running scripts. As a result, the first thing the main pom does is install the grpc interface into a repository under the root project via mvn install:install-file.
