### PR TITLE
Add method in AnviltopAdmin used by the hbase shell but not defined by

### DIFF
--- a/anviltop-client-core/src/main/java/org/apache/hadoop/hbase/client/AnviltopAdmin.java
+++ b/anviltop-client-core/src/main/java/org/apache/hadoop/hbase/client/AnviltopAdmin.java
@@ -152,7 +152,6 @@ public class AnviltopAdmin implements Admin {
       i++;
     }
     return tableNames;
-
   }
 
   @Override


### PR DESCRIPTION
the Admin interface.
