### PR TITLE
Getting Export to work

### DIFF
--- a/anviltop-client-core/src/main/java/com/google/cloud/anviltop/hbase/AnviltopOptions.java
+++ b/anviltop-client-core/src/main/java/com/google/cloud/anviltop/hbase/AnviltopOptions.java
@@ -157,6 +157,6 @@ public class AnviltopOptions {
   }
 
   public ServerName getServerName() {
-    return ServerName.valueOf(host.toString(), port, 0);
+    return ServerName.valueOf(host.getHostName(), port, 0);
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
        <stubby.driver.path>/google/data/ro/teams/cloud-bigtable/driver_mpm/live/driver_with_deps.jar</stubby.driver.path>
        <stubby.driver.group>com.google.bigtable.anviltop</stubby.driver.group>
        <stubby.driver.artifact>anviltop-grpc-interface</stubby.driver.artifact>
-       <stubby.driver.version>0.2</stubby.driver.version>
+       <stubby.driver.version>0.3-SNAPSHOT</stubby.driver.version>
        <hbase.version>0.99.2</hbase.version>
        <hadoop.version>2.4.1</hadoop.version>
        <compat.module>hbase-hadoop2-compat</compat.module>


### PR DESCRIPTION
Updating the atop grpc driver to 0.3-SNAPSHOT.  
Fixed a bug in AnviltopOptions that caused malformed URLs in the ServerName.
