### PR TITLE
Removing anviltopIntegrationTest profile.

### DIFF
--- a/bigtable-hbase/pom.xml
+++ b/bigtable-hbase/pom.xml
@@ -63,11 +63,6 @@
             </build>
         </profile>
         <profile>
-            <!-- This profile exists to prevent failed builds. It should be removed as soon as the
-            build definitions are updated -->
-            <id>anviltopIntegrationTest</id>
-        </profile>
-        <profile>
             <id>anviltopGapTest</id>
             <build>
                 <plugins>


### PR DESCRIPTION
This profile is outdated.  I removed any mention of it from jenkins today.  I'd like to remove this from the pom.xml
