### PR TITLE
Add support for proto filters in top-level Scan and Get.

### DIFF
--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BatchExecutor.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BatchExecutor.java
@@ -147,7 +147,7 @@ public class BatchExecutor {
   protected final BigtableOptions options;
   protected final TableMetadataSetter tableMetadataSetter;
   protected final ListeningExecutorService service;
-  protected final GetAdapter getAdapter;
+  protected final OperationAdapter<Get, ReadRowsRequest.Builder> getAdapter;
   protected final OperationAdapter<Put, MutateRowRequest.Builder> putAdapter;
   protected final OperationAdapter<Delete, MutateRowRequest.Builder> deleteAdapter;
   protected final RowMutationsAdapter rowMutationsAdapter;
@@ -161,7 +161,7 @@ public class BatchExecutor {
       BigtableOptions options,
       TableMetadataSetter tableMetadataSetter,
       ListeningExecutorService service,
-      GetAdapter getAdapter,
+      OperationAdapter<Get, ReadRowsRequest.Builder> getAdapter,
       OperationAdapter<Put, MutateRowRequest.Builder> putAdapter,
       OperationAdapter<Delete, MutateRowRequest.Builder> deleteAdapter,
       RowMutationsAdapter rowMutationsAdapter,

--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableOptionsFactory.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableOptionsFactory.java
@@ -107,6 +107,11 @@ public class BigtableOptionsFactory {
       "google.bigtable.not_recommended.daemonized.io.threadpools.enable";
   public static final boolean ENABLE_DAEMONIZED_THREADS_DEFAULT = false;
 
+  // TODO(angusdavis): Remove this key once fully transitioned
+  public static final String ENABLE_PROTO_FILTER_LANGUAGE_KEY =
+      "google.bigtable.tmp.proto.filter.language.enable";
+  public static final boolean ENABLE_PROTO_FILTER_LANGUAGE_DEFAULT = false;
+
   public static BigtableOptions fromConfiguration(Configuration configuration) throws IOException {
     BigtableOptions.Builder optionsBuilder = new BigtableOptions.Builder();
 

--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/GetProtoAdapter.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/GetProtoAdapter.java
@@ -1,0 +1,29 @@
+package com.google.cloud.bigtable.hbase.adapters;
+
+import com.google.bigtable.v1.ReadRowsRequest;
+import com.google.protobuf.ByteString;
+
+import org.apache.hadoop.hbase.client.Get;
+import org.apache.hadoop.hbase.client.Scan;
+
+/**
+ * A Get adapter that transform the Get into a ReadRowsRequest using the proto-based
+ * filter language.
+ * TODO(angusdavis): Rename this GetAdapter when fully implemented.
+ */
+public class GetProtoAdapter implements OperationAdapter<Get, ReadRowsRequest.Builder> {
+
+  protected final ScanProtoAdapter scanAdapter;
+  public GetProtoAdapter(ScanProtoAdapter scanAdapter) {
+    this.scanAdapter = scanAdapter;
+  }
+
+  @Override
+  public ReadRowsRequest.Builder adapt(Get operation) {
+    Scan operationAsScan = new Scan(operation);
+    scanAdapter.throwIfUnsupportedScan(operationAsScan);
+    return ReadRowsRequest.newBuilder()
+        .setFilter(scanAdapter.buildFilter(operationAsScan))
+        .setRowKey(ByteString.copyFrom(operation.getRow()));
+  }
+}

--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/ReaderExpressionHelper.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/ReaderExpressionHelper.java
@@ -56,7 +56,7 @@ public class ReaderExpressionHelper {
   /**
    * An OutputStream that performs RE2:QuoteMeta as bytes are written.
    */
-  protected static class QuoteMetaOutputStream extends OutputStream {
+  static class QuoteMetaOutputStream extends OutputStream {
     protected final OutputStream delegate;
 
     public QuoteMetaOutputStream(OutputStream delegate) {

--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/ScanProtoAdapter.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/ScanProtoAdapter.java
@@ -1,0 +1,181 @@
+package com.google.cloud.bigtable.hbase.adapters;
+
+import com.google.bigtable.v1.ReadRowsRequest;
+import com.google.bigtable.v1.ReadRowsRequest.Builder;
+import com.google.bigtable.v1.RowFilter;
+import com.google.bigtable.v1.RowFilter.Chain;
+import com.google.bigtable.v1.RowFilter.Interleave;
+import com.google.bigtable.v1.RowRange;
+import com.google.bigtable.v1.TimestampRange;
+import com.google.cloud.bigtable.hbase.BigtableConstants;
+import com.google.cloud.bigtable.hbase.adapters.ReaderExpressionHelper.QuoteMetaOutputStream;
+import com.google.protobuf.ByteString;
+
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.io.TimeRange;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.NavigableSet;
+
+/**
+ * An adapter for Scan operation that makes use of the proto filter language.
+ * TODO(angusdavis): Rename this to 'ScanAdapter' when we've fully migrated.
+ */
+public class ScanProtoAdapter
+    implements OperationAdapter<Scan, ReadRowsRequest.Builder> {
+
+  private static final int UNSET_MAX_RESULTS_PER_COLUMN_FAMILY = -1;
+
+  private final FilterAdapter filterAdapter;
+  // TOOD(angusdavis): Migrate this to proto filter adapter post PR/186.
+  public ScanProtoAdapter(FilterAdapter filterAdapter) {
+    this.filterAdapter = filterAdapter;
+  }
+
+  public void throwIfUnsupportedScan(Scan scan) {
+    if (scan.getFilter() != null) {
+      filterAdapter.throwIfUnsupportedFilter(scan, scan.getFilter());
+    }
+
+    if (scan.getMaxResultsPerColumnFamily() != UNSET_MAX_RESULTS_PER_COLUMN_FAMILY) {
+      throw new UnsupportedOperationException(
+          "Limiting of max results per column family is not supported.");
+    }
+  }
+
+  /**
+   * Given a Scan, build a RowFilter that include matching columns
+   */
+  public RowFilter buildFilter(Scan scan) {
+    RowFilter.Chain.Builder chainBuilder = RowFilter.Chain.newBuilder();
+    chainBuilder.addFilters(createColumnFamilyFilter(scan));
+    chainBuilder.addFilters(createColumnLimitFilter(scan.getMaxVersions()));
+
+    if (scan.getTimeRange() != null && !scan.getTimeRange().isAllTime()) {
+      RowFilter timeRangeFilter = createTimeRangeFilter(scan.getTimeRange());
+      chainBuilder.addFilters(timeRangeFilter);
+    }
+
+    if (scan.getFilter() != null) {
+      // TODO(angusdavis): Wire in proto user filter adapters post PR/186
+      // RowFilter userFilter = createUserFilter();
+      // chainBuilder.addFilters(userFilter);
+    }
+
+    if (chainBuilder.getFiltersCount() == 1) {
+      return chainBuilder.getFilters(0);
+    } else {
+      return RowFilter.newBuilder().setChain(chainBuilder).build();
+    }
+  }
+
+  @Override
+  public Builder adapt(Scan scan) {
+    throwIfUnsupportedScan(scan);
+
+    return ReadRowsRequest.newBuilder()
+        .setFilter(buildFilter(scan))
+        .setRowRange(
+            RowRange.newBuilder()
+                .setStartKey(ByteString.copyFrom(scan.getStartRow()))
+                .setEndKey(ByteString.copyFrom(scan.getStopRow())));
+  }
+
+  private static byte[] quoteRegex(byte[] unquoted)  {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream(unquoted.length * 2);
+    QuoteMetaOutputStream metaQuotingStream =
+        new QuoteMetaOutputStream(baos);
+    try {
+      metaQuotingStream.write(unquoted);
+    } catch (IOException e) {
+      throw new IllegalStateException(
+          "IOException when writing to ByteArrayOutputStream", e);
+    }
+    return baos.toByteArray();
+  }
+
+  private RowFilter createColumnQualifierFilter(byte[] unquotedQualifier) {
+    return RowFilter.newBuilder()
+        .setColumnQualifierRegexFilter(
+            ByteString.copyFrom(
+                quoteRegex(unquotedQualifier)))
+        .build();
+  }
+
+  private RowFilter createFamilyFilter(byte[] familyName) {
+    return RowFilter.newBuilder()
+        .setFamilyNameRegexFilter(
+            new String(quoteRegex(familyName), StandardCharsets.UTF_8))
+        .build();
+  }
+
+  private RowFilter createColumnLimitFilter(int maxVersionsPerColumn) {
+    return RowFilter.newBuilder()
+        .setCellsPerColumnLimitFilter(maxVersionsPerColumn)
+        .build();
+  }
+
+  private RowFilter createTimeRangeFilter(TimeRange timeRange) {
+    TimestampRange.Builder rangeBuilder = TimestampRange.newBuilder();
+
+    long lowerBound = BigtableConstants.BIGTABLE_TIMEUNIT.convert(
+        timeRange.getMin(), BigtableConstants.HBASE_TIMEUNIT);
+    rangeBuilder.setStartTimestampMicros(lowerBound);
+
+    if (timeRange.getMax() != Long.MAX_VALUE) {
+      long upperBound = BigtableConstants.BIGTABLE_TIMEUNIT.convert(
+          timeRange.getMax(), BigtableConstants.HBASE_TIMEUNIT);
+      rangeBuilder.setEndTimestampMicros(upperBound);
+    }
+
+    return RowFilter.newBuilder()
+        .setTimestampRangeFilter(rangeBuilder)
+        .build();
+  }
+
+  private RowFilter createColumnFamilyFilter(Scan scan) {
+    // Build a filter of the form:
+    // (fam1 | (qual1 + qual2 + qual3)) + (fam2 | qual1) + (fam3)
+    RowFilter.Interleave.Builder interleaveBuilder =
+        RowFilter.Interleave.newBuilder();
+    Map<byte[],NavigableSet<byte[]>> familyMap = scan.getFamilyMap();
+    if (!scan.getFamilyMap().isEmpty()) {
+      for (Map.Entry<byte[], NavigableSet<byte[]>> entry : familyMap.entrySet()) {
+        if (entry.getValue() == null) {
+          // No qualifier, add the entire family:
+          interleaveBuilder.addFilters(
+              createFamilyFilter(entry.getKey()));
+        } else if (entry.getValue().size() == 1) {
+          // Build filter of the form "family | qual"
+          Chain.Builder familyBuilder =
+              interleaveBuilder.addFiltersBuilder().getChainBuilder();
+          familyBuilder.addFilters(createFamilyFilter(entry.getKey()));
+          familyBuilder.addFilters(createColumnQualifierFilter(entry.getValue().first()));
+        } else {
+          // Build filter of the form "family | (qual1 + qual2 + qual3)"
+          Chain.Builder familyBuilder =
+              interleaveBuilder.addFiltersBuilder().getChainBuilder();
+          familyBuilder.addFilters(createFamilyFilter(entry.getKey()));
+          // Add a qualifier filter for each specified qualifier:
+          Interleave.Builder columnFilters =
+              familyBuilder.addFiltersBuilder().getInterleaveBuilder();
+          for (byte[] qualifier : entry.getValue()) {
+            columnFilters.addFilters(createColumnQualifierFilter(qualifier));
+          }
+        }
+      }
+    } else {
+      // Simplify processing a bit and add an explicit inclusion of all families:
+      interleaveBuilder.addFiltersBuilder().setFamilyNameRegexFilter(".*");
+    }
+
+    if (interleaveBuilder.getFiltersCount() > 1) {
+      return RowFilter.newBuilder().setInterleave(interleaveBuilder).build();
+    } else {
+      return interleaveBuilder.getFilters(0);
+    }
+  }
+}

--- a/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/TestGetProtoAdapter.java
+++ b/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/TestGetProtoAdapter.java
@@ -1,0 +1,121 @@
+package com.google.cloud.bigtable.hbase.adapters;
+
+import com.google.bigtable.v1.ReadRowsRequest;
+import com.google.bigtable.v1.RowFilter;
+import com.google.bigtable.v1.RowFilter.Chain;
+import com.google.bigtable.v1.RowFilter.Interleave;
+import com.google.cloud.bigtable.hbase.DataGenerationHelper;
+import com.google.protobuf.ByteString;
+
+import org.apache.hadoop.hbase.client.Get;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Unit tests for the {@link GetProtoAdapter}
+ */
+@RunWith(JUnit4.class)
+public class TestGetProtoAdapter {
+
+  private GetProtoAdapter getAdapter =
+      new GetProtoAdapter(new ScanProtoAdapter(new FilterAdapter()));
+  private DataGenerationHelper dataHelper = new DataGenerationHelper();
+
+  private Get makeValidGet(byte[] rowKey) throws IOException {
+    Get get = new Get(rowKey);
+    get.setMaxVersions(Integer.MAX_VALUE);
+    return get;
+  }
+
+  @Test
+  public void rowKeyIsSetInRequest() throws IOException {
+    Get get = makeValidGet(dataHelper.randomData("rk1"));
+    ReadRowsRequest.Builder rowRequestBuilder = getAdapter.adapt(get);
+    ByteString adaptedRowKey = rowRequestBuilder.getRowKey();
+    Assert.assertEquals(
+        new String(get.getRow(), StandardCharsets.UTF_8),
+        adaptedRowKey.toStringUtf8());
+  }
+
+  @Test
+  public void maxVersionsIsSet() throws IOException {
+    Get get = makeValidGet(dataHelper.randomData("rk1"));
+    get.setMaxVersions(10);
+    ReadRowsRequest.Builder rowRequestBuilder = getAdapter.adapt(get);
+    Assert.assertEquals(
+        Chain.newBuilder()
+            .addFilters(RowFilter.newBuilder()
+                .setFamilyNameRegexFilter(".*"))
+            .addFilters(RowFilter.newBuilder()
+                .setCellsPerColumnLimitFilter(10))
+            .build(),
+        rowRequestBuilder.getFilter().getChain());
+  }
+
+  @Test
+  public void columnFamilyIsSet() throws IOException {
+    Get get = makeValidGet(dataHelper.randomData("rk1"));
+    get.addFamily(Bytes.toBytes("f1"));
+    ReadRowsRequest.Builder rowRequestBuilder = getAdapter.adapt(get);
+    Assert.assertEquals(
+        Chain.newBuilder()
+            .addFilters(RowFilter.newBuilder()
+                .setFamilyNameRegexFilter("f1"))
+            .addFilters(RowFilter.newBuilder()
+                .setCellsPerColumnLimitFilter(Integer.MAX_VALUE))
+            .build(),
+        rowRequestBuilder.getFilter().getChain());
+  }
+
+  @Test
+  public void columnQualifierIsSet() throws IOException {
+    Get get = makeValidGet(dataHelper.randomData("rk1"));
+    get.addColumn(Bytes.toBytes("f1"), Bytes.toBytes("q1"));
+    ReadRowsRequest.Builder rowRequestBuilder = getAdapter.adapt(get);
+    Assert.assertEquals(
+        Chain.newBuilder()
+            .addFilters(
+                RowFilter.newBuilder().setChain(Chain.newBuilder()
+                    .addFilters(RowFilter.newBuilder()
+                        .setFamilyNameRegexFilter("f1"))
+                    .addFilters(RowFilter.newBuilder()
+                        .setColumnQualifierRegexFilter(ByteString.copyFromUtf8("q1")))))
+            .addFilters(RowFilter.newBuilder()
+                .setCellsPerColumnLimitFilter(Integer.MAX_VALUE))
+            .build(),
+        rowRequestBuilder.getFilter().getChain());
+  }
+
+  @Test
+  public void multipleQualifiersAreSet() throws IOException {
+    Get get = makeValidGet(dataHelper.randomData("rk1"));
+    get.addColumn(Bytes.toBytes("f1"), Bytes.toBytes("q1"));
+    get.addColumn(Bytes.toBytes("f1"), Bytes.toBytes("q2"));
+    ReadRowsRequest.Builder rowRequestBuilder = getAdapter.adapt(get);
+    Assert.assertEquals(
+        Chain.newBuilder()
+            .addFilters(
+                RowFilter.newBuilder().setChain(Chain.newBuilder()
+                    .addFilters(RowFilter.newBuilder()
+                        .setFamilyNameRegexFilter("f1"))
+                    .addFilters(RowFilter.newBuilder()
+                        .setInterleave(
+                            Interleave.newBuilder()
+                                .addFilters(RowFilter.newBuilder()
+                                    .setColumnQualifierRegexFilter(
+                                        ByteString.copyFromUtf8("q1")))
+                                .addFilters(RowFilter.newBuilder()
+                                    .setColumnQualifierRegexFilter(
+                                        ByteString.copyFromUtf8("q2")))))))
+            .addFilters(RowFilter.newBuilder()
+                .setCellsPerColumnLimitFilter(Integer.MAX_VALUE))
+            .build(),
+        rowRequestBuilder.getFilter().getChain());
+  }
+}

--- a/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/TestScanProtoAdapter.java
+++ b/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/TestScanProtoAdapter.java
@@ -1,0 +1,53 @@
+package com.google.cloud.bigtable.hbase.adapters;
+
+import com.google.bigtable.v1.ReadRowsRequest;
+import com.google.bigtable.v1.ReadRowsRequest.TargetCase;
+import com.google.bigtable.v1.RowFilter;
+import com.google.bigtable.v1.RowFilter.Chain;
+
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.io.IOException;
+
+/**
+ * Lightweight tests for the ScanAdapter. Many of the methods, such as filter building are
+ * already tested in {@link TestGetProtoAdapter}.
+ */
+@RunWith(JUnit4.class)
+public class TestScanProtoAdapter {
+
+  private ScanProtoAdapter scanAdapter = new ScanProtoAdapter(new FilterAdapter());
+
+  @Test
+  public void testStartAndEndKeysAreSet() {
+    byte[] startKey = Bytes.toBytes("startKey");
+    byte[] stopKey = Bytes.toBytes("stopKey");
+    Scan scan = new Scan();
+    scan.setStartRow(startKey);
+    scan.setStopRow(stopKey);
+    ReadRowsRequest.Builder request = scanAdapter.adapt(scan);
+    Assert.assertEquals(TargetCase.ROW_RANGE, request.getTargetCase());
+    Assert.assertArrayEquals(startKey, request.getRowRange().getStartKey().toByteArray());
+    Assert.assertArrayEquals(stopKey, request.getRowRange().getEndKey().toByteArray());
+  }
+
+  @Test
+  public void maxVersionsIsSet() throws IOException {
+    Scan scan = new Scan();
+    scan.setMaxVersions(10);
+    ReadRowsRequest.Builder rowRequestBuilder = scanAdapter.adapt(scan);
+    Assert.assertEquals(
+        Chain.newBuilder()
+            .addFilters(RowFilter.newBuilder()
+                .setFamilyNameRegexFilter(".*"))
+            .addFilters(RowFilter.newBuilder()
+                .setCellsPerColumnLimitFilter(10))
+            .build(),
+        rowRequestBuilder.getFilter().getChain());
+  }
+}

--- a/bigtable-hbase/src/test/resources/bigtable-test.xml
+++ b/bigtable-hbase/src/test/resources/bigtable-test.xml
@@ -47,6 +47,10 @@
         <value>${google.bigtable.call.report.directory}</value>
     </property>
     <property>
+        <name>google.bigtable.tmp.proto.filter.language.enable</name>
+        <value>false</value>
+    </property>
+    <property>
         <name>google.bigtable.auth.service.account.email</name>
         <value>450300683590-th0dk93ks4nicmug2ts9d05f7p2q0mda@developer.gserviceaccount.com</value>
     </property>


### PR DESCRIPTION
Add new ScanProtoAdapter and GetProtoAdapter that will create
ReadRowRequests from Scans and Gets using the protobuf-base filter
language.

Add a new temporary configuration value to use *ProtoAdapter variants instead
of *Adapter. The default is to use ScanAdapter (string filters).
