### PR TITLE
Complete conversion from string to proto for scan and get filters.

### DIFF
--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableOptionsFactory.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableOptionsFactory.java
@@ -101,7 +101,7 @@ public class BigtableOptionsFactory {
   // TODO(angusdavis): Remove this key once fully transitioned
   public static final String ENABLE_PROTO_FILTER_LANGUAGE_KEY =
       "google.bigtable.tmp.proto.filter.language.enable";
-  public static final boolean ENABLE_PROTO_FILTER_LANGUAGE_DEFAULT = false;
+  public static final boolean ENABLE_PROTO_FILTER_LANGUAGE_DEFAULT = true;
 
   /**
    * The number of grpc channels to open for asynchronous processing such as puts.

--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableTable.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableTable.java
@@ -639,7 +639,9 @@ public class BigtableTable implements Table {
     if (conf.getBoolean(
         BigtableOptionsFactory.ENABLE_PROTO_FILTER_LANGUAGE_KEY,
         BigtableOptionsFactory.ENABLE_PROTO_FILTER_LANGUAGE_DEFAULT)) {
-      return new ScanProtoAdapter(new FilterAdapter());
+      // This ugly line goes away as soon as the original FilterAdapter is removed:
+      return new ScanProtoAdapter(
+          com.google.cloud.bigtable.hbase.adapters.filters.FilterAdapter.buildAdapter());
     }
     return new ScanAdapter(new FilterAdapter());
   }
@@ -648,7 +650,10 @@ public class BigtableTable implements Table {
     if (conf.getBoolean(
         BigtableOptionsFactory.ENABLE_PROTO_FILTER_LANGUAGE_KEY,
         BigtableOptionsFactory.ENABLE_PROTO_FILTER_LANGUAGE_DEFAULT)) {
-      return new GetProtoAdapter(new ScanProtoAdapter(new FilterAdapter()));
+      // This ugly line goes away as soon as the original FilterAdapter is removed:
+      return new GetProtoAdapter(
+          new ScanProtoAdapter(
+              com.google.cloud.bigtable.hbase.adapters.filters.FilterAdapter.buildAdapter()));
     }
     return new GetAdapter(new ScanAdapter(new FilterAdapter()));
   }

--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/ReaderExpressionHelper.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/ReaderExpressionHelper.java
@@ -2,6 +2,7 @@ package com.google.cloud.bigtable.hbase.adapters;
 
 import org.apache.hadoop.hbase.util.Bytes;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 
@@ -52,6 +53,12 @@ public class ReaderExpressionHelper {
     QuoteMetaOutputStream quoteMetaOutputStream =
         new QuoteMetaOutputStream(quoteFilterExpressionStream);
     quoteMetaOutputStream.write(unquoted);
+  }
+
+  public byte[] quoteRegularExpression(byte[] unquoted) throws IOException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream(unquoted.length * 2);
+    writeQuotedRegularExpression(unquoted, baos);
+    return baos.toByteArray();
   }
 
   /**

--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/ColumnCountGetFilterAdapter.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/ColumnCountGetFilterAdapter.java
@@ -1,0 +1,37 @@
+package com.google.cloud.bigtable.hbase.adapters.filters;
+
+import com.google.bigtable.v1.RowFilter;
+import com.google.bigtable.v1.RowFilter.Chain;
+
+import org.apache.hadoop.hbase.filter.ColumnCountGetFilter;
+
+import java.io.IOException;
+
+/**
+ * Adapter for the ColumnCountGetFilter.
+ * This filter does not work properly with Scans.
+ */
+public class ColumnCountGetFilterAdapter implements TypedFilterAdapter<ColumnCountGetFilter> {
+
+  @Override
+  public RowFilter adapt(FilterAdapterContext context, ColumnCountGetFilter filter)
+      throws IOException {
+    // This is fairly broken for all scans, but I'm simply going for bug-for-bug
+    // compatible with string reader expressions.
+    return RowFilter.newBuilder()
+        .setChain(Chain.newBuilder()
+            .addFilters(
+                RowFilter.newBuilder()
+                    .setCellsPerColumnLimitFilter(1))
+            .addFilters(
+                RowFilter.newBuilder()
+                    .setCellsPerRowLimitFilter(filter.getLimit())))
+        .build();
+  }
+
+  @Override
+  public FilterSupportStatus isFilterSupported(FilterAdapterContext context,
+      ColumnCountGetFilter filter) {
+    return FilterSupportStatus.SUPPORTED;
+  }
+}

--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/ColumnPaginationFilterAdapter.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/ColumnPaginationFilterAdapter.java
@@ -1,0 +1,81 @@
+package com.google.cloud.bigtable.hbase.adapters.filters;
+
+import com.google.bigtable.v1.ColumnRange;
+import com.google.bigtable.v1.RowFilter;
+import com.google.bigtable.v1.RowFilter.Chain;
+import com.google.protobuf.ByteString;
+
+import org.apache.hadoop.hbase.filter.ColumnPaginationFilter;
+import org.apache.hadoop.hbase.util.Bytes;
+
+import java.io.IOException;
+
+/**
+ * Adapter to convert a ColumnPaginationFilter to a RowFilter.
+ */
+public class ColumnPaginationFilterAdapter implements TypedFilterAdapter<ColumnPaginationFilter> {
+
+  private static final FilterSupportStatus UNSUPPORTED_STATUS =
+      FilterSupportStatus.newNotSupported(
+          "ColumnPaginationFilter requires specifying a single column family for the Scan "
+              + "when specifying a qualifier as the column offset.");
+
+  @Override
+  public RowFilter adapt(FilterAdapterContext context, ColumnPaginationFilter filter)
+      throws IOException {
+    if (filter.getColumnOffset() != null) {
+      byte[] family = context.getScan().getFamilies()[0];
+      // Include all cells starting at the qualifier scan.getColumnOffset()
+      // up to limit cells.
+      return createChain(
+          filter,
+          RowFilter.newBuilder()
+              .setColumnRangeFilter(
+                  ColumnRange.newBuilder()
+                      .setFamilyName(Bytes.toString(family))
+                      .setStartQualifierInclusive(
+                          ByteString.copyFrom(filter.getColumnOffset()))));
+    } else if (filter.getOffset() > 0) {
+      // Include starting at an integer offset up to limit cells.
+      return createChain(
+          filter,
+          RowFilter.newBuilder()
+              .setCellsPerRowOffsetFilter(filter.getOffset()));
+    } else {
+      // No meaningful offset supplied.
+      return createChain(filter, null);
+    }
+  }
+
+  /**
+   * Create a filter chain that allows the latest values for each
+   * qualifier, those cells that pass an option intermediate filter
+   * and are less than the limit per row.
+   */
+  private RowFilter createChain(
+      ColumnPaginationFilter filter, RowFilter.Builder intermediate) {
+    Chain.Builder builder = Chain.newBuilder();
+    builder.addFilters(
+        RowFilter.newBuilder()
+            .setCellsPerColumnLimitFilter(1));
+    if (intermediate != null) {
+      builder.addFilters(intermediate);
+    }
+    builder.addFilters(
+        RowFilter.newBuilder()
+            .setCellsPerRowLimitFilter(filter.getLimit()));
+    return RowFilter.newBuilder().setChain(builder).build();
+  }
+
+  @Override
+  public FilterSupportStatus isFilterSupported(
+      FilterAdapterContext context,
+      ColumnPaginationFilter filter) {
+    // We require a single column family to be specified:
+    int familyCount = context.getScan().numFamilies();
+    if (filter.getColumnOffset() != null && familyCount != 1) {
+      return UNSUPPORTED_STATUS;
+    }
+    return FilterSupportStatus.SUPPORTED;
+  }
+}

--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/FilterAdapter.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/FilterAdapter.java
@@ -4,12 +4,16 @@ import com.google.bigtable.v1.RowFilter;
 import com.google.common.collect.ImmutableList;
 
 import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.filter.ColumnCountGetFilter;
+import org.apache.hadoop.hbase.filter.ColumnPaginationFilter;
 import org.apache.hadoop.hbase.filter.ColumnPrefixFilter;
 import org.apache.hadoop.hbase.filter.ColumnRangeFilter;
 import org.apache.hadoop.hbase.filter.Filter;
 import org.apache.hadoop.hbase.filter.FilterList;
+import org.apache.hadoop.hbase.filter.FirstKeyOnlyFilter;
 import org.apache.hadoop.hbase.filter.KeyOnlyFilter;
 import org.apache.hadoop.hbase.filter.MultipleColumnPrefixFilter;
+import org.apache.hadoop.hbase.filter.SingleColumnValueFilter;
 import org.apache.hadoop.hbase.filter.TimestampsFilter;
 import org.apache.hadoop.hbase.filter.ValueFilter;
 
@@ -41,6 +45,14 @@ public class FilterAdapter {
         TimestampsFilter.class, new TimestampsFilterAdapter());
     adapter.addFilterAdapter(
         ValueFilter.class, new ValueFilterAdapter());
+    adapter.addFilterAdapter(
+        SingleColumnValueFilter.class, new SingleColumnValueFilterAdapter());
+    adapter.addFilterAdapter(
+        ColumnPaginationFilter.class, new ColumnPaginationFilterAdapter());
+    adapter.addFilterAdapter(
+        FirstKeyOnlyFilter.class, new FirstKeyOnlyFilterAdapter());
+    adapter.addFilterAdapter(
+        ColumnCountGetFilter.class, new ColumnCountGetFilterAdapter());
 
     // Passing the FilterAdapter in to the FilterListAdapter is a bit
     // unfortunate, but makes adapting the FilterList's subfilters simpler.

--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/FirstKeyOnlyFilterAdapter.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/FirstKeyOnlyFilterAdapter.java
@@ -1,0 +1,27 @@
+package com.google.cloud.bigtable.hbase.adapters.filters;
+
+import com.google.bigtable.v1.RowFilter;
+
+import org.apache.hadoop.hbase.filter.FirstKeyOnlyFilter;
+
+import java.io.IOException;
+
+/**
+ * Adapter for FirstKeyOnlyFilter to RowFilter.
+ */
+public class FirstKeyOnlyFilterAdapter implements TypedFilterAdapter<FirstKeyOnlyFilter> {
+
+  @Override
+  public RowFilter adapt(FilterAdapterContext context, FirstKeyOnlyFilter filter)
+      throws IOException {
+    return RowFilter.newBuilder()
+        .setCellsPerRowLimitFilter(1)
+        .build();
+  }
+
+  @Override
+  public FilterSupportStatus isFilterSupported(FilterAdapterContext context,
+      FirstKeyOnlyFilter filter) {
+    return FilterSupportStatus.SUPPORTED;
+  }
+}

--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/SingleColumnValueFilterAdapter.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/SingleColumnValueFilterAdapter.java
@@ -1,0 +1,119 @@
+package com.google.cloud.bigtable.hbase.adapters.filters;
+
+import com.google.bigtable.v1.RowFilter;
+import com.google.bigtable.v1.RowFilter.Chain;
+import com.google.bigtable.v1.RowFilter.Condition;
+import com.google.cloud.bigtable.hbase.adapters.ReaderExpressionHelper;
+import com.google.protobuf.ByteString;
+
+import org.apache.hadoop.hbase.filter.BinaryComparator;
+import org.apache.hadoop.hbase.filter.CompareFilter;
+import org.apache.hadoop.hbase.filter.SingleColumnValueFilter;
+import org.apache.hadoop.hbase.util.Bytes;
+
+import java.io.IOException;
+
+/**
+ * Adapt SingleColumnValueFilter instances into bigtable RowFilters.
+ */
+public class SingleColumnValueFilterAdapter implements TypedFilterAdapter<SingleColumnValueFilter> {
+
+  private static final RowFilter ALL_VALUES_FILTER =
+      RowFilter.newBuilder()
+          .setCellsPerColumnLimitFilter(Integer.MAX_VALUE)
+          .build();
+  private final ReaderExpressionHelper helper = new ReaderExpressionHelper();
+
+  public SingleColumnValueFilterAdapter() {
+  }
+
+  @Override
+  public RowFilter adapt(FilterAdapterContext context, SingleColumnValueFilter filter)
+      throws IOException {
+    if (filter.getFilterIfMissing()) {
+      return createEmitRowsWithValueFilter(filter);
+    } else {
+      return RowFilter.newBuilder()
+          .setCondition(
+              Condition.newBuilder()
+                  .setPredicateFilter(createColumnSpecFilter(filter))
+                  .setTrueFilter(createEmitRowsWithValueFilter(filter))
+                  .setFalseFilter(ALL_VALUES_FILTER))
+          .build();
+    }
+  }
+
+  /**
+   * Create a filter that will match a given family, qualifier, and cells per qualifier.
+   */
+  private RowFilter createColumnSpecFilter(SingleColumnValueFilter filter) throws IOException {
+    return RowFilter.newBuilder()
+        .setChain(Chain.newBuilder()
+            .addFilters(RowFilter.newBuilder()
+                .setFamilyNameRegexFilter(
+                    Bytes.toString(helper.quoteRegularExpression(filter.getFamily()))))
+            .addFilters(RowFilter.newBuilder()
+                .setColumnQualifierRegexFilter(
+                    ByteString.copyFrom(helper.quoteRegularExpression(filter.getQualifier()))))
+            .addFilters(createVersionLimitFilter(filter)))
+        .build();
+  }
+
+  /**
+   * Emit a filter that will limit the number of cell versions that will be emitted.
+   */
+  private RowFilter createVersionLimitFilter(SingleColumnValueFilter filter) {
+    return RowFilter.newBuilder()
+        .setCellsPerColumnLimitFilter(
+            filter.getLatestVersionOnly() ? 1 : Integer.MAX_VALUE)
+        .build();
+  }
+
+  /**
+   * Emit a filter that will match against a single value.
+   */
+  private RowFilter createValueMatchFilter(
+      SingleColumnValueFilter filter) throws IOException {
+    return RowFilter.newBuilder()
+        .setValueRegexFilter(
+            ByteString.copyFrom(
+                helper.quoteRegularExpression(
+                    filter.getComparator().getValue())))
+        .build();
+  }
+
+  /**
+   * Create a filter that will emit all cells in a row if a given qualifier
+   * has a given value.
+   */
+  private RowFilter createEmitRowsWithValueFilter(SingleColumnValueFilter filter)
+      throws IOException {
+    return RowFilter.newBuilder()
+        .setCondition(
+            Condition.newBuilder()
+                .setPredicateFilter(
+                    RowFilter.newBuilder()
+                        .setChain(
+                            Chain.newBuilder()
+                                .addFilters(createColumnSpecFilter(filter))
+                                .addFilters(createValueMatchFilter(filter))))
+                .setTrueFilter(ALL_VALUES_FILTER))
+        .build();
+  }
+
+  @Override
+  public FilterSupportStatus isFilterSupported(
+      FilterAdapterContext context, SingleColumnValueFilter filter) {
+    if (!filter.getOperator().equals(CompareFilter.CompareOp.EQUAL)) {
+      return FilterSupportStatus.newNotSupported(String.format(
+          "CompareOp.EQUAL is the only supported SingleColumnValueFilterAdapter compareOp. "
+              + "Found: '%s'",
+          filter.getOperator()));
+    } else if (!(filter.getComparator() instanceof BinaryComparator)) {
+      return FilterSupportStatus.newNotSupported(String.format(
+          "ByteArrayComparisons of type %s are not supported in SingleColumnValueFilterAdapter",
+          filter.getComparator().getClass()));
+    }
+    return FilterSupportStatus.SUPPORTED;
+  }
+}

--- a/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/TestGetProtoAdapter.java
+++ b/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/TestGetProtoAdapter.java
@@ -5,6 +5,7 @@ import com.google.bigtable.v1.RowFilter;
 import com.google.bigtable.v1.RowFilter.Chain;
 import com.google.bigtable.v1.RowFilter.Interleave;
 import com.google.cloud.bigtable.hbase.DataGenerationHelper;
+import com.google.cloud.bigtable.hbase.adapters.filters.FilterAdapter;
 import com.google.protobuf.ByteString;
 
 import org.apache.hadoop.hbase.client.Get;
@@ -24,7 +25,7 @@ import java.nio.charset.StandardCharsets;
 public class TestGetProtoAdapter {
 
   private GetProtoAdapter getAdapter =
-      new GetProtoAdapter(new ScanProtoAdapter(new FilterAdapter()));
+      new GetProtoAdapter(new ScanProtoAdapter(FilterAdapter.buildAdapter()));
   private DataGenerationHelper dataHelper = new DataGenerationHelper();
 
   private Get makeValidGet(byte[] rowKey) throws IOException {

--- a/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/TestScanProtoAdapter.java
+++ b/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/TestScanProtoAdapter.java
@@ -4,6 +4,7 @@ import com.google.bigtable.v1.ReadRowsRequest;
 import com.google.bigtable.v1.ReadRowsRequest.TargetCase;
 import com.google.bigtable.v1.RowFilter;
 import com.google.bigtable.v1.RowFilter.Chain;
+import com.google.cloud.bigtable.hbase.adapters.filters.FilterAdapter;
 
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.util.Bytes;
@@ -21,7 +22,7 @@ import java.io.IOException;
 @RunWith(JUnit4.class)
 public class TestScanProtoAdapter {
 
-  private ScanProtoAdapter scanAdapter = new ScanProtoAdapter(new FilterAdapter());
+  private ScanProtoAdapter scanAdapter = new ScanProtoAdapter(FilterAdapter.buildAdapter());
 
   @Test
   public void testStartAndEndKeysAreSet() {

--- a/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestColumnCountGetFilterAdapter.java
+++ b/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestColumnCountGetFilterAdapter.java
@@ -1,0 +1,38 @@
+package com.google.cloud.bigtable.hbase.adapters.filters;
+
+import com.google.bigtable.v1.RowFilter;
+import com.google.bigtable.v1.RowFilter.Chain;
+
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.filter.ColumnCountGetFilter;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.io.IOException;
+
+@RunWith(JUnit4.class)
+public class TestColumnCountGetFilterAdapter {
+
+  ColumnCountGetFilterAdapter adapter = new ColumnCountGetFilterAdapter();
+
+  @Test
+  public void testSimpleColumnCount() throws IOException {
+    RowFilter adaptedFilter =
+        adapter.adapt(
+            new FilterAdapterContext(new Scan()),
+            new ColumnCountGetFilter(2));
+    Assert.assertEquals(
+        RowFilter.newBuilder()
+            .setChain(Chain.newBuilder()
+                .addFilters(
+                    RowFilter.newBuilder()
+                        .setCellsPerColumnLimitFilter(1))
+                .addFilters(
+                    RowFilter.newBuilder()
+                        .setCellsPerRowLimitFilter(2)))
+        .build(),
+        adaptedFilter);
+  }
+}

--- a/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestColumnPaginationFilterAdapter.java
+++ b/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestColumnPaginationFilterAdapter.java
@@ -1,0 +1,88 @@
+package com.google.cloud.bigtable.hbase.adapters.filters;
+
+import com.google.bigtable.v1.ColumnRange;
+import com.google.bigtable.v1.RowFilter;
+import com.google.bigtable.v1.RowFilter.Chain;
+import com.google.protobuf.ByteString;
+
+
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.filter.ColumnPaginationFilter;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.io.IOException;
+
+@RunWith(JUnit4.class)
+public class TestColumnPaginationFilterAdapter {
+
+  ColumnPaginationFilterAdapter adapter = new ColumnPaginationFilterAdapter();
+
+  @Test
+  public void integerLimitsAreApplied() throws IOException {
+    ColumnPaginationFilter filter = new ColumnPaginationFilter(10, 20);
+    RowFilter adaptedFilter = adapter.adapt(
+        new FilterAdapterContext(new Scan()), filter);
+    Assert.assertEquals(
+        RowFilter.newBuilder()
+            .setChain(
+                Chain.newBuilder()
+                    .addFilters(RowFilter.newBuilder()
+                        .setCellsPerColumnLimitFilter(1))
+                    .addFilters(RowFilter.newBuilder()
+                        .setCellsPerRowOffsetFilter(20))
+                    .addFilters(RowFilter.newBuilder()
+                        .setCellsPerRowLimitFilter(10)))
+            .build(),
+        adaptedFilter);
+  }
+
+  @Test
+  public void zeroOffsetLimitIsSupported() throws IOException {
+    ColumnPaginationFilter filter = new ColumnPaginationFilter(10, 0);
+    RowFilter adaptedFilter = adapter.adapt(
+        new FilterAdapterContext(new Scan()), filter);
+    Assert.assertEquals(
+        RowFilter.newBuilder()
+            .setChain(
+                Chain.newBuilder()
+                    .addFilters(RowFilter.newBuilder()
+                        .setCellsPerColumnLimitFilter(1))
+                    .addFilters(RowFilter.newBuilder()
+                        .setCellsPerRowLimitFilter(10)))
+            .build(),
+        adaptedFilter);
+  }
+
+  @Test
+  public void qualifierOffsetIsPartiallySupported() throws IOException {
+    ColumnPaginationFilter filter =
+        new ColumnPaginationFilter(10, Bytes.toBytes("q1"));
+    RowFilter adaptedFilter = adapter.adapt(
+        new FilterAdapterContext(
+            new Scan().addFamily(Bytes.toBytes("f1"))),
+        filter);
+    Assert.assertEquals(
+        RowFilter.newBuilder()
+            .setChain(
+                Chain.newBuilder()
+                    .addFilters(
+                        RowFilter.newBuilder()
+                            .setCellsPerColumnLimitFilter(1))
+                    .addFilters(
+                        RowFilter.newBuilder()
+                            .setColumnRangeFilter(
+                                ColumnRange.newBuilder()
+                                    .setFamilyName("f1")
+                                    .setStartQualifierInclusive(
+                                        ByteString.copyFromUtf8("q1"))))
+                    .addFilters(
+                        RowFilter.newBuilder()
+                            .setCellsPerRowLimitFilter(10)))
+            .build(),
+        adaptedFilter);
+  }
+}

--- a/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestFirstKeyOnlyFilterAdapter.java
+++ b/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestFirstKeyOnlyFilterAdapter.java
@@ -1,0 +1,29 @@
+package com.google.cloud.bigtable.hbase.adapters.filters;
+
+import com.google.bigtable.v1.RowFilter;
+
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.filter.FirstKeyOnlyFilter;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.io.IOException;
+
+@RunWith(JUnit4.class)
+public class TestFirstKeyOnlyFilterAdapter {
+
+  FirstKeyOnlyFilterAdapter adapter = new FirstKeyOnlyFilterAdapter();
+
+  @Test
+  public void onlyTheFirstKeyFromEachRowIsEmitted() throws IOException {
+    RowFilter adaptedFilter = adapter.adapt(
+        new FilterAdapterContext(new Scan()), new FirstKeyOnlyFilter());
+    Assert.assertEquals(
+        RowFilter.newBuilder()
+            .setCellsPerRowLimitFilter(1)
+            .build(),
+        adaptedFilter);
+  }
+}

--- a/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestSingleColumnValueFilterAdapter.java
+++ b/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestSingleColumnValueFilterAdapter.java
@@ -1,0 +1,208 @@
+package com.google.cloud.bigtable.hbase.adapters.filters;
+
+import com.google.bigtable.v1.RowFilter;
+import com.google.bigtable.v1.RowFilter.Chain;
+import com.google.protobuf.ByteString;
+
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.filter.BinaryComparator;
+import org.apache.hadoop.hbase.filter.CompareFilter;
+import org.apache.hadoop.hbase.filter.SingleColumnValueFilter;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.io.IOException;
+
+@RunWith(JUnit4.class)
+public class TestSingleColumnValueFilterAdapter  {
+
+  SingleColumnValueFilterAdapter adapter = new SingleColumnValueFilterAdapter();
+
+  @Test
+  public void latestVersionOnlyComparisonsAreDone() throws IOException {
+    byte[] filterValue = Bytes.toBytes("foobar");
+    byte[] qualifier = Bytes.toBytes("someColumn");
+    byte[] family = Bytes.toBytes("f");
+
+    SingleColumnValueFilter filter = new SingleColumnValueFilter(
+        family,
+        qualifier,
+        CompareFilter.CompareOp.EQUAL,
+        new BinaryComparator(filterValue));
+
+    filter.setFilterIfMissing(false);
+    filter.setLatestVersionOnly(true);
+
+    RowFilter adaptedFilter = adapter.adapt(
+        new FilterAdapterContext(new Scan()),
+        filter);
+
+    assertFilterIfNotMIssingMatches(
+        family,
+        qualifier,
+        filterValue,
+        1 /* latest version only = true */,
+        adaptedFilter);
+  }
+
+  @Test
+  public void allVersionComparisonAreDone() throws IOException {
+    byte[] filterValue = Bytes.toBytes("foobar");
+    byte[] qualifier = Bytes.toBytes("someColumn");
+    byte[] family = Bytes.toBytes("f");
+
+    SingleColumnValueFilter filter = new SingleColumnValueFilter(
+        family,
+        qualifier,
+        CompareFilter.CompareOp.EQUAL,
+        new BinaryComparator(filterValue));
+
+    filter.setFilterIfMissing(false);
+    filter.setLatestVersionOnly(false);
+
+    RowFilter adaptedFilter = adapter.adapt(
+        new FilterAdapterContext(new Scan()),
+        filter);
+
+    assertFilterIfNotMIssingMatches(
+        family,
+        qualifier,
+        filterValue,
+        Integer.MAX_VALUE /* latest version only = false */,
+        adaptedFilter);
+  }
+
+  @Test
+  public void filterIfMissingIsApplied() throws IOException {
+    byte[] filterValue = Bytes.toBytes("foobar");
+    byte[] qualifier = Bytes.toBytes("someColumn");
+    byte[] family = Bytes.toBytes("f");
+
+    SingleColumnValueFilter filter = new SingleColumnValueFilter(
+        family,
+        qualifier,
+        CompareFilter.CompareOp.EQUAL,
+        new BinaryComparator(filterValue));
+
+    filter.setFilterIfMissing(true);
+    filter.setLatestVersionOnly(false);
+
+    RowFilter adaptedFilter = adapter.adapt(
+        new FilterAdapterContext(new Scan()),
+        filter);
+
+    assertColumnSpecification(
+        Bytes.toString(family),
+        qualifier,
+        Integer.MAX_VALUE,
+        adaptedFilter
+            .getCondition()
+            .getPredicateFilter()
+            .getChain()
+            .getFilters(0)
+            .getChain());
+
+    Assert.assertEquals(
+        RowFilter.newBuilder()
+            .setValueRegexFilter(ByteString.copyFromUtf8("foobar"))
+            .build(),
+        adaptedFilter
+            .getCondition()
+            .getPredicateFilter()
+            .getChain()
+            .getFilters(1));
+
+    Assert.assertEquals(
+        RowFilter.newBuilder()
+            .setCellsPerColumnLimitFilter(Integer.MAX_VALUE)
+            .build(),
+        adaptedFilter.getCondition().getTrueFilter());
+  }
+
+  // Assert that the given family, qualifier and versions are applied
+  // via the given Chain.
+  private void assertColumnSpecification(
+      String family, byte[] qualifier, int versions, Chain chain) {
+    Chain expected =
+        Chain.newBuilder()
+          .addFilters(
+              RowFilter.newBuilder()
+                  .setFamilyNameRegexFilter(family))
+          .addFilters(
+              RowFilter.newBuilder()
+                  .setColumnQualifierRegexFilter(
+                      ByteString.copyFrom(qualifier)))
+          .addFilters(
+              RowFilter.newBuilder()
+                  .setCellsPerColumnLimitFilter(versions))
+        .build();
+
+    Assert.assertEquals(expected, chain);
+  }
+
+  private void assertFilterIfNotMIssingMatches(
+      byte[] family,
+      byte[] qualifier,
+      byte[] value,
+      int versions,
+      RowFilter adaptedFilter) {
+    // We won't be doing a filter if missing, so start by seeing if the cell
+    // is in the row - if it is, we'll perform the value filter otherwise we'll
+    // include all cells in the row:
+    assertColumnSpecification(
+        Bytes.toString(family),
+        qualifier,
+        versions,
+        adaptedFilter
+            .getCondition()
+            .getPredicateFilter()
+            .getChain());
+
+    // Cell is not in the row, include all cells in the false branch:
+    Assert.assertEquals(
+        RowFilter.newBuilder()
+            .setCellsPerColumnLimitFilter(
+                Integer.MAX_VALUE)
+            .build(),
+        adaptedFilter.getCondition().getFalseFilter());
+
+    RowFilter cellExistsBranch =
+        adaptedFilter
+            .getCondition()
+            .getTrueFilter();
+
+    assertColumnSpecification(
+        Bytes.toString(family),
+        qualifier,
+        versions,
+        cellExistsBranch
+            .getCondition()
+            .getPredicateFilter()
+            .getChain()
+            .getFilters(0)
+            .getChain());
+
+    // Assert that the condition includes a value filter:
+    Assert.assertEquals(
+        RowFilter.newBuilder()
+            .setValueRegexFilter(ByteString.copyFrom(value))
+            .build(),
+        cellExistsBranch
+            .getCondition()
+            .getPredicateFilter()
+            .getChain()
+            .getFilters(1));
+
+    // Include all cells that match the value filter and cell spec:
+    Assert.assertEquals(
+        RowFilter.newBuilder()
+            .setCellsPerColumnLimitFilter(Integer.MAX_VALUE)
+            .build(),
+        cellExistsBranch
+            .getCondition()
+            .getTrueFilter());
+  }
+}

--- a/bigtable-hbase/src/test/resources/bigtable-test.xml
+++ b/bigtable-hbase/src/test/resources/bigtable-test.xml
@@ -47,10 +47,6 @@
         <value>${google.bigtable.call.report.directory}</value>
     </property>
     <property>
-        <name>google.bigtable.tmp.proto.filter.language.enable</name>
-        <value>false</value>
-    </property>
-    <property>
         <name>google.bigtable.auth.service.account.email</name>
         <value>450300683590-th0dk93ks4nicmug2ts9d05f7p2q0mda@developer.gserviceaccount.com</value>
     </property>


### PR DESCRIPTION
- Implement proto-based SingleColumnValueFilter, FirstKeyOnlyFilter,
  ColumnPaginationFilter, and ColumnCountGetFilter to the extent that they
  are currently implemented for the string-based filter language.
- Cut-over the default adapters for scan and get to be proto-based.
