### PR TITLE
Loosen the bounds in testRandomRowFilter.

### DIFF
--- a/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestFilters.java
+++ b/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestFilters.java
@@ -1241,8 +1241,8 @@ public class TestFilters extends AbstractTest {
     Result[] results = scanner.next(100);
 
     Assert.assertTrue(
-        "Using p=0.5, expected half of added rows.",
-        40 <= results.length && results.length <= 60);
+        String.format("Using p=0.5, expected half of added rows, found %s", results.length),
+        25 <= results.length && results.length <= 75);
   }
 
   @Test


### PR DESCRIPTION
The test 'testRandomRowFilter' is flaky with 100 input rows, p=0.5 and
an assertion that rows returned must be between 40 and 60. Loosen these
bounds so that returned rows must be between 25 and 75 and in case of
failure, add in the number of results returned.
