### PR TITLE
Increase compatibility of SingleColumnValueFilter.

### DIFF
--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/FilterAdapter.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/FilterAdapter.java
@@ -45,9 +45,11 @@ public class FilterAdapter {
         MultipleColumnPrefixFilter.class, new MultipleColumnPrefixFilterAdapter());
     adapter.addFilterAdapter(
         TimestampsFilter.class, new TimestampsFilterAdapter());
+    ValueFilterAdapter valueFilterAdapter = new ValueFilterAdapter();
     adapter.addFilterAdapter(
-        ValueFilter.class, new ValueFilterAdapter());
-    SingleColumnValueFilterAdapter scvfa = new SingleColumnValueFilterAdapter();
+        ValueFilter.class, valueFilterAdapter);
+    SingleColumnValueFilterAdapter scvfa =
+        new SingleColumnValueFilterAdapter(valueFilterAdapter);
     adapter.addFilterAdapter(
         SingleColumnValueFilter.class, scvfa);
     adapter.addFilterAdapter(

--- a/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestSingleColumnValueFilterAdapter.java
+++ b/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestSingleColumnValueFilterAdapter.java
@@ -19,7 +19,8 @@ import java.io.IOException;
 @RunWith(JUnit4.class)
 public class TestSingleColumnValueFilterAdapter  {
 
-  SingleColumnValueFilterAdapter adapter = new SingleColumnValueFilterAdapter();
+  SingleColumnValueFilterAdapter adapter =
+      new SingleColumnValueFilterAdapter(new ValueFilterAdapter());
 
   @Test
   public void latestVersionOnlyComparisonsAreDone() throws IOException {


### PR DESCRIPTION
Use ValueFilterAdapter to create the value_match (or value_range)
portion of the SingleColumnValueFilter. This allows us to support regex
and ranges.
