### PR TITLE
Adding more info to BigtableConnection.toString().

### DIFF
--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableOptions.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableOptions.java
@@ -251,6 +251,14 @@ public class BigtableOptions {
     return optionsBuilder.build();
   }
 
+  public InetAddress getHost() {
+    return host;
+  }
+
+  public InetAddress getAdminHost() {
+    return adminHost;
+  }
+
   public TransportOptions getTransportOptions() throws IOException {
     return createTransportOptions(this.host);
   }
@@ -273,7 +281,7 @@ public class BigtableOptions {
           @Override
           public SslContext create() {
             try {
-              // We create multiple channels via refreshing and pooling channel implementation.  
+              // We create multiple channels via refreshing and pooling channel implementation.
               // Each one needs its own SslContext.
               return SslContext.newClientContext();
             } catch (SSLException e) {

--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableTable.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableTable.java
@@ -14,6 +14,7 @@
 package com.google.cloud.bigtable.hbase;
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -27,6 +28,7 @@ import org.apache.hadoop.hbase.DoNotRetryIOException;
 import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Append;
+import org.apache.hadoop.hbase.client.BigtableConnection;
 import org.apache.hadoop.hbase.client.Delete;
 import org.apache.hadoop.hbase.client.Durability;
 import org.apache.hadoop.hbase.client.Get;
@@ -67,6 +69,7 @@ import com.google.cloud.bigtable.hbase.adapters.TableMetadataSetter;
 import com.google.cloud.bigtable.hbase.adapters.UnsupportedOperationAdapter;
 import com.google.cloud.bigtable.hbase.adapters.filters.FilterAdapter;
 import com.google.cloud.bigtable.grpc.BigtableClient;
+import com.google.common.base.MoreObjects;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.protobuf.ByteString;
@@ -581,12 +584,14 @@ public class BigtableTable implements Table {
 
   @Override
   public String toString() {
-    return String.format("BigtableTable-0x%s.  Table: %s, Project: %s, Zone: %sm Cluster: %s",
-        Integer.toHexString(hashCode()),
-        tableName,
-        options.getProjectId(),
-        options.getZone(),
-        options.getCluster());
+    InetAddress host = options.getHost();
+    return MoreObjects.toStringHelper(BigtableTable.class)
+        .add("hashCode", "0x" + Integer.toHexString(hashCode()))
+        .add("zone", options.getZone())
+        .add("project", options.getProjectId())
+        .add("cluster", options.getCluster())
+        .add("host", host)
+        .toString();
   }
 
   protected boolean wasMutationApplied(

--- a/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/BigtableAdmin.java
+++ b/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/BigtableAdmin.java
@@ -5,6 +5,7 @@ import io.grpc.Status;
 import io.grpc.Status.OperationRuntimeException;
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -58,6 +59,7 @@ import com.google.cloud.bigtable.hbase.adapters.ColumnFamilyFormatter;
 import com.google.cloud.bigtable.hbase.adapters.TableAdapter;
 import com.google.cloud.bigtable.hbase.adapters.TableMetadataSetter;
 import com.google.cloud.bigtable.grpc.BigtableAdminClient;
+import com.google.common.base.MoreObjects;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 
 public class BigtableAdmin implements Admin {
@@ -955,7 +957,13 @@ public class BigtableAdmin implements Admin {
 
   @Override
   public String toString() {
-    return String
-        .format("BigtableAdmin-0x%s. %s", Integer.toHexString(hashCode()), getConnection());
+    InetAddress adminHost = options.getAdminHost();
+    return MoreObjects.toStringHelper(BigtableAdmin.class)
+        .add("connectionId", connection.getId())
+        .add("zone", options.getZone())
+        .add("project", options.getProjectId())
+        .add("cluster", options.getCluster())
+        .add("adminHost", adminHost)
+        .toString();
   }
 }

--- a/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/BigtableConnection.java
+++ b/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/BigtableConnection.java
@@ -17,6 +17,7 @@ package org.apache.hadoop.hbase.client;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.net.InetAddress;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
@@ -45,6 +46,7 @@ import com.google.cloud.bigtable.grpc.BigtableClient;
 import com.google.cloud.bigtable.grpc.BigtableGrpcClient;
 import com.google.cloud.bigtable.grpc.ChannelOptions;
 import com.google.cloud.bigtable.grpc.TransportOptions;
+import com.google.common.base.MoreObjects;
 
 public class BigtableConnection implements Connection, Closeable {
   public static final String MAX_INFLIGHT_RPCS_KEY =
@@ -283,9 +285,16 @@ public class BigtableConnection implements Connection, Closeable {
 
   @Override
   public String toString() {
-    return String.format("BigtableConnection-0x%s.  Project: %s, Zone: %s, Cluster: %s",
-      Integer.toHexString(hashCode()), options.getProjectId(), options.getZone(),
-      options.getCluster());
+    InetAddress host = options.getHost();
+    InetAddress adminHost = options.getAdminHost();
+    return MoreObjects.toStringHelper(BigtableConnection.class)
+      .add("id", id)
+      .add("zone", options.getZone())
+      .add("project", options.getProjectId())
+      .add("cluster", options.getCluster())
+      .add("host", host)
+      .add("adminHost", adminHost)
+      .toString();
   }
 
   // Copied from org.apache.hadoop.hbase.client.HConnectionManager#getBatchPool()
@@ -334,5 +343,9 @@ public class BigtableConnection implements Connection, Closeable {
         this.batchPool.shutdownNow();
       }
     }
+  }
+
+  public Integer getId() {
+    return id;
   }
 }


### PR DESCRIPTION
Fixing BigtableTable.toString().

I looked at a to string unit test.  I didn't want to make it too prescriptive to allow for future enhancements.  I also didn't want to change the BigtableConnection and BigtableTable too much to accommodate toString() tests.  I couldn't do that easily.
