### PR TITLE
Removing references to bigtable.grpc.repo.fullpath

### DIFF
--- a/bigtable-hbase-integration-tests/pom.xml
+++ b/bigtable-hbase-integration-tests/pom.xml
@@ -26,17 +26,6 @@ limitations under the License.
     <artifactId>bigtable-hbase-integration-tests</artifactId>
     <packaging>jar</packaging>
 
-    <repositories>
-        <repository>
-            <id>repo</id>
-            <url>file://${bigtable.grpc.repo.fullpath}</url>
-        </repository>
-    </repositories>
-
-    <properties>
-        <bigtable.grpc.repo.fullpath>${project.basedir}/../${bigtable.grpc.repo.dir}</bigtable.grpc.repo.fullpath>
-    </properties>
-
     <profiles>
         <profile>
             <id>bigtableIntegrationTest</id>

--- a/bigtable-hbase/pom.xml
+++ b/bigtable-hbase/pom.xml
@@ -26,17 +26,6 @@ limitations under the License.
     <artifactId>bigtable-hbase</artifactId>
     <packaging>jar</packaging>
 
-    <repositories>
-        <repository>
-            <id>repo</id>
-            <url>file://${bigtable.grpc.repo.fullpath}</url>
-        </repository>
-    </repositories>
-
-    <properties>
-        <bigtable.grpc.repo.fullpath>${project.basedir}/../${bigtable.grpc.repo.dir}</bigtable.grpc.repo.fullpath>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
The code I removed was an old artifact, and is causing some problems for Doug.
