### PR TITLE
Defaulting max default inflight ops to 50 per channel.

### DIFF
--- a/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/BigtableConnection.java
+++ b/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/BigtableConnection.java
@@ -54,7 +54,7 @@ public class BigtableConnection implements Connection, Closeable {
       "google.bigtable.buffered.mutator.max.inflight.rpcs";
 
   // Default rpc count per channel.
-  public static final int MAX_INFLIGHT_RPCS_DEFAULT = 2000;
+  public static final int MAX_INFLIGHT_RPCS_DEFAULT = 50;
 
   /**
    * The maximum amount of memory to be used for asynchronous buffered mutator RPCs.


### PR DESCRIPTION
2000 concurrent requests seemed to have choked the client.  Reducing to 50 which seems to give similar performance.
