### PR TITLE
Move ReconnectingChannel's async close to its own Executor.

### DIFF
--- a/bigtable-grpc-interface/src/main/java/com/google/cloud/bigtable/grpc/BigtableChannels.java
+++ b/bigtable-grpc-interface/src/main/java/com/google/cloud/bigtable/grpc/BigtableChannels.java
@@ -112,10 +112,12 @@ public class BigtableChannels {
     return wrapChannel(channelOptions, executor, channel, createChannelClose(channel));
   }
 
-  private static CloseableChannel createRefreshingChannel(final TransportOptions transportOptions,
-      final ExecutorService executor, long timeoutMs) {
+  private static CloseableChannel createRefreshingChannel(
+      final TransportOptions transportOptions,
+      final ExecutorService executor,
+      long timeoutMs) {
     if (timeoutMs > 0) {
-      return new ReconnectingChannel(timeoutMs, executor, new ReconnectingChannel.Factory() {
+      return new ReconnectingChannel(timeoutMs, new ReconnectingChannel.Factory() {
         @Override
         public CloseableChannel create() {
           return createCloseableChannel(transportOptions, executor);

--- a/bigtable-grpc-interface/src/main/java/com/google/cloud/bigtable/grpc/ReconnectingChannel.java
+++ b/bigtable-grpc-interface/src/main/java/com/google/cloud/bigtable/grpc/ReconnectingChannel.java
@@ -20,6 +20,8 @@ import io.grpc.MethodDescriptor;
 
 import java.io.IOException;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock.ReadLock;
@@ -28,6 +30,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import com.google.common.base.Preconditions;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 /**
  * A ClosableChannel that refreshes itself based on a user supplied timeout.
@@ -36,6 +39,20 @@ public class ReconnectingChannel implements CloseableChannel {
 
   protected static final Logger log = Logger.getLogger(ChannelPool.class.getName());
   protected static final long CLOSE_WAIT_TIME = 5000;
+  // This executor is used to shutdown & await termination of
+  // grpc connections. The work done on these threads should be minial
+  // as long as we don't perform a shutdownNow() call (or similar). As
+  // a result, allow there to be an unbounded number of these.
+  // It is not expected to happen often, but there are cases where
+  // shutdown will never complete and we don't want to take up a thread
+  // that could be used to indicate that a Call is completed (and would
+  // then finish client shutdown).
+  protected static final ExecutorService closeExecutor =
+      Executors.newCachedThreadPool(
+          new ThreadFactoryBuilder()
+              .setNameFormat("reconnection-async-close-%s")
+              .setDaemon(true)
+              .build());
 
   /**
    * Creates a fresh CloseableChannel.
@@ -58,13 +75,21 @@ public class ReconnectingChannel implements CloseableChannel {
   private long nextRefresh;
   private CloseableChannel delegate;
 
-  public ReconnectingChannel(long maxRefreshTime, Executor executor, final Factory factory) {
+  public ReconnectingChannel(
+      long maxRefreshTime,
+      ExecutorService executor,
+      Factory connectionFactory) {
     Preconditions.checkArgument(maxRefreshTime > 0, "maxRefreshTime has to be greater than 0.");
     this.maxRefreshTime = maxRefreshTime;
     this.executor = executor;
-    this.delegate = factory.create();
+    this.delegate = connectionFactory.create();
     this.nextRefresh = calculateNewRefreshTime();
-    this.factory = factory;
+    this.factory = connectionFactory;
+  }
+
+  public ReconnectingChannel(
+      long maxRefreshTime, Factory factory) {
+    this(maxRefreshTime, closeExecutor, factory);
   }
 
   @Override
@@ -145,7 +170,7 @@ public class ReconnectingChannel implements CloseableChannel {
 
   private void asyncClose(final CloseableChannel channel) {
     closingAsynchronously.incrementAndGet();
-    executor.execute(new Runnable() {
+    closeExecutor.execute(new Runnable() {
       @Override
       public void run() {
         try {


### PR DESCRIPTION
Per the commit comments for shutdown() and awaitTerminated(), they can
sometimes hang. As a result, we should move close to its own
ExecutorService so that we don't block a Call from completing (which
could in turn complete channel shutdown).