### PR TITLE
Fix comment on ReadRowsRequest.filter.

### DIFF
--- a/bigtable-protos/src/main/proto/google/bigtable/v1approved/bigtable_service_messages.proto
+++ b/bigtable-protos/src/main/proto/google/bigtable/v1approved/bigtable_service_messages.proto
@@ -42,7 +42,7 @@ message ReadRowsRequest {
   string DEPRECATED_string_filter = 4;
 
   // The filter to apply to the contents of the specified row(s). If unset,
-  // reads the most recent value from all readable columns.
+  // reads the entire table.
   RowFilter filter = 5;
 
   // By default, rows are read sequentially, producing results which are


### PR DESCRIPTION
If no filter is specified, all values are read, not just the most recent values.