### PR TITLE
Fix ReadRows and SampleRowKeys to be streaming methods.

### DIFF
--- a/bigtable-protos/src/main/proto/google/bigtable/v1approved/bigtable_service.proto
+++ b/bigtable-protos/src/main/proto/google/bigtable/v1approved/bigtable_service.proto
@@ -33,7 +33,7 @@ service BigtableService {
   // the same Reader filter to each. Depending on their size, rows may be
   // broken up across multiple responses, but atomicity of each row will still
   // be preserved.
-  rpc ReadRows(ReadRowsRequest) returns (ReadRowsResponse) {
+  rpc ReadRows(ReadRowsRequest) returns (stream ReadRowsResponse) {
     option (google.api.http) = { post: "/v1/{table_name=projects/*/zones/*/clusters/*/tables/*}/rows:read" body: "*" };
   }
 
@@ -41,7 +41,7 @@ service BigtableService {
   // delimit contiguous sections of the table of approximately equal size,
   // which can be used to break up the data for distributed tasks like
   // mapreduces.
-  rpc SampleRowKeys(SampleRowKeysRequest) returns (SampleRowKeysResponse) {
+  rpc SampleRowKeys(SampleRowKeysRequest) returns (stream SampleRowKeysResponse) {
     option (google.api.http) = { get: "/v1/{table_name=projects/*/zones/*/clusters/*/tables/*}/rows:sampleKeys" };
   }
 


### PR DESCRIPTION
In production, these RPC methods return streams.