### PR TITLE
Add logging to the BigtableConnection constructor.

### DIFF
--- a/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/BigtableConnection.java
+++ b/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/BigtableConnection.java
@@ -127,7 +127,13 @@ public class BigtableConnection implements Connection, Closeable {
       batchPool = getBatchPool();
     }
 
-    this.options = BigtableOptionsFactory.fromConfiguration(conf);
+    try {
+      this.options = BigtableOptionsFactory.fromConfiguration(conf);
+    } catch (IOException ioe) {
+      LOG.error("Error loading BigtableOptions from Configuration.", ioe);
+      throw ioe;
+    }
+
     TransportOptions dataTransportOptions = options.getDataTransportOptions();
     ChannelOptions channelOptions = options.getChannelOptions();
     TransportOptions tableAdminTransportOptions = options.getTableAdminTransportOptions();
@@ -155,8 +161,13 @@ public class BigtableConnection implements Connection, Closeable {
       ChannelOptions channelOptions,
       ExecutorService executorService) {
 
-    return BigtableTableAdminGrpcClient.createClient(
-        tableAdminTransportOptions, channelOptions, executorService);
+    try {
+      return BigtableTableAdminGrpcClient.createClient(
+          tableAdminTransportOptions, channelOptions, executorService);
+    } catch (RuntimeException re) {
+      LOG.error("Error constructing table admin client.", re);
+      throw re;
+    }
   }
 
   protected BigtableClient getBigtableClient(
@@ -164,8 +175,13 @@ public class BigtableConnection implements Connection, Closeable {
       ChannelOptions channelOptions,
       ExecutorService executorService) {
 
-    return BigtableGrpcClient.createClient(
-        dataTransportOptions, channelOptions, executorService);
+    try {
+      return BigtableGrpcClient.createClient(
+          dataTransportOptions, channelOptions, executorService);
+    } catch (RuntimeException re) {
+      LOG.error("Error constructing data client.", re);
+      throw re;
+    }
   }
 
   @Override


### PR DESCRIPTION
This adds error-level log lines when an exception is raised from the
BigtableConnection constructor. This is intended primarily to aid in
debugging hbase shell issues.