### PR TITLE
Makings BigtableOptionsFactory usable without an HBase Configuration 

### DIFF
--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/CheckConfig.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/CheckConfig.java
@@ -46,7 +46,7 @@ public class CheckConfig {
 
     BigtableOptions options;
     try {
-      options = BigtableOptionsFactory.fromConfiguration(fullConfiguration);
+      options = HBaseBigtableOptionsFactory.fromConfiguration(fullConfiguration);
     } catch (IOException | RuntimeException exc) {
       logger.warn("Encountered errors attempting to parse configuration.", exc);
       return;

--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/HBaseBigtableOptionsFactory.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/HBaseBigtableOptionsFactory.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase;
+
+import java.io.IOException;
+
+import org.apache.hadoop.conf.Configuration;
+
+import com.google.cloud.bigtable.config.BigtableOptions;
+import com.google.cloud.bigtable.config.BigtableOptions.Builder;
+import com.google.cloud.bigtable.config.BigtableOptionsFactory;
+import com.google.cloud.bigtable.config.BigtableOptionsFactory.PropertyRetriever;
+
+/**
+ * Static methods to convert an instance of {@link Configuration}
+ * to a {@link BigtableOptions} instance.
+ */
+public class HBaseBigtableOptionsFactory {
+
+  private static class ConfigurationPropertiesAdapter implements BigtableOptionsFactory.PropertyRetriever {
+
+    private final Configuration configuration;
+
+    public ConfigurationPropertiesAdapter(Configuration configuration) {
+      this.configuration = configuration;
+    }
+
+    @Override
+    public String get(String key) {
+      return configuration.get(key);
+    }
+
+    @Override
+    public String get(String key, String defaultValue) {
+      return configuration.get(key, defaultValue);
+    }
+
+    @Override
+    public int getInt(String key, int defaultValue) {
+      return configuration.getInt(key, defaultValue);
+    }
+
+    @Override
+    public long getLong(String key, long defaultValue) {
+      return configuration.getLong(key, defaultValue);
+    }
+
+    @Override
+    public boolean getBoolean(String key, boolean defaultValue) {
+      return configuration.getBoolean(key, defaultValue);
+    }
+  }
+
+  public static BigtableOptions fromConfiguration(final Configuration configuration) throws IOException {
+    PropertyRetriever properties = new ConfigurationPropertiesAdapter(configuration);
+    Builder optionsBuilder = BigtableOptionsFactory.fromProperties(properties);
+    optionsBuilder.setUserAgent(BigtableConstants.USER_AGENT);
+    return optionsBuilder.build();
+  }
+}

--- a/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableConnection.java
+++ b/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableConnection.java
@@ -7,10 +7,12 @@ import org.apache.hadoop.hbase.client.AbstractBigtableAdmin;
 import org.apache.hadoop.hbase.client.AbstractBigtableConnection;
 import org.apache.hadoop.hbase.client.Admin;
 
+import com.google.cloud.bigtable.config.BigtableOptions;
+
 public class TestBigtableConnection extends AbstractBigtableConnection {
 
-  public TestBigtableConnection(Configuration conf) throws IOException {
-    super(conf);
+  public TestBigtableConnection(Configuration conf, BigtableOptions options) throws IOException {
+    super(conf, options);
   }
 
   @Override

--- a/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableOptionsFactory.java
+++ b/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableOptionsFactory.java
@@ -28,6 +28,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 import com.google.cloud.bigtable.config.BigtableOptions;
+import com.google.cloud.bigtable.config.BigtableOptionsFactory;
 
 @RunWith(JUnit4.class)
 public class TestBigtableOptionsFactory {
@@ -57,7 +58,7 @@ public class TestBigtableOptionsFactory {
     configuration.unset(BigtableOptionsFactory.PROJECT_ID_KEY);
 
     expectedException.expect(IllegalArgumentException.class);
-    BigtableOptionsFactory.fromConfiguration(configuration);
+    HBaseBigtableOptionsFactory.fromConfiguration(configuration);
   }
 
   @Test
@@ -66,7 +67,7 @@ public class TestBigtableOptionsFactory {
     configuration.unset(BigtableOptionsFactory.BIGTABLE_HOST_KEY);
 
     expectedException.expect(IllegalArgumentException.class);
-    BigtableOptionsFactory.fromConfiguration(configuration);
+    HBaseBigtableOptionsFactory.fromConfiguration(configuration);
   }
 
   @Test
@@ -75,7 +76,7 @@ public class TestBigtableOptionsFactory {
     configuration.unset(BigtableOptionsFactory.CLUSTER_KEY);
 
     expectedException.expect(IllegalArgumentException.class);
-    BigtableOptionsFactory.fromConfiguration(configuration);
+    HBaseBigtableOptionsFactory.fromConfiguration(configuration);
   }
 
   @Test
@@ -84,7 +85,7 @@ public class TestBigtableOptionsFactory {
     configuration.unset(BigtableOptionsFactory.ZONE_KEY);
 
     expectedException.expect(IllegalArgumentException.class);
-    BigtableOptionsFactory.fromConfiguration(configuration);
+    HBaseBigtableOptionsFactory.fromConfiguration(configuration);
   }
 
   @Test
@@ -93,7 +94,7 @@ public class TestBigtableOptionsFactory {
     configuration.set(BigtableOptionsFactory.BIGTABLE_TABLE_ADMIN_HOST_KEY, TEST_HOST);
     configuration.setBoolean(BigtableOptionsFactory.BIGTABE_USE_SERVICE_ACCOUNTS_KEY, false);
     configuration.setBoolean(BigtableOptionsFactory.BIGTABLE_NULL_CREDENTIAL_ENABLE_KEY, true);
-    BigtableOptions options = BigtableOptionsFactory.fromConfiguration(configuration);
+    BigtableOptions options = HBaseBigtableOptionsFactory.fromConfiguration(configuration);
     Assert.assertEquals(TEST_HOST, options.getTableAdminTransportOptions().getHost().getHostName());
   }
 
@@ -102,7 +103,7 @@ public class TestBigtableOptionsFactory {
     configuration.set(BigtableOptionsFactory.BIGTABLE_HOST_KEY, TEST_HOST);
     configuration.setBoolean(BigtableOptionsFactory.BIGTABE_USE_SERVICE_ACCOUNTS_KEY, false);
     configuration.setBoolean(BigtableOptionsFactory.BIGTABLE_NULL_CREDENTIAL_ENABLE_KEY, true);
-    BigtableOptions options = BigtableOptionsFactory.fromConfiguration(configuration);
+    BigtableOptions options = HBaseBigtableOptionsFactory.fromConfiguration(configuration);
     Assert.assertEquals(TEST_HOST, options.getDataTransportOptions().getHost().getHostName());
     Assert.assertEquals(TEST_PROJECT_ID, options.getProjectId());
     Assert.assertEquals(TEST_CLUSTER_NAME, options.getCluster());
@@ -121,7 +122,7 @@ public class TestBigtableOptionsFactory {
     configuration.setBoolean(BigtableOptionsFactory.BIGTABE_USE_SERVICE_ACCOUNTS_KEY, false);
     configuration.setBoolean(BigtableOptionsFactory.BIGTABLE_NULL_CREDENTIAL_ENABLE_KEY, true);
     configuration.setLong(BigtableOptionsFactory.BIGTABLE_CHANNEL_TIMEOUT_MS_KEY, 60000);
-    BigtableOptionsFactory.fromConfiguration(configuration);
+    HBaseBigtableOptionsFactory.fromConfiguration(configuration);
   }
 
   @Test
@@ -131,7 +132,7 @@ public class TestBigtableOptionsFactory {
     configuration.setBoolean(BigtableOptionsFactory.BIGTABLE_NULL_CREDENTIAL_ENABLE_KEY, true);
     configuration.setLong(BigtableOptionsFactory.BIGTABLE_CHANNEL_TIMEOUT_MS_KEY, 59999);
     expectedException.expect(IllegalArgumentException.class);
-    BigtableOptionsFactory.fromConfiguration(configuration);
+    HBaseBigtableOptionsFactory.fromConfiguration(configuration);
   }
 
   @Test
@@ -140,7 +141,7 @@ public class TestBigtableOptionsFactory {
     configuration.setBoolean(BigtableOptionsFactory.BIGTABE_USE_SERVICE_ACCOUNTS_KEY, false);
     configuration.setBoolean(BigtableOptionsFactory.BIGTABLE_NULL_CREDENTIAL_ENABLE_KEY, true);
     configuration.setLong(BigtableOptionsFactory.BIGTABLE_CHANNEL_TIMEOUT_MS_KEY, 0);
-    BigtableOptionsFactory.fromConfiguration(configuration);
+    HBaseBigtableOptionsFactory.fromConfiguration(configuration);
   }
 
 }

--- a/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestClusterAPI.java
+++ b/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestClusterAPI.java
@@ -21,7 +21,6 @@ import io.grpc.Status.OperationRuntimeException;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map.Entry;
 import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.Executors;
@@ -52,6 +51,7 @@ import com.google.bigtable.admin.cluster.v1.ListZonesRequest;
 import com.google.bigtable.admin.cluster.v1.ListZonesResponse;
 import com.google.bigtable.admin.cluster.v1.Zone;
 import com.google.cloud.bigtable.config.BigtableOptions;
+import com.google.cloud.bigtable.config.BigtableOptionsFactory;
 import com.google.cloud.bigtable.grpc.BigtableClusterAdminClient;
 import com.google.cloud.bigtable.grpc.BigtableClusterAdminGrpcClient;
 import com.google.common.util.concurrent.UncheckedExecutionException;
@@ -67,6 +67,46 @@ public class TestClusterAPI {
   private static final String TEST_CLUSTER_ID = "test-cluster-api";
   public static final byte[] COLUMN_FAMILY = Bytes.toBytes("test_family");
 
+  private static class EnvironmentVariableProperties implements BigtableOptionsFactory.PropertyRetriever {
+    @Override
+    public String get(String key) {
+      return System.getProperty(key);
+    }
+
+    @Override
+    public String get(String key, String defaultValue) {
+      return System.getProperty(key, defaultValue);
+    }
+
+    @Override
+    public int getInt(String key, int defaultValue) {
+      if (System.getProperties().contains(key)) {
+        return new Integer(get(key));
+      } else {
+        return defaultValue;
+      }
+    }
+
+    @Override
+    public long getLong(String key, long defaultValue) {
+      if (System.getProperties().contains(key)) {
+        return new Long(get(key));
+      } else {
+        return defaultValue;
+      }
+    }
+
+    @Override
+    public boolean getBoolean(String key, boolean defaultValue) {
+      if (System.getProperties().contains(key)) {
+        return new Boolean(get(key));
+      } else {
+        return defaultValue;
+      }
+    }
+
+  }
+
   @Test
   public void setup() throws IOException {
     String shouldTest = System.getProperty("bigtable.test.cluster.api");
@@ -74,15 +114,13 @@ public class TestClusterAPI {
       return;
     }
 
-    Configuration configuration = new Configuration();
-    for (Entry<Object, Object> entry : System.getProperties().entrySet()) {
-      configuration.set(entry.getKey().toString(), entry.getValue().toString());
-    }
+    BigtableOptions.Builder optionsBuilder =
+        BigtableOptionsFactory.fromProperties(new EnvironmentVariableProperties());
+    optionsBuilder.setUserAgent("TestClusterAPI - Java");
+    BigtableOptions options = optionsBuilder.build();
+    BigtableClusterAdminClient client = createClusterAdminStub(options);
 
-    BigtableOptions originalOptions = BigtableOptionsFactory.fromConfiguration(configuration);
-    BigtableClusterAdminClient client = createClusterAdminStub(originalOptions);
-
-    String projectId = originalOptions.getProjectId();
+    String projectId = options.getProjectId();
     List<Cluster> clusters = getClusters(client, projectId);
 
     // cleanup any old clusters
@@ -99,14 +137,16 @@ public class TestClusterAPI {
     Cluster cluster = createACluster(client, fullyQualifiedZoneName, TEST_CLUSTER_ID);
     waitForOperation(client, cluster.getCurrentOperation().getName(), MAX_WAIT_SECONDS);
 
-    configuration.set(BigtableOptionsFactory.ZONE_KEY,
-      clusterId.replaceFirst(".*/zones/([^/]+)/.*", "$1"));
-    configuration.set(BigtableOptionsFactory.CLUSTER_KEY,
-      clusterId.replaceFirst(".*/clusters/([^/]+)", "$1"));
+    optionsBuilder.setZone(clusterId.replaceFirst(".*/zones/([^/]+)/.*", "$1"));
+    optionsBuilder.setCluster(TEST_CLUSTER_ID);
 
     TableName autoDeletedTableName =
         TableName.valueOf("auto-deleted-" + UUID.randomUUID().toString());
-    try (Connection connection = new TestBigtableConnection(configuration);
+
+    // The Configuration is used for optional parameters, and we don't want to provide any for this
+    // test. The BigtableOptions drives the core connection configuration.
+    try (Connection connection =
+        new TestBigtableConnection(new Configuration(), optionsBuilder.build());
         Admin admin = connection.getAdmin()) {
       countTables(admin, 0);
       createTable(admin, autoDeletedTableName);


### PR DESCRIPTION
Moving BigtableOptionsFactory to bigtable-grpc so that the connection configuration can be done without having an HBase Configuration object.

This is a step towards getting a Bigtable API that's independent of hbase 