### PR TITLE
Add support for HBase PageFilters.

### DIFF
--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/DefaultReadHooks.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/DefaultReadHooks.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.adapters;
+
+import com.google.bigtable.v1.ReadRowsRequest;
+import com.google.common.base.Function;
+import com.google.common.base.Functions;
+
+/**
+ * Default implementation of {@link ReadHooks}.
+ */
+public class DefaultReadHooks implements ReadHooks {
+  private Function<ReadRowsRequest, ReadRowsRequest> preSendHook = Functions.identity();
+  public void composePreSendHook(Function<ReadRowsRequest, ReadRowsRequest> newHook) {
+    preSendHook = Functions.compose(newHook, preSendHook);
+  }
+
+  @Override
+  public ReadRowsRequest applyPreSendHook(ReadRowsRequest readRowsRequest) {
+    return preSendHook.apply(readRowsRequest);
+  }
+}

--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/GetAdapter.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/GetAdapter.java
@@ -16,6 +16,7 @@
 package com.google.cloud.bigtable.hbase.adapters;
 
 import com.google.bigtable.v1.ReadRowsRequest;
+import com.google.bigtable.v1.ReadRowsRequest.Builder;
 import com.google.protobuf.ByteString;
 
 import org.apache.hadoop.hbase.client.Get;
@@ -25,7 +26,7 @@ import org.apache.hadoop.hbase.client.Scan;
  * A Get adapter that transform the Get into a ReadRowsRequest using the proto-based
  * filter language.
  */
-public class GetAdapter implements OperationAdapter<Get, ReadRowsRequest.Builder> {
+public class GetAdapter implements ReadOperationAdapter<Get> {
 
   protected final ScanAdapter scanAdapter;
   public GetAdapter(ScanAdapter scanAdapter) {
@@ -33,11 +34,11 @@ public class GetAdapter implements OperationAdapter<Get, ReadRowsRequest.Builder
   }
 
   @Override
-  public ReadRowsRequest.Builder adapt(Get operation) {
+  public Builder adapt(Get operation, ReadHooks readHooks) {
     Scan operationAsScan = new Scan(operation);
     scanAdapter.throwIfUnsupportedScan(operationAsScan);
     return ReadRowsRequest.newBuilder()
-        .setFilter(scanAdapter.buildFilter(operationAsScan))
+        .setFilter(scanAdapter.buildFilter(operationAsScan, readHooks))
         .setRowKey(ByteString.copyFrom(operation.getRow()));
   }
 }

--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/ReadHooks.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/ReadHooks.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.adapters;
+
+import com.google.bigtable.v1.ReadRowsRequest;
+import com.google.common.base.Function;
+
+/**
+ * Hooks for modifying a ReadRowsRequest before being sent to Cloud Bigtable.
+ *
+ * Note that it is expected that this will be extended to include post-read
+ * hooks to transform Rows when appropriate.
+ */
+public interface ReadHooks {
+
+  /**
+   * Add a Function that will modify the ReadRowsRequest before it is sent to Cloud Bigtable.
+   */
+  void composePreSendHook(Function<ReadRowsRequest, ReadRowsRequest> newHook);
+
+  /**
+   * Apply all pre-send hooks to the given request.
+   */
+  ReadRowsRequest applyPreSendHook(ReadRowsRequest readRowsRequest);
+}

--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/ReadOperationAdapter.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/ReadOperationAdapter.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.adapters;
+
+import com.google.bigtable.v1.ReadRowsRequest;
+
+import org.apache.hadoop.hbase.client.Operation;
+
+/**
+ * Interface used for Scan and Get operation adapters.
+ */
+public interface ReadOperationAdapter<T extends Operation> {
+  ReadRowsRequest.Builder adapt(T request, ReadHooks readHooks);
+}

--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/FilterListAdapter.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/FilterListAdapter.java
@@ -77,8 +77,10 @@ public class FilterListAdapter
       FilterAdapterContext context,
       FilterList filter) {
     List<FilterSupportStatus> unsupportedSubfilters = new ArrayList<>();
-    collectUnsupportedStatuses(context, filter, unsupportedSubfilters);
-    if (!unsupportedSubfilters.isEmpty()) {
+    try (ContextCloseable ignored = context.beginFilterList(filter)) {
+      collectUnsupportedStatuses(context, filter, unsupportedSubfilters);
+    }
+    if (unsupportedSubfilters.isEmpty()) {
       return FilterSupportStatus.SUPPORTED;
     } else {
       return FilterSupportStatus.newCompositeNotSupported(unsupportedSubfilters);

--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/PageFilterAdapter.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/PageFilterAdapter.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.adapters.filters;
+
+import com.google.bigtable.v1.ReadRowsRequest;
+import com.google.bigtable.v1.RowFilter;
+import com.google.common.base.Function;
+import com.google.common.base.Optional;
+
+import org.apache.hadoop.hbase.filter.FilterList;
+import org.apache.hadoop.hbase.filter.FilterList.Operator;
+import org.apache.hadoop.hbase.filter.PageFilter;
+
+import java.io.IOException;
+
+/**
+ * A TypedFilterAdapter for adapting PageFilter instances.
+ */
+public class PageFilterAdapter implements TypedFilterAdapter<PageFilter> {
+
+  private static final FilterSupportStatus TOP_LEVEL_ONLY =
+      FilterSupportStatus.newNotSupported(
+          "Page filters may only appear as top level filters or be contained within "
+              + "a top-level FilterList instances with MUST_PASS_ALL as its Operator");
+
+  @Override
+  public RowFilter adapt(FilterAdapterContext context, PageFilter filter) throws IOException {
+    final long pageSize = filter.getPageSize();
+    context.getReadHooks().composePreSendHook(new Function<ReadRowsRequest, ReadRowsRequest>() {
+      @Override
+      public ReadRowsRequest apply(ReadRowsRequest request) {
+        return request.toBuilder().setNumRowsLimit(pageSize).build();
+      }
+    });
+    // This filter cannot be translated to a RowFilter, all logic is done as a read hook.
+    return null;
+  }
+
+  @Override
+  public FilterSupportStatus isFilterSupported(FilterAdapterContext context, PageFilter filter) {
+    Optional<FilterList> currentList = context.getCurrentFilterList();
+    if ((currentList.isPresent() && !isFilterListSupported(currentList.get(), filter))
+        || context.getFilterListDepth() > 1) {
+      return TOP_LEVEL_ONLY;
+    }
+    return FilterSupportStatus.SUPPORTED;
+  }
+
+  private static boolean isFilterListSupported(FilterList list, PageFilter currentFilter) {
+    // The PageFilter must be the last filter in the FilterList && it must only appear once
+    // in the FilterList (perhaps this second part is a pathological case that isn't worthy
+    // of the cycles required to traverse the list)...
+    return list.getOperator() == Operator.MUST_PASS_ALL
+        && list.getFilters().indexOf(currentFilter) == list.getFilters().size() - 1;
+  }
+}

--- a/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestColumnCountGetFilterAdapter.java
+++ b/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestColumnCountGetFilterAdapter.java
@@ -36,7 +36,7 @@ public class TestColumnCountGetFilterAdapter {
   public void testSimpleColumnCount() throws IOException {
     RowFilter adaptedFilter =
         adapter.adapt(
-            new FilterAdapterContext(new Scan()),
+            new FilterAdapterContext(new Scan(), null),
             new ColumnCountGetFilter(2));
     Assert.assertEquals(
         RowFilter.newBuilder()

--- a/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestColumnPaginationFilterAdapter.java
+++ b/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestColumnPaginationFilterAdapter.java
@@ -40,7 +40,7 @@ public class TestColumnPaginationFilterAdapter {
   public void integerLimitsAreApplied() throws IOException {
     ColumnPaginationFilter filter = new ColumnPaginationFilter(10, 20);
     RowFilter adaptedFilter = adapter.adapt(
-        new FilterAdapterContext(new Scan()), filter);
+        new FilterAdapterContext(new Scan(), null), filter);
     Assert.assertEquals(
         RowFilter.newBuilder()
             .setChain(
@@ -59,7 +59,7 @@ public class TestColumnPaginationFilterAdapter {
   public void zeroOffsetLimitIsSupported() throws IOException {
     ColumnPaginationFilter filter = new ColumnPaginationFilter(10, 0);
     RowFilter adaptedFilter = adapter.adapt(
-        new FilterAdapterContext(new Scan()), filter);
+        new FilterAdapterContext(new Scan(), null), filter);
     Assert.assertEquals(
         RowFilter.newBuilder()
             .setChain(
@@ -78,7 +78,7 @@ public class TestColumnPaginationFilterAdapter {
         new ColumnPaginationFilter(10, Bytes.toBytes("q1"));
     RowFilter adaptedFilter = adapter.adapt(
         new FilterAdapterContext(
-            new Scan().addFamily(Bytes.toBytes("f1"))),
+            new Scan().addFamily(Bytes.toBytes("f1")), null),
         filter);
     Assert.assertEquals(
         RowFilter.newBuilder()

--- a/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestColumnPrefixFilterAdapter.java
+++ b/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestColumnPrefixFilterAdapter.java
@@ -32,7 +32,7 @@ public class TestColumnPrefixFilterAdapter {
 
   ColumnPrefixFilterAdapter adapter = new ColumnPrefixFilterAdapter();
   Scan emptyScan = new Scan();
-  FilterAdapterContext emptyScanContext = new FilterAdapterContext(emptyScan);
+  FilterAdapterContext emptyScanContext = new FilterAdapterContext(emptyScan, null);
 
   @Test
   public void columnPrefixFiltersAreAdapted() throws IOException {

--- a/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestColumnRangeFilterAdapter.java
+++ b/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestColumnRangeFilterAdapter.java
@@ -32,7 +32,7 @@ public class TestColumnRangeFilterAdapter {
 
   ColumnRangeFilterAdapter filterAdapter = new ColumnRangeFilterAdapter();
   Scan emptyScan = new Scan();
-  FilterAdapterContext emptyScanContext = new FilterAdapterContext(emptyScan);
+  FilterAdapterContext emptyScanContext = new FilterAdapterContext(emptyScan, null);
 
   @Test
   public void testColumnRangeFilterThrowsWithNoFamilies() throws IOException {
@@ -47,7 +47,7 @@ public class TestColumnRangeFilterAdapter {
         Bytes.toBytes("a"), true, Bytes.toBytes("b"), false);
     Scan familyScan = new Scan().addFamily(Bytes.toBytes("foo"));
     RowFilter rowFilter = filterAdapter.adapt(
-        new FilterAdapterContext(familyScan), filter);
+        new FilterAdapterContext(familyScan, null), filter);
 
     Assert.assertEquals(
         "a",

--- a/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestFilterListAdapter.java
+++ b/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestFilterListAdapter.java
@@ -38,7 +38,7 @@ public class TestFilterListAdapter {
   // and the filter adapter.
   FilterAdapter filterAdapter = FilterAdapter.buildAdapter();
   Scan emptyScan = new Scan();
-  FilterAdapterContext emptyScanContext = new FilterAdapterContext(emptyScan);
+  FilterAdapterContext emptyScanContext = new FilterAdapterContext(emptyScan, null);
 
   FilterList makeFilterList(Operator filterOperator) {
     return new FilterList(
@@ -50,7 +50,7 @@ public class TestFilterListAdapter {
   @Test
   public void interleavedFiltersAreAdapted() throws IOException {
     FilterList filterList = makeFilterList(Operator.MUST_PASS_ONE);
-    RowFilter rowFilter = filterAdapter.adaptFilter(emptyScanContext, filterList);
+    RowFilter rowFilter = filterAdapter.adaptFilter(emptyScanContext, filterList).get();
     Assert.assertEquals(
         "value",
         rowFilter.getInterleave().getFilters(0).getValueRegexFilter().toStringUtf8());
@@ -62,7 +62,7 @@ public class TestFilterListAdapter {
   @Test
   public void chainedFiltersAreAdapted() throws IOException {
     FilterList filterList = makeFilterList(Operator.MUST_PASS_ALL);
-    RowFilter rowFilter = filterAdapter.adaptFilter(emptyScanContext, filterList);
+    RowFilter rowFilter = filterAdapter.adaptFilter(emptyScanContext, filterList).get();
     Assert.assertEquals(
         "value",
         rowFilter.getChain().getFilters(0).getValueRegexFilter().toStringUtf8());

--- a/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestFilterListAdapter.java
+++ b/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestFilterListAdapter.java
@@ -20,16 +20,20 @@ import com.google.bigtable.v1.RowFilter;
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.filter.BinaryComparator;
 import org.apache.hadoop.hbase.filter.CompareFilter.CompareOp;
+import org.apache.hadoop.hbase.filter.Filter;
 import org.apache.hadoop.hbase.filter.FilterList;
 import org.apache.hadoop.hbase.filter.FilterList.Operator;
 import org.apache.hadoop.hbase.filter.ValueFilter;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 @RunWith(JUnit4.class)
 public class TestFilterListAdapter {
@@ -38,7 +42,12 @@ public class TestFilterListAdapter {
   // and the filter adapter.
   FilterAdapter filterAdapter = FilterAdapter.buildAdapter();
   Scan emptyScan = new Scan();
-  FilterAdapterContext emptyScanContext = new FilterAdapterContext(emptyScan, null);
+  FilterAdapterContext emptyScanContext = null;
+
+  @Before
+  public void setup() {
+    emptyScanContext = new FilterAdapterContext(emptyScan, null);
+  }
 
   FilterList makeFilterList(Operator filterOperator) {
     return new FilterList(
@@ -69,5 +78,48 @@ public class TestFilterListAdapter {
     Assert.assertEquals(
         "value2",
         rowFilter.getChain().getFilters(1).getValueRegexFilter().toStringUtf8());
+  }
+
+  @Test
+  public void compositeFilterSupportStatusIsReturnedForUnsupportedChildFilters() {
+    FilterListAdapter filterListAdapter = new FilterListAdapter(new FilterAdapter() {
+      @Override
+      public void collectUnsupportedStatuses(FilterAdapterContext context, Filter filter,
+          List<FilterSupportStatus> statuses) {
+        Assert.assertEquals(
+            "FilterListDepth should be incremented in isFilterSupported.",
+            1,
+            context.getFilterListDepth());
+        statuses.add(FilterSupportStatus.newNotSupported("Test"));
+      }
+    });
+
+    FilterList filterList = makeFilterList(Operator.MUST_PASS_ALL);
+    FilterSupportStatus status = filterListAdapter.isFilterSupported(emptyScanContext, filterList);
+    Assert.assertFalse(
+        "collectUnsupportedStatuses should have been invoked returning unsupported statuses.",
+        status.isSupported());
+  }
+
+  @Test
+  public void collectUnsupportedStatusesStartsANewContext() {
+    FilterListAdapter filterListAdapter = new FilterListAdapter(new FilterAdapter() {
+      @Override
+      public void collectUnsupportedStatuses(FilterAdapterContext context, Filter filter,
+          List<FilterSupportStatus> statuses) {
+        Assert.assertEquals(
+            "FilterListDepth should be incremented in isFilterSupported.",
+            1,
+            context.getFilterListDepth());
+        statuses.add(FilterSupportStatus.newNotSupported("Test"));
+      }
+    });
+
+    Assert.assertEquals("Initial depth should be 0.", 0, emptyScanContext.getFilterListDepth());
+    FilterList filterList = makeFilterList(Operator.MUST_PASS_ALL);
+    FilterSupportStatus status = filterListAdapter.isFilterSupported(emptyScanContext, filterList);
+    Assert.assertFalse(
+        "collectUnsupportedStatuses should have been invoked returning unsupported statuses.",
+        status.isSupported());
   }
 }

--- a/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestFirstKeyOnlyFilterAdapter.java
+++ b/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestFirstKeyOnlyFilterAdapter.java
@@ -34,7 +34,7 @@ public class TestFirstKeyOnlyFilterAdapter {
   @Test
   public void onlyTheFirstKeyFromEachRowIsEmitted() throws IOException {
     RowFilter adaptedFilter = adapter.adapt(
-        new FilterAdapterContext(new Scan()), new FirstKeyOnlyFilter());
+        new FilterAdapterContext(new Scan(), null), new FirstKeyOnlyFilter());
     Assert.assertEquals(
         RowFilter.newBuilder()
             .setCellsPerRowLimitFilter(1)

--- a/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestFuzzyRowFilterAdapter.java
+++ b/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestFuzzyRowFilterAdapter.java
@@ -37,7 +37,7 @@ import java.util.List;
 public class TestFuzzyRowFilterAdapter {
   FuzzyRowFilterAdapter adapter = new FuzzyRowFilterAdapter();
   Scan emptyScan = new Scan();
-  FilterAdapterContext context = new FilterAdapterContext(emptyScan);
+  FilterAdapterContext context = new FilterAdapterContext(emptyScan, null);
 
   @Test
   public void fuzzyKeysAreTranslatedToRegularExpressions() throws IOException {

--- a/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestKeyOnlyFilterAdapter.java
+++ b/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestKeyOnlyFilterAdapter.java
@@ -31,7 +31,7 @@ public class TestKeyOnlyFilterAdapter {
 
   KeyOnlyFilterAdapter filterAdapter = new KeyOnlyFilterAdapter();
   Scan emptyScan = new Scan();
-  FilterAdapterContext emptyScanContext = new FilterAdapterContext(emptyScan);
+  FilterAdapterContext emptyScanContext = new FilterAdapterContext(emptyScan, null);
 
   @Test
   public void stripValuesIsApplied() throws IOException {

--- a/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestMultipleColumnPrefxiFilterAdapter.java
+++ b/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestMultipleColumnPrefxiFilterAdapter.java
@@ -33,7 +33,7 @@ public class TestMultipleColumnPrefxiFilterAdapter {
 
   MultipleColumnPrefixFilterAdapter filterAdapter = new MultipleColumnPrefixFilterAdapter();
   Scan emptyScan = new Scan();
-  FilterAdapterContext emptyScanContext = new FilterAdapterContext(emptyScan);
+  FilterAdapterContext emptyScanContext = new FilterAdapterContext(emptyScan, null);
 
   @Test
   public void multiplePrefixesAreAdapted() throws IOException {

--- a/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestPageFilterAdapter.java
+++ b/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestPageFilterAdapter.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.adapters.filters;
+
+import com.google.bigtable.v1.ReadRowsRequest;
+import com.google.bigtable.v1.RowFilter;
+import com.google.cloud.bigtable.hbase.adapters.DefaultReadHooks;
+import com.google.cloud.bigtable.hbase.adapters.ReadHooks;
+import com.google.cloud.bigtable.hbase.adapters.filters.FilterAdapterContext.ContextCloseable;
+
+
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.filter.BinaryComparator;
+import org.apache.hadoop.hbase.filter.CompareFilter.CompareOp;
+import org.apache.hadoop.hbase.filter.FilterList;
+import org.apache.hadoop.hbase.filter.FilterList.Operator;
+import org.apache.hadoop.hbase.filter.PageFilter;
+import org.apache.hadoop.hbase.filter.ValueFilter;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.io.IOException;
+
+@RunWith(JUnit4.class)
+public class TestPageFilterAdapter {
+
+  PageFilterAdapter pageFilterAdapter = new PageFilterAdapter();
+  @Test
+  public void mustPassOneIsNotSupported() {
+    FilterAdapterContext context = new FilterAdapterContext(new Scan(), new DefaultReadHooks());
+    PageFilter filter = new PageFilter(20);
+    FilterList filterList = new FilterList(Operator.MUST_PASS_ONE, filter);
+    try(ContextCloseable ignroed = context.beginFilterList(filterList)) {
+      FilterSupportStatus status =
+          pageFilterAdapter.isFilterSupported(context, filter);
+      Assert.assertFalse(
+          "MUST_PASS_ONE FilterLists should not be supported.", status.isSupported());
+    }
+  }
+
+  @Test
+  public void topLevelPageFilterIsSupported() {
+    FilterAdapterContext context = new FilterAdapterContext(new Scan(), new DefaultReadHooks());
+    PageFilter filter = new PageFilter(20);
+    FilterSupportStatus status =
+        pageFilterAdapter.isFilterSupported(context, filter);
+    Assert.assertTrue(
+        "Top-level page filter should be supported", status.isSupported());
+  }
+
+  @Test
+  public void mustPassAllIsSupportedAtTopLevel() {
+    FilterAdapterContext context = new FilterAdapterContext(new Scan(), new DefaultReadHooks());
+    PageFilter filter = new PageFilter(20);
+    FilterList filterList = new FilterList(Operator.MUST_PASS_ALL, filter);
+    try(ContextCloseable ignored = context.beginFilterList(filterList)) {
+      FilterSupportStatus status =
+          pageFilterAdapter.isFilterSupported(context, filter);
+      Assert.assertTrue(
+          "MUST_PASS_ALL should be supported at the top-level.", status.isSupported());
+    }
+  }
+
+  @Test
+  public void pageFilterMustBeInLastPosition() {
+    FilterAdapterContext context = new FilterAdapterContext(new Scan(), new DefaultReadHooks());
+    ValueFilter valueFilter =
+        new ValueFilter(CompareOp.EQUAL, new BinaryComparator(Bytes.toBytes("value")));
+    PageFilter pageFilter = new PageFilter(20);
+    FilterList filterList = new FilterList(Operator.MUST_PASS_ALL, pageFilter, valueFilter);
+    try(ContextCloseable ignored = context.beginFilterList(filterList)) {
+      FilterSupportStatus status =
+          pageFilterAdapter.isFilterSupported(context, pageFilter);
+      Assert.assertFalse(
+          "PageFilter must be in the last position of a MUST_PASS_ALL filter list",
+          status.isSupported());
+    }
+  }
+
+  @Test
+  public void mustPassAllIsNotSupportedBelowTopLevel() {
+    FilterAdapterContext context = new FilterAdapterContext(new Scan(), new DefaultReadHooks());
+    PageFilter pageFilter = new PageFilter(20);
+    FilterList secondLevelList = new FilterList(Operator.MUST_PASS_ALL, pageFilter);
+    FilterList topLevelList = new FilterList(Operator.MUST_PASS_ALL, secondLevelList);
+    try (ContextCloseable ignored = context.beginFilterList(topLevelList)) {
+      try (ContextCloseable evenMoreIgnored = context.beginFilterList(secondLevelList)) {
+        FilterSupportStatus status =
+            pageFilterAdapter.isFilterSupported(context, pageFilter);
+        Assert.assertFalse(
+            "MUST_PASS_ALL should not be supported lower than top level.", status.isSupported());
+      }
+    }
+  }
+
+  @Test
+  public void pageFilterIsAppliedToReadRowsRequest() throws IOException {
+    ReadHooks hooks = new DefaultReadHooks();
+    FilterAdapterContext context = new FilterAdapterContext(new Scan(), hooks);
+    PageFilter pageFilter = new PageFilter(20);
+    RowFilter adaptedFilter = pageFilterAdapter.adapt(context, pageFilter);
+    Assert.assertNull("PageFilterAdapter should not return a RowFilter.", adaptedFilter);
+
+    ReadRowsRequest request = ReadRowsRequest.newBuilder().setNumRowsLimit(100).build();
+    ReadRowsRequest postHookRequest = hooks.applyPreSendHook(request);
+    Assert.assertEquals(20, postHookRequest.getNumRowsLimit());
+  }
+}

--- a/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestPrefixFilterAdapter.java
+++ b/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestPrefixFilterAdapter.java
@@ -40,7 +40,7 @@ public class TestPrefixFilterAdapter {
     String prefix = "Foobar";
     PrefixFilter filter = new PrefixFilter(Bytes.toBytes(prefix));
     Scan emptyScan = new Scan();
-    FilterAdapterContext context = new FilterAdapterContext(emptyScan);
+    FilterAdapterContext context = new FilterAdapterContext(emptyScan, null);
 
     byte[] prefixRegex = Bytes.toBytes(prefix + "\\C*");
     Assert.assertEquals(

--- a/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestQualifierFilterAdapter.java
+++ b/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestQualifierFilterAdapter.java
@@ -50,7 +50,7 @@ public class TestQualifierFilterAdapter {
   QualifierFilterAdapter adapter = new QualifierFilterAdapter();
   Scan scanWithOnFamily = new Scan().addFamily(Bytes.toBytes(FAMILY_NAME));
   FilterAdapterContext scanWithOnFamilyScanContext =
-      new FilterAdapterContext(scanWithOnFamily);
+      new FilterAdapterContext(scanWithOnFamily, null);
 
   private void assertAdaptedForm(
       ByteArrayComparable comparable, CompareFilter.CompareOp op, RowFilter expectedFilter)

--- a/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestSingleColumnValueFilterAdapter.java
+++ b/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestSingleColumnValueFilterAdapter.java
@@ -53,7 +53,7 @@ public class TestSingleColumnValueFilterAdapter  {
     filter.setLatestVersionOnly(true);
 
     RowFilter adaptedFilter = adapter.adapt(
-        new FilterAdapterContext(new Scan()),
+        new FilterAdapterContext(new Scan(), null),
         filter);
 
     assertFilterIfNotMIssingMatches(
@@ -80,7 +80,7 @@ public class TestSingleColumnValueFilterAdapter  {
     filter.setLatestVersionOnly(false);
 
     RowFilter adaptedFilter = adapter.adapt(
-        new FilterAdapterContext(new Scan()),
+        new FilterAdapterContext(new Scan(), null),
         filter);
 
     assertFilterIfNotMIssingMatches(
@@ -107,7 +107,7 @@ public class TestSingleColumnValueFilterAdapter  {
     filter.setLatestVersionOnly(false);
 
     RowFilter adaptedFilter = adapter.adapt(
-        new FilterAdapterContext(new Scan()),
+        new FilterAdapterContext(new Scan(), null),
         filter);
 
     assertColumnSpecification(

--- a/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestTimestampsFilterAdapter.java
+++ b/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestTimestampsFilterAdapter.java
@@ -30,7 +30,7 @@ public class TestTimestampsFilterAdapter {
 
   TimestampsFilterAdapter filterAdapter = new TimestampsFilterAdapter();
   Scan emptyScan = new Scan();
-  FilterAdapterContext emptyScanContext = new FilterAdapterContext(emptyScan);
+  FilterAdapterContext emptyScanContext = new FilterAdapterContext(emptyScan, null);
 
   @Test
   public void timestampFiltersAreAdapted() {

--- a/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestValueFilterAdapter.java
+++ b/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestValueFilterAdapter.java
@@ -43,7 +43,7 @@ public class TestValueFilterAdapter {
 
   ValueFilterAdapter adapter = new ValueFilterAdapter();
   Scan emptyScan = new Scan();
-  FilterAdapterContext emptyScanContext = new FilterAdapterContext(emptyScan);
+  FilterAdapterContext emptyScanContext = new FilterAdapterContext(emptyScan, null);
 
   private void assertAdaptedForm(
       ByteArrayComparable comparable, CompareFilter.CompareOp op, RowFilter expectedFilter)


### PR DESCRIPTION
Add a PageFilterAdapter which will adapt PageFilter instances so long as
they appear at the top-level or as the last element of the top-most
FilterList.

Add the concept of ReadHooks. Right now, ReadHooks are for modifying a
ReadRowsRequest before sending the request to CBT.

Add a ReadOperationAdapter interface for Scan and Get adapters and move
from plain OperationAdapter to ReadOperationAdapter.