### PR TITLE
Fixing potential problems with resource accounting in BigtableBufferedMutator

### DIFF
--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutator.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutator.java
@@ -4,9 +4,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock.ReadLock;
@@ -36,6 +37,9 @@ import org.apache.hadoop.hbase.client.Mutation;
 import org.apache.hadoop.hbase.client.RetriesExhaustedWithDetailsException;
 import org.apache.hadoop.hbase.client.Row;
 
+import com.google.cloud.bigtable.config.BigtableOptions;
+import com.google.cloud.bigtable.config.Logger;
+import com.google.cloud.bigtable.grpc.BigtableClient;
 import com.google.cloud.bigtable.hbase.adapters.AppendAdapter;
 import com.google.cloud.bigtable.hbase.adapters.DeleteAdapter;
 import com.google.cloud.bigtable.hbase.adapters.GetAdapter;
@@ -48,14 +52,13 @@ import com.google.cloud.bigtable.hbase.adapters.ScanAdapter;
 import com.google.cloud.bigtable.hbase.adapters.TableMetadataSetter;
 import com.google.cloud.bigtable.hbase.adapters.UnsupportedOperationAdapter;
 import com.google.cloud.bigtable.hbase.adapters.filters.FilterAdapter;
-import com.google.cloud.bigtable.config.BigtableOptions;
-import com.google.cloud.bigtable.config.Logger;
-import com.google.cloud.bigtable.grpc.BigtableClient;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.protobuf.GeneratedMessage;
 
 /**
@@ -71,14 +74,20 @@ public class BigtableBufferedMutator implements BufferedMutator {
   // that improper waiting is minimal.
   private static final long WAIT_MILLIS = 250;
 
-  // In flush, wait up to this number of milliseconds without any operations completing.  If
-  // this amount of time goes by without any updates, flush will log a warning.  Flush()
+  // In flush, wait up to this number of milliseconds without any operations completing. If
+  // this amount of time goes by without any updates, flush will log a warning. Flush()
   // will still wait to complete.
-  private static final long INTERVAL_NO_SUCCESS_WARNING = 300000;
+  private static final long COMPLETION_GRACE_PERIOD_MILLIS = 60000;
+
+  protected final ExecutorService heapSizeExecutor = Executors.newCachedThreadPool(
+    new ThreadFactoryBuilder()
+        .setNameFormat("heapSize-async-%s")
+        .setDaemon(true)
+        .build());
 
   /**
-   * This class ensures that operations meet heap size and max RPC counts.  A wait will occur
-   * if RPCs are requested after heap and RPC count thresholds are exceeded.
+   * This class ensures that operations meet heap size and max RPC counts. A wait will occur if RPCs
+   * are requested after heap and RPC count thresholds are exceeded.
    */
   @VisibleForTesting
   static class HeapSizeManager {
@@ -88,8 +97,9 @@ public class BigtableBufferedMutator implements BufferedMutator {
     private long operationSequenceGenerator = 0;
 
     @VisibleForTesting
-    final Map<Long, Long> pendingOperationsWithSize = new HashMap<>();
+    final Map<Long, RequestAccountant> activeRequests = new HashMap<>();
     private long lastOperationChange = System.currentTimeMillis();
+    private long nextLogOrSweep = -1L;
 
     public HeapSizeManager(long maxHeapSize, int maxInflightRpcs) {
       this.maxHeapSize = maxHeapSize;
@@ -101,51 +111,121 @@ public class BigtableBufferedMutator implements BufferedMutator {
     }
 
     public synchronized void waitUntilAllOperationsAreDone() throws InterruptedException {
-      boolean performedWarning = false;
-      while(!pendingOperationsWithSize.isEmpty()) {
-        if (!performedWarning
-            && lastOperationChange + INTERVAL_NO_SUCCESS_WARNING < System.currentTimeMillis()) {
-          long lastUpdated = (System.currentTimeMillis() - lastOperationChange) / 1000;
-          LOG.warn("No operations completed within the last %d seconds."
-              + "There are still %d operations in progress.", lastUpdated,
-            pendingOperationsWithSize.size());
-          performedWarning = true;
-        }
-        wait(WAIT_MILLIS);
+      cleanupCompletedCallbacks();
+      while (!activeRequests.isEmpty()) {
+        waitForCompletions();
       }
-      if (performedWarning) {
-        LOG.info("flush() completed");
-      }
+      LOG.trace("flush() completed");
+      nextLogOrSweep = -1L;
     }
 
-    public synchronized long registerOperationWithHeapSize(long heapSize)
+    /**
+     * Initialize an AccountingFutureCallback once heap size and max in flight rpcs restrictions are
+     * satisfied. This method will block the current thread if heap size or max in flight limits are
+     * violated.
+     */
+    public synchronized void initializeOperation(RequestAccountant callback)
         throws InterruptedException {
-      long operationId = ++operationSequenceGenerator;
-      while (currentWriteBufferSize >= maxHeapSize
-          || pendingOperationsWithSize.size() >= maxInFlightRpcs) {
-        wait(WAIT_MILLIS);
+      while (currentWriteBufferSize >= maxHeapSize || activeRequests.size() >= maxInFlightRpcs) {
+        waitForCompletions();
       }
 
+      callback.operationSequenceId = ++operationSequenceGenerator;
+      currentWriteBufferSize += callback.heapSize;
+      callback.sizeWasAdded = true;
       lastOperationChange = System.currentTimeMillis();
-      pendingOperationsWithSize.put(operationId, heapSize);
-      currentWriteBufferSize += heapSize;
-      return operationId;
     }
 
-    public synchronized void operationComplete(long operationSequenceId) {
-      lastOperationChange = System.currentTimeMillis();
-      Long heapSize = pendingOperationsWithSize.remove(operationSequenceId);
-      if (heapSize != null) {
-        currentWriteBufferSize -= heapSize;
-        notifyAll();
+    /**
+     * Add the callback once it's underlying operation actually started successfully.
+     */
+    public synchronized void registerInvokedCallback(RequestAccountant callback) {
+      // There could have been a backlog of RPCs, and the RPC completed by the time the synchronized
+      // registerInvokedCallback method was finally called. In that case, simply clean up the heap
+      // size. Otherwise, keep track of the callback in the activeRequests Map.
+      if (callback.isRequestDone()) {
+        operationComplete(callback);
       } else {
-        LOG.warn("An operation completion was recieved multiple times. Your operations completed."
-            + " Please notify Google that this occurred.");
+        this.activeRequests.put(callback.operationSequenceId, callback);
+      }
+    }
+
+    public synchronized void operationComplete(RequestAccountant callback) {
+      if (removeAndDecrement(callback)){
+        lastOperationChange = System.currentTimeMillis();
+        notifyAll();
       }
     }
 
     public synchronized boolean hasInflightRequests() {
-      return !pendingOperationsWithSize.isEmpty();
+      return !activeRequests.isEmpty();
+    }
+
+    private void waitForCompletions() throws InterruptedException {
+      long now = System.currentTimeMillis();
+      long lastUpdated = now - lastOperationChange;
+
+      if (now >= nextLogOrSweep && COMPLETION_GRACE_PERIOD_MILLIS < lastUpdated) {
+        if (cleanupCompletedCallbacks()) {
+          return;
+        } else {
+          LOG.warn("No operations completed within the last %d seconds."
+              + "There are still %d operations in progress with buffer size %d ", lastUpdated,
+            activeRequests.size(), currentWriteBufferSize);
+          nextLogOrSweep = System.currentTimeMillis() + COMPLETION_GRACE_PERIOD_MILLIS;
+        }
+      }
+      wait(WAIT_MILLIS);
+    }
+
+    /**
+     * gRPC may have finished operations without calling the callback. Check to make sure that all
+     * registered callbacks that are actually complete are removed from the heap size manager.
+     */
+    private boolean cleanupCompletedCallbacks() {
+      boolean updated = false;
+      for (RequestAccountant callback : new ArrayList<>(activeRequests.values())) {
+        // Remove this callback if somehow the operation completed without the listener being
+        // invoked or if something went wrong during the startup process.
+        if (callback.isRequestDone()) {
+          updated |= removeAndDecrement(callback);
+        }
+      }
+      if (updated) {
+        lastOperationChange = System.currentTimeMillis();
+        notifyAll();
+      }
+      return updated;
+    }
+
+    /**
+     * If the callback was not removed before, then remove it from the callbacks Map and
+     * decrement the heap size from the cumulative currentWriteBufferSize value.
+     *
+     * @return true if either heap size or in flight rpc count changed.
+     */
+    private boolean removeAndDecrement(RequestAccountant callback) {
+      boolean accountingUpdated = false;
+
+      // Update the currentWriteBufferSize.
+      if (callback.sizeWasAdded && !callback.sizeWasRemoved) {
+        currentWriteBufferSize -= callback.getHeapSize();
+        callback.sizeWasRemoved = true;
+        accountingUpdated = true;
+      }
+
+      // Remove the callback if it was in the aggregated Map.
+      if (activeRequests.remove(callback.operationSequenceId) != null) {
+        accountingUpdated = true;
+      }
+
+      // If true, either the currentWriteBufferSize or in flight rpc count were updated
+      return accountingUpdated;
+    }
+
+    @VisibleForTesting
+    synchronized Object getHeapSize() {
+      return currentWriteBufferSize;
     }
   }
 
@@ -162,14 +242,14 @@ public class BigtableBufferedMutator implements BufferedMutator {
 
   private final Configuration configuration;
   private final TableName tableName;
-  
+
   @VisibleForTesting
   final HeapSizeManager sizeManager;
   private boolean closed = false;
 
   /**
-   * Makes sure that mutations and flushes are safe to proceed.  Ensures that while the mutator
-   * is closing, there will be no additional writes.
+   * Makes sure that mutations and flushes are safe to proceed. Ensures that while the mutator is
+   * closing, there will be no additional writes.
    */
   private final ReentrantReadWriteLock mutationLock = new ReentrantReadWriteLock();
   private final BatchExecutor batchExecutor;
@@ -183,26 +263,14 @@ public class BigtableBufferedMutator implements BufferedMutator {
 
   private final String host;
 
-  public BigtableBufferedMutator(
-      Configuration configuration,
-      TableName tableName,
-      int maxInflightRpcs,
-      long maxHeapSize,
-      BigtableClient client,
-      BigtableOptions options,
-      ExecutorService executorService,
-      BufferedMutator.ExceptionListener listener) {
+  public BigtableBufferedMutator(Configuration configuration, TableName tableName,
+      int maxInflightRpcs, long maxHeapSize, BigtableClient client, BigtableOptions options,
+      ExecutorService executorService, BufferedMutator.ExceptionListener listener) {
     this.sizeManager = new HeapSizeManager(maxHeapSize, maxInflightRpcs);
     this.configuration = configuration;
     this.tableName = tableName;
     this.exceptionListener = listener;
-    InetAddress host = null;
-
-    try {
-      host = options.getDataTransportOptions().getHost();
-    } catch (IOException e) {
-      LOG.warn("Could not get the host used for writes", options);
-    }
+    InetAddress host = options.getDataHost();
     this.host = host == null ? null : host.toString();
 
     DeleteAdapter deleteAdapter = new DeleteAdapter();
@@ -211,38 +279,22 @@ public class BigtableBufferedMutator implements BufferedMutator {
     GetAdapter getAdapter = new GetAdapter(scanAdapter);
 
     RowMutationsAdapter rowMutationsAdapter =
-        new RowMutationsAdapter(
-            new MutationAdapter(
-                deleteAdapter,
-                putAdapter,
-                new UnsupportedOperationAdapter<Increment>("increment"),
-                new UnsupportedOperationAdapter<Append>("append")));
+        new RowMutationsAdapter(new MutationAdapter(deleteAdapter, putAdapter,
+            new UnsupportedOperationAdapter<Increment>("increment"),
+            new UnsupportedOperationAdapter<Append>("append")));
 
     ListeningExecutorService listeningExecutorService =
         MoreExecutors.listeningDecorator(executorService);
 
-    batchExecutor = new BatchExecutor(
-        client,
-        options,
-        TableMetadataSetter.from(tableName, options),
-        listeningExecutorService,
-        getAdapter,
-        putAdapter,
-        deleteAdapter,
-        rowMutationsAdapter,
-        new AppendAdapter(),
-        new IncrementAdapter(),
-        new RowAdapter());
+    batchExecutor =
+        new BatchExecutor(client, options, TableMetadataSetter.from(tableName, options),
+            listeningExecutorService, getAdapter, putAdapter, deleteAdapter, rowMutationsAdapter,
+            new AppendAdapter(), new IncrementAdapter(), new RowAdapter());
   }
 
   @VisibleForTesting
-  public BigtableBufferedMutator(
-      BatchExecutor batchExecutor,
-      long maxHeapSize,
-      ExceptionListener exceptionListener,
-      String host,
-      int maxInflightRpcs,
-      TableName tableName) {
+  public BigtableBufferedMutator(BatchExecutor batchExecutor, long maxHeapSize,
+      ExceptionListener exceptionListener, String host, int maxInflightRpcs, TableName tableName) {
     this.batchExecutor = batchExecutor;
     this.configuration = null;
     this.exceptionListener = exceptionListener;
@@ -258,6 +310,7 @@ public class BigtableBufferedMutator implements BufferedMutator {
     try {
       if (!closed) {
         doFlush();
+        heapSizeExecutor.shutdown();
         closed = true;
       }
     } finally {
@@ -321,9 +374,13 @@ public class BigtableBufferedMutator implements BufferedMutator {
   }
 
   /**
-   * Being a Mutation. This method will block if either of the following are true:
-   * 1) There are more than {@code maxInflightRpcs} RPCs in flight
-   * 2) There are more than {@link #getWriteBufferSize()} bytes pending
+   * <p>
+   * This will write a single mutation. This method will block if either of the following are true:
+   * </p>
+   * <ol>
+   * <li>There are more than {@code maxInflightRpcs} RPCs in flight
+   * <li>There are more than {@link #getWriteBufferSize()} bytes pending
+   * </ol>
    */
   @Override
   public void mutate(final Mutation mutation) throws IOException {
@@ -340,21 +397,30 @@ public class BigtableBufferedMutator implements BufferedMutator {
     }
   }
 
-  private void doMutation(final Mutation mutation) throws RetriesExhaustedWithDetailsException {
-    Long sequenceId = null;
+  private void doMutation(final Mutation mutation) throws IOException {
+    RequestAccountant accountant = new RequestAccountant(mutation);
     try {
-      // registerOperationWithHeapSize() waits until both the memory and rpc count maximum
-      // requirements are achieved.
-      sequenceId = sizeManager.registerOperationWithHeapSize(mutation.heapSize());
+      // initializeOperation() waits until heapSize and rpc counts are not at their maximum
+      // values. It then adds the mutation's heapSize to the accumulated value.
+      sizeManager.initializeOperation(accountant);
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
-    }
-    AccountingFutureCallback callback = new AccountingFutureCallback(mutation, sequenceId);
 
-    // TODO: Consider adding the callback in another executor for the blocking call. There are some
-    // concerns running this callback on the rpc threadpool. This callback requires locks on
-    // resources. If they cannot be acquired, the callback would block future completions.
-    Futures.addCallback(batchExecutor.issueRequest(mutation), callback);
+      // Cleanup the callback. We can remove the heapSize from the accumulated heapSize value.
+      accountant.onFailure(e);
+      throw new IOException("doMutation was interruptted", e);
+    }
+    try {
+      accountant.request = batchExecutor.issueRequest(mutation);
+    } catch (RuntimeException e) {
+      // The issueRequest might throw a validation exception or something like that. Make sure that
+      // the callback's clean up method gets invoked so that the HeapSizeManager doesn't block
+      // future requests.
+      accountant.onFailure(e);
+      throw e;
+    }
+    Futures.addCallback(accountant.request, accountant, heapSizeExecutor);
+    sizeManager.registerInvokedCallback(accountant);
   }
 
   /**
@@ -366,14 +432,17 @@ public class BigtableBufferedMutator implements BufferedMutator {
     if (hasExceptions.get()) {
       ArrayList<MutationException> mutationExceptions = null;
       synchronized (globalExceptions) {
-        mutationExceptions = new ArrayList<>(globalExceptions);
-        globalExceptions.clear();
+        if (!hasExceptions.get()) {
+          return;
+        }
         hasExceptions.set(false);
-      }
 
-      if (mutationExceptions.isEmpty()) {
-        // This should never happen.
-        return;
+        if (globalExceptions.isEmpty()) {
+          return;
+        } else {
+          mutationExceptions = new ArrayList<>(globalExceptions);
+          globalExceptions.clear();
+        }
       }
 
       List<Throwable> problems = new ArrayList<>(mutationExceptions.size());
@@ -386,33 +455,54 @@ public class BigtableBufferedMutator implements BufferedMutator {
         hostnames.add(host);
       }
 
-      RetriesExhaustedWithDetailsException exception = new RetriesExhaustedWithDetailsException(
-          problems, failedMutations, hostnames);
+      RetriesExhaustedWithDetailsException exception =
+          new RetriesExhaustedWithDetailsException(problems, failedMutations, hostnames);
       exceptionListener.onException(exception, this);
     }
   }
 
-  private class AccountingFutureCallback implements FutureCallback<GeneratedMessage> {
-    private final long operationSequenceId;
-    private final Row mutation;
+  class RequestAccountant implements FutureCallback<GeneratedMessage> {
+    private final Row row;
+    private final long heapSize;
 
-    public AccountingFutureCallback(Row mutation, long operationSequenceId) {
-      this.mutation = mutation;
-      this.operationSequenceId = operationSequenceId;
+    private Long operationSequenceId;
+    private ListenableFuture<? extends GeneratedMessage> request;
+    private boolean sizeWasAdded = false;
+    private boolean sizeWasRemoved = false;
+
+    public RequestAccountant(Mutation mutation) {
+      this.row = mutation;
+      this.heapSize = mutation.heapSize();
+    }
+
+    public long getHeapSize() {
+      return heapSize;
+    }
+
+    public boolean isRequestDone() {
+      return request != null && request.isDone();
     }
 
     @Override
-    public void onFailure(Throwable t) {
+    public void onFailure(final Throwable t) {
+      sizeManager.operationComplete(this);
       synchronized (globalExceptions) {
-        globalExceptions.add(new MutationException(mutation, t));
+        globalExceptions.add(new MutationException(row, t));
+        hasExceptions.set(true);
       }
-      hasExceptions.set(true);
-      sizeManager.operationComplete(operationSequenceId);
     }
 
     @Override
     public void onSuccess(GeneratedMessage ignored) {
-      sizeManager.operationComplete(operationSequenceId);
+      sizeManager.operationComplete(this);
+    }
+
+    public boolean sizeWasAdded() {
+      return sizeWasAdded;
+    }
+
+    public boolean sizeWasRemoved() {
+      return sizeWasRemoved;
     }
   }
 


### PR DESCRIPTION
Handling a case where the RPC is already complete before it gets registered.