### PR TITLE
Removing netty-all and older netty dependencies.

### DIFF
--- a/bigtable-grpc-interface/pom.xml
+++ b/bigtable-grpc-interface/pom.xml
@@ -49,7 +49,7 @@ limitations under the License.
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
-            <artifactId>netty-all</artifactId>
+            <artifactId>netty-codec-http2</artifactId>
             <version>${netty.version}</version>
         </dependency>
 

--- a/bigtable-hbase-1.1/pom.xml
+++ b/bigtable-hbase-1.1/pom.xml
@@ -105,7 +105,7 @@ limitations under the License.
                                     <include>com.google.protobuf:*</include>
                                     <include>com.twitter:hpack</include>
                                     <include>com.fasterxml.jackson.core:*</include>
-                                    <include>io.netty:netty-all</include>
+                                    <include>io.netty:*</include>
                                     <include>io.grpc:grpc-all</include>
                                 </includes>
                             </artifactSet>

--- a/bigtable-hbase/pom.xml
+++ b/bigtable-hbase/pom.xml
@@ -43,7 +43,7 @@ limitations under the License.
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
-            <artifactId>netty-all</artifactId>
+            <artifactId>netty-codec-http2</artifactId>
             <version>${netty.version}</version>
         </dependency>
 
@@ -110,6 +110,10 @@ limitations under the License.
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hbase</groupId>
+            <artifactId>hadoop-mapreduce-client-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.hbase</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -248,6 +248,17 @@ limitations under the License.
             </dependency>
             <dependency>
                 <groupId>org.apache.hbase</groupId>
+                <artifactId>hadoop-mapreduce-client-core</artifactId>
+                <version>${hbase.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>io.netty</groupId>
+                        <artifactId>netty-all</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.hbase</groupId>
                 <artifactId>hbase-client</artifactId>
                 <version>${hbase.version}</version>
                 <exclusions>
@@ -255,12 +266,22 @@ limitations under the License.
                         <groupId>com.google.protobuf</groupId>
                         <artifactId>protobuf-java</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>io.netty</groupId>
+                        <artifactId>netty-all</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.hbase</groupId>
                 <artifactId>hbase-server</artifactId>
                 <version>${hbase.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>io.netty</groupId>
+                        <artifactId>netty-all</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.hbase</groupId>
@@ -268,6 +289,12 @@ limitations under the License.
                 <version>${hbase.version}</version>
                 <type>test-jar</type>
                 <scope>test</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>io.netty</groupId>
+                        <artifactId>netty-all</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.hbase</groupId>


### PR DESCRIPTION
Older versions of netty-all are exposed via some of the maven dependencies we have.  We need to have a consistent version of netty.