### PR TITLE
Removing netty-all and older netty dependencies.

### DIFF
--- a/bigtable-grpc-interface/pom.xml
+++ b/bigtable-grpc-interface/pom.xml
@@ -49,7 +49,7 @@ limitations under the License.
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
-            <artifactId>netty-all</artifactId>
+            <artifactId>netty-codec-http2</artifactId>
             <version>${netty.version}</version>
         </dependency>
 

--- a/bigtable-hbase-1.0/pom.xml
+++ b/bigtable-hbase-1.0/pom.xml
@@ -105,7 +105,14 @@ limitations under the License.
                                     <include>com.google.protobuf:*</include>
                                     <include>com.twitter:hpack</include>
                                     <include>com.fasterxml.jackson.core:*</include>
-                                    <include>io.netty:netty-all</include>
+                                    <include>io.netty:netty-codec-http2</include>
+                                    <include>io.netty:netty-codec-http</include>
+                                    <include>io.netty:netty-codec</include>
+                                    <include>io.netty:netty-handler</include>
+                                    <include>io.netty:netty-buffer</include>
+                                    <include>io.netty:netty-common</include>
+                                    <include>io.netty:netty-transport</include>
+                                    <include>io.netty:netty-resolver</include>
                                     <include>io.grpc:grpc-all</include>
                                 </includes>
                             </artifactSet>

--- a/bigtable-hbase-1.1/pom.xml
+++ b/bigtable-hbase-1.1/pom.xml
@@ -105,7 +105,14 @@ limitations under the License.
                                     <include>com.google.protobuf:*</include>
                                     <include>com.twitter:hpack</include>
                                     <include>com.fasterxml.jackson.core:*</include>
-                                    <include>io.netty:netty-all</include>
+                                    <include>io.netty:netty-codec-http2</include>
+                                    <include>io.netty:netty-codec-http</include>
+                                    <include>io.netty:netty-codec</include>
+                                    <include>io.netty:netty-handler</include>
+                                    <include>io.netty:netty-buffer</include>
+                                    <include>io.netty:netty-common</include>
+                                    <include>io.netty:netty-transport</include>
+                                    <include>io.netty:netty-resolver</include>
                                     <include>io.grpc:grpc-all</include>
                                 </includes>
                             </artifactSet>

--- a/bigtable-hbase-integration-tests/pom.xml
+++ b/bigtable-hbase-integration-tests/pom.xml
@@ -143,6 +143,13 @@ limitations under the License.
         </profile>
         <profile>
             <id>hbaseLocalMiniClusterTest</id>
+            <dependencies>
+                <dependency>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-all</artifactId>
+                    <version>4.0.24.Final</version>
+                </dependency>
+            </dependencies>
             <build>
                 <plugins>
                     <plugin>

--- a/bigtable-hbase/pom.xml
+++ b/bigtable-hbase/pom.xml
@@ -43,7 +43,7 @@ limitations under the License.
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
-            <artifactId>netty-all</artifactId>
+            <artifactId>netty-codec-http2</artifactId>
             <version>${netty.version}</version>
         </dependency>
 
@@ -110,6 +110,10 @@ limitations under the License.
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-mapreduce-client-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.hbase</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -247,6 +247,17 @@ limitations under the License.
                 <version>${hbase.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.apache.hadoop</groupId>
+                <artifactId>hadoop-mapreduce-client-core</artifactId>
+                <version>${hadoop.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>io.netty</groupId>
+                        <artifactId>netty-all</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.hbase</groupId>
                 <artifactId>hbase-client</artifactId>
                 <version>${hbase.version}</version>
@@ -255,12 +266,22 @@ limitations under the License.
                         <groupId>com.google.protobuf</groupId>
                         <artifactId>protobuf-java</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>io.netty</groupId>
+                        <artifactId>netty-all</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.hbase</groupId>
                 <artifactId>hbase-server</artifactId>
                 <version>${hbase.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>io.netty</groupId>
+                        <artifactId>netty-all</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.hbase</groupId>
@@ -268,6 +289,12 @@ limitations under the License.
                 <version>${hbase.version}</version>
                 <type>test-jar</type>
                 <scope>test</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>io.netty</groupId>
+                        <artifactId>netty-all</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.hbase</groupId>


### PR DESCRIPTION
Older versions of netty-all are exposed via some of the maven dependencies we have. We need to have a consistent version of netty.