### PR TITLE
Excluding older guava versions in the root pom.xml.

### DIFF
--- a/bigtable-hbase-1.0/pom.xml
+++ b/bigtable-hbase-1.0/pom.xml
@@ -80,6 +80,37 @@ limitations under the License.
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>1.4</version>
+                <executions>
+                    <execution>
+                        <id>enforce-banned-dependencies</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <bannedDependencies>
+                                    <excludes>
+                                        <exclude>com.google.guava:guava-jdk5:*</exclude>
+<!-- This needs to work in the near future
+                                        <exclude>io.netty:netty-all:*</exclude>
+                                        <exclude>io.netty:netty:*</exclude>
+-->
+                                    </excludes>
+                                    <includes>
+                                        <include>com.google.guava:guava:${guava.version}</include>
+                                        <include>io.nett:*:${netty.version}</include>
+                                    </includes>
+                                </bannedDependencies>
+                           </rules>
+                          <fail>true</fail>
+                      </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <executions>
                     <execution>

--- a/bigtable-hbase-integration-tests/pom.xml
+++ b/bigtable-hbase-integration-tests/pom.xml
@@ -178,6 +178,11 @@ limitations under the License.
 
     <dependencies>
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>13.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
             <type>test-jar</type>

--- a/bigtable-hbase/pom.xml
+++ b/bigtable-hbase/pom.xml
@@ -50,7 +50,6 @@ limitations under the License.
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>18.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.http-client</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@ limitations under the License.
         <!-- For Netty HTTP2/TLS negotiation -->
         <alpn.version>7.0.0.v20140317</alpn.version>
         <netty.version>4.1.0.Beta5</netty.version>
+        <guava.version>18.0</guava.version>
 
         <!-- Values for integration testing. Set these in ~/.m2/settings.xml or
              via command-line -D flags. -->
@@ -129,6 +130,12 @@ limitations under the License.
                 <artifactId>mockito-core</artifactId>
                 <version>${mockito.version}</version>
                 <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>${guava.version}</version>
             </dependency>
 
             <dependency>
@@ -330,8 +337,8 @@ limitations under the License.
                     <exclusion>
                         <groupId>com.google.guava</groupId>
                         <artifactId>guava</artifactId>
-                    <exclusion>
                     </exclusion>
+                    <exclusion>
                         <groupId>io.netty</groupId>
                         <artifactId>netty-all</artifactId>
                     </exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -142,6 +142,12 @@ limitations under the License.
                 <groupId>com.google.api-client</groupId>
                 <artifactId>google-api-client-jackson2</artifactId>
                 <version>${google.api.client.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.google.guava</groupId>
+                        <artifactId>guava-jdk5</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>com.google.api-client</groupId>
@@ -149,7 +155,6 @@ limitations under the License.
                 <version>${google.api.client.version}</version>
                 <exclusions>
                     <exclusion>
-                        <!-- this version hides too many things -->
                         <groupId>com.google.guava</groupId>
                         <artifactId>guava-jdk5</artifactId>
                     </exclusion>
@@ -172,6 +177,12 @@ limitations under the License.
                 <artifactId>hadoop-common</artifactId>
                 <version>${hadoop.version}</version>
                 <scope>provided</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.google.guava</groupId>
+                        <artifactId>guava</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.hadoop</groupId>
@@ -179,6 +190,12 @@ limitations under the License.
                 <version>${hadoop.version}</version>
                 <type>test-jar</type>
                 <scope>test</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.google.guava</groupId>
+                        <artifactId>guava</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.hadoop</groupId>
@@ -199,6 +216,10 @@ limitations under the License.
                     <exclusion>
                         <groupId>io.netty</groupId>
                         <artifactId>netty</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.google.guava</groupId>
+                        <artifactId>guava</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -233,6 +254,12 @@ limitations under the License.
                 <artifactId>hbase-common</artifactId>
                 <version>${hbase.version}</version>
                 <scope>provided</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.google.guava</groupId>
+                        <artifactId>guava</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.hbase</groupId>
@@ -240,6 +267,12 @@ limitations under the License.
                 <version>${hbase.version}</version>
                 <type>test-jar</type>
                 <scope>test</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.google.guava</groupId>
+                        <artifactId>guava</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.hbase</groupId>
@@ -261,6 +294,12 @@ limitations under the License.
                 <groupId>org.apache.hbase</groupId>
                 <artifactId>hbase-server</artifactId>
                 <version>${hbase.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.google.guava</groupId>
+                        <artifactId>guava</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.hbase</groupId>
@@ -268,6 +307,12 @@ limitations under the License.
                 <version>${hbase.version}</version>
                 <type>test-jar</type>
                 <scope>test</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.google.guava</groupId>
+                        <artifactId>guava</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.hbase</groupId>
@@ -288,6 +333,12 @@ limitations under the License.
                 <version>${hbase.version}</version>
                 <type>test-jar</type>
                 <scope>test</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.google.guava</groupId>
+                        <artifactId>guava</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Explicitely relying on guava 13 for the integration tests.