### PR TITLE
Adding an explicit dependency on commons-lang.

### DIFF
--- a/bigtable-hbase/pom.xml
+++ b/bigtable-hbase/pom.xml
@@ -153,6 +153,10 @@ limitations under the License.
             <groupId>com.google.oauth-client</groupId>
             <artifactId>google-oauth-client-java6</artifactId>
         </dependency>
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -289,6 +289,11 @@ limitations under the License.
                 <type>test-jar</type>
                 <scope>test</scope>
             </dependency>
+            <dependency>
+                <groupId>commons-lang</groupId>
+                <artifactId>commons-lang</artifactId>
+                <version>2.6</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
Currently, relying on bigtable-hbase-1.0 by itself isn't enough to pull in commons-lang.  Applications need it at runtime, otherwise they fail with ClassNotFoundException.