### PR TITLE
Allow override of bigtable-hbase version under test.

### DIFF
--- a/bigtable-hbase-integration-tests/pom.xml
+++ b/bigtable-hbase-integration-tests/pom.xml
@@ -33,7 +33,8 @@ limitations under the License.
     <properties>
         <google.bigtable.auth.service.account.enable>true</google.bigtable.auth.service.account.enable>
         <hbase.version>1.0.1</hbase.version>
-        <google.bigtable.version.under.test>bigtable-hbase-1.0</google.bigtable.version.under.test>
+        <google.bigtable.project.under.test>bigtable-hbase-1.0</google.bigtable.project.under.test>
+        <google.bigtable.version.under.test>${project.version}</google.bigtable.version.under.test>
         <google.bigtable.connection.impl>com.google.cloud.bigtable.hbase1_0.BigtableConnection</google.bigtable.connection.impl>
     </properties>
 
@@ -43,8 +44,8 @@ limitations under the License.
             <dependencies>
                 <dependency>
                     <groupId>${project.groupId}</groupId>
-                    <artifactId>${google.bigtable.version.under.test}</artifactId>
-                    <version>${project.version}</version>
+                    <artifactId>${google.bigtable.project.under.test}</artifactId>
+                    <version>${google.bigtable.version.under.test}</version>
                     <classifier>shaded</classifier>
                 </dependency>
             </dependencies>


### PR DESCRIPTION
This will help with the "external" jobs that run in Jenkins when versions change.  A paramater override will allow us to keep a consistent version for those tests.