### PR TITLE
Moving up protobuf-java and grpc versions to the parent pom.

### DIFF
--- a/bigtable-grpc-interface/pom.xml
+++ b/bigtable-grpc-interface/pom.xml
@@ -40,12 +40,10 @@ limitations under the License.
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>${protobuff-java.version}</version>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-all</artifactId>
-            <version>${grpc.version}</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>

--- a/bigtable-hbase-1.0/pom.xml
+++ b/bigtable-hbase-1.0/pom.xml
@@ -38,7 +38,6 @@ limitations under the License.
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>${protobuff-java.version}</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/bigtable-hbase-1.1/pom.xml
+++ b/bigtable-hbase-1.1/pom.xml
@@ -38,7 +38,6 @@ limitations under the License.
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>${protobuff-java.version}</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/bigtable-hbase/pom.xml
+++ b/bigtable-hbase/pom.xml
@@ -34,12 +34,10 @@ limitations under the License.
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>${protobuff-java.version}</version>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-all</artifactId>
-            <version>${grpc.version}</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>

--- a/bigtable-protos/pom.xml
+++ b/bigtable-protos/pom.xml
@@ -34,12 +34,10 @@ limitations under the License.
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>${protobuff-java.version}</version>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-all</artifactId>
-            <version>${grpc.version}</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,24 @@ limitations under the License.
             </dependency>
 
             <dependency>
+                <groupId>io.grpc</groupId>
+                <artifactId>grpc-all</artifactId>
+                <version>${grpc.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.google.protobuf.nano</groupId>
+                        <artifactId>protobuf-nano</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>com.google.protobuf</groupId>
+                <artifactId>protobuf-java</artifactId>
+                <version>${protobuff-java.version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>org.mortbay.jetty.alpn</groupId>
                 <artifactId>alpn-boot</artifactId>
                 <version>${alpn.version}</version>


### PR DESCRIPTION
I did some of this work for the shaded jar.  This seems independently useful.