### PR TITLE
Updating commons-lang, protobuf and shade plugin versions

### DIFF
--- a/bigtable-hbase/pom.xml
+++ b/bigtable-hbase/pom.xml
@@ -106,7 +106,6 @@ limitations under the License.
         <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>
@@ -153,10 +152,6 @@ limitations under the License.
         <dependency>
             <groupId>com.google.oauth-client</groupId>
             <artifactId>google-oauth-client-java6</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
         </dependency>
     </dependencies>
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@ limitations under the License.
         <compat.module>hbase-hadoop2-compat</compat.module>
         <junit.version>4.11</junit.version>
         <mockito.version>1.9.5</mockito.version>
-        <protobuff-java.version>3.0.0-alpha-2</protobuff-java.version>
+        <protobuff-java.version>3.0.0-alpha-3</protobuff-java.version>
         <grpc.version>0.7.1</grpc.version>
         <google.api.client.version>1.19.0</google.api.client.version>
         <!-- For Netty HTTP2/TLS negotiation -->
@@ -109,7 +109,6 @@ limitations under the License.
                 <groupId>commons-lang</groupId>
                 <artifactId>commons-lang</artifactId>
                 <version>2.6</version>
-                <scope>test</scope>
             </dependency>
 
             <dependency>
@@ -389,11 +388,6 @@ limitations under the License.
                     </exclusion>
                 </exclusions>
             </dependency>
-            <dependency>
-                <groupId>commons-lang</groupId>
-                <artifactId>commons-lang</artifactId>
-                <version>2.6</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -455,7 +449,7 @@ limitations under the License.
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
-                    <version>2.3</version>
+                    <version>2.4</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
Removed commons-lang duplicate dependencies.
Updated Protobuf version to be compatible with grpc.  We had problems with our newly generated java files via the gradle generateProto plugin due to version incompatilibities.
Updated shade plugin to the latest.