### PR TITLE
Updating protobuf version in the bigtable-hbase-integration-tests

### DIFF
--- a/bigtable-hbase-integration-tests/pom.xml
+++ b/bigtable-hbase-integration-tests/pom.xml
@@ -36,6 +36,7 @@ limitations under the License.
         <google.bigtable.project.under.test>bigtable-hbase-1.0</google.bigtable.project.under.test>
         <google.bigtable.version.under.test>${project.version}</google.bigtable.version.under.test>
         <google.bigtable.connection.impl>com.google.cloud.bigtable.hbase1_0.BigtableConnection</google.bigtable.connection.impl>
+        <protobuff-java.version>2.5.0</protobuff-java.version>
     </properties>
 
     <profiles>


### PR DESCRIPTION
This change fixes the broken hbase mini cluster test.