### PR TITLE
Fixing issue with retries and sslConext

### DIFF
--- a/bigtable-grpc-interface/src/main/java/com/google/cloud/bigtable/config/BigtableOptions.java
+++ b/bigtable-grpc-interface/src/main/java/com/google/cloud/bigtable/config/BigtableOptions.java
@@ -15,7 +15,6 @@
  */
 package com.google.cloud.bigtable.config;
 
-import io.grpc.transport.netty.GrpcSslContexts;
 import io.netty.channel.EventLoopGroup;
 import io.netty.handler.ssl.SslContext;
 
@@ -44,7 +43,7 @@ public class BigtableOptions {
           try {
             // We create multiple channels via refreshing and pooling channel implementation.
             // Each one needs its own SslContext.
-            return GrpcSslContexts.forClient().build();
+            return SslContext.newClientContext();
           } catch (SSLException e) {
             throw new IllegalStateException("Could not create an ssl context.", e);
           }

--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableOptionsFactory.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableOptionsFactory.java
@@ -285,6 +285,8 @@ public class BigtableOptionsFactory {
     // TODO(kevinsi): Make this configurable.
     retryOptionsBuilder.setMaxElapsedBackoffMillis(180000); // 3 minutes
 
+    optionsBuilder.setRetryOptions(retryOptionsBuilder.build());
+
     int channelCount =
         configuration.getInt(BIGTABLE_CHANNEL_COUNT_KEY, BIGTABLE_CHANNEL_COUNT_DEFAULT);
     optionsBuilder.setChannelCount(channelCount);


### PR DESCRIPTION
The Grpc SSL context code also needs to be honed.  The change from SslContext to GrpcSslContext broke the cluster tests.