### PR TITLE
Adding some startup performance enhancements

### DIFF
--- a/bigtable-grpc-interface/src/main/java/com/google/cloud/bigtable/config/CredentialFactory.java
+++ b/bigtable-grpc-interface/src/main/java/com/google/cloud/bigtable/config/CredentialFactory.java
@@ -78,7 +78,7 @@ public class CredentialFactory {
    * Returns shared httpTransport instance; initializes httpTransport if it hasn't already been
    * initialized.
    */
-  private static synchronized HttpTransport getHttpTransport()
+  public static synchronized HttpTransport getHttpTransport()
       throws IOException, GeneralSecurityException {
     if (httpTransport == null) {
       httpTransport = GoogleNetHttpTransport.newTrustedTransport();


### PR DESCRIPTION
Parallelizing Host lookup and credential lookup, both of which can be expensive operations.

Adding some startup performance enhancements

Parallelizing Host lookup and credential lookup, both of which can be expensive operations.

Renaming the types in getHost parameters
Adding comments around the use of retryExecutor.

This is a continuation of #357 which got messed up