### PR TITLE
Updating integration tests to have a single version

### DIFF
--- a/bigtable-hbase-integration-tests/pom.xml
+++ b/bigtable-hbase-integration-tests/pom.xml
@@ -34,7 +34,6 @@ limitations under the License.
         <google.bigtable.auth.service.account.enable>true</google.bigtable.auth.service.account.enable>
         <hbase.version>1.0.1</hbase.version>
         <google.bigtable.project.under.test>bigtable-hbase-1.0</google.bigtable.project.under.test>
-        <google.bigtable.version.under.test>${project.version}</google.bigtable.version.under.test>
         <google.bigtable.connection.impl>com.google.cloud.bigtable.hbase1_0.BigtableConnection</google.bigtable.connection.impl>
         <protobuff-java.version>2.5.0</protobuff-java.version>
     </properties>
@@ -46,7 +45,7 @@ limitations under the License.
                 <dependency>
                     <groupId>${project.groupId}</groupId>
                     <artifactId>${google.bigtable.project.under.test}</artifactId>
-                    <version>${google.bigtable.version.under.test}</version>
+                    <version>${project.version}</version>
                 </dependency>
             </dependencies>
             <build>
@@ -97,7 +96,7 @@ limitations under the License.
                 <dependency>
                     <groupId>${project.groupId}</groupId>
                     <artifactId>${google.bigtable.project.under.test}</artifactId>
-                    <version>${google.bigtable.version.under.test}</version>
+                    <version>${project.version}</version>
                     <classifier>shaded</classifier>
                 </dependency>
             </dependencies>


### PR DESCRIPTION
The release process doesn't currently work because the integration tests pom.xml allows for multiple versions to be tested.  Reverting back to the old way of having only the current version to be testable.  We switched our jenkins jobs to pull in older versions of the tests using tags in so the pom.xml flexibility is no longer needed anyway.