### PR TITLE
Updating bigtable-hbase-1.1 and bigtable-hbase-mapreduce pom.xml

### DIFF
--- a/bigtable-hbase-1.1/pom.xml
+++ b/bigtable-hbase-1.1/pom.xml
@@ -84,7 +84,7 @@ limitations under the License.
                         </goals>
                         <configuration>
                             <shadeTestJar>true</shadeTestJar>
-                          <!--
+                            <!--
                                 KEEP shadedArtifactAttached=false.  DO NOTE CHANGE shadedArtifactAttached to true!
 
                                 Dependencies get messed up if shadedArtifactAttached=true.  The relocations
@@ -121,17 +121,8 @@ limitations under the License.
                                     <include>com.google.protobuf:*</include>
                                     <include>com.twitter:hpack</include>
                                     <include>com.fasterxml.jackson.core:*</include>
-                                    <include>io.netty:netty-codec-http2</include>
-                                    <include>io.netty:netty-codec-http</include>
-                                    <include>io.netty:netty-codec</include>
-                                    <include>io.netty:netty-handler</include>
-                                    <include>io.netty:netty-buffer</include>
-                                    <include>io.netty:netty-common</include>
-                                    <include>io.netty:netty-transport</include>
-                                    <include>io.netty:netty-resolver</include>
-                                    <include>io.grpc:grpc-core</include>
-                                    <include>io.grpc:grpc-stub</include>
-                                    <include>io.grpc:grpc-protobuf</include>
+                                    <include>io.netty:*</include>
+                                    <include>io.grpc:*</include>
                                 </includes>
                             </artifactSet>
                             <relocations>

--- a/bigtable-hbase-mapreduce/pom.xml
+++ b/bigtable-hbase-mapreduce/pom.xml
@@ -33,7 +33,7 @@ limitations under the License.
     </description>
 
     <properties>
-        <hbase.version>1.0.1</hbase.version>
+        <hbase.version>1.1.1</hbase.version>
     </properties>
 
     <dependencies>
@@ -63,7 +63,7 @@ limitations under the License.
         </dependency>
         <dependency>
             <groupId>com.google.cloud.bigtable</groupId>
-            <artifactId>bigtable-hbase-1.0</artifactId>
+            <artifactId>bigtable-hbase-1.1</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
@@ -109,7 +109,7 @@ limitations under the License.
                             <shadedArtifactAttached>true</shadedArtifactAttached>
                             <artifactSet>
                                 <includes>
-                                    <include>com.google.cloud.bigtable:bigtable-hbase-1.0</include>
+                                    <include>com.google.cloud.bigtable:bigtable-hbase-1.1</include>
                                 </includes>
                             </artifactSet>
                         </configuration>


### PR DESCRIPTION
bigtable-hbase-1.1 is missing dependencies in the shaded jar.  Adding them in.
bigtable-hbase-mapreduce is now using hbase-1.1 instead of hbase-1.0 since hbase-1.1.1 has some fixes to the thrift and rest servers, and hbase 1.0 is not updated yet.