### PR TITLE
Moving more defaults into *Options objects.

### DIFF
--- a/bigtable-grpc-interface/src/main/java/com/google/cloud/bigtable/config/RetryOptions.java
+++ b/bigtable-grpc-interface/src/main/java/com/google/cloud/bigtable/config/RetryOptions.java
@@ -17,17 +17,29 @@ package com.google.cloud.bigtable.config;
 
 import java.util.concurrent.TimeUnit;
 
-import com.google.cloud.bigtable.grpc.BigtableGrpcClient;
-
 /**
  * Options for retrying requests, including back off configuration.
  */
 public class RetryOptions {
 
-  public static int DEFAULT_STREAMING_BUFFER_SIZE = BigtableGrpcClient.SCANNER_BUFFER_SIZE;
-  // We can timeout when reading large cells with a low value here. With a 10MB
-  // cell limit, 60 seconds allows our connection to drop to ~170kbyte/s. A 10 second
-  // timeout requires 1Mbyte/s
+  public static int DEFAULT_STREAMING_BUFFER_SIZE = 32;
+
+  /**
+   * Flag indicating whether or not grpc retries should be enabled.
+   * The default is to enable retries on failed idempotent operations.
+   */
+  public static boolean ENABLE_GRPC_RETRIES_DEFAULT = true;
+
+  /**
+   * Flag indicating whether or not to retry grpc call on deadline exceeded.
+   * This flag is used only when grpc retries is enabled.
+   */
+  public static boolean ENABLE_GRPC_RETRY_DEADLINE_EXCEEDED_DEFAULT = true;
+
+  /** We can timeout when reading large cells with a low value here. With a 10MB
+   * cell limit, 60 seconds allows our connection to drop to ~170kbyte/s. A 10 second
+   * timeout requires 1Mbyte/s
+   */
   public static int DEFAULT_READ_PARTIAL_ROW_TIMEOUT_MS =
       (int) TimeUnit.MILLISECONDS.convert(60, TimeUnit.SECONDS);
 
@@ -42,15 +54,15 @@ public class RetryOptions {
   /**
    * Maximum amount of time to retry before failing the operation (default value: 60 seconds).
    */
-  public static final int DEFAULT_MAX_ELAPSED_BACKOFF_MILLIS = 60 * 1000;
-
+  public static final int DEFAULT_MAX_ELAPSED_BACKOFF_MILLIS =
+      (int) TimeUnit.MILLISECONDS.convert(60, TimeUnit.SECONDS);
 
   /**
    * A Builder for ChannelOptions objects.
    */
   public static class Builder {
-    private boolean enableRetries = false;
-    private boolean retryOnDeadlineExceeded = true;
+    private boolean enableRetries = ENABLE_GRPC_RETRIES_DEFAULT;
+    private boolean retryOnDeadlineExceeded = ENABLE_GRPC_RETRY_DEADLINE_EXCEEDED_DEFAULT;
     private int initialBackoffMillis = DEFAULT_INITIAL_BACKOFF_MILLIS;
     private double backoffMultiplier = DEFAULT_BACKOFF_MULTIPLIER;
     private int maxElaspedBackoffMillis = DEFAULT_MAX_ELAPSED_BACKOFF_MILLIS;

--- a/bigtable-grpc-interface/src/main/java/com/google/cloud/bigtable/grpc/BigtableGrpcClient.java
+++ b/bigtable-grpc-interface/src/main/java/com/google/cloud/bigtable/grpc/BigtableGrpcClient.java
@@ -133,12 +133,6 @@ public class BigtableGrpcClient implements BigtableClient {
     }
   }
 
-  /**
-   * The number of rows to read in before blocking.
-   * TODO: Wire this into a settable option.
-   */
-  public static final int SCANNER_BUFFER_SIZE = 32;
-
   // We usually have many asynchronous writes.
   private final Channel writeChannel;
 

--- a/bigtable-grpc-interface/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
+++ b/bigtable-grpc-interface/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
@@ -41,10 +41,8 @@ import io.grpc.Channel;
 import io.grpc.ChannelImpl;
 import io.grpc.ClientInterceptor;
 import io.grpc.ClientInterceptors;
-import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.auth.ClientAuthInterceptor;
-import io.grpc.stub.MetadataUtils;
 import io.grpc.transport.netty.GrpcSslContexts;
 import io.grpc.transport.netty.NegotiationType;
 import io.grpc.transport.netty.NettyChannelBuilder;
@@ -178,7 +176,7 @@ public class BigtableSession implements AutoCloseable {
         }
       }
     });
-    for (final String host : Arrays.asList(BigtableOptions.BIGTABLE_HOST_DEFAULT,
+    for (final String host : Arrays.asList(BigtableOptions.BIGTABLE_DATA_HOST_DEFAULT,
       BigtableOptions.BIGTABLE_CLUSTER_ADMIN_HOST_DEFAULT,
       BigtableOptions.BIGTABLE_CLUSTER_ADMIN_HOST_DEFAULT)) {
       connectionStartupExecutor.execute(new Runnable() {
@@ -393,12 +391,6 @@ public class BigtableSession implements AutoCloseable {
       }
     } catch (InterruptedException | ExecutionException e) {
       throw new IllegalStateException("Could not initialize credentials.");
-    }
-
-    if (options.getAuthority() != null) {
-      Metadata.Headers headers = new Metadata.Headers();
-      headers.setAuthority(options.getAuthority());
-      interceptors.add(MetadataUtils.newAttachHeadersInterceptor(headers));
     }
 
     CallCompletionStatusInterceptor preRetryCallStatusInterceptor = null;

--- a/bigtable-grpc-interface/src/main/java/com/google/cloud/bigtable/grpc/UnaryCallRetryInterceptor.java
+++ b/bigtable-grpc-interface/src/main/java/com/google/cloud/bigtable/grpc/UnaryCallRetryInterceptor.java
@@ -16,10 +16,7 @@
 package com.google.cloud.bigtable.grpc;
 
 import com.google.api.client.util.ExponentialBackOff;
-import com.google.common.base.Function;
 import com.google.common.base.Predicate;
-import com.google.common.base.Predicates;
-import com.google.common.collect.Maps;
 
 import io.grpc.Call;
 import io.grpc.Channel;
@@ -27,7 +24,6 @@ import io.grpc.MethodDescriptor;
 import io.grpc.MethodType;
 
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
 
 /**
@@ -41,27 +37,6 @@ public class UnaryCallRetryInterceptor extends Channel {
   private final int initialBackoffMillis;
   private final double backoffMultiplier;
   private final int maxElapsedBackoffMillis;
-
-  public UnaryCallRetryInterceptor(
-      Channel delegate,
-      ScheduledExecutorService executorService,
-      Set<MethodDescriptor<?, ?>> retriableMethods,
-      int initialBackoffMillis,
-      double backoffMultiplier,
-      int maxElapsedBackoffMillis) {
-    this(
-        delegate,
-        executorService,
-        Maps.asMap(retriableMethods, new Function<MethodDescriptor<?, ?>, Predicate<?>>() {
-          @Override
-          public Predicate<Object> apply(MethodDescriptor<?, ?> methodDescriptor) {
-            return Predicates.alwaysTrue();
-          }
-        }),
-        initialBackoffMillis,
-        backoffMultiplier,
-        maxElapsedBackoffMillis);
-  }
 
   public UnaryCallRetryInterceptor(
       Channel delegate,


### PR DESCRIPTION
BigtableOptions sets default hosts and performance tuning options. Removing BigtableOptions.authority, which is no longer needed.
RetryOptions sets defaults for boolean flags.
UnaryCallRetryInterceptorTest setup was removed from UnaryCallRetryInterceptor.  All defaults for UnaryCallRetryInterceptorTest are now taken from the default RetryOptions configuration.
Most BigtableOptionsFactory were moved to BigtableOptions and RetryOptions.