### PR TITLE
Some usability improvements to BigtableSession.

### DIFF
--- a/bigtable-grpc-interface/src/test/java/com/google/cloud/bigtable/grpc/BigtableSessionTests.java
+++ b/bigtable-grpc-interface/src/test/java/com/google/cloud/bigtable/grpc/BigtableSessionTests.java
@@ -24,8 +24,6 @@ import com.google.bigtable.v1.CheckAndMutateRowRequest;
 import com.google.bigtable.v1.MutateRowRequest;
 import com.google.bigtable.v1.Mutation;
 import com.google.bigtable.v1.Mutation.SetCell;
-import com.google.cloud.bigtable.config.BigtableOptions;
-import com.google.cloud.bigtable.config.BigtableOptionsTestFactory;
 import com.google.common.base.Predicate;
 
 import org.junit.Test;
@@ -39,12 +37,10 @@ import java.util.Map;
 @RunWith(JUnit4.class)
 public class BigtableSessionTests {
 
-  @SuppressWarnings({ "unchecked", "resource" })
+  @SuppressWarnings({ "unchecked" })
   @Test
   public void createMethodRetryMap() throws Exception {
-    BigtableOptions options = BigtableOptionsTestFactory.build();
-    BigtableSession bs = new BigtableSession(options, null, null, null);
-    Map<MethodDescriptor<?, ?>, Predicate<?>> map = bs.createMethodRetryMap();
+    Map<MethodDescriptor<?, ?>, Predicate<?>> map = BigtableSession.createMethodRetryMap();
     for (MethodDescriptor<?, ?> method: BigtableServiceGrpc.CONFIG.methods()) {
       if (method == BigtableServiceGrpc.CONFIG.mutateRow) {
         assertMutateRowPredicate((Predicate<MutateRowRequest>) map.get(method));

--- a/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestClusterAPI.java
+++ b/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestClusterAPI.java
@@ -81,7 +81,7 @@ public class TestClusterAPI {
     }
 
     BigtableOptions originalOptions = BigtableOptionsFactory.fromConfiguration(configuration);
-    BigtableSession originalSession = new BigtableSession(originalOptions, Executors.newFixedThreadPool(10));
+    BigtableSession originalSession = new BigtableSession(originalOptions);
     BigtableClusterAdminClient client = originalSession.getClusterAdminClient();
 
     String projectId = originalOptions.getProjectId();
@@ -123,6 +123,7 @@ public class TestClusterAPI {
       countTables(admin, 1);
     } finally {
       dropCluster(client, clusterName);
+      originalSession.close();
     }
   }
 


### PR DESCRIPTION
close() does not have 'throws Exception' in the signature
Added a new constructor for BigtableSession that only takes in a BigtableOption.
BigtableSessionTests now does not open a BigtableSession.
TestClusterAPI uses the new single parameter BigtableSession constructor.