### PR TITLE
Use ResumingBigtableResultScanner to handle rescan.

### DIFF
--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataClient.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataClient.java
@@ -84,9 +84,14 @@ public interface BigtableDataClient {
       SampleRowKeysRequest request);
 
   /**
-   * Perform a scan over rows.
+   * Perform a scan over rows with resumable defaults to {@code false}.
    */
   ResultScanner<Row> readRows(ReadRowsRequest request);
+
+  /**
+   * Perform a scan over rows with resumable option.
+   */
+  ResultScanner<Row> readRows(ReadRowsRequest request, boolean resumable);
 
   /**
    * Read multiple Rows into an in-memory list, returning a Future that will complete when the

--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ResumableResultScanner.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ResumableResultScanner.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.grpc.scanner;
+
+
+import com.google.bigtable.v1.ReadRowsRequest;
+
+/**
+ * A resumable scanner of Bigtable rows.
+ * @param <T> The type of Rows this scanner will iterate over. Expected Bigtable Row objects.
+ */
+public interface ResumableResultScanner<T> extends ResultScanner<T> {
+  /**
+   * Stop and start a new scan with {@code newRequest}. The subclass should maintain the last row
+   * read if the starting row matters when resuming the scan.
+   *
+   * @param newRequest the quest to be used when resuming a new scan
+   * @param skipLastRow if should skip the last row read and start scanning from the next row
+   */
+  void resume(ReadRowsRequest.Builder newRequest, boolean skipLastRow);
+}

--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ResumingBigtableResultScanner.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ResumingBigtableResultScanner.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.grpc.scanner;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.google.api.client.repackaged.com.google.common.annotations.VisibleForTesting;
+import com.google.bigtable.v1.ReadRowsRequest;
+import com.google.bigtable.v1.Row;
+import com.google.protobuf.ByteString;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import java.io.IOException;
+
+/**
+ * A ResultScanner that can resume scan by invoking {@link #resume(ReadRowsRequest.Builder,
+ * boolean)}.
+ */
+public class ResumingBigtableResultScanner
+    extends AbstractBigtableResultScanner implements ResumableResultScanner<Row> {
+
+  private static final Log LOG = LogFactory.getLog(ResumingBigtableResultScanner.class);
+
+  private static final ByteString NEXT_ROW_SUFFIX = ByteString.copyFrom(new byte[]{0x00});
+  private final BigtableResultScannerFactory scannerFactory;
+
+  private ResultScanner<Row> delegate;
+
+  /**
+   * Construct a ByteString containing the next possible row key.
+   */
+  static ByteString nextRowKey(ByteString previous) {
+    return previous.concat(NEXT_ROW_SUFFIX);
+  }
+
+  private ByteString lastRowKey = null;
+  // The number of rows read so far.
+  private long rowCount = 0;
+
+  public ResumingBigtableResultScanner(
+      ReadRowsRequest originalRequest,
+      BigtableResultScannerFactory scannerFactory) {
+    this.scannerFactory = scannerFactory;
+    delegate = scannerFactory.createScanner(originalRequest);
+  }
+
+  @Override
+  public void close() throws IOException {
+    delegate.close();
+  }
+
+  @Override
+  public Row next() throws IOException {
+    Row result = delegate.next();
+    if (result != null) {
+      lastRowKey = result.getKey();
+      rowCount++;
+    }
+
+    return result;
+  }
+
+  @Override
+  public void resume(ReadRowsRequest.Builder newRequest, boolean skipLastRow) {
+    try {
+      delegate.close();
+    } catch (IOException ioe) {
+      LOG.warn("Error closing scanner before reissuing request: ", ioe);
+    }
+
+    if (lastRowKey != null) {
+      ByteString startKey = lastRowKey;
+      if (skipLastRow) {
+        startKey = nextRowKey(lastRowKey);
+      }
+      newRequest.getRowRangeBuilder().setStartKey(startKey);
+    }
+
+    // If the row limit is set, update it.
+    long numRowsLimit = newRequest.getNumRowsLimit();
+    if (numRowsLimit > 0) {
+      // Updates the {@code numRowsLimit} by removing the number of rows already read.
+      numRowsLimit -= rowCount;
+
+      // Includes the last row read by incrementing {@code numRowsLimit} if it was reduced earlier.
+      if (!skipLastRow && rowCount > 0) {
+        numRowsLimit++;
+      }
+
+      checkArgument(numRowsLimit > 0, "The remaining number of rows must be greater than 0.");
+
+      // Sets the updated {@code numRowsLimit} in {@code newRequest}.
+      newRequest.setNumRowsLimit(numRowsLimit);
+    }
+
+    delegate = scannerFactory.createScanner(newRequest.build());
+  }
+
+  @VisibleForTesting
+  ByteString getLastRowKey() {
+    return lastRowKey;
+  }
+
+  @VisibleForTesting
+  long getRowCount() {
+    return rowCount;
+  }
+}

--- a/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/BigtableDataGrpcClientTest.java
+++ b/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/BigtableDataGrpcClientTest.java
@@ -1,0 +1,118 @@
+package com.google.cloud.bigtable.grpc;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.when;
+
+import com.google.bigtable.v1.BigtableServiceGrpc;
+import com.google.bigtable.v1.ReadRowsRequest;
+import com.google.bigtable.v1.ReadRowsResponse;
+import com.google.bigtable.v1.Row;
+import com.google.bigtable.v1.RowFilter;
+import com.google.bigtable.v1.RowFilter.Chain;
+import com.google.bigtable.v1.RowFilter.Interleave;
+import com.google.cloud.bigtable.config.RetryOptions;
+import com.google.cloud.bigtable.grpc.scanner.ResultScanner;
+import com.google.cloud.bigtable.grpc.scanner.ResumingBigtableResultScanner;
+import com.google.cloud.bigtable.grpc.scanner.RetryingStreamingResultScanner;
+import com.google.cloud.bigtable.grpc.scanner.StreamingBigtableResultScanner;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import io.grpc.Call;
+import io.grpc.Channel;
+
+import java.util.concurrent.ExecutorService;
+
+/**
+ * Test for the {@link BigtableDataGrpcClient}.
+ */
+@RunWith(JUnit4.class)
+public class BigtableDataGrpcClientTest {
+
+  @Mock
+  Channel mockChannel;
+  @Mock
+  ExecutorService mockExecutorService;
+  @Mock
+  Call<ReadRowsRequest, ReadRowsResponse> mockCall;
+
+  @Before
+  public void setup() {
+    MockitoAnnotations.initMocks(this);
+
+    when(mockChannel.newCall(BigtableServiceGrpc.CONFIG.readRows)).thenReturn(mockCall);
+  }
+
+  @Test
+  public void testReadRows_retriable() {
+    RetryOptions retryOptions =
+        new RetryOptions.Builder()
+            .setEnableRetries(true)
+            .setRetryOnDeadlineExceeded(true)
+            .setInitialBackoffMillis(100)
+            .setBackoffMultiplier(2D)
+            .setMaxElapsedBackoffMillis(500)
+            .build();
+    BigtableDataGrpcClient client =
+        new BigtableDataGrpcClient(mockChannel, mockExecutorService, retryOptions);
+    ResultScanner<Row> scanner = client.readRows(ReadRowsRequest.getDefaultInstance());
+    assertTrue(scanner instanceof  RetryingStreamingResultScanner);
+  }
+
+  @Test
+  public void testReadRows_retriable_resumable() {
+    RetryOptions retryOptions =
+        new RetryOptions.Builder()
+            .setEnableRetries(true)
+            .setRetryOnDeadlineExceeded(true)
+            .setInitialBackoffMillis(100)
+            .setBackoffMultiplier(2D)
+            .setMaxElapsedBackoffMillis(500)
+            .build();
+    BigtableDataGrpcClient client =
+        new BigtableDataGrpcClient(mockChannel, mockExecutorService, retryOptions);
+    ResultScanner<Row> scanner = client.readRows(ReadRowsRequest.getDefaultInstance(), true);
+    assertTrue(scanner instanceof  RetryingStreamingResultScanner);
+  }
+
+  @Test
+  public void testReadRows_resumable() {
+    RetryOptions retryOptions =
+        new RetryOptions.Builder()
+            .setEnableRetries(false)
+            .setRetryOnDeadlineExceeded(true)
+            .setInitialBackoffMillis(100)
+            .setBackoffMultiplier(2D)
+            .setMaxElapsedBackoffMillis(500)
+            .build();
+    BigtableDataGrpcClient client =
+        new BigtableDataGrpcClient(mockChannel, mockExecutorService, retryOptions);
+    ReadRowsRequest requestWithWileMatchFilter = ReadRowsRequest.newBuilder()
+        .setFilter(RowFilter.newBuilder().setApplyLabelTransformer("label"))
+        .build();
+    ResultScanner<Row> scanner = client.readRows(requestWithWileMatchFilter, true);
+    assertTrue(scanner instanceof  ResumingBigtableResultScanner);
+  }
+
+  @Test
+  public void testReadRows_nonresumable() {
+    RetryOptions retryOptions =
+        new RetryOptions.Builder()
+            .setEnableRetries(false)
+            .setRetryOnDeadlineExceeded(true)
+            .setInitialBackoffMillis(100)
+            .setBackoffMultiplier(2D)
+            .setMaxElapsedBackoffMillis(500)
+            .build();
+    BigtableDataGrpcClient client =
+        new BigtableDataGrpcClient(mockChannel, mockExecutorService, retryOptions);
+    ResultScanner<Row> scanner = client.readRows(ReadRowsRequest.getDefaultInstance());
+    assertTrue(scanner instanceof  StreamingBigtableResultScanner);
+  }
+}
+

--- a/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/scanner/ResumingBigtableResultScannerTest.java
+++ b/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/scanner/ResumingBigtableResultScannerTest.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.grpc.scanner;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.bigtable.v1.ReadRowsRequest;
+import com.google.bigtable.v1.Row;
+import com.google.bigtable.v1.RowRange;
+import com.google.cloud.bigtable.grpc.scanner.BigtableResultScannerFactory;
+import com.google.cloud.bigtable.grpc.scanner.ResultScanner;
+import com.google.protobuf.ByteString;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.io.IOException;
+
+/**
+ * Test for the {@link ResumingBigtableResultScanner}.
+ */
+@RunWith(JUnit4.class)
+public class ResumingBigtableResultScannerTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+  @Mock
+  ResultScanner<Row> mockScanner;
+  @Mock
+  BigtableResultScannerFactory mockScannerFactory;
+
+  ResumingBigtableResultScanner scanner;
+
+  @Before
+  public void setup() {
+    MockitoAnnotations.initMocks(this);
+
+    ReadRowsRequest request = ReadRowsRequest.getDefaultInstance();
+    when(mockScannerFactory.createScanner(eq(request))).thenReturn(mockScanner);
+    scanner = new ResumingBigtableResultScanner(request, mockScannerFactory);
+  }
+
+  static Row buildRow(String rowKey) {
+    return Row.newBuilder()
+        .setKey(ByteString.copyFromUtf8(rowKey))
+        .build();
+  }
+
+  static void assertRowKey(String expectedRowKey, Row row) {
+    assertEquals(expectedRowKey, row.getKey().toStringUtf8());
+  }
+
+  @Test
+  public void testNextRowKey() {
+    ByteString previous = ByteString.copyFromUtf8("row1");
+    byte[] previousBytes = previous.toByteArray();
+    byte[] expected = new byte[previousBytes.length + 1];
+    System.arraycopy(previousBytes, 0, expected, 0, previousBytes.length);
+    expected[previousBytes.length] = 0;
+
+    ByteString next = ResumingBigtableResultScanner.nextRowKey(previous);
+    assertArrayEquals(expected, next.toByteArray());
+  }
+
+  @Test
+  public void testClose() throws IOException {
+    scanner.close();
+    verify(mockScanner, times(1)).close();
+  }
+  
+  @Test
+  public void testNext_withException() throws IOException {
+    assertNull(scanner.getLastRowKey());
+    assertEquals(0, scanner.getRowCount());
+
+    IOException expectedException = new IOException("dummy");
+    when(mockScanner.next()).thenThrow(expectedException);
+    thrown.expect(IOException.class);
+    thrown.expectMessage("dummy");
+
+    scanner.next();
+    assertNull(scanner.getLastRowKey());
+    assertEquals(0, scanner.getRowCount());
+  }
+
+  @Test
+  public void testNext() throws IOException {
+    assertNull(scanner.getLastRowKey());
+    assertEquals(0, scanner.getRowCount());
+
+    Row row1 = buildRow("row1");
+    when(mockScanner.next()).thenReturn(row1);
+
+    scanner.next();
+    assertEquals(row1.getKey(), scanner.getLastRowKey());
+    assertEquals(1, scanner.getRowCount());
+
+    Row row2 = buildRow("row2");
+    when(mockScanner.next()).thenReturn(row2);
+
+    scanner.next();
+    assertEquals(row2.getKey(), scanner.getLastRowKey());
+    assertEquals(2, scanner.getRowCount());
+
+    verify(mockScanner, times(2)).next();
+  }
+
+  @Test
+  public void testResume_firstRow() throws IOException {
+    assertResume(false, 0);
+  }
+  
+  @Test
+  public void testResume_firstRow_withNumRowsLimit() throws IOException {
+    assertResume(false, 10);
+  }
+
+  @Test
+  public void testResume_firstRow_skipLastRow() throws IOException {
+    assertResume(true, 0);
+  }
+
+  @Test
+  public void testResume_firstRow_skipLastRow_withNumRowsLimit() throws IOException {
+    assertResume(true, 10);
+  }
+
+  @Test
+  public void testResume_nextRow() throws IOException {
+    Row row1 = buildRow("row1");
+    when(mockScanner.next()).thenReturn(row1);
+    scanner.next();
+
+    assertResume(false, 0);
+    verify(mockScanner, times(1)).next();
+  }
+  
+  @Test
+  public void testResume_nextRow_withNumRowsLimit() throws IOException {
+    Row row1 = buildRow("row1");
+    when(mockScanner.next()).thenReturn(row1);
+    scanner.next();
+
+    assertResume(false, 10);
+    verify(mockScanner, times(1)).next();
+  }
+
+  @Test
+  public void testResume_nextRow_skipLastRow() throws IOException {
+    Row row1 = buildRow("row1");
+    when(mockScanner.next()).thenReturn(row1);
+    scanner.next();
+
+    assertResume(true, 0);
+    verify(mockScanner, times(1)).next();
+  }
+
+  @Test
+  public void testResume_nextRow_skipLastRow_withNumRowsLimit() throws IOException {
+    Row row1 = buildRow("row1");
+    when(mockScanner.next()).thenReturn(row1);
+    scanner.next();
+
+    assertResume(true, 10);
+    verify(mockScanner, times(1)).next();
+  }
+
+  private void assertResume(boolean skipLastRow, long numRowsLimit) throws IOException {
+    ByteString rowKey = buildRow("row").getKey();
+    ReadRowsRequest newRequest = ReadRowsRequest.newBuilder()
+        .setRowRange(RowRange.newBuilder().setStartKey(rowKey))
+        .setNumRowsLimit(numRowsLimit)
+        .build();
+    scanner.resume(newRequest.toBuilder(), skipLastRow);
+
+    verify(mockScanner, times(1)).close();
+ 
+    ByteString expectedRowKey = scanner.getLastRowKey();
+    if (expectedRowKey == null) {
+      expectedRowKey = rowKey;
+    } else if (skipLastRow) {
+      expectedRowKey = ResumingBigtableResultScanner.nextRowKey(expectedRowKey);
+    }
+
+    long exepctedNumRowsLimit = numRowsLimit;
+    if (numRowsLimit > 0) {
+      exepctedNumRowsLimit = numRowsLimit - scanner.getRowCount();
+      if (!skipLastRow && scanner.getRowCount() > 0) {
+        exepctedNumRowsLimit++;
+      }
+    }
+    ReadRowsRequest expectedRequest =
+        newRequest.toBuilder()
+            .setRowRange(RowRange.newBuilder().setStartKey(expectedRowKey))
+            .setNumRowsLimit(exepctedNumRowsLimit)
+            .build();
+    verify(mockScannerFactory, times(1)).createScanner(eq(expectedRequest));
+  }
+}


### PR DESCRIPTION
Use ResumingBigtableResultScanner for rescan.

Rename the orginal ResumingBigtableResultScanner to RetryingStreamingResultScanner as it is for retry on errors.