### PR TITLE
Making RowMerger a top level object.

### DIFF
--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataGrpcClient.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataGrpcClient.java
@@ -33,9 +33,9 @@ import com.google.cloud.bigtable.grpc.io.CancellationToken;
 import com.google.cloud.bigtable.grpc.scanner.BigtableResultScannerFactory;
 import com.google.cloud.bigtable.grpc.scanner.ResultScanner;
 import com.google.cloud.bigtable.grpc.scanner.ResumingStreamingResultScanner;
+import com.google.cloud.bigtable.grpc.scanner.RowMerger;
 import com.google.cloud.bigtable.grpc.scanner.ScanRetriesExhaustedException;
 import com.google.cloud.bigtable.grpc.scanner.StreamingBigtableResultScanner;
-import com.google.cloud.bigtable.grpc.scanner.StreamingBigtableResultScanner.RowMerger;
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.FutureFallback;
@@ -227,11 +227,7 @@ public class BigtableDataGrpcClient implements BigtableDataClient {
                 List<Row> result = new ArrayList<>();
                 Iterator<ReadRowsResponse> responseIterator = responses.iterator();
                 while (responseIterator.hasNext()) {
-                  RowMerger currentRowMerger = new RowMerger();
-                  while (responseIterator.hasNext() && !currentRowMerger.isRowCommitted()) {
-                    currentRowMerger.addPartialRow(responseIterator.next());
-                  }
-                  result.add(currentRowMerger.buildRow());
+                  result.add(RowMerger.readNextRow(responseIterator));
                 }
                 return result;
               }

--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/RowMerger.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/RowMerger.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.grpc.scanner;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+import com.google.bigtable.v1.Family;
+import com.google.bigtable.v1.ReadRowsResponse;
+import com.google.bigtable.v1.Row;
+import com.google.bigtable.v1.ReadRowsResponse.Chunk;
+import com.google.common.base.Preconditions;
+import com.google.protobuf.ByteString;
+
+/**
+ * <p>Builds a complete Row from partial ReadRowsResponse objects. This class
+ * does not currently handle multiple interleaved rows. It is assumed that it is
+ * handling results for a request with allow_row_interleaving = false.
+ * </p>
+ * <p>Each RowMerger object is valid only for building a single Row. Expected usage
+ * is along the lines of:
+ * </p>
+ * <pre>
+ * RowMerger rm = new RowMerger();
+ * while (!rm.isRowCommited()) {
+ *   rm.addPartialRow(...);
+ * }
+ * Row r = rm.buildRow();
+ * </pre>
+ * 
+ * <p> {@link RowMerger#readNextRow(Iterator)} will essentially perform the code above.</p>
+ */
+public class RowMerger {
+
+  /**
+   * Reads the next {@link Row} from the responseIterator.
+   */
+  public static Row readNextRow(Iterator<ReadRowsResponse> responseIterator) {
+    Preconditions.checkState(responseIterator.hasNext(),
+      "End of stream marker encountered while merging a row.");
+
+    RowMerger rowMerger = new RowMerger();
+    while (responseIterator.hasNext() && !rowMerger.isRowCommitted()) {
+      rowMerger.addPartialRow(responseIterator.next());
+    }
+
+    Preconditions.checkState(rowMerger.isRowCommitted(),
+      "End of stream marker encountered while merging a row.");
+
+    return rowMerger.buildRow();
+  }
+
+  private final Map<String, Family.Builder> familyMap = new HashMap<>();
+  private boolean committed = false;
+  private ByteString currentRowKey;
+
+  /**
+   * Add a partial row response to this builder.
+   */
+  public void addPartialRow(ReadRowsResponse partialRow) {
+    Preconditions.checkState(
+        currentRowKey == null || currentRowKey.equals(partialRow.getRowKey()),
+        "Interleaved ReadRowResponse messages are not supported.");
+
+    if (currentRowKey == null) {
+      currentRowKey = partialRow.getRowKey();
+    }
+
+    for (Chunk chunk : partialRow.getChunksList()) {
+      Preconditions.checkState(!committed, "Encountered chunk after row commit.");
+      switch (chunk.getChunkCase()) {
+        case ROW_CONTENTS:
+          merge(familyMap, chunk.getRowContents());
+          break;
+        case RESET_ROW:
+          familyMap.clear();
+          break;
+        case COMMIT_ROW:
+          committed = true;
+          break;
+        default:
+          throw new IllegalStateException(String.format("Unknown ChunkCase encountered %s",
+            chunk.getChunkCase()));
+      }
+    }
+  }
+
+  /**
+   * Indicate whether a Chunk of type COMMIT_ROW been encountered.
+   */
+  public boolean isRowCommitted() {
+    return committed;
+  }
+
+  /**
+   * Construct a row from previously seen partial rows. This method may only be invoked
+   * when isRowCommitted returns true indicating a COMMIT_ROW chunk has been encountered.
+   */
+  public Row buildRow() {
+    Preconditions.checkState(committed,
+        "Cannot build a Row object if we have not yet encountered a COMMIT_ROW chunk.");
+    Row.Builder currentRowBuilder = Row.newBuilder();
+    currentRowBuilder.setKey(currentRowKey);
+    for (Family.Builder builder : familyMap.values()) {
+      currentRowBuilder.addFamilies(builder.build());
+    }
+    return currentRowBuilder.build();
+  }
+
+  // Merge newRowContents into the map of family builders, creating one if necessary.
+  private void merge(Map<String, Family.Builder> familyBuilderMap, Family newRowContents) {
+    String familyName = newRowContents.getName();
+    Family.Builder familyBuilder = familyBuilderMap.get(familyName);
+    if (familyBuilder == null) {
+      familyBuilder = Family.newBuilder().setName(familyName);
+      familyBuilderMap.put(familyName, familyBuilder);
+    }
+    familyBuilder.addAllColumns(newRowContents.getColumnsList());
+  }
+}

--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/StreamingBigtableResultScanner.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/StreamingBigtableResultScanner.java
@@ -15,18 +15,13 @@
  */
 package com.google.cloud.bigtable.grpc.scanner;
 
-import com.google.bigtable.v1.Family;
 import com.google.bigtable.v1.ReadRowsResponse;
-import com.google.bigtable.v1.ReadRowsResponse.Chunk;
 import com.google.bigtable.v1.Row;
 import com.google.cloud.bigtable.grpc.io.CancellationToken;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
-import com.google.protobuf.ByteString;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
@@ -35,92 +30,6 @@ import java.util.concurrent.TimeUnit;
  * A {@link ResultScanner} implementation against the v1 bigtable API.
  */
 public class StreamingBigtableResultScanner extends AbstractBigtableResultScanner {
-
-  /**
-   * <p>Builds a complete Row from partial ReadRowsResponse objects. This class
-   * does not currently handle multiple interleaved rows. It is assumed that it is
-   * handling results for a request with allow_row_interleaving = false.
-   * </p>
-   * <p>Each RowMerger object is valid only for building a single Row. Expected usage
-   * is along the lines of:
-   * </p>
-   * <pre>
-   * RowMerger rm = new RowMerger();
-   * while (!rm.isRowCommited()) {
-   *   rm.addPartialRow(...);
-   * }
-   * Row r = rm.buildRow();
-   * </pre>
-   */
-  public static class RowMerger {
-    private final Map<String, Family.Builder> familyMap = new HashMap<>();
-    private boolean committed = false;
-    private ByteString currentRowKey;
-
-    /**
-     * Add a partial row response to this builder.
-     */
-    public void addPartialRow(ReadRowsResponse partialRow) {
-      Preconditions.checkState(
-          currentRowKey == null || currentRowKey.equals(partialRow.getRowKey()),
-          "Interleaved ReadRowResponse messages are not supported.");
-
-      if (currentRowKey == null) {
-        currentRowKey = partialRow.getRowKey();
-      }
-
-      for (Chunk chunk : partialRow.getChunksList()) {
-        Preconditions.checkState(!committed, "Encountered chunk after row commit.");
-        switch (chunk.getChunkCase()) {
-          case ROW_CONTENTS:
-            merge(familyMap, chunk.getRowContents());
-            break;
-          case RESET_ROW:
-            familyMap.clear();
-            break;
-          case COMMIT_ROW:
-            committed = true;
-            break;
-          default:
-            throw new IllegalStateException(String.format("Unknown ChunkCase encountered %s",
-              chunk.getChunkCase()));
-        }
-      }
-    }
-
-    /**
-     * Indicate whether a Chunk of type COMMIT_ROW been encountered.
-     */
-    public boolean isRowCommitted() {
-      return committed;
-    }
-
-    /**
-     * Construct a row from previously seen partial rows. This method may only be invoked
-     * when isRowCommitted returns true indicating a COMMIT_ROW chunk has been encountered.
-     */
-    public Row buildRow() {
-      Preconditions.checkState(committed,
-          "Cannot build a Row object if we have not yet encountered a COMMIT_ROW chunk.");
-      Row.Builder currentRowBuilder = Row.newBuilder();
-      currentRowBuilder.setKey(currentRowKey);
-      for (Family.Builder builder : familyMap.values()) {
-        currentRowBuilder.addFamilies(builder.build());
-      }
-      return currentRowBuilder.build();
-    }
-
-    // Merge newRowContents into the map of family builders, creating one if necessary.
-    private void merge(Map<String, Family.Builder> familyBuilderMap, Family newRowContents) {
-      String familyName = newRowContents.getName();
-      Family.Builder familyBuilder = familyBuilderMap.get(familyName);
-      if (familyBuilder == null) {
-        familyBuilder = Family.newBuilder().setName(familyName);
-        familyBuilderMap.put(familyName, familyBuilder);
-      }
-      familyBuilder.addAllColumns(newRowContents.getColumnsList());
-    }
-  }
 
   /**
    * Helper to read a queue of ResultQueueEntries and use the RowMergers to reconstruct


### PR DESCRIPTION
RowMerger seems to be useful outside of StreamingBigtableResultScanner.  StreamingBigtableResultScanner may be going away in favor of a different solution.  Pulling out RowMerger into a separate file to prepare for that eventuality.