### PR TITLE
Point to an HTTPS URL for the HBase API docs

### DIFF
--- a/bigtable-hbase-dataflow/pom.xml
+++ b/bigtable-hbase-dataflow/pom.xml
@@ -128,7 +128,7 @@ limitations under the License.
                                     <location>${basedir}/javadoc/dataflow-docs</location>
                                 </offlineLink>
                                 <offlineLink>
-                                    <url>http://hbase.apache.org/apidocs/</url>
+                                    <url>https://hbase.apache.org/apidocs/</url>
                                     <location>${basedir}/javadoc/hbase-docs</location>
                                 </offlineLink>
                             </offlineLinks>


### PR DESCRIPTION
This is a small fix that should allow links to the HBase API to work once the docs are hosted on cloud.google.com. These links currently fail because cloud.google.com is HTTPS-only, so the browser refuses to load insecure resources from hbase.apache.org.