### PR TITLE
Refactoring ReadAsync functionality into ...bigtable.grpc.async.

### DIFF
--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AsyncUnaryOperationObserver.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AsyncUnaryOperationObserver.java
@@ -1,0 +1,33 @@
+package com.google.cloud.bigtable.grpc.async;
+
+import io.grpc.stub.StreamObserver;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
+
+/**
+ * A StreamObserver for unary async operations. It assumes that the operation is complete
+ * as soon as a single response is received.
+ * @param <T> The response type.
+ */
+public class AsyncUnaryOperationObserver<T> implements StreamObserver<T> {
+  private final SettableFuture<T> completionFuture = SettableFuture.create();
+
+  @Override
+  public void onValue(T t) {
+    completionFuture.set(t);
+  }
+
+  @Override
+  public void onError(Throwable throwable) {
+    completionFuture.setException(throwable);
+  }
+
+  @Override
+  public void onCompleted() {
+  }
+
+  public ListenableFuture<T> getCompletionFuture() {
+    return completionFuture;
+  }
+}

--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/CollectingStreamObserver.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/CollectingStreamObserver.java
@@ -1,0 +1,37 @@
+package com.google.cloud.bigtable.grpc.async;
+
+import io.grpc.stub.StreamObserver;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
+
+/**
+ * CollectingStreamObserver buffers all stream messages in an internal
+ * List and signals the result of {@link #getResponseCompleteFuture()} when complete.
+ */
+public class CollectingStreamObserver<T> implements StreamObserver<T> {
+  private final SettableFuture<List<T>> responseCompleteFuture = SettableFuture.create();
+  private final List<T> buffer = new ArrayList<>();
+
+  public ListenableFuture<List<T>> getResponseCompleteFuture() {
+    return responseCompleteFuture;
+  }
+
+  @Override
+  public void onValue(T value) {
+    buffer.add(value);
+  }
+
+  @Override
+  public void onError(Throwable throwable) {
+    responseCompleteFuture.setException(throwable);
+  }
+
+  @Override
+  public void onCompleted() {
+    responseCompleteFuture.set(buffer);
+  }
+}

--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/ReadAsync.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/ReadAsync.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.grpc.async;
+
+import java.util.List;
+
+import com.google.common.util.concurrent.ListenableFuture;
+
+public interface ReadAsync<REQUEST, RESPONSE> {
+  ListenableFuture<List<RESPONSE>> readAsync(REQUEST request);
+}

--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/ReadAsyncFactory.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/ReadAsyncFactory.java
@@ -1,0 +1,75 @@
+package com.google.cloud.bigtable.grpc.async;
+
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.MethodDescriptor;
+import io.grpc.stub.ClientCalls;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import com.google.bigtable.v1.BigtableServiceGrpc;
+import com.google.bigtable.v1.ReadRowsRequest;
+import com.google.bigtable.v1.ReadRowsResponse;
+import com.google.bigtable.v1.Row;
+import com.google.bigtable.v1.SampleRowKeysRequest;
+import com.google.bigtable.v1.SampleRowKeysResponse;
+import com.google.cloud.bigtable.grpc.scanner.RowMerger;
+import com.google.common.base.Function;
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+
+public final class ReadAsyncFactory {
+
+  private static final Function<List<SampleRowKeysResponse>, List<SampleRowKeysResponse>> IMMUTABLE_LIST_TRANSFORMER =
+      new Function<List<SampleRowKeysResponse>, List<SampleRowKeysResponse>>() {
+        @Override
+        public List<SampleRowKeysResponse> apply(List<SampleRowKeysResponse> list) {
+          return ImmutableList.copyOf(list);
+        }
+      };
+
+  private static Function<List<ReadRowsResponse>, List<Row>> ROW_TRANSFORMER =
+      new Function<List<ReadRowsResponse>, List<Row>>() {
+        @Override
+        public List<Row> apply(List<ReadRowsResponse> responses) {
+          List<Row> result = new ArrayList<>();
+          Iterator<ReadRowsResponse> responseIterator = responses.iterator();
+          while (responseIterator.hasNext()) {
+            result.add(RowMerger.readNextRow(responseIterator));
+          }
+          return result;
+        }
+      };
+
+  public static ReadAsync<SampleRowKeysRequest, SampleRowKeysResponse>
+      createSampleRowKeyAsyncReader(final Channel channel) {
+    return createReadAsync(channel, BigtableServiceGrpc.METHOD_SAMPLE_ROW_KEYS,
+      IMMUTABLE_LIST_TRANSFORMER);
+  }
+
+  public static ReadAsync<ReadRowsRequest, Row> createRowKeyAysncReader(final Channel channel) {
+    return createReadAsync(channel, BigtableServiceGrpc.METHOD_READ_ROWS, ROW_TRANSFORMER);
+  }
+
+  private static <RequestT, ResponseT, OutputT> ReadAsync<RequestT, OutputT> createReadAsync(
+      final Channel channel, final MethodDescriptor<RequestT, ResponseT> method,
+      final Function<List<ResponseT>, List<OutputT>> function) {
+    return new ReadAsync<RequestT, OutputT>() {
+      @Override
+      public ListenableFuture<List<OutputT>> readAsync(RequestT request) {
+        ClientCall<RequestT, ResponseT> readRowsCall =
+            channel.newCall(method, CallOptions.DEFAULT);
+        CollectingStreamObserver<ResponseT> responseCollector = new CollectingStreamObserver<>();
+        ClientCalls.asyncServerStreamingCall(readRowsCall, request, responseCollector);
+        return Futures.transform(responseCollector.getResponseCompleteFuture(), function);
+      }
+    };
+  }
+
+  private ReadAsyncFactory(){
+  }
+}


### PR DESCRIPTION
This is a part of a larger refactoring to come.  There needs to be a grpc version of BigtableBufferedMutator as well as fixes to BatchExecutor.  This is one step towards that goal by moving out shared logic from BigtableDataGrpcClient.

Note, call.request(1) was also removed.  That was not a good addition to our codebase.