### PR TITLE
Renaming ReadAsync to RetryableRpc.

### DIFF
--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataGrpcClient.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataGrpcClient.java
@@ -36,7 +36,7 @@ import com.google.bigtable.v1.SampleRowKeysRequest;
 import com.google.bigtable.v1.SampleRowKeysResponse;
 import com.google.cloud.bigtable.config.RetryOptions;
 import com.google.cloud.bigtable.grpc.async.BigtableAsyncUtilities;
-import com.google.cloud.bigtable.grpc.async.ReadAsync;
+import com.google.cloud.bigtable.grpc.async.RetryableRpc;
 import com.google.cloud.bigtable.grpc.io.CancellationToken;
 import com.google.cloud.bigtable.grpc.scanner.BigtableResultScannerFactory;
 import com.google.cloud.bigtable.grpc.scanner.ResultScanner;
@@ -91,8 +91,8 @@ public class BigtableDataGrpcClient implements BigtableDataClient {
           return streamRows(request);
         }
       };
-  private final ReadAsync<SampleRowKeysRequest, SampleRowKeysResponse> sampleRowKeysAsync;
-  private final ReadAsync<ReadRowsRequest, Row> readRowsAsync;
+  private final RetryableRpc<SampleRowKeysRequest, List<SampleRowKeysResponse>> sampleRowKeysAsync;
+  private final RetryableRpc<ReadRowsRequest, List<Row>> readRowsAsync;
 
   public BigtableDataGrpcClient(
       Channel channel,

--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/RetryableRpc.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/RetryableRpc.java
@@ -15,13 +15,11 @@
  */
 package com.google.cloud.bigtable.grpc.async;
 
-import java.util.List;
-
 import com.google.common.util.concurrent.ListenableFuture;
 
 /**
- * This interface represents an asynchronous read.
+ * This interface represents an RPC that is retryable.
  */
-public interface ReadAsync<REQUEST, RESPONSE> {
-  ListenableFuture<List<RESPONSE>> readAsync(REQUEST request);
+public interface RetryableRpc<REQUEST, RESPONSE> {
+  ListenableFuture<RESPONSE> call(REQUEST request);
 }


### PR DESCRIPTION
This is in preparation for moving muate and checkAdMutate to use this grpc.async package.