### PR TITLE
Introducing BigtableAsyncExecutor

### DIFF
--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BigtableAsyncExecutor.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BigtableAsyncExecutor.java
@@ -1,0 +1,286 @@
+/*
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.grpc.async;
+
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock.ReadLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock.WriteLock;
+
+import com.google.bigtable.v1.CheckAndMutateRowRequest;
+import com.google.bigtable.v1.CheckAndMutateRowResponse;
+import com.google.bigtable.v1.MutateRowRequest;
+import com.google.bigtable.v1.ReadModifyWriteRowRequest;
+import com.google.bigtable.v1.ReadRowsRequest;
+import com.google.bigtable.v1.Row;
+import com.google.cloud.bigtable.config.Logger;
+import com.google.cloud.bigtable.grpc.BigtableDataClient;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.google.protobuf.Empty;
+import com.google.protobuf.GeneratedMessage;
+
+/**
+ * Performs asynchronous mutations and reads w
+ */
+// TODO: Cleanup the interface so that @VisibleForTesting can be reduced.
+public class BigtableAsyncExecutor implements Closeable {
+
+  protected static final Logger LOG = new Logger(BigtableAsyncExecutor.class);
+
+  // Flush is not properly synchronized with respect to waiting. It will never exit
+  // improperly, but it might wait more than it has to. Setting this to a low value ensures
+  // that improper waiting is minimal.
+  private static final long WAIT_MILLIS = 250;
+
+  // In flush, wait up to this number of milliseconds without any operations completing.  If
+  // this amount of time goes by without any updates, flush will log a warning.  Flush()
+  // will still wait to complete.
+  private static final long INTERVAL_NO_SUCCESS_WARNING = 300000;
+
+  public interface Callback<ReqT, RespT> {
+    void onSuccess(ReqT request, RespT response);
+    void onFailure(ReqT request, Throwable t);
+  }
+
+  protected final ExecutorService heapSizeExecutor = Executors.newCachedThreadPool(
+    new ThreadFactoryBuilder()
+        .setNameFormat("heapSize-async-%s")
+        .setDaemon(true)
+        .build());
+
+  /**
+   * This class ensures that operations meet heap size and max RPC counts.  A wait will occur
+   * if RPCs are requested after heap and RPC count thresholds are exceeded.
+   */
+  @VisibleForTesting
+  static class HeapSizeManager {
+    private final long maxHeapSize;
+    private final int maxInFlightRpcs;
+    private long currentWriteBufferSize = 0;
+    private long operationSequenceGenerator = 0;
+
+    @VisibleForTesting
+    final Map<Long, Long> pendingOperationsWithSize = new HashMap<>();
+    private long lastOperationChange = System.currentTimeMillis();
+
+    HeapSizeManager(long maxHeapSize, int maxInflightRpcs) {
+      this.maxHeapSize = maxHeapSize;
+      this.maxInFlightRpcs = maxInflightRpcs;
+    }
+
+    private long getMaxHeapSize() {
+      return maxHeapSize;
+    }
+
+    private synchronized void waitUntilAllOperationsAreDone() throws InterruptedException {
+      boolean performedWarning = false;
+      while(!pendingOperationsWithSize.isEmpty()) {
+        if (!performedWarning
+            && lastOperationChange + INTERVAL_NO_SUCCESS_WARNING < System.currentTimeMillis()) {
+          long lastUpdated = (System.currentTimeMillis() - lastOperationChange) / 1000;
+          LOG.warn("No operations completed within the last %d seconds."
+              + "There are still %d operations in progress.", lastUpdated,
+            pendingOperationsWithSize.size());
+          performedWarning = true;
+        }
+        wait(WAIT_MILLIS);
+      }
+      if (performedWarning) {
+        LOG.info("flush() completed");
+      }
+    }
+
+    private synchronized long registerOperationWithHeapSize(long heapSize)
+        throws InterruptedException {
+      long operationId = ++operationSequenceGenerator;
+      while (currentWriteBufferSize >= maxHeapSize
+          || pendingOperationsWithSize.size() >= maxInFlightRpcs) {
+        wait(WAIT_MILLIS);
+      }
+
+      lastOperationChange = System.currentTimeMillis();
+      pendingOperationsWithSize.put(operationId, heapSize);
+      currentWriteBufferSize += heapSize;
+      return operationId;
+    }
+
+    @VisibleForTesting
+    synchronized void operationComplete(long operationSequenceId) {
+      lastOperationChange = System.currentTimeMillis();
+      Long heapSize = pendingOperationsWithSize.remove(operationSequenceId);
+      if (heapSize != null) {
+        currentWriteBufferSize -= heapSize;
+        notifyAll();
+      } else {
+        LOG.warn("An operation completion was recieved multiple times. Your operations completed."
+            + " Please notify Google that this occurred.");
+      }
+    }
+
+    private synchronized boolean hasInflightRequests() {
+      return !pendingOperationsWithSize.isEmpty();
+    }
+
+    @VisibleForTesting
+    synchronized long getHeapSize() {
+      return currentWriteBufferSize;
+    }
+  }
+
+  @VisibleForTesting
+  final HeapSizeManager sizeManager;
+  private boolean closed = false;
+
+  /**
+   * Makes sure that mutations and flushes are safe to proceed.  Ensures that while the mutator
+   * is closing, there will be no additional writes.
+   */
+  private final ReentrantReadWriteLock rpcLock = new ReentrantReadWriteLock();
+  private final BigtableDataClient client;
+  private final Executor executor;
+
+  public BigtableAsyncExecutor(int maxInflightRpcs, long maxHeapSize, BigtableDataClient client,
+      Executor executor) {
+    this.sizeManager = new HeapSizeManager(maxHeapSize, maxInflightRpcs);
+    this.client = client;
+    this.executor = executor;
+  }
+
+  @Override
+  public void close() throws IOException {
+    WriteLock lock = rpcLock.writeLock();
+    lock.lock();
+    try {
+      if (!closed) {
+        closed = true;
+        doFlush();
+        heapSizeExecutor.shutdown();
+      }
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  public void flush() throws IOException {
+    WriteLock lock = rpcLock.writeLock();
+    lock.lock();
+    try {
+      doFlush();
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  private void doFlush() throws IOException {
+    LOG.trace("Flushing");
+    try {
+      sizeManager.waitUntilAllOperationsAreDone();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+    LOG.trace("Done flushing");
+  }
+
+  public long getWriteBufferSize() {
+    return this.sizeManager.getMaxHeapSize();
+  }
+
+  /**
+   * Being a Mutation. This method will block if either of the following are true:
+   * 1) There are more than {@code maxInflightRpcs} RPCs in flight
+   * 2) There are more than {@link #getWriteBufferSize()} bytes pending
+   */
+  public ListenableFuture<Empty> mutateRowAsync(MutateRowRequest request) {
+    FutureCallback<Empty> callback = register(request);
+    ListenableFuture<Empty> future = client.mutateRowAsync(request);
+    Futures.addCallback(future, callback, executor);
+    return future;
+  }
+
+  public ListenableFuture<CheckAndMutateRowResponse> checkAndMutateRowAsync(
+      CheckAndMutateRowRequest request) {
+    FutureCallback<CheckAndMutateRowResponse> callback = register(request);
+    ListenableFuture<CheckAndMutateRowResponse> future = client.checkAndMutateRowAsync(request);
+    Futures.addCallback(future, callback, executor);
+    return future;
+  }
+
+  public ListenableFuture<Row> readModifyWriteRowAsync(ReadModifyWriteRowRequest request) {
+    FutureCallback<Row> callback = register(request);
+    ListenableFuture<Row> future = client.readModifyWriteRowAsync(request);
+    Futures.addCallback(future, callback, executor);
+    return future;
+  }
+
+  public ListenableFuture<List<com.google.bigtable.v1.Row>> readRowsAsync(ReadRowsRequest request) {
+    FutureCallback<List<Row>> callback = register(request);
+    ListenableFuture<List<Row>> future = client.readRowsAsync(request);
+    Futures.addCallback(future, callback, executor);
+    return future;
+  }
+
+  private <T> AccountingFutureCallback<T> register(GeneratedMessage request) {
+    long id;
+    ReadLock readLock = rpcLock.readLock();
+    readLock.lock();
+    try {
+      // registerOperationWithHeapSize() waits until both the memory and rpc count maximum
+      // requirements are achieved.
+      id = sizeManager.registerOperationWithHeapSize(request.getSerializedSize());
+    } catch (InterruptedException e) {
+      // The handleExceptions() or may not throw an exception. Don't continue processing.
+      Thread.currentThread().interrupt();
+      throw new RuntimeException("Interrupted while trying to perform a batch operation", e);
+    } finally {
+      readLock.unlock();
+    }
+    return new AccountingFutureCallback<T>(id);
+  }
+
+  private class AccountingFutureCallback<T> implements FutureCallback<T> {
+    private final long operationSequenceId;
+
+    public AccountingFutureCallback(long operationSequenceId) {
+      this.operationSequenceId = operationSequenceId;
+    }
+
+    @Override
+    public void onSuccess(T result) {
+      sizeManager.operationComplete(operationSequenceId);
+    }
+
+    @Override
+    public void onFailure(Throwable t) {
+      sizeManager.operationComplete(operationSequenceId);
+    }
+  }
+
+  public boolean hasInflightRequests() {
+    return sizeManager.hasInflightRequests();
+  }
+}

--- a/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestBigtableAsyncExecutor.java
+++ b/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestBigtableAsyncExecutor.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2015 Google Inc. All Rights Reserved. Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable
+ * law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
+ * for the specific language governing permissions and limitations under the License.
+ */
+package com.google.cloud.bigtable.grpc.async;
+
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Matchers.*;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import com.google.bigtable.v1.CheckAndMutateRowRequest;
+import com.google.bigtable.v1.MutateRowRequest;
+import com.google.bigtable.v1.ReadModifyWriteRowRequest;
+import com.google.cloud.bigtable.grpc.BigtableDataClient;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.protobuf.GeneratedMessage;
+
+/**
+ * Tests for {@link BigtableAsyncExecutor}
+ */
+@SuppressWarnings("unchecked")
+@RunWith(JUnit4.class)
+public class TestBigtableAsyncExecutor {
+
+  private BigtableAsyncExecutor underTest;
+
+  @Mock
+  BigtableDataClient client;
+
+  @SuppressWarnings("rawtypes")
+  @Mock
+  private ListenableFuture future;
+
+  private List<Runnable> runnables = new ArrayList<>();
+  @Mock
+  Executor executor;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+    setup();
+  }
+
+  private void setup() {
+    underTest = new BigtableAsyncExecutor(100, 100000000l, client, executor);
+    runnables.clear();
+    Mockito.doAnswer(new Answer<Void>() {
+      @Override
+      public Void answer(InvocationOnMock invocation) throws Throwable {
+        Runnable r = (Runnable) invocation.getArguments()[0];
+        runnables.add(r);
+        return null;
+      }
+    }).when(future).addListener(any(Runnable.class), any(Executor.class));
+  }
+
+  @Test
+  public void testNoMutation() throws IOException {
+    Assert.assertFalse(underTest.hasInflightRequests());
+    Assert.assertEquals(0l, underTest.sizeManager.getHeapSize());
+  }
+
+  @Test
+  public void testMutation() throws IOException, InterruptedException, ExecutionException {
+    MutateRowRequest request = MutateRowRequest.getDefaultInstance();
+    when(client.mutateRowAsync(eq(request))).thenReturn(future);
+    when(future.get()).thenReturn(null);
+    underTest.mutateRowAsync(request);
+    verify(client, times(1)).mutateRowAsync(eq(request));
+    verifyGoodCall(request);
+  }
+
+  @Test
+  public void testCheckAndMutate() throws IOException, InterruptedException, ExecutionException {
+    CheckAndMutateRowRequest request = CheckAndMutateRowRequest.getDefaultInstance();
+    when(client.checkAndMutateRowAsync(eq(request))).thenReturn(future);
+    underTest.checkAndMutateRowAsync(request);
+    when(future.get()).thenReturn(null);
+    verify(client, times(1)).checkAndMutateRowAsync(eq(request));
+    verifyGoodCall(request);
+  }
+
+  @Test
+  public void testRedModifyWrite() throws IOException, InterruptedException, ExecutionException {
+    ReadModifyWriteRowRequest request = ReadModifyWriteRowRequest.getDefaultInstance();
+    when(client.readModifyWriteRowAsync(eq(request))).thenReturn(future);
+    when(future.get()).thenReturn(null);
+    underTest.readModifyWriteRowAsync(request);
+    verify(client, times(1)).readModifyWriteRowAsync(eq(request));
+    verifyGoodCall(request);
+  }
+
+  private void verifyGoodCall(GeneratedMessage request) {
+    Assert.assertTrue(underTest.hasInflightRequests());
+    Assert.assertEquals(request.getSerializedSize(), underTest.sizeManager.getHeapSize());
+    completeCall();
+    Assert.assertFalse(underTest.hasInflightRequests());
+    Assert.assertEquals(0l, underTest.sizeManager.getHeapSize());
+  }
+
+  private void completeCall() {
+    for (Runnable r : runnables) {
+      r.run();
+    }
+  }
+
+  @Test
+  public void testInvalidPut() throws Exception {
+    MutateRowRequest request = MutateRowRequest.getDefaultInstance();
+    when(client.mutateRowAsync(eq(request))).thenReturn(future);
+    underTest.mutateRowAsync(request);
+    completeCall();
+    // wait until the handling in the heapSizeExecutor kicks in.
+    Assert.assertFalse(underTest.hasInflightRequests());
+    Assert.assertEquals(0l, underTest.sizeManager.getHeapSize());
+  }
+}

--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableTable.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableTable.java
@@ -73,6 +73,7 @@ import com.google.cloud.bigtable.config.BigtableOptions;
 import com.google.cloud.bigtable.config.Logger;
 import com.google.cloud.bigtable.grpc.BigtableDataClient;
 import com.google.cloud.bigtable.grpc.BigtableTableName;
+import com.google.cloud.bigtable.grpc.async.BigtableAsyncExecutor;
 import com.google.cloud.bigtable.hbase.adapters.Adapters;
 import com.google.cloud.bigtable.hbase.adapters.DefaultReadHooks;
 import com.google.cloud.bigtable.hbase.adapters.MutationAdapter;
@@ -128,7 +129,8 @@ public class BigtableTable implements Table {
       TableName tableName,
       BigtableOptions options,
       BigtableDataClient client,
-      ExecutorService executorService) {
+      ExecutorService executorService,
+      BigtableAsyncExecutor asyncExecutor) {
     this.bigtableConnection = bigtableConnection;
     this.tableName = tableName;
     this.options = options;
@@ -138,12 +140,11 @@ public class BigtableTable implements Table {
     rowMutationsAdapter = new RowMutationsAdapter(mutationAdapter);
     this.bigtableTableName = options.getClusterName().toTableName(tableName.getNameAsString());
     this.batchExecutor = new BatchExecutor(
-        client,
-        options,
         this.bigtableTableName,
         MoreExecutors.listeningDecorator(executorService),
         putAdapter,
-        rowMutationsAdapter);
+        rowMutationsAdapter,
+        asyncExecutor);
   }
 
   @Override

--- a/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableTable.java
+++ b/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableTable.java
@@ -34,6 +34,7 @@ import com.google.bigtable.v1.RowFilter.Chain;
 import com.google.cloud.bigtable.config.BigtableOptions;
 import com.google.cloud.bigtable.config.RetryOptions;
 import com.google.cloud.bigtable.grpc.BigtableDataClient;
+import com.google.cloud.bigtable.grpc.async.BigtableAsyncExecutor;
 import com.google.cloud.bigtable.grpc.scanner.ResultScanner;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.ServiceException;
@@ -86,6 +87,9 @@ public class TestBigtableTable {
   @Mock
   private ResultScanner<Row> mockResultScanner;
 
+  @Mock
+  private BigtableAsyncExecutor asyncExecutor;
+
   public BigtableTable table;
 
   @Before
@@ -112,7 +116,9 @@ public class TestBigtableTable {
         TableName.valueOf(TEST_TABLE),
         options,
         mockClient,
-        Executors.newCachedThreadPool());
+        Executors.newCachedThreadPool(),
+        asyncExecutor
+        );
   }
 
   @Test
@@ -188,7 +194,7 @@ public class TestBigtableTable {
         new QualifierFilter(CompareOp.EQUAL, new BinaryComparator(Bytes.toBytes("x")));
     assertFalse(BigtableTable.hasWhileMatchFilter(filter));
   }
-  
+
   @Test
   public void hasWhileMatchFilter_yesAtTopLevel() {
     QualifierFilter filter =
@@ -196,7 +202,7 @@ public class TestBigtableTable {
     WhileMatchFilter whileMatchFilter = new WhileMatchFilter(filter);
     assertTrue(BigtableTable.hasWhileMatchFilter(whileMatchFilter));
   }
-  
+
   @Test
   public void hasWhileMatchFilter_noInNested() {
     QualifierFilter filter =
@@ -213,7 +219,7 @@ public class TestBigtableTable {
     FilterList filterList = new FilterList(whileMatchFilter);
     assertTrue(BigtableTable.hasWhileMatchFilter(filterList));
   }
-  
+
   @Test
   public void getScanner_withBigtableResultScannerAdapter() throws IOException {
     when(mockClient.readRows(isA(ReadRowsRequest.class))).thenReturn(mockResultScanner);
@@ -240,7 +246,7 @@ public class TestBigtableTable {
         result.getColumnCells("family_name".getBytes(), "q_name".getBytes());
     assertEquals(1, cells.size());
     assertEquals("value", new String(CellUtil.cloneValue(cells.get(0))));
-    
+
     verify(mockClient).readRows(isA(ReadRowsRequest.class));
     verify(mockResultScanner).next();
   }


### PR DESCRIPTION
BigtableAsyncExecutor is a grpc version of BigtableBufferedMutator.  It should be usable by people who want to use BigtableSession without the HBase API.  Moving BigtableBufferedMutator and BatchExecutor to use it.

If this is too big of a commit, it could probably be broken up.