### PR TITLE
Using AsyncMutator in BatchExecutor.

### DIFF
--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableTable.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableTable.java
@@ -107,13 +107,15 @@ public class BigtableTable implements Table {
       AbstractBigtableConnection bigtableConnection,
       TableName tableName,
       BigtableOptions options,
+      BigtableDataClient client,
+      HBaseRequestAdapter hbaseAdapter,
       BatchExecutor batchExecutor) {
     this.bigtableConnection = bigtableConnection;
     this.tableName = tableName;
     this.options = options;
-    this.client = batchExecutor.getClient();
+    this.client = client;
     this.batchExecutor = batchExecutor;
-    this.hbaseAdapter = batchExecutor.getHbaseAdapter();
+    this.hbaseAdapter = hbaseAdapter;
   }
 
   @Override

--- a/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableBufferedMutator.java
+++ b/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableBufferedMutator.java
@@ -45,7 +45,7 @@ import org.mockito.stubbing.Answer;
 import com.google.bigtable.v1.MutateRowRequest;
 import com.google.cloud.bigtable.grpc.BigtableClusterName;
 import com.google.cloud.bigtable.grpc.BigtableDataClient;
-import com.google.cloud.bigtable.grpc.async.AsyncMutator;
+import com.google.cloud.bigtable.grpc.async.AsyncExecutor;
 import com.google.cloud.bigtable.hbase.adapters.HBaseRequestAdapter;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
@@ -91,8 +91,8 @@ public class TestBigtableBufferedMutator {
         client,
         new HBaseRequestAdapter(clusterName,  TableName.valueOf("TABLE"), configuration),
         configuration,
-        AsyncMutator.MAX_INFLIGHT_RPCS_DEFAULT,
-        AsyncMutator.ASYNC_MUTATOR_MAX_MEMORY_DEFAULT,
+        AsyncExecutor.MAX_INFLIGHT_RPCS_DEFAULT,
+        AsyncExecutor.ASYNC_MUTATOR_MAX_MEMORY_DEFAULT,
         null,
         listener,
         heapSizeExecutorService);

--- a/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableTable.java
+++ b/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableTable.java
@@ -112,10 +112,10 @@ public class TestBigtableTable {
     TableName tableName = TableName.valueOf(TEST_TABLE);
     HBaseRequestAdapter hbaseAdapter =
         new HBaseRequestAdapter(options.getClusterName(), tableName, config);
-    Mockito.when(batchExecutor.getClient()).thenReturn(mockClient);
-    Mockito.when(batchExecutor.getHbaseAdapter()).thenReturn(hbaseAdapter);
     Mockito.when(mockConnection.getConfiguration()).thenReturn(config);
-    table = new BigtableTable(mockConnection, tableName, options, batchExecutor);
+    table =
+        new BigtableTable(mockConnection, tableName, options, mockClient, hbaseAdapter,
+            batchExecutor);
   }
 
   @Test


### PR DESCRIPTION
This change fixes a problem with BigtableTable.batch() operations which use BatchExecutor under the cover.  Users have had problems with OOMing and too many streams.  This will fix the issue by using the same throttling mechanism for batch() that's used in BufferedMutator.