### PR TITLE
Revert "Revert "Set max message size limit to 256 MB to match the ser…

### DIFF
--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
@@ -397,6 +397,7 @@ public class BigtableSession implements AutoCloseable {
       public Channel createChannel() throws IOException {
         return NettyChannelBuilder
             .forAddress(host)
+            .maxMessageSize(256 * 1024 * 1024) // 256 MB, server has 256 MB limit.
             .sslContext(createSslContext())
             .eventLoopGroup(elg)
             .executor(batchPool)


### PR DESCRIPTION
Reverts GoogleCloudPlatform/cloud-bigtable-client#456
Set max message size to 256 MB as we are using gRPC 0.9.0 now/