### PR TITLE
Removing the Generics from the Dataflow *Configuration classes.

### DIFF
--- a/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/CloudBigtableConfiguration.java
+++ b/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/CloudBigtableConfiguration.java
@@ -17,7 +17,6 @@ package com.google.cloud.bigtable.dataflow;
 
 import java.io.IOException;
 import java.io.Serializable;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -41,8 +40,7 @@ public class CloudBigtableConfiguration implements Serializable {
   /**
    * Builds a {@link CloudBigtableConfiguration}.
    */
-  @SuppressWarnings("unchecked")
-  public static class Builder<T extends Builder<?>> {
+  public static class Builder {
     protected String projectId;
     protected String zoneId;
     protected String clusterId;
@@ -64,9 +62,9 @@ public class CloudBigtableConfiguration implements Serializable {
      * @param projectId The project ID for the cluster.
      * @return The original {@link CloudBigtableConfiguration.Builder} for chaining convenience.
      */
-    public T withProjectId(String projectId) {
+    public Builder withProjectId(String projectId) {
       this.projectId = projectId;
-      return (T) this;
+      return this;
     }
 
     /**
@@ -74,9 +72,9 @@ public class CloudBigtableConfiguration implements Serializable {
      * @param zoneId The zone where the cluster is located.
      * @return The original {@link CloudBigtableConfiguration.Builder} for chaining convenience.
      */
-    public T withZoneId(String zoneId) {
+    public Builder withZoneId(String zoneId) {
       this.zoneId = zoneId;
-      return (T) this;
+      return this;
     }
 
     /**
@@ -84,9 +82,9 @@ public class CloudBigtableConfiguration implements Serializable {
      * @param clusterId The cluster ID for the cluster.
      * @return The original {@link CloudBigtableConfiguration.Builder} for chaining convenience.
      */
-    public T withClusterId(String clusterId) {
+    public Builder withClusterId(String clusterId) {
       this.clusterId = clusterId;
-      return (T) this;
+      return this;
     }
 
     /**
@@ -94,10 +92,10 @@ public class CloudBigtableConfiguration implements Serializable {
      * {@link BigtableOptionsFactory#fromConfiguration(Configuration)} for more information about
      * configuration options.
      */
-    public T withConfiguration(String key, String value) {
+    public Builder withConfiguration(String key, String value) {
       Preconditions.checkArgument(value != null, "Value cannot be null");
       this.additionalConfiguration.put(key, value);
-      return (T) this;
+      return this;
     }
 
     /**
@@ -193,7 +191,6 @@ public class CloudBigtableConfiguration implements Serializable {
    * Creates a new Builder from the configuration
    * @return A new {@link Builder}
    */
-  @SuppressWarnings({ "rawtypes", "unchecked" })
   public Builder toBuilder() {
     return new Builder(getConfiguration());
   }

--- a/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/CloudBigtableScanConfiguration.java
+++ b/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/CloudBigtableScanConfiguration.java
@@ -67,7 +67,7 @@ public class CloudBigtableScanConfiguration extends CloudBigtableTableConfigurat
   /**
    * Builds a {@link CloudBigtableScanConfiguration}.
    */
-  public static class Builder extends CloudBigtableTableConfiguration.Builder<Builder> {
+  public static class Builder extends CloudBigtableTableConfiguration.Builder {
     protected Scan scan = new Scan();
 
     public Builder() {
@@ -84,6 +84,55 @@ public class CloudBigtableScanConfiguration extends CloudBigtableTableConfigurat
      */
     public Builder withScan(Scan scan) {
       this.scan = scan;
+      return this;
+    }
+
+    /*
+     * Overrides of the CloudBigtableConfiguration.Builder's with*() so that they return
+     * CloudBigtableScanConfiguration.Builder.
+     */
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Builder withProjectId(String projectId) {
+      super.withProjectId(projectId);
+      return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Builder withZoneId(String zoneId) {
+      super.withZoneId(zoneId);
+      return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Builder withClusterId(String clusterId) {
+      super.withClusterId(clusterId);
+      return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Builder withConfiguration(String key, String value) {
+      super.withConfiguration(key, value);
+      return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Builder withTableId(String tableId) {
+      super.withTableId(tableId);
       return this;
     }
 

--- a/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/CloudBigtableTableConfiguration.java
+++ b/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/CloudBigtableTableConfiguration.java
@@ -43,8 +43,7 @@ public class CloudBigtableTableConfiguration extends CloudBigtableConfiguration 
   /**
    * Builds a {@link CloudBigtableTableConfiguration}.
    */
-  @SuppressWarnings("unchecked")
-  public static class Builder<T extends Builder<?>> extends CloudBigtableConfiguration.Builder<T> {
+  public static class Builder extends CloudBigtableConfiguration.Builder {
     protected String tableId;
 
     public Builder() {
@@ -60,9 +59,49 @@ public class CloudBigtableTableConfiguration extends CloudBigtableConfiguration 
      * @return The original {@link CloudBigtableTableConfiguration.Builder} for chaining
      * 		convenience.
      */
-    public T withTableId(String tableId) {
+    public Builder withTableId(String tableId) {
       this.tableId = tableId;
-      return (T) this;
+      return this;
+    }
+
+    /*
+     * Overrides of the CloudBigtableConfiguration.Builder's with*() so that they return
+     * CloudBigtableTableConfiguration.Builder.
+     */
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Builder withProjectId(String projectId) {
+      super.withProjectId(projectId);
+      return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Builder withZoneId(String zoneId) {
+      super.withZoneId(zoneId);
+      return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Builder withClusterId(String clusterId) {
+      super.withClusterId(clusterId);
+      return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Builder withConfiguration(String key, String value) {
+      super.withConfiguration(key, value);
+      return this;
     }
 
     /**
@@ -102,7 +141,6 @@ public class CloudBigtableTableConfiguration extends CloudBigtableConfiguration 
     return tableId;
   }
 
-  @SuppressWarnings({ "rawtypes", "unchecked" })
   @Override
   public Builder toBuilder() {
     return new Builder(getConfiguration())

--- a/bigtable-hbase-dataflow/src/test/java/com/google/cloud/bigtable/dataflow/CloudBigtableIOIntegrationTest.java
+++ b/bigtable-hbase-dataflow/src/test/java/com/google/cloud/bigtable/dataflow/CloudBigtableIOIntegrationTest.java
@@ -48,7 +48,6 @@ public class CloudBigtableIOIntegrationTest {
   private static BigtableConnection connection;
   private static CloudBigtableConfiguration config;
 
-  @SuppressWarnings("rawtypes")
   @BeforeClass
   public static void setup() throws IOException {
     config =

--- a/bigtable-hbase-dataflow/src/test/java/com/google/cloud/bigtable/dataflow/CloudBigtableScanConfigurationTest.java
+++ b/bigtable-hbase-dataflow/src/test/java/com/google/cloud/bigtable/dataflow/CloudBigtableScanConfigurationTest.java
@@ -89,6 +89,5 @@ public class CloudBigtableScanConfigurationTest {
     Assert.assertNotSame(underTest, copy);
     Assert.assertEquals(underTest, copy);
   }
-
 }
 


### PR DESCRIPTION
The Generics in the Builder hierarchy causes all sorts of issues.  Removing them required some additional verbosity in overridden methods.  I think that the change will increase framework code, but reduce complexity from the user's perspective.