### PR TITLE
Switch from Pipeline Options to Dataflow Pipeline Options

### DIFF
--- a/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/CloudBigtableOptions.java
+++ b/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/CloudBigtableOptions.java
@@ -15,17 +15,18 @@
  */
 package com.google.cloud.bigtable.dataflow;
 
+import com.google.cloud.dataflow.sdk.options.DataflowPipelineOptions;
 import com.google.cloud.dataflow.sdk.options.Description;
-import com.google.cloud.dataflow.sdk.options.PipelineOptions;
+
 
 /**
- * CloudBigtableOptions is an extension of {@link PipelineOptions} containing the information
- * required for a connection to Cloud Bigtable.
+ * CloudBigtableOptions is an extension of {@link DataflowPipelineOptions} containing the
+ * information required for a connection to Cloud Bigtable.
  */
 @Description("Options used to configure CloudBigtable.  " +
    "see https://cloud.google.com/bigtable/ for more information.  " +
    "See https://cloud.google.com/bigtable/docs/creating-cluster for getting started with Bigtable.")
-public interface CloudBigtableOptions extends PipelineOptions {
+public interface CloudBigtableOptions extends DataflowPipelineOptions {
 
   @Description("The Google Cloud projectId for the Cloud Bigtable cluster.")
   String getBigtableProjectId();


### PR DESCRIPTION
Currently you can't use CloudBigtableOptions and use flags like setStreaming() since those are contained in StreamingOptions. This forces you to make extra classes to do the same thing. You could have BigtableOptions just extend StreamingOptions but DataflowPipelineOptions seems to contain a lot of useful additional options along with it.