### PR TITLE
Using a retry with back off for auth refreshing.

### DIFF
--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
@@ -302,7 +302,8 @@ public class BigtableSession implements AutoCloseable {
     if (credentials != null) {
       if (credentials instanceof OAuth2Credentials) {
         final RefreshingOAuth2CredentialsInterceptor oauth2Interceptor =
-            new RefreshingOAuth2CredentialsInterceptor(batchPool, (OAuth2Credentials) credentials);
+            new RefreshingOAuth2CredentialsInterceptor(batchPool, (OAuth2Credentials) credentials,
+                this.options.getRetryOptions());
         credentialRefreshFuture = batchPool.submit(new Callable<Void>() {
           @Override
           public Void call() throws Exception {

--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/RetryingRpcFutureFallback.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/RetryingRpcFutureFallback.java
@@ -32,7 +32,7 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 
 /**
- * A FutureFallback that retries a RetryableRpc request.
+ * A {@link FutureFallback} that retries a {@link RetryableRpc} request.
  */
 public class RetryingRpcFutureFallback<RequestT, ResponseT> implements FutureFallback<ResponseT> {
 
@@ -41,18 +41,6 @@ public class RetryingRpcFutureFallback<RequestT, ResponseT> implements FutureFal
     return new RetryingRpcFutureFallback<RequestT, ResponseT>(retryOptions, request, retryableRpc);
   }
 
-  @VisibleForTesting
-  interface Sleeper {
-    void sleep(long ms) throws InterruptedException;
-  }
-
-  static Sleeper THREAD_SLEEPER = new Sleeper() {
-    @Override
-    public void sleep(long ms) throws InterruptedException {
-      Thread.sleep(ms);
-    }
-  };
-
   protected final Log LOG = LogFactory.getLog(RetryingRpcFutureFallback.class);
 
   private final RequestT request;
@@ -60,7 +48,7 @@ public class RetryingRpcFutureFallback<RequestT, ResponseT> implements FutureFal
   @VisibleForTesting
   BackOff currentBackoff;
   @VisibleForTesting
-  Sleeper sleeper = THREAD_SLEEPER;
+  Sleeper sleeper = Sleeper.DEFAULT;
 
   private final RetryableRpc<RequestT, ResponseT> retryableRpc;
   private final RetryOptions retryOptions;

--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/Sleeper.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/Sleeper.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.grpc.async;
+
+/**
+ * An interface that wraps Thread.sleep for test purposes 
+ */
+public interface Sleeper {
+  /**
+   * Usually a wrapper for Thread.sleep.  Can be overridden for testing purposes.
+   */
+  void sleep(long ms) throws InterruptedException;
+
+  /**
+   * A Sleeper that uses {@link Thread#sleep()}
+   */
+  public static Sleeper DEFAULT = new Sleeper() {
+    @Override
+    public void sleep(long ms) throws InterruptedException {
+      Thread.sleep(ms);
+    }
+  };
+}

--- a/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/RetryingRpcFutureFallbackTest.java
+++ b/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/RetryingRpcFutureFallbackTest.java
@@ -97,7 +97,7 @@ public class RetryingRpcFutureFallbackTest {
         return start + totalSleep.get();
       }
     });
-    underTest.sleeper = new RetryingRpcFutureFallback.Sleeper() {
+    underTest.sleeper = new Sleeper() {
       @Override
       public void sleep(long ms) throws InterruptedException {
         totalSleep.addAndGet(ms * 1000000);


### PR DESCRIPTION
The Credential retrieval has occassional issues under load.  Dataflow, for example, will start a whole bunch of jobs that need to get credentials at the same time, and we've seen intermittent failures because of that issue; the retry should fix, or at least improve, those types of situations.