### PR TITLE
Adding a tcnative option for integration testing.

### DIFF
--- a/bigtable-hbase-integration-tests/pom.xml
+++ b/bigtable-hbase-integration-tests/pom.xml
@@ -47,6 +47,10 @@ limitations under the License.
                     <artifactId>${google.bigtable.project.under.test}</artifactId>
                     <version>${project.version}</version>
                 </dependency>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                </dependency>
             </dependencies>
             <build>
                 <plugins>
@@ -90,6 +94,56 @@ limitations under the License.
                 </plugins>
             </build>
         </profile>
+       <profile>
+            <id>bigtableIntegrationTcnativeTest</id>
+            <dependencies>
+                <dependency>
+                    <groupId>${project.groupId}</groupId>
+                    <artifactId>${google.bigtable.project.under.test}</artifactId>
+                    <version>${project.version}</version>
+                </dependency>
+                <dependency>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-tcnative</artifactId>
+                    <version>1.1.33.Fork9</version>
+                    <classifier>${os.detected.classifier}</classifier>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>api-integration-test</id>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <phase>none</phase>
+                            </execution>
+                            <execution>
+                                <id>api-gap-test</id>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <phase>integration-test</phase>
+                                <configuration>
+                                    <forkCount>1</forkCount>
+                                    <includes>
+                                        <include>**/IntegrationTestsNoKnownGap.java</include>
+                                    </includes>
+                                    <reportNameSuffix>bigtable-server</reportNameSuffix>
+                                    <systemPropertyVariables>
+                                        <bigtable.test.extra.resources>bigtable-test.xml</bigtable.test.extra.resources>
+                                    </systemPropertyVariables>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <profile>
             <id>bigtableGapTest</id>
             <dependencies>
@@ -97,6 +151,10 @@ limitations under the License.
                     <groupId>${project.groupId}</groupId>
                     <artifactId>${google.bigtable.project.under.test}</artifactId>
                     <version>${project.version}</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
                 </dependency>
             </dependencies>
             <build>
@@ -248,12 +306,16 @@ limitations under the License.
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.mortbay.jetty.alpn</groupId>
-            <artifactId>alpn-boot</artifactId>
-        </dependency>
     </dependencies>
     <build>
+        <extensions>
+            <!-- Use os-maven-plugin to initialize the "os.detected" properties -->
+            <extension>
+                <groupId>kr.motd.maven</groupId>
+                <artifactId>os-maven-plugin</artifactId>
+                <version>1.4.1.Final</version>
+            </extension>
+        </extensions>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Moving the alpn-boot dependency to the two existing bigtable integration test profiles.  Adding a new profile, bigtableIntegrationTcnativeTest, that uses tcnative instead of alpn.