### PR TITLE
Better handling of ALPN configuration at startup, plus debug info.

### DIFF
--- a/bigtable-hbase-dataflow/src/test/java/com/google/cloud/bigtable/dataflow/CloudBigtableIOIntegrationTest.java
+++ b/bigtable-hbase-dataflow/src/test/java/com/google/cloud/bigtable/dataflow/CloudBigtableIOIntegrationTest.java
@@ -1,10 +1,7 @@
 package com.google.cloud.bigtable.dataflow;
 
-import com.google.bigtable.v1.SampleRowKeysRequest;
 import com.google.bigtable.v1.SampleRowKeysResponse;
 import com.google.cloud.bigtable.config.Logger;
-import com.google.cloud.bigtable.grpc.BigtableClusterName;
-import com.google.cloud.bigtable.grpc.BigtableTableName;
 import com.google.cloud.bigtable.hbase1_0.BigtableConnection;
 import com.google.cloud.dataflow.sdk.io.BoundedSource;
 import com.google.cloud.dataflow.sdk.io.BoundedSource.BoundedReader;


### PR DESCRIPTION
gRPC provides some information about the state of ALPN configuration.  Using that information for BigtableSession startup as well as CloudBigtableIO client side validation.

NOTE: This checkin contains some code that will be used for a short period of time on our Jenkins server to diagnose the tcnative issues we're having there.