### PR TITLE
Adding ability to dual configure alpn-boot and tcnative

### DIFF
--- a/bigtable-hbase-integration-tests/pom.xml
+++ b/bigtable-hbase-integration-tests/pom.xml
@@ -33,8 +33,10 @@ limitations under the License.
     <properties>
         <google.bigtable.auth.service.account.enable>true</google.bigtable.auth.service.account.enable>
         <hbase.version>1.0.1</hbase.version>
+        <force.jdk.provider>true</force.jdk.provider>
         <google.bigtable.project.under.test>bigtable-hbase-1.0</google.bigtable.project.under.test>
         <google.bigtable.connection.impl>com.google.cloud.bigtable.hbase1_0.BigtableConnection</google.bigtable.connection.impl>
+        <google.bigtable.force.jdk.provider>true</google.bigtable.force.jdk.provider>
         <protobuff-java.version>2.5.0</protobuff-java.version>
     </properties>
 
@@ -46,10 +48,6 @@ limitations under the License.
                     <groupId>${project.groupId}</groupId>
                     <artifactId>${google.bigtable.project.under.test}</artifactId>
                     <version>${project.version}</version>
-                </dependency>
-                <dependency>
-                    <groupId>org.mortbay.jetty.alpn</groupId>
-                    <artifactId>alpn-boot</artifactId>
                 </dependency>
             </dependencies>
             <build>
@@ -79,56 +77,6 @@ limitations under the License.
                                     <argLine>
                                         -Xbootclasspath/p:${settings.localRepository}/org/mortbay/jetty/alpn/alpn-boot/${alpn.version}/alpn-boot-${alpn.version}.jar
                                     </argLine>
-                                    <forkCount>1</forkCount>
-                                    <includes>
-                                        <include>**/IntegrationTestsNoKnownGap.java</include>
-                                    </includes>
-                                    <reportNameSuffix>bigtable-server</reportNameSuffix>
-                                    <systemPropertyVariables>
-                                        <bigtable.test.extra.resources>bigtable-test.xml</bigtable.test.extra.resources>
-                                    </systemPropertyVariables>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-       <profile>
-            <id>bigtableIntegrationTcnativeTest</id>
-            <dependencies>
-                <dependency>
-                    <groupId>${project.groupId}</groupId>
-                    <artifactId>${google.bigtable.project.under.test}</artifactId>
-                    <version>${project.version}</version>
-                </dependency>
-                <dependency>
-                    <groupId>io.netty</groupId>
-                    <artifactId>netty-tcnative</artifactId>
-                    <version>1.1.33.Fork9</version>
-                    <classifier>${os.detected.classifier}</classifier>
-                </dependency>
-            </dependencies>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>api-integration-test</id>
-                                <goals>
-                                    <goal>test</goal>
-                                </goals>
-                                <phase>none</phase>
-                            </execution>
-                            <execution>
-                                <id>api-gap-test</id>
-                                <goals>
-                                    <goal>test</goal>
-                                </goals>
-                                <phase>integration-test</phase>
-                                <configuration>
                                     <forkCount>1</forkCount>
                                     <includes>
                                         <include>**/IntegrationTestsNoKnownGap.java</include>
@@ -305,6 +253,16 @@ limitations under the License.
             <artifactId>${compat.module}</artifactId>
             <type>test-jar</type>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mortbay.jetty.alpn</groupId>
+            <artifactId>alpn-boot</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-tcnative</artifactId>
+            <version>1.1.33.Fork9</version>
+            <classifier>${os.detected.classifier}</classifier>
         </dependency>
     </dependencies>
     <build>

--- a/bigtable-hbase-integration-tests/src/test/resources/bigtable-test.xml
+++ b/bigtable-hbase-integration-tests/src/test/resources/bigtable-test.xml
@@ -69,4 +69,8 @@ limitations under the License.
         <name>google.bigtable.auth.service.account.keyfile</name>
         <value>${google.bigtable.auth.service.account.keyfile}</value>
     </property>
+    <property>
+        <name>google.bigtable.force.jdk.provider</name>
+        <value>${google.bigtable.force.jdk.provider}</value>
+    </property>
 </configuration>

--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableOptionsFactory.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableOptionsFactory.java
@@ -130,6 +130,12 @@ public class BigtableOptionsFactory {
   public static final String BIGTABLE_CHANNEL_TIMEOUT_MS_KEY =
       "google.bigtable.grpc.channel.timeout.ms";
 
+  /**
+   * Force the use of the JDK provider rather than Native if the native provider (OpenSsl) is
+   * available.  This is useful for testing purposes.
+   */
+  public static final String FORCE_JDK_PROVIDER_KEY = "google.bigtable.force.jdk.provider";
+
   public static BigtableOptions fromConfiguration(final Configuration configuration)
       throws IOException {
 
@@ -138,7 +144,10 @@ public class BigtableOptionsFactory {
     bigtableOptionsBuilder.setProjectId(getValue(configuration, PROJECT_ID_KEY, "Project ID"));
     bigtableOptionsBuilder.setZoneId(getValue(configuration, ZONE_KEY, "Zone"));
     bigtableOptionsBuilder.setClusterId(getValue(configuration, CLUSTER_KEY, "Cluster"));
-
+    boolean jdkProvider = configuration.getBoolean(FORCE_JDK_PROVIDER_KEY,
+      false);
+    System.out.println("JDK PRovider? " + configuration.get(FORCE_JDK_PROVIDER_KEY) + " " + jdkProvider);
+    bigtableOptionsBuilder.setForceJdkTlsProvider(jdkProvider);
     String overrideIp = configuration.get(IP_OVERRIDE_KEY);
     if (!isNullOrEmpty(overrideIp)) {
       LOG.debug("Using override IP address %s", overrideIp);


### PR DESCRIPTION
Our performance test team wants to dual configure tcnative and alpn-boot and configure the implementation.  With this runtime change, it was also ideal to simply theconfiguration of our integration-testing pom.xml.

see #506