### PR TITLE
Wrapping ClientCalls static methods for better testability

### DIFF
--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataGrpcClient.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataGrpcClient.java
@@ -95,10 +95,17 @@ public class BigtableDataGrpcClient implements BigtableDataClient {
   private RetryableRpc<SampleRowKeysRequest, List<SampleRowKeysResponse>> sampleRowKeysAsync;
   private RetryableRpc<ReadRowsRequest, List<Row>> readRowsAsync;
 
-  @VisibleForTesting
   private ClientCallService clientCallService;
 
   public BigtableDataGrpcClient(
+    Channel channel,
+    ExecutorService executorService,
+    RetryOptions retryOptions) {
+    this(channel, executorService, retryOptions, ClientCallService.DEFAULT);
+  }
+
+  @VisibleForTesting
+  BigtableDataGrpcClient(
       Channel channel,
       ExecutorService executorService,
       RetryOptions retryOptions,

--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataGrpcClient.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataGrpcClient.java
@@ -18,7 +18,6 @@ package com.google.cloud.bigtable.grpc;
 import io.grpc.CallOptions;
 import io.grpc.Channel;
 import io.grpc.ClientCall;
-import io.grpc.stub.ClientCalls;
 import io.grpc.stub.StreamObserver;
 
 import java.util.List;
@@ -38,10 +37,12 @@ import com.google.cloud.bigtable.config.RetryOptions;
 import com.google.cloud.bigtable.grpc.async.BigtableAsyncUtilities;
 import com.google.cloud.bigtable.grpc.async.RetryableRpc;
 import com.google.cloud.bigtable.grpc.io.CancellationToken;
+import com.google.cloud.bigtable.grpc.io.ClientCallService;
 import com.google.cloud.bigtable.grpc.scanner.BigtableResultScannerFactory;
 import com.google.cloud.bigtable.grpc.scanner.ResultScanner;
 import com.google.cloud.bigtable.grpc.scanner.ResumingStreamingResultScanner;
 import com.google.cloud.bigtable.grpc.scanner.StreamingBigtableResultScanner;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.protobuf.Empty;
@@ -91,38 +92,43 @@ public class BigtableDataGrpcClient implements BigtableDataClient {
           return streamRows(request);
         }
       };
-  private final RetryableRpc<SampleRowKeysRequest, List<SampleRowKeysResponse>> sampleRowKeysAsync;
-  private final RetryableRpc<ReadRowsRequest, List<Row>> readRowsAsync;
+  private RetryableRpc<SampleRowKeysRequest, List<SampleRowKeysResponse>> sampleRowKeysAsync;
+  private RetryableRpc<ReadRowsRequest, List<Row>> readRowsAsync;
+
+  @VisibleForTesting
+  private ClientCallService clientCallService;
 
   public BigtableDataGrpcClient(
       Channel channel,
       ExecutorService executorService,
-      RetryOptions retryOptions) {
+      RetryOptions retryOptions,
+      ClientCallService clientCallService) {
     this.channel = channel;
     this.executorService = executorService;
     this.retryOptions = retryOptions;
-
-    this.sampleRowKeysAsync = BigtableAsyncUtilities.createSampleRowKeyAsyncReader(this.channel);
-    this.readRowsAsync = BigtableAsyncUtilities.createRowKeyAysncReader(this.channel);
+    this.clientCallService = clientCallService;
+    this.sampleRowKeysAsync =
+        BigtableAsyncUtilities.createSampleRowKeyAsyncReader(this.channel, clientCallService);
+    this.readRowsAsync =
+        BigtableAsyncUtilities.createRowKeyAysncReader(this.channel, clientCallService);
   }
 
   @Override
   public Empty mutateRow(MutateRowRequest request) throws ServiceException {
-    return ClientCalls.blockingUnaryCall(
+    return clientCallService.blockingUnaryCall(
       channel.newCall(BigtableServiceGrpc.METHOD_MUTATE_ROW, CallOptions.DEFAULT), request);
   }
 
   @Override
   public ListenableFuture<Empty> mutateRowAsync(MutateRowRequest request) {
-    return BigtableAsyncUtilities.listenableAsyncCall(
-        channel,
-        BigtableServiceGrpc.METHOD_MUTATE_ROW, request);
+    return clientCallService.listenableAsyncCall(request,
+      channel.newCall(BigtableServiceGrpc.METHOD_MUTATE_ROW, CallOptions.DEFAULT));
   }
 
   @Override
   public CheckAndMutateRowResponse checkAndMutateRow(CheckAndMutateRowRequest request)
       throws ServiceException {
-    return ClientCalls.blockingUnaryCall(
+    return clientCallService.blockingUnaryCall(
       channel.newCall(BigtableServiceGrpc.METHOD_CHECK_AND_MUTATE_ROW, CallOptions.DEFAULT),
       request);
   }
@@ -130,26 +136,26 @@ public class BigtableDataGrpcClient implements BigtableDataClient {
   @Override
   public ListenableFuture<CheckAndMutateRowResponse> checkAndMutateRowAsync(
       CheckAndMutateRowRequest request) {
-    return BigtableAsyncUtilities.listenableAsyncCall(channel,
-      BigtableServiceGrpc.METHOD_CHECK_AND_MUTATE_ROW, request);
+    return clientCallService.listenableAsyncCall(request,
+      channel.newCall(BigtableServiceGrpc.METHOD_CHECK_AND_MUTATE_ROW, CallOptions.DEFAULT));
   }
 
   @Override
   public Row readModifyWriteRow(ReadModifyWriteRowRequest request) {
-    return ClientCalls.blockingUnaryCall(
+    return clientCallService.blockingUnaryCall(
       channel.newCall(BigtableServiceGrpc.METHOD_READ_MODIFY_WRITE_ROW, CallOptions.DEFAULT),
       request);
   }
 
   @Override
   public ListenableFuture<Row> readModifyWriteRowAsync(ReadModifyWriteRowRequest request) {
-    return BigtableAsyncUtilities.listenableAsyncCall(channel,
-      BigtableServiceGrpc.METHOD_READ_MODIFY_WRITE_ROW, request);
+    return clientCallService.listenableAsyncCall(request,
+      channel.newCall(BigtableServiceGrpc.METHOD_READ_MODIFY_WRITE_ROW, CallOptions.DEFAULT));
   }
 
   @Override
   public ImmutableList<SampleRowKeysResponse> sampleRowKeys(SampleRowKeysRequest request) {
-    return ImmutableList.copyOf(ClientCalls.blockingServerStreamingCall(
+    return ImmutableList.copyOf(clientCallService.blockingServerStreamingCall(
       channel.newCall(BigtableServiceGrpc.METHOD_SAMPLE_ROW_KEYS, CallOptions.DEFAULT), request));
   }
 
@@ -178,7 +184,7 @@ public class BigtableDataGrpcClient implements BigtableDataClient {
   }
 
   private ResultScanner<Row> streamRows(ReadRowsRequest request) {
-    final ClientCall<ReadRowsRequest , ReadRowsResponse> readRowsCall =
+    final ClientCall<ReadRowsRequest, ReadRowsResponse> readRowsCall =
         channel.newCall(BigtableServiceGrpc.METHOD_READ_ROWS, CallOptions.DEFAULT);
 
     // If the scanner is close()d before we're done streaming, we want to cancel the RPC:
@@ -196,7 +202,7 @@ public class BigtableDataGrpcClient implements BigtableDataClient {
           retryOptions.getReadPartialRowTimeoutMillis(),
           cancellationToken);
 
-    ClientCalls.asyncServerStreamingCall(
+    clientCallService.asyncServerStreamingCall(
         readRowsCall,
         request,
         new ReadRowsStreamObserver(resultScanner));

--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
@@ -28,7 +28,6 @@ import com.google.cloud.bigtable.config.Logger;
 import com.google.cloud.bigtable.config.RetryOptions;
 import com.google.cloud.bigtable.grpc.io.CallCompletionStatusInterceptor;
 import com.google.cloud.bigtable.grpc.io.ChannelPool;
-import com.google.cloud.bigtable.grpc.io.ClientCallService;
 import com.google.cloud.bigtable.grpc.io.ReconnectingChannel;
 import com.google.cloud.bigtable.grpc.io.RefreshingOAuth2CredentialsInterceptor;
 import com.google.cloud.bigtable.grpc.io.UnaryCallRetryInterceptor;
@@ -356,7 +355,7 @@ public class BigtableSession implements AutoCloseable {
   private BigtableDataClient initializeDataClient() throws IOException {
     Channel channel = createChannel(options.getDataHost(), options.getChannelCount());
     RetryOptions retryOptions = options.getRetryOptions();
-    return new BigtableDataGrpcClient(channel, batchPool, retryOptions, ClientCallService.DEFAULT);
+    return new BigtableDataGrpcClient(channel, batchPool, retryOptions);
   }
 
   private BigtableTableAdminClient initializeAdminClient() throws IOException {

--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
@@ -28,6 +28,7 @@ import com.google.cloud.bigtable.config.Logger;
 import com.google.cloud.bigtable.config.RetryOptions;
 import com.google.cloud.bigtable.grpc.io.CallCompletionStatusInterceptor;
 import com.google.cloud.bigtable.grpc.io.ChannelPool;
+import com.google.cloud.bigtable.grpc.io.ClientCallService;
 import com.google.cloud.bigtable.grpc.io.ReconnectingChannel;
 import com.google.cloud.bigtable.grpc.io.RefreshingOAuth2CredentialsInterceptor;
 import com.google.cloud.bigtable.grpc.io.UnaryCallRetryInterceptor;
@@ -355,7 +356,7 @@ public class BigtableSession implements AutoCloseable {
   private BigtableDataClient initializeDataClient() throws IOException {
     Channel channel = createChannel(options.getDataHost(), options.getChannelCount());
     RetryOptions retryOptions = options.getRetryOptions();
-    return new BigtableDataGrpcClient(channel, batchPool, retryOptions);
+    return new BigtableDataGrpcClient(channel, batchPool, retryOptions, ClientCallService.DEFAULT);
   }
 
   private BigtableTableAdminClient initializeAdminClient() throws IOException {

--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/ClientCallService.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/ClientCallService.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.grpc.io;
+
+import io.grpc.ClientCall;
+import io.grpc.stub.ClientCalls;
+import io.grpc.stub.StreamObserver;
+
+import java.util.Iterator;
+
+import com.google.cloud.bigtable.grpc.async.AsyncUnaryOperationObserver;
+import com.google.common.util.concurrent.ListenableFuture;
+
+/**
+ * Wraps gRPC's {@link ClientCall} methods to allow for unit testing.
+ */
+public interface ClientCallService {
+
+  <ReqT, RespT> void asyncServerStreamingCall(ClientCall<ReqT, RespT> call,
+      ReqT request, StreamObserver<RespT> observer);
+
+
+  <ReqT, RespT> Iterator<RespT> blockingServerStreamingCall(ClientCall<ReqT, RespT> call,
+      ReqT request);
+
+  <ReqT, RespT> RespT blockingUnaryCall(ClientCall<ReqT, RespT> call, ReqT request);
+
+  <ReqT, RespT> ListenableFuture<RespT> listenableAsyncCall(ReqT request,
+      ClientCall<ReqT, RespT> call);
+
+  ClientCallService DEFAULT = new ClientCallService() {
+
+    @Override
+    public <ReqT, RespT> void asyncServerStreamingCall(ClientCall<ReqT, RespT> call,
+        ReqT request, StreamObserver<RespT> observer) {
+      ClientCalls.asyncServerStreamingCall(call, request, observer);
+    }
+
+    @Override
+    public <ReqT, RespT> Iterator<RespT> blockingServerStreamingCall(ClientCall<ReqT, RespT> call,
+        ReqT request) {
+      return ClientCalls.blockingServerStreamingCall(call, request);
+    }
+
+    @Override
+    public <ReqT, RespT> RespT blockingUnaryCall(ClientCall<ReqT, RespT> call, ReqT request) {
+      return ClientCalls.blockingUnaryCall(call, request);
+    }
+
+    @Override
+    public <ReqT, RespT> ListenableFuture<RespT> listenableAsyncCall(ReqT request,
+        ClientCall<ReqT, RespT> call) {
+      AsyncUnaryOperationObserver<RespT> observer = new AsyncUnaryOperationObserver<>();
+      ClientCalls.asyncUnaryCall(call, request, observer);
+      return observer.getCompletionFuture();
+    }
+  };
+
+}


### PR DESCRIPTION
The ClientCalls static methods are core to executing RPC calls.  Adding in a way to perform unit tests in BigtableDataGrpcClient that would bypass the need to actually perform an RPC.

Tests will come later.