### PR TITLE
Moving duplicated RetryOptions test build logic into a utility.

### DIFF
--- a/bigtable-client-core/src/test/java/com/google/cloud/bigtable/config/RetryOptionsUtil.java
+++ b/bigtable-client-core/src/test/java/com/google/cloud/bigtable/config/RetryOptionsUtil.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.config;
+
+import static com.google.cloud.bigtable.config.RetryOptions.DEFAULT_BACKOFF_MULTIPLIER;
+import static com.google.cloud.bigtable.config.RetryOptions.DEFAULT_INITIAL_BACKOFF_MILLIS;
+import static com.google.cloud.bigtable.config.RetryOptions.DEFAULT_MAX_ELAPSED_BACKOFF_MILLIS;
+import static com.google.cloud.bigtable.config.RetryOptions.DEFAULT_READ_PARTIAL_ROW_TIMEOUT_MS;
+import static com.google.cloud.bigtable.config.RetryOptions.DEFAULT_STREAMING_BUFFER_SIZE;
+
+import com.google.api.client.util.ExponentialBackOff;
+import com.google.api.client.util.NanoClock;
+
+/**
+ * Testing utility for creating RetryOptions
+ */
+public class RetryOptionsUtil {
+  public static RetryOptions createTestRetryOptions(final NanoClock nanoClock) {
+    return new RetryOptions(true, true, DEFAULT_INITIAL_BACKOFF_MILLIS, DEFAULT_BACKOFF_MULTIPLIER,
+        DEFAULT_MAX_ELAPSED_BACKOFF_MILLIS, DEFAULT_STREAMING_BUFFER_SIZE,
+        DEFAULT_READ_PARTIAL_ROW_TIMEOUT_MS) {
+      @Override
+      protected ExponentialBackOff.Builder createBackoffBuilder() {
+        return super.createBackoffBuilder().setNanoClock(nanoClock);
+      }
+    };
+  }
+}

--- a/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/RetryingRpcFutureFallbackTest.java
+++ b/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/RetryingRpcFutureFallbackTest.java
@@ -32,13 +32,12 @@ import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
-import com.google.api.client.util.ExponentialBackOff;
 import com.google.api.client.util.NanoClock;
 import com.google.bigtable.v1.ReadRowsRequest;
 import com.google.cloud.bigtable.config.RetryOptions;
+import com.google.cloud.bigtable.config.RetryOptionsUtil;
 import com.google.cloud.bigtable.grpc.scanner.ScanRetriesExhaustedException;
 
-import static com.google.cloud.bigtable.config.RetryOptions.*;
 /**
  * Test for {@link RetryingRpcFutureFallback}
  */
@@ -60,15 +59,7 @@ public class RetryingRpcFutureFallbackTest {
   @Before
   public void setup() {
     MockitoAnnotations.initMocks(this);
-    RetryOptions retryOptions =
-        new RetryOptions(true, true, DEFAULT_INITIAL_BACKOFF_MILLIS, DEFAULT_BACKOFF_MULTIPLIER,
-            DEFAULT_MAX_ELAPSED_BACKOFF_MILLIS, DEFAULT_STREAMING_BUFFER_SIZE,
-            DEFAULT_READ_PARTIAL_ROW_TIMEOUT_MS) {
-          @Override
-          protected ExponentialBackOff.Builder createBackoffBuilder() {
-            return super.createBackoffBuilder().setNanoClock(nanoClock);
-          }
-        };
+    RetryOptions retryOptions = RetryOptionsUtil.createTestRetryOptions(nanoClock);
     underTest =
         RetryingRpcFutureFallback.create(retryOptions, ReadRowsRequest.getDefaultInstance(),
           readAsync);

--- a/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptorTest.java
+++ b/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptorTest.java
@@ -15,11 +15,6 @@
  */
 package com.google.cloud.bigtable.grpc.io;
 
-import static com.google.cloud.bigtable.config.RetryOptions.DEFAULT_BACKOFF_MULTIPLIER;
-import static com.google.cloud.bigtable.config.RetryOptions.DEFAULT_INITIAL_BACKOFF_MILLIS;
-import static com.google.cloud.bigtable.config.RetryOptions.DEFAULT_MAX_ELAPSED_BACKOFF_MILLIS;
-import static com.google.cloud.bigtable.config.RetryOptions.DEFAULT_READ_PARTIAL_ROW_TIMEOUT_MS;
-import static com.google.cloud.bigtable.config.RetryOptions.DEFAULT_STREAMING_BUFFER_SIZE;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.atLeast;
@@ -50,12 +45,12 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import com.google.api.client.util.Clock;
-import com.google.api.client.util.ExponentialBackOff;
 import com.google.api.client.util.NanoClock;
 import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.OAuth2Credentials;
 import com.google.cloud.bigtable.config.Logger;
 import com.google.cloud.bigtable.config.RetryOptions;
+import com.google.cloud.bigtable.config.RetryOptionsUtil;
 import com.google.cloud.bigtable.grpc.async.Sleeper;
 import com.google.cloud.bigtable.grpc.io.RefreshingOAuth2CredentialsInterceptor.CacheState;
 import com.google.cloud.bigtable.grpc.io.RefreshingOAuth2CredentialsInterceptor.HeaderCacheElement;
@@ -97,15 +92,7 @@ public class RefreshingOAuth2CredentialsInterceptorTest {
         return getTimeInMilliseconds() * 1000000;
       }
     });
-    retryOptions =
-        new RetryOptions(true, true, DEFAULT_INITIAL_BACKOFF_MILLIS, DEFAULT_BACKOFF_MULTIPLIER,
-            DEFAULT_MAX_ELAPSED_BACKOFF_MILLIS, DEFAULT_STREAMING_BUFFER_SIZE,
-            DEFAULT_READ_PARTIAL_ROW_TIMEOUT_MS) {
-          @Override
-          protected ExponentialBackOff.Builder createBackoffBuilder() {
-            return super.createBackoffBuilder().setNanoClock(nanoClock);
-          }
-        };
+    retryOptions = RetryOptionsUtil.createTestRetryOptions(nanoClock);
     setTimeInMillieconds(0L);
   }
 


### PR DESCRIPTION
We use a nanoClock override for the BackoffBuilder in our unit tests.  We have two copies of nasty looking, but useful code.  I found a third use for it, and figured that I'd centralize the logic before adding the third test.