### PR TITLE
Moving header interceptors to a new interface.

### DIFF
--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/HeaderInterceptor.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/HeaderInterceptor.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.grpc.io;
+
+import io.grpc.Metadata;
+
+/**
+ * This interface provides a simple mechanism to update headers before a gRPC method is called.
+ */
+public interface HeaderInterceptor {
+  /**
+   * Modify the headers before an RPC call is made.
+   */
+  void updateHeaders(Metadata headers) throws Exception;
+}

--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/UserAgentInterceptor.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/UserAgentInterceptor.java
@@ -17,18 +17,13 @@ package com.google.cloud.bigtable.grpc.io;
 
 import com.google.common.net.HttpHeaders;
 
-import io.grpc.CallOptions;
-import io.grpc.ClientCall;
-import io.grpc.Channel;
 import io.grpc.ClientInterceptor;
-import io.grpc.ForwardingClientCall.SimpleForwardingClientCall;
 import io.grpc.Metadata;
-import io.grpc.MethodDescriptor;
 
 /**
  * An {@link ClientInterceptor} that updates "User-Agent" header.
  */
-public class UserAgentInterceptor implements ClientInterceptor {
+public class UserAgentInterceptor implements HeaderInterceptor {
 
   private final static Metadata.Key<String> USER_AGENT_KEY =
       Metadata.Key.of(HttpHeaders.USER_AGENT, Metadata.ASCII_STRING_MARSHALLER);
@@ -40,20 +35,13 @@ public class UserAgentInterceptor implements ClientInterceptor {
   }
 
   @Override
-  public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
-      MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next) {
-    return new SimpleForwardingClientCall<ReqT, RespT>(next.newCall(method, callOptions)) {
-      @Override
-      public void start(Listener<RespT> responseListener, Metadata headers) {
-        String userAgents = headers.get(USER_AGENT_KEY);
-        if (userAgents == null) {
-          userAgents = userAgent;
-        } else {
-          userAgents += " " + userAgent;
-        }
-        headers.put(USER_AGENT_KEY, userAgents);
-        super.start(responseListener, headers);
-      }
-    };
+  public void updateHeaders(Metadata headers) throws Exception {
+    String userAgents = headers.get(USER_AGENT_KEY);
+    if (userAgents == null) {
+      userAgents = userAgent;
+    } else {
+      userAgents += " " + userAgent;
+    }
+    headers.put(USER_AGENT_KEY, userAgents);
   }
 }

--- a/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/io/ChannelPoolTest.java
+++ b/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/io/ChannelPoolTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.grpc.io;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+
+import java.util.Collections;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+
+@RunWith(JUnit4.class)
+@SuppressWarnings({"rawtypes", "unchecked"})
+public class ChannelPoolTest {
+
+  @Mock
+  private Channel channel;
+  @Mock
+  private MethodDescriptor descriptor;
+  @Mock
+  private ClientCall callStub;
+  @Mock
+  private ClientCall.Listener responseListenerStub;
+  @Mock
+  private HeaderInterceptor interceptor;
+
+  @Test
+  public void testInterceptorIsCalled() throws Exception {
+    MockitoAnnotations.initMocks(this);
+    when(channel.newCall(any(MethodDescriptor.class), any(CallOptions.class))).thenReturn(
+      callStub);
+    ChannelPool pool =
+        new ChannelPool(new Channel[] { channel }, Collections.singletonList(interceptor));
+    ClientCall call = pool.newCall(descriptor, CallOptions.DEFAULT);
+    Metadata headers = new Metadata();
+    call.start(null, headers);
+    verify(interceptor, times(1)).updateHeaders(eq(headers));
+  }
+}

--- a/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/io/UserAgentUpdaterInterceptorTest.java
+++ b/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/io/UserAgentUpdaterInterceptorTest.java
@@ -15,25 +15,15 @@
  */
 package com.google.cloud.bigtable.grpc.io;
 
-import static org.mockito.Mockito.when;
 
-import com.google.bigtable.v1.BigtableServiceGrpc;
-import com.google.bigtable.v1.MutateRowRequest;
 import com.google.cloud.bigtable.grpc.io.UserAgentInterceptor;
 import com.google.common.net.HttpHeaders;
-import com.google.protobuf.Empty;
 
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 
-import io.grpc.CallOptions;
-import io.grpc.ClientCall;
-import io.grpc.Channel;
 import io.grpc.Metadata;
 
 @RunWith(JUnit4.class)
@@ -41,31 +31,12 @@ public class UserAgentUpdaterInterceptorTest {
 
   private static final String userAgent = "project/version";
   
-  @Mock
-  private Channel channelStub;
-  @Mock
-  private ClientCall<MutateRowRequest, Empty> callStub;
-  @Mock
-  private ClientCall.Listener<Empty> responseListenerStub;
-
-  private UserAgentInterceptor interceptor;
-
-  @Before
-  public void setup() {
-    MockitoAnnotations.initMocks(this);
-    interceptor = new UserAgentInterceptor(userAgent);
-  }
+  private UserAgentInterceptor interceptor = new UserAgentInterceptor(userAgent);
 
   @Test
-  public void interceptCall_addHeader() {
-    when(channelStub.newCall(BigtableServiceGrpc.METHOD_MUTATE_ROW, CallOptions.DEFAULT))
-        .thenReturn(callStub);
-
-    ClientCall<MutateRowRequest, Empty> wrappedCall =
-        interceptor.interceptCall(BigtableServiceGrpc.METHOD_MUTATE_ROW, CallOptions.DEFAULT,
-          channelStub);
-   Metadata headers = new Metadata();
-    wrappedCall.start(responseListenerStub, headers);
+  public void interceptCall_addHeader() throws Exception {
+    Metadata headers = new Metadata();
+    interceptor.updateHeaders(headers);
 
     Metadata.Key<String> key =
         Metadata.Key.of(HttpHeaders.USER_AGENT, Metadata.ASCII_STRING_MARSHALLER);
@@ -73,18 +44,12 @@ public class UserAgentUpdaterInterceptorTest {
   }
 
   @Test
-  public void interceptCall_appendHeader() {
-    when(channelStub.newCall(BigtableServiceGrpc.METHOD_MUTATE_ROW, CallOptions.DEFAULT))
-        .thenReturn(callStub);
-
-    ClientCall<MutateRowRequest, Empty> wrappedCall =
-        interceptor.interceptCall(BigtableServiceGrpc.METHOD_MUTATE_ROW, CallOptions.DEFAULT,
-          channelStub);
+  public void interceptCall_appendHeader() throws Exception {
     Metadata headers = new Metadata();
     Metadata.Key<String> key =
         Metadata.Key.of(HttpHeaders.USER_AGENT, Metadata.ASCII_STRING_MARSHALLER);
     headers.put(key, "dummy");
-    wrappedCall.start(responseListenerStub, headers);
+    interceptor.updateHeaders(headers);
 
     Assert.assertEquals("dummy " + userAgent, headers.get(key));
   }


### PR DESCRIPTION
This change removes all ClientInterceptors out of BigtableSession and makes the header interception process a bit simpler.