### PR TITLE
Adding a maven property for LD_LIBRARY_PATH in tcnative test

### DIFF
--- a/bigtable-hbase-integration-tests/pom.xml
+++ b/bigtable-hbase-integration-tests/pom.xml
@@ -36,6 +36,7 @@ limitations under the License.
         <google.bigtable.project.under.test>bigtable-hbase-1.0</google.bigtable.project.under.test>
         <google.bigtable.connection.impl>com.google.cloud.bigtable.hbase1_0.BigtableConnection</google.bigtable.connection.impl>
         <protobuff-java.version>2.5.0</protobuff-java.version>
+        <ld.library.path>/usr/local/lib</ld.library.path>
     </properties>
 
     <profiles>
@@ -130,6 +131,9 @@ limitations under the License.
                                 <phase>integration-test</phase>
                                 <configuration>
                                     <forkCount>1</forkCount>
+                                    <environmentVariables>
+                                        <LD_LIBRARY_PATH>${ld.library.path}</LD_LIBRARY_PATH>
+                                    </environmentVariables>
                                     <includes>
                                         <include>**/IntegrationTestsNoKnownGap.java</include>
                                     </includes>


### PR DESCRIPTION
This will help us run Jenkins tests with the right version of openssl.