### PR TITLE
Fixing the deleting while scanning issue.

### DIFF
--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
@@ -303,7 +303,7 @@ public class BigtableSession implements AutoCloseable {
   }
 
   private BigtableDataClient initializeDataClient() throws IOException {
-    Channel channel = createChannel(options.getDataHost(), options.getChannelCount());
+    ChannelPool channel = createChannel(options.getDataHost(), options.getChannelCount());
     RetryOptions retryOptions = options.getRetryOptions();
     return new BigtableDataGrpcClient(channel, batchPool, scheduledRetries, retryOptions);
   }

--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/ChannelPool.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/ChannelPool.java
@@ -4,9 +4,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -26,6 +26,8 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Logger;
 
+import com.google.common.annotations.VisibleForTesting;
+
 /**
  * Manages a set of ClosableChannels and uses them in a round robin.
  */
@@ -33,7 +35,38 @@ public class ChannelPool extends Channel {
 
   protected static final Logger log = Logger.getLogger(ChannelPool.class.getName());
 
-  private final Channel[] channels;
+  /**
+   * An implementation of {@link Channle} that knows how to return itself to the {@link ChannelPool}
+   */
+  public class PooledChannel extends Channel {
+    private final Channel delegate;
+    private boolean returned = false;
+
+    private PooledChannel(Channel delegate, boolean returned) {
+      this.delegate = delegate;
+      this.returned = returned;
+    }
+
+    @Override
+    public <RequestT, ResponseT> ClientCall<RequestT, ResponseT> newCall(
+        MethodDescriptor<RequestT, ResponseT> methodDescriptor, CallOptions callOptions) {
+      return createWrappedCall(methodDescriptor, callOptions, delegate);
+    }
+
+    @Override
+    public String authority() {
+      return delegate.authority();
+    }
+
+    public synchronized void returnToPool() {
+      if (!returned) {
+        ChannelPool.this.returnChannel(this);
+        returned = true;
+      }
+    }
+  }
+
+  private Channel[] channels;
   private final AtomicInteger requestCount = new AtomicInteger();
   private final List<HeaderInterceptor> headerInterceptors;
 
@@ -43,17 +76,21 @@ public class ChannelPool extends Channel {
   }
 
   @Override
-  public <RequestT, ResponseT> ClientCall<RequestT, ResponseT> newCall(
-      MethodDescriptor<RequestT, ResponseT> methodDescriptor, CallOptions callOptions) {
-    int currentRequestNum = requestCount.getAndIncrement();
-    int index = Math.abs(currentRequestNum % channels.length);
-    ClientCall<RequestT, ResponseT> delegate =
-        channels[index].newCall(methodDescriptor, callOptions);
-    return new CheckedForwardingClientCall<RequestT, ResponseT>(delegate) {
+  public <ReqT, RespT> ClientCall<ReqT, RespT> newCall(
+      MethodDescriptor<ReqT, RespT> methodDescriptor, CallOptions callOptions) {
+    return createWrappedCall(methodDescriptor, callOptions, getNextChannel());
+  }
+
+  private <ReqT, RespT> ClientCall<ReqT, RespT> createWrappedCall(
+      MethodDescriptor<ReqT, RespT> methodDescriptor, CallOptions callOptions, Channel channel) {
+    return wrap(channel.newCall(methodDescriptor, callOptions));
+  }
+
+  private <ReqT, RespT> ClientCall<ReqT, RespT> wrap(ClientCall<ReqT, RespT> delegate) {
+    return new CheckedForwardingClientCall<ReqT, RespT>(delegate) {
       @Override
-      protected void
-          checkedStart(ClientCall.Listener<ResponseT> responseListener, Metadata headers)
-              throws Exception {
+      protected void checkedStart(ClientCall.Listener<RespT> responseListener, Metadata headers)
+          throws Exception {
         for (HeaderInterceptor interceptor : headerInterceptors) {
           interceptor.updateHeaders(headers);
         }
@@ -62,8 +99,48 @@ public class ChannelPool extends Channel {
     };
   }
 
+  private synchronized Channel getNextChannel() {
+    int currentRequestNum = requestCount.getAndIncrement();
+    int index = Math.abs(currentRequestNum % channels.length);
+    return channels[index];
+  }
+
   @Override
   public String authority() {
     return channels[0].authority();
+  }
+
+  /**
+   * Gets a channel from the pool. Long running streaming RPCs can cause a contention issue if there
+   * is another RPC started on the same channel. If the pool only has a single channel, keep the
+   * channel in the pool so that other RPCs can at least attempt to use it.
+   */
+  public synchronized PooledChannel reserveChannel() {
+    Channel reserved;
+    boolean returned = false;
+    if (channels.length == 1) {
+      reserved = channels[0];
+      returned = true;
+    } else {
+      reserved = channels[channels.length - 1];
+      Channel[] newChannelArray = new Channel[channels.length - 1];
+      System.arraycopy(channels, 0, newChannelArray, 0, channels.length - 1);
+      channels = newChannelArray;
+    }
+    return new PooledChannel(reserved, returned);
+  }
+
+  private synchronized void returnChannel(PooledChannel channel){
+    if (!channel.returned) {
+      Channel[] newChannelArray = new Channel[channels.length + 1];
+      System.arraycopy(channels, 0, newChannelArray, 0, channels.length);
+      newChannelArray[channels.length] = channel.delegate;
+      channels = newChannelArray;
+    }
+  }
+
+  @VisibleForTesting
+  public synchronized int size() {
+    return channels.length;
   }
 }

--- a/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/BigtableDataGrpcClientTests.java
+++ b/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/BigtableDataGrpcClientTests.java
@@ -22,7 +22,6 @@ import static org.mockito.Matchers.same;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import io.grpc.CallOptions;
-import io.grpc.Channel;
 import io.grpc.ClientCall;
 import io.grpc.MethodDescriptor;
 
@@ -42,6 +41,7 @@ import com.google.bigtable.v1.MutateRowRequest;
 import com.google.bigtable.v1.Mutation;
 import com.google.bigtable.v1.Mutation.SetCell;
 import com.google.cloud.bigtable.config.RetryOptionsUtil;
+import com.google.cloud.bigtable.grpc.io.ChannelPool;
 import com.google.cloud.bigtable.grpc.io.ClientCallService;
 import com.google.cloud.bigtable.grpc.io.RetryingCall;
 import com.google.common.base.Predicate;
@@ -52,7 +52,7 @@ import com.google.protobuf.ServiceException;
 public class BigtableDataGrpcClientTests {
 
   @Mock
-  Channel channel;
+  ChannelPool channel;
 
   @SuppressWarnings("rawtypes")
   @Mock

--- a/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/io/ChannelPoolTest.java
+++ b/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/io/ChannelPoolTest.java
@@ -15,8 +15,9 @@
  */
 package com.google.cloud.bigtable.grpc.io;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -31,35 +32,61 @@ import java.util.Collections;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import com.google.cloud.bigtable.grpc.io.ChannelPool.PooledChannel;
 
 @RunWith(JUnit4.class)
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class ChannelPoolTest {
 
-  @Mock
-  private Channel channel;
-  @Mock
-  private MethodDescriptor descriptor;
-  @Mock
-  private ClientCall callStub;
-  @Mock
-  private ClientCall.Listener responseListenerStub;
-  @Mock
-  private HeaderInterceptor interceptor;
-
   @Test
   public void testInterceptorIsCalled() throws Exception {
-    MockitoAnnotations.initMocks(this);
-    when(channel.newCall(any(MethodDescriptor.class), any(CallOptions.class))).thenReturn(
+    Channel channel = mock(Channel.class);
+    MethodDescriptor descriptor = mock(MethodDescriptor.class);
+    ClientCall callStub = mock(ClientCall.class);
+    HeaderInterceptor interceptor = mock(HeaderInterceptor.class);
+    when(channel.newCall(same(descriptor), same(CallOptions.DEFAULT))).thenReturn(
       callStub);
     ChannelPool pool =
         new ChannelPool(new Channel[] { channel }, Collections.singletonList(interceptor));
     ClientCall call = pool.newCall(descriptor, CallOptions.DEFAULT);
     Metadata headers = new Metadata();
     call.start(null, headers);
-    verify(interceptor, times(1)).updateHeaders(eq(headers));
+    verify(interceptor, times(1)).updateHeaders(same(headers));
+  }
+
+  @Test
+  public void testChannelsAreRoundRobinned() {
+    Channel channel1 = mock(Channel.class);
+    Channel channel2 = mock(Channel.class);
+    MethodDescriptor descriptor = mock(MethodDescriptor.class);
+    MockitoAnnotations.initMocks(this);
+    ChannelPool pool = new ChannelPool(new Channel[] { channel1, channel2 }, null);
+    pool.newCall(descriptor, CallOptions.DEFAULT);
+    verify(channel1, times(1)).newCall(same(descriptor), same(CallOptions.DEFAULT));
+    verify(channel2, times(0)).newCall(same(descriptor), same(CallOptions.DEFAULT));
+    pool.newCall(descriptor, CallOptions.DEFAULT);
+    verify(channel1, times(1)).newCall(same(descriptor), same(CallOptions.DEFAULT));
+    verify(channel2, times(1)).newCall(same(descriptor), same(CallOptions.DEFAULT));
+  }
+  
+  @Test
+  public void testReturnToPool() {
+    ChannelPool pool = new ChannelPool(new Channel[] { null, null }, null);
+    assertEquals(2, pool.size());
+    PooledChannel reserved = pool.reserveChannel();
+    assertEquals(1, pool.size());
+    reserved.returnToPool();
+    assertEquals(2, pool.size());
+  }
+
+  @Test
+  public void testReserveNeverExhaustsPool() {
+    ChannelPool pool = new ChannelPool(new Channel[] { null, null }, null);
+    for (int i = 0; i < 10; i++) {
+      pool.reserveChannel();
+      assertEquals(1, pool.size());
+    }
   }
 }


### PR DESCRIPTION
A scan prevents other operations from being done on a channel.  Reserve a channel specifically for the scan, and let the other operations proceed on the pool.