### PR TITLE
Adding connection pooling for cbt/cdf.

### DIFF
--- a/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/CloudBigtableConnectionPool.java
+++ b/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/CloudBigtableConnectionPool.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.dataflow;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.client.Connection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.cloud.bigtable.hbase.BigtableOptionsFactory;
+import com.google.cloud.bigtable.hbase1_0.BigtableConnection;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.LinkedHashMultimap;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+
+/**
+ * Pubsub and other windowed sources can have a large quantity of bundles in short amounts of time.
+ * {@link CloudBigtableIO.AbstractCloudBigtableTableWriteFn} should not create a connection per
+ * bundle, since that could happen ever few milliseconds. Rather, it should rely on a connection
+ * pool to better manage connection life-cycles.
+ */
+public class CloudBigtableConnectionPool {
+
+  private static final int MAX_TTL_MILLISECONDS = 30 * 60 * 1000;
+  protected static final Logger LOG = LoggerFactory.getLogger(CloudBigtableConnectionPool.class);
+
+  /**
+   * This class abstracts a connection that could be returned to a
+   * {@link CloudBigtableConnectionPool}.
+   */
+  public static class PoolEntry {
+    private final String key;
+    private final Connection connection;
+    private final long expiresTimeMs;
+
+    private static long getExpiration() {
+      return System.currentTimeMillis() + MAX_TTL_MILLISECONDS;
+    }
+
+    public PoolEntry(String key, Connection connection) {
+      this(key, connection, getExpiration());
+    }
+
+    @VisibleForTesting
+    PoolEntry(String key, Connection connection, long expiresTimeMs) {
+      this.key = key;
+      this.connection = connection;
+      this.expiresTimeMs = expiresTimeMs;
+    }
+
+    public Connection getConnection() {
+      return connection;
+    }
+
+    public String getKey() {
+      return key;
+    }
+
+    public boolean isExpired() {
+      return System.currentTimeMillis() > expiresTimeMs;
+    }
+
+    @Override
+    public String toString() {
+      return String.format("%s key=%s, hash=%s", getClass().getName(), key, super.toString());
+    }
+  }
+
+  private static ExecutorService createDefaultCloseExecutorService() {
+    return Executors.newCachedThreadPool(
+      new ThreadFactoryBuilder()
+          .setNameFormat("CloudBigtableConnectionPool-cleanup-%s")
+          .setDaemon(true)
+          .build());
+  }
+
+  private final LinkedHashMultimap<String, PoolEntry> connections = LinkedHashMultimap.create();
+  private final ExecutorService connectionCloseExecutor;
+
+  public CloudBigtableConnectionPool() {
+    this(createDefaultCloseExecutorService());
+  }
+
+  @VisibleForTesting
+  CloudBigtableConnectionPool(ExecutorService executorService) {
+    this.connectionCloseExecutor = executorService;
+  }
+
+  public PoolEntry getConnection(Configuration config) throws IOException {
+    String key = BigtableOptionsFactory.fromConfiguration(config).getClusterName().toString();
+    return getConnection(config, key);
+  }
+
+  protected synchronized PoolEntry getConnection(Configuration config, String key)
+      throws IOException {
+    Set<PoolEntry> entries = connections.get(key);
+    if (entries.isEmpty()) {
+      return createConnection(config, key);
+    }
+    for (Iterator<PoolEntry> iterator = entries.iterator(); iterator.hasNext();) {
+      PoolEntry entry = iterator.next();
+      iterator.remove();
+      if (entry.isExpired()) {
+        closeAsynchronously(entry);
+      } else {
+        return entry;
+      }
+    }
+    return createConnection(config, key);
+  }
+
+  @VisibleForTesting
+  protected PoolEntry createConnection(Configuration config, String key) throws IOException {
+    return new PoolEntry(key, new BigtableConnection(config));
+  }
+
+  public synchronized void returnConnection(PoolEntry entry) throws IOException {
+    if (entry.isExpired()) {
+      closeAsynchronously(entry);
+    } else {
+      connections.put(entry.getKey(), entry);
+    }
+  }
+
+  private void closeAsynchronously(final PoolEntry entry) throws IOException {
+    connectionCloseExecutor.submit(new Callable<Void>() {
+      @Override
+      public Void call() throws Exception {
+        try {
+          entry.connection.close();
+        } catch (Exception e) {
+          LOG.warn("Could not close a connection asynchronously.", e);
+        }
+        return null;
+      }
+    });
+  }
+}

--- a/bigtable-hbase-dataflow/src/test/java/com/google/cloud/bigtable/dataflow/CloudBigtableConnectionPoolTest.java
+++ b/bigtable-hbase-dataflow/src/test/java/com/google/cloud/bigtable/dataflow/CloudBigtableConnectionPoolTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.dataflow;
+
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutorService;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.client.Connection;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import com.google.cloud.bigtable.dataflow.CloudBigtableConnectionPool.PoolEntry;
+import com.google.common.util.concurrent.MoreExecutors;
+
+/**
+ * Tests for {@link CloudBigtableConnectionPool}.
+ */
+@RunWith(JUnit4.class)
+public class CloudBigtableConnectionPoolTest {
+
+  private static Configuration config = new Configuration();
+  private static ExecutorService executorService = MoreExecutors.newDirectExecutorService();
+
+  private static class TestCloudbigtableConnectionPool extends CloudBigtableConnectionPool {
+    private long expireTime = System.currentTimeMillis() + 100000;
+
+    public TestCloudbigtableConnectionPool() {
+      super(executorService);
+    }
+
+    @Override
+    protected PoolEntry createConnection(Configuration config, String key) throws IOException {
+      return new PoolEntry(key, mock(Connection.class), expireTime);
+    }
+  }
+
+  @Test
+  public void testConnectionIsPooled() throws IOException{
+    TestCloudbigtableConnectionPool pool = new TestCloudbigtableConnectionPool();
+    PoolEntry entry = pool.getConnection(config, "key");
+    pool.returnConnection(entry);
+    for (int i = 0; i < 100; i++) {
+      PoolEntry newEntry = pool.getConnection(config, "key");
+      assertSame(entry, newEntry);
+      pool.returnConnection(newEntry);
+    }
+  }
+
+  @Test
+  public void testExpiredConnectionIsRemoved() throws IOException{
+    TestCloudbigtableConnectionPool pool = new TestCloudbigtableConnectionPool();
+    pool.expireTime = System.currentTimeMillis() - 10;
+    PoolEntry entry = pool.getConnection(config, "key");
+    pool.returnConnection(entry);
+    assertNotSame(entry, pool.getConnection(config, "key"));
+    verify(entry.getConnection(), times(1)).close();
+  }
+
+  @Test
+  public void testConnectionsGetCycled() throws IOException{
+    TestCloudbigtableConnectionPool pool = new TestCloudbigtableConnectionPool();
+    PoolEntry entry1 = pool.getConnection(config, "key");
+    PoolEntry entry2 = pool.getConnection(config, "key");
+    assertNotSame(entry1, entry2);
+    pool.returnConnection(entry1);
+    pool.returnConnection(entry2);
+    for (int i = 0; i < 100; i++) {
+      PoolEntry newEntry = pool.getConnection(config, "key");
+      assertSame(i % 2 == 0 ? entry1 : entry2, newEntry);
+      pool.returnConnection(newEntry);
+    }
+  }
+
+  @Test
+  public void testDifferentKeys() throws IOException{
+    TestCloudbigtableConnectionPool pool = new TestCloudbigtableConnectionPool();
+    PoolEntry entry1 = pool.getConnection(config, "key1");
+    PoolEntry entry2 = pool.getConnection(config, "key2");
+    pool.returnConnection(entry1);
+    pool.returnConnection(entry2);
+    for (int i = 0; i < 100; i++) {
+      PoolEntry newEntry1 = pool.getConnection(config, "key1");
+      assertSame(entry1, newEntry1);
+      pool.returnConnection(newEntry1);
+
+      PoolEntry newEntry2 = pool.getConnection(config, "key2");
+      assertSame(entry2, newEntry2);
+      pool.returnConnection(newEntry2);
+    }
+  }
+}


### PR DESCRIPTION
Pub/Sub connectors can create a bundle every few milliseconds.  The existing solution creates a new connection, which takes a few seconds.  The pooling will allow the bundles to be handled in a better fashion.