### PR TITLE
Implement available on RowScanner

### DIFF
--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ResultScanner.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ResultScanner.java
@@ -4,9 +4,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -35,4 +35,10 @@ public interface ResultScanner<T> extends Closeable {
    * @param count The number of rows to read.
    */
   T[] next(int count) throws IOException;
+
+  /**
+   * Check number of rows immediately available. Calls to {@link #next()} will not block on network for at least
+   * n results.
+   */
+  int available();
 }

--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ResumingStreamingResultScanner.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ResumingStreamingResultScanner.java
@@ -122,6 +122,11 @@ public class ResumingStreamingResultScanner extends AbstractBigtableResultScanne
     }
   }
 
+  @Override
+  public int available() {
+    return currentDelegate.available();
+  }
+
   /**
    * Backs off and reissues request.
    *

--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/StreamingBigtableResultScanner.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/StreamingBigtableResultScanner.java
@@ -145,6 +145,11 @@ public class StreamingBigtableResultScanner extends AbstractBigtableResultScanne
   }
 
   @Override
+  public int available() {
+    return resultQueue.size();
+  }
+
+  @Override
   public void close() throws IOException {
     cancellationToken.cancel();
     reservedChannel.returnToPool();

--- a/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableTable.java
+++ b/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableTable.java
@@ -146,6 +146,11 @@ public class TestBigtableTable {
           }
 
           @Override
+          public int available() {
+            return 0;
+          }
+
+          @Override
           public void close() throws IOException {
           }
         });


### PR DESCRIPTION
As referenced in #535:

I changed my mind a little, obviously `mayBlock()` is just `available() == 0`. I can add both, I just figured the more general method is more interesting.

It compiles and tests seem to pass, so that's nice. What I'm not sure about is how to test _my_ implementation. I think it's trivially correct given the calls to the underlying collections, but tests would be nice.

I'll have a think about it tomorrow. I also checked the impl of `size()` for LinkedBlockingQueue's: it's just a [read on an atomic int](http://grepcode.com/file/repository.grepcode.com/java/root/jdk/openjdk/6-b14/java/util/concurrent/LinkedBlockingQueue.java#LinkedBlockingQueue.size%28%29), at least in openjdk, so shouldn't be too costly.