### PR TITLE
Doing all work in AbstractBigtableConnection without an Executor.

### DIFF
--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AsyncExecutor.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AsyncExecutor.java
@@ -17,7 +17,6 @@ package com.google.cloud.bigtable.grpc.async;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.concurrent.ExecutorService;
 
 import com.google.bigtable.v1.CheckAndMutateRowRequest;
 import com.google.bigtable.v1.CheckAndMutateRowResponse;
@@ -89,13 +88,9 @@ public class AsyncExecutor {
   private final BigtableDataClient client;
   private final HeapSizeManager sizeManager;
 
-  public AsyncExecutor(
-      BigtableDataClient client,
-      int maxInflightRpcs,
-      long maxHeapSize,
-      ExecutorService heapSizeExecutor) {
+  public AsyncExecutor(BigtableDataClient client, HeapSizeManager heapSizeManager) {
     this.client = client;
-    this.sizeManager = new HeapSizeManager(maxHeapSize, maxInflightRpcs, heapSizeExecutor);
+    this.sizeManager = heapSizeManager;
   }
 
   public ListenableFuture<Empty> mutateRowAsync(MutateRowRequest request)

--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutator.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutator.java
@@ -18,7 +18,6 @@ package com.google.cloud.bigtable.hbase;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock.ReadLock;
@@ -38,6 +37,7 @@ import org.apache.hadoop.hbase.client.Row;
 import com.google.cloud.bigtable.config.Logger;
 import com.google.cloud.bigtable.grpc.BigtableDataClient;
 import com.google.cloud.bigtable.grpc.async.AsyncExecutor;
+import com.google.cloud.bigtable.grpc.async.HeapSizeManager;
 import com.google.cloud.bigtable.hbase.adapters.HBaseRequestAdapter;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.FutureCallback;
@@ -89,16 +89,14 @@ public class BigtableBufferedMutator implements BufferedMutator {
       BigtableDataClient client,
       HBaseRequestAdapter adapter,
       Configuration configuration,
-      int maxInflightRpcs,
-      long maxHeapSize,
       String dataHost,
       BufferedMutator.ExceptionListener listener,
-      ExecutorService heapSizeExecutor) {
+      HeapSizeManager heapSizeManager) {
     this.adapter = adapter;
     this.configuration = configuration;
     this.exceptionListener = listener;
     this.host = dataHost;
-    this.asyncExecutor = new AsyncExecutor(client, maxInflightRpcs, maxHeapSize, heapSizeExecutor);
+    this.asyncExecutor = new AsyncExecutor(client, heapSizeManager);
   }
 
   @Override


### PR DESCRIPTION
The Executor service was creating a ton of threads.  Adding a method that reduces the need for multi-threaded handling of call completions in HeapSizeManager which removes the thread explosion.  It may have a performance benefit as well.