### PR TITLE
Using an extra call.request() in streaming readRows.

### DIFF
--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataGrpcClient.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataGrpcClient.java
@@ -279,6 +279,9 @@ public class BigtableDataGrpcClient implements BigtableDataClient {
         request,
         new ReadRowsStreamObserver(resultScanner));
 
+    // ClientCalls does this as well.  This will ensure that there are always 2 ongoing requests.
+    readRowsCall.request(1);
+
     return resultScanner;
   }
 }

--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ResponseQueueReader.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ResponseQueueReader.java
@@ -29,6 +29,7 @@ import com.google.common.base.Preconditions;
  * complete Row objects from the partial ReadRowsResponse objects.
  */
 class ResponseQueueReader {
+  private static final long OFFER_WAIT_SECONDS = 5;
   private final BlockingQueue<ResultQueueEntry<ReadRowsResponse>> resultQueue;
   private final int readPartialRowTimeoutMillis;
   private boolean lastResponseProcessed = false;
@@ -94,6 +95,6 @@ class ResponseQueueReader {
   }
 
   public void add(ResultQueueEntry<ReadRowsResponse> entry) throws InterruptedException {
-    resultQueue.put(entry);
+    resultQueue.offer(entry, OFFER_WAIT_SECONDS, TimeUnit.SECONDS);
   }
 }

--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/StreamingBigtableResultScanner.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/StreamingBigtableResultScanner.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2015 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,7 +24,7 @@ import com.google.cloud.bigtable.grpc.io.ChannelPool.PooledChannel;
 import com.google.common.base.Preconditions;
 
 /**
- * A {@link ResultScanner} implementation against the v1 bigtable API.
+ * A {@link ResultScanner} implementation against the v1 Bigtable API.
  */
 public class StreamingBigtableResultScanner extends AbstractBigtableResultScanner {
 
@@ -47,7 +47,7 @@ public class StreamingBigtableResultScanner extends AbstractBigtableResultScanne
       responseQueueReader.add(entry);
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
-      throw new RuntimeException("Interrupted while adding a ResultQueueEntry", e);
+      throw new RuntimeException("Interrupted while adding a ResultQueueEntry.", e);
     }
   }
 

--- a/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/scanner/StreamingBigtableResultScannerTest.java
+++ b/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/scanner/StreamingBigtableResultScannerTest.java
@@ -435,7 +435,7 @@ public class StreamingBigtableResultScannerTest {
   }
 
   @Test
-  public void readTimeoutOnPartialRows() throws IOException, InterruptedException {
+  public void readTimeoutOnPartialRows() throws IOException {
     CancellationToken cancellationToken = new CancellationToken();
     try (final StreamingBigtableResultScanner scanner =
         new StreamingBigtableResultScanner(channel, 10, 10 /* timeout millis */, cancellationToken)) {

--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableOptionsFactory.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableOptionsFactory.java
@@ -51,6 +51,7 @@ public class BigtableOptionsFactory {
   public static final String CLUSTER_KEY = "google.bigtable.cluster.name";
   public static final String ZONE_KEY = "google.bigtable.zone.name";
 
+
   /**
    * If set, bypass DNS host lookup and use the given IP address.
    */
@@ -109,12 +110,18 @@ public class BigtableOptionsFactory {
    */
   public static final String MAX_ELAPSED_BACKOFF_MILLIS_KEY =
       "google.bigtable.grpc.retry.max.elapsed.backoff.ms";
- 
+
   /**
    * Key to set the amount of time to wait when reading a partial row.
    */
   public static final String READ_PARTIAL_ROW_TIMEOUT_MS =
       "google.bigtable.grpc.read.partial.row.timeout.ms";
+
+  /**
+   * Key to set the number of buffered read row responses (scanned rows) to read from gRPC.
+   */
+  public static final String STREMING_ROW_BUFFER_SIZE =
+      "google.bigtable.grpc.sreaming.buffer.capacity";
 
   /**
    * The number of grpc channels to open for asynchronous processing such as puts.
@@ -256,6 +263,11 @@ public class BigtableOptionsFactory {
         READ_PARTIAL_ROW_TIMEOUT_MS, RetryOptions.DEFAULT_READ_PARTIAL_ROW_TIMEOUT_MS);
     LOG.debug("gRPC read partial row timeout (millis): %d", readPartialRowTimeoutMillis);
     retryOptionsBuilder.setReadPartialRowTimeoutMillis(readPartialRowTimeoutMillis);
+
+    int streamingBufferSize = configuration.getInt(
+      STREMING_ROW_BUFFER_SIZE, RetryOptions.DEFAULT_STREAMING_BUFFER_SIZE);
+    LOG.debug("gRPC streaming buffer size (count): %d", streamingBufferSize);
+    retryOptionsBuilder.setStreamingBufferSize(streamingBufferSize);
 
     return retryOptionsBuilder.build();
   }


### PR DESCRIPTION
This should improve throughput.