### PR TITLE
Using ByteStringer.wrap in more places.

### DIFF
--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ResumingStreamingResultScanner.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ResumingStreamingResultScanner.java
@@ -16,6 +16,9 @@
 package com.google.cloud.bigtable.grpc.scanner;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import io.grpc.Status;
+
+import java.io.IOException;
 
 import com.google.api.client.util.BackOff;
 import com.google.api.client.util.ExponentialBackOff;
@@ -27,12 +30,9 @@ import com.google.bigtable.v1.Row;
 import com.google.cloud.bigtable.config.Logger;
 import com.google.cloud.bigtable.config.RetryOptions;
 import com.google.cloud.bigtable.grpc.io.IOExceptionWithStatus;
+import com.google.cloud.bigtable.util.ByteStringer;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.ByteString;
-
-import io.grpc.Status;
-
-import java.io.IOException;
 
 
 /**
@@ -43,7 +43,7 @@ public class ResumingStreamingResultScanner extends AbstractBigtableResultScanne
 
   private static final Logger LOG = new Logger(ResumingStreamingResultScanner.class);
 
-  private static final ByteString NEXT_ROW_SUFFIX = ByteString.copyFrom(new byte[]{0x00});
+  private static final ByteString NEXT_ROW_SUFFIX = ByteStringer.wrap(new byte[]{0x00});
   private final BigtableResultScannerFactory scannerFactory;
 
   /**

--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/util/ByteStringer.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/util/ByteStringer.java
@@ -37,17 +37,9 @@ public class ByteStringer {
    * Wraps a byte array in a {@link ByteString} without copying it.
    */
   public static ByteString wrap(final byte[] array) {
-    return USE_ZEROCOPYBYTESTRING? BigtableZeroCopyByteStringUtil.wrap(array): ByteString.copyFrom(array);
+    return USE_ZEROCOPYBYTESTRING ? BigtableZeroCopyByteStringUtil.wrap(array) : ByteString
+        .copyFrom(array);
   }
-  
-  /**
-   * Wraps a subset of a byte array in a {@link ByteString} without copying it.
-   */
-  public static ByteString wrap(final byte[] array, int offset, int length) {
-    return USE_ZEROCOPYBYTESTRING? BigtableZeroCopyByteStringUtil.wrap(array, offset, length):
-      ByteString.copyFrom(array, offset, length);
-  }
-
 
   public static byte[] extract(ByteString buf) {
     return USE_ZEROCOPYBYTESTRING ? BigtableZeroCopyByteStringUtil.zeroCopyGetBytes(buf) : buf

--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableConstants.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableConstants.java
@@ -17,6 +17,7 @@ package com.google.cloud.bigtable.hbase;
 
 
 import com.google.cloud.bigtable.config.Logger;
+import com.google.cloud.bigtable.util.ByteStringer;
 import com.google.protobuf.ByteString;
 
 import java.io.IOException;
@@ -45,7 +46,7 @@ public class BigtableConstants {
    * Byte string of the column family and column name separator for Bigtable.
    */
   public static final ByteString BIGTABLE_COLUMN_SEPARATOR_BYTE_STRING =
-      ByteString.copyFrom(new byte[] {BIGTABLE_COLUMN_SEPARATOR_BYTE});
+      ByteStringer.wrap(new byte[] {BIGTABLE_COLUMN_SEPARATOR_BYTE});
 
   /**
    * TimeUnit in which HBase clients expects messages to be sent and received.

--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableTable.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableTable.java
@@ -64,9 +64,9 @@ import com.google.cloud.bigtable.grpc.BigtableDataClient;
 import com.google.cloud.bigtable.hbase.adapters.Adapters;
 import com.google.cloud.bigtable.hbase.adapters.ReadHooks;
 import com.google.cloud.bigtable.hbase.adapters.HBaseRequestAdapter;
+import com.google.cloud.bigtable.util.ByteStringer;
 import com.google.common.base.Function;
 import com.google.common.base.MoreObjects;
-import com.google.protobuf.ByteString;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.Message;
 import com.google.protobuf.Service;
@@ -599,7 +599,7 @@ public class BigtableTable implements Table {
 
     requestBuilder.setTableName(hbaseAdapter.getBigtableTableName().toString());
 
-    requestBuilder.setRowKey(ByteString.copyFrom(row));
+    requestBuilder.setRowKey(ByteStringer.wrap(row));
     Scan scan = new Scan().addColumn(family, qualifier);
     scan.setMaxVersions(1);
     if (value == null) {

--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/AppendAdapter.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/AppendAdapter.java
@@ -17,6 +17,7 @@ package com.google.cloud.bigtable.hbase.adapters;
 
 import com.google.bigtable.v1.ReadModifyWriteRowRequest;
 import com.google.bigtable.v1.ReadModifyWriteRule;
+import com.google.cloud.bigtable.util.ByteStringer;
 import com.google.protobuf.ByteString;
 
 import org.apache.hadoop.hbase.Cell;
@@ -34,7 +35,7 @@ public class AppendAdapter implements OperationAdapter<Append, ReadModifyWriteRo
   @Override
   public ReadModifyWriteRowRequest.Builder adapt(Append operation) {
     ReadModifyWriteRowRequest.Builder result = ReadModifyWriteRowRequest.newBuilder();
-    result.setRowKey(ByteString.copyFrom(operation.getRow()));
+    result.setRowKey(ByteStringer.wrap(operation.getRow()));
 
     for (Map.Entry<byte[], List<Cell>> entry : operation.getFamilyCellMap().entrySet()){
       String familyName = Bytes.toString(entry.getKey());

--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/DeleteAdapter.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/DeleteAdapter.java
@@ -15,21 +15,22 @@
  */
 package com.google.cloud.bigtable.hbase.adapters;
 
-import com.google.bigtable.v1.MutateRowRequest;
-import com.google.bigtable.v1.Mutation;
-import com.google.bigtable.v1.Mutation.Builder;
-import com.google.bigtable.v1.Mutation.DeleteFromFamily;
-import com.google.bigtable.v1.Mutation.DeleteFromRow;
-import com.google.cloud.bigtable.hbase.BigtableConstants;
-import com.google.protobuf.ByteString;
+import java.util.List;
+import java.util.Map;
 
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.client.Delete;
 
-import java.util.List;
-import java.util.Map;
+import com.google.bigtable.v1.MutateRowRequest;
+import com.google.bigtable.v1.Mutation;
+import com.google.bigtable.v1.Mutation.Builder;
+import com.google.bigtable.v1.Mutation.DeleteFromFamily;
+import com.google.bigtable.v1.Mutation.DeleteFromRow;
+import com.google.cloud.bigtable.hbase.BigtableConstants;
+import com.google.cloud.bigtable.util.ByteStringer;
+import com.google.protobuf.ByteString;
 
 /**
  * Adapt a single Delete operation to a Bigtable RowMutation
@@ -131,7 +132,7 @@ public class DeleteAdapter implements OperationAdapter<Delete, MutateRowRequest.
   @Override
   public MutateRowRequest.Builder adapt(Delete operation) {
     MutateRowRequest.Builder result = MutateRowRequest.newBuilder();
-    result.setRowKey(ByteString.copyFrom(operation.getRow()));
+    result.setRowKey(ByteStringer.wrap(operation.getRow()));
 
     if (operation.getFamilyCellMap().isEmpty()) {
       throwIfUnsupportedDeleteRow(operation);
@@ -140,7 +141,7 @@ public class DeleteAdapter implements OperationAdapter<Delete, MutateRowRequest.
     } else {
       for (Map.Entry<byte[], List<Cell>> entry : operation.getFamilyCellMap().entrySet()) {
 
-        ByteString familyByteString = ByteString.copyFrom(entry.getKey());
+        ByteString familyByteString = ByteStringer.wrap(entry.getKey());
 
         for (Cell cell : entry.getValue()) {
           if (isColumnDelete(cell) || isPointDelete(cell)) {

--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/IncrementAdapter.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/IncrementAdapter.java
@@ -18,6 +18,7 @@ package com.google.cloud.bigtable.hbase.adapters;
 
 import com.google.bigtable.v1.ReadModifyWriteRowRequest;
 import com.google.bigtable.v1.ReadModifyWriteRule;
+import com.google.cloud.bigtable.util.ByteStringer;
 import com.google.protobuf.ByteString;
 
 import org.apache.hadoop.hbase.Cell;
@@ -44,7 +45,7 @@ public class IncrementAdapter
 
     ReadModifyWriteRowRequest.Builder result = ReadModifyWriteRowRequest.newBuilder();
 
-    result.setRowKey(ByteString.copyFrom(operation.getRow()));
+    result.setRowKey(ByteStringer.wrap(operation.getRow()));
 
     for (Map.Entry<byte[], NavigableMap<byte[], Long>> familyEntry :
         operation.getFamilyMapOfLongs().entrySet()) {

--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/PutAdapter.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/PutAdapter.java
@@ -42,7 +42,7 @@ public class PutAdapter implements OperationAdapter<Put, MutateRowRequest.Builde
   @Override
   public MutateRowRequest.Builder adapt(Put operation) {
     MutateRowRequest.Builder result = MutateRowRequest.newBuilder();
-    result.setRowKey(ByteString.copyFrom(operation.getRow()));
+    result.setRowKey(ByteStringer.wrap(operation.getRow()));
 
     if (operation.isEmpty()) {
       throw new IllegalArgumentException("No columns to insert");
@@ -65,7 +65,7 @@ public class PutAdapter implements OperationAdapter<Put, MutateRowRequest.Builde
         Mutation.Builder modBuilder = result.addMutationsBuilder();
         Builder setCellBuilder = modBuilder.getSetCellBuilder();
 
-        ByteString cellQualifierByteString = ByteStringer.wrap(
+        ByteString cellQualifierByteString = ByteString.copyFrom(
             cell.getQualifierArray(),
             cell.getQualifierOffset(),
             cell.getQualifierLength());
@@ -83,7 +83,7 @@ public class PutAdapter implements OperationAdapter<Put, MutateRowRequest.Builde
         }
 
         setCellBuilder.setValue(
-            ByteStringer.wrap(
+            ByteString.copyFrom(
                 cell.getValueArray(),
                 cell.getValueOffset(),
                 cell.getValueLength()));

--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/RowMutationsAdapter.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/RowMutationsAdapter.java
@@ -16,11 +16,11 @@
 package com.google.cloud.bigtable.hbase.adapters;
 
 
-import com.google.bigtable.v1.MutateRowRequest;
-import com.google.protobuf.ByteString;
-
 import org.apache.hadoop.hbase.client.Mutation;
 import org.apache.hadoop.hbase.client.RowMutations;
+
+import com.google.bigtable.v1.MutateRowRequest;
+import com.google.cloud.bigtable.util.ByteStringer;
 
 /**
  * An adapter that adapts a {@link RowMutations} object into an Bigtable
@@ -39,7 +39,7 @@ public class RowMutationsAdapter {
   public MutateRowRequest.Builder adapt(RowMutations mutations) {
     MutateRowRequest.Builder result = MutateRowRequest.newBuilder();
 
-    result.setRowKey(ByteString.copyFrom(mutations.getRow()));
+    result.setRowKey(ByteStringer.wrap(mutations.getRow()));
 
     for (Mutation mutation : mutations.getMutations()) {
       MutateRowRequest.Builder bigtableBuilder = mutationAdapter.adapt(mutation);

--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/ColumnPaginationFilterAdapter.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/ColumnPaginationFilterAdapter.java
@@ -18,7 +18,7 @@ package com.google.cloud.bigtable.hbase.adapters.filters;
 import com.google.bigtable.v1.ColumnRange;
 import com.google.bigtable.v1.RowFilter;
 import com.google.bigtable.v1.RowFilter.Chain;
-import com.google.protobuf.ByteString;
+import com.google.cloud.bigtable.util.ByteStringer;
 
 import org.apache.hadoop.hbase.filter.ColumnPaginationFilter;
 import org.apache.hadoop.hbase.util.Bytes;
@@ -49,7 +49,7 @@ public class ColumnPaginationFilterAdapter implements TypedFilterAdapter<ColumnP
                   ColumnRange.newBuilder()
                       .setFamilyName(Bytes.toString(family))
                       .setStartQualifierInclusive(
-                          ByteString.copyFrom(filter.getColumnOffset()))));
+                          ByteStringer.wrap(filter.getColumnOffset()))));
     } else if (filter.getOffset() > 0) {
       // Include starting at an integer offset up to limit cells.
       return createChain(

--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/ColumnPrefixFilterAdapter.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/ColumnPrefixFilterAdapter.java
@@ -17,7 +17,7 @@ package com.google.cloud.bigtable.hbase.adapters.filters;
 
 import com.google.bigtable.v1.RowFilter;
 import com.google.cloud.bigtable.hbase.adapters.ReaderExpressionHelper;
-import com.google.protobuf.ByteString;
+import com.google.cloud.bigtable.util.ByteStringer;
 
 import org.apache.hadoop.hbase.filter.ColumnPrefixFilter;
 
@@ -42,9 +42,7 @@ public class ColumnPrefixFilterAdapter implements TypedFilterAdapter<ColumnPrefi
     outputStream.write(ReaderExpressionHelper.ALL_QUALIFIERS_BYTES);
 
     return RowFilter.newBuilder()
-        .setColumnQualifierRegexFilter(
-            ByteString.copyFrom(
-                outputStream.toByteArray()))
+        .setColumnQualifierRegexFilter(ByteStringer.wrap(outputStream.toByteArray()))
         .build();
   }
 

--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/ColumnRangeFilterAdapter.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/ColumnRangeFilterAdapter.java
@@ -17,6 +17,7 @@ package com.google.cloud.bigtable.hbase.adapters.filters;
 
 import com.google.bigtable.v1.ColumnRange;
 import com.google.bigtable.v1.RowFilter;
+import com.google.cloud.bigtable.util.ByteStringer;
 import com.google.protobuf.ByteString;
 
 import org.apache.hadoop.hbase.client.Scan;
@@ -43,14 +44,14 @@ public class ColumnRangeFilterAdapter implements TypedFilterAdapter<ColumnRangeF
     ColumnRange.Builder rangeBuilder = ColumnRange.newBuilder();
     rangeBuilder.setFamilyName(Bytes.toString(familyName));
 
-    ByteString startQualifier = ByteString.copyFrom(filter.getMinColumn());
+    ByteString startQualifier = ByteStringer.wrap(filter.getMinColumn());
     if (filter.getMinColumnInclusive()) {
       rangeBuilder.setStartQualifierInclusive(startQualifier);
     } else {
       rangeBuilder.setStartQualifierExclusive(startQualifier);
     }
 
-    ByteString endQualifier = ByteString.copyFrom(filter.getMaxColumn());
+    ByteString endQualifier = ByteStringer.wrap(filter.getMaxColumn());
     if (filter.getMaxColumnInclusive()) {
       rangeBuilder.setEndQualifierInclusive(endQualifier);
     } else {

--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/FuzzyRowFilterAdapter.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/FuzzyRowFilterAdapter.java
@@ -30,6 +30,7 @@ import com.google.bigtable.v1.RowFilter;
 import com.google.bigtable.v1.RowFilter.Interleave;
 import com.google.cloud.bigtable.hbase.adapters.ReaderExpressionHelper;
 import com.google.cloud.bigtable.hbase.adapters.ReaderExpressionHelper.QuoteMetaOutputStream;
+import com.google.cloud.bigtable.util.ByteStringer;
 import com.google.protobuf.ByteString;
 
 /**
@@ -71,7 +72,7 @@ public class FuzzyRowFilterAdapter implements TypedFilterAdapter<FuzzyRowFilter>
         baos.write(ReaderExpressionHelper.ANY_BYTE_BYTES);
       }
     }
-    ByteString quotedValue = ByteString.copyFrom(baos.toByteArray());
+    ByteString quotedValue = ByteStringer.wrap(baos.toByteArray());
     quotingStream.close();
     return RowFilter.newBuilder().setRowKeyRegexFilter(quotedValue).build();
   }

--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/MultipleColumnPrefixFilterAdapter.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/MultipleColumnPrefixFilterAdapter.java
@@ -18,7 +18,7 @@ package com.google.cloud.bigtable.hbase.adapters.filters;
 import com.google.bigtable.v1.RowFilter;
 import com.google.bigtable.v1.RowFilter.Interleave;
 import com.google.cloud.bigtable.hbase.adapters.ReaderExpressionHelper;
-import com.google.protobuf.ByteString;
+import com.google.cloud.bigtable.util.ByteStringer;
 
 import org.apache.hadoop.hbase.filter.MultipleColumnPrefixFilter;
 
@@ -49,8 +49,7 @@ public class MultipleColumnPrefixFilterAdapter
 
       RowFilter.Builder singlePrefixBuilder = RowFilter.newBuilder();
       singlePrefixBuilder.setColumnQualifierRegexFilter(
-          ByteString.copyFrom(
-              outputStream.toByteArray()));
+            ByteStringer.wrap(outputStream.toByteArray()));
 
       interleaveBuilder.addFilters(singlePrefixBuilder);
     }

--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/PrefixFilterAdapter.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/PrefixFilterAdapter.java
@@ -15,14 +15,15 @@
  */
 package com.google.cloud.bigtable.hbase.adapters.filters;
 
-import com.google.bigtable.v1.RowFilter;
-import com.google.cloud.bigtable.hbase.adapters.ReaderExpressionHelper;
-import com.google.protobuf.ByteString;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 
 import org.apache.hadoop.hbase.filter.PrefixFilter;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
+import com.google.bigtable.v1.RowFilter;
+import com.google.cloud.bigtable.hbase.adapters.ReaderExpressionHelper;
+import com.google.cloud.bigtable.util.ByteStringer;
+import com.google.protobuf.ByteString;
 
 /**
  * Adapter for HBase {@link PrefixFilter} instances.
@@ -36,7 +37,7 @@ public class PrefixFilterAdapter implements TypedFilterAdapter<PrefixFilter> {
     ReaderExpressionHelper.writeQuotedRegularExpression(baos, filter.getPrefix());
     // Unquoted all bytes:
     baos.write(ReaderExpressionHelper.ALL_QUALIFIERS_BYTES);
-    ByteString quotedValue = ByteString.copyFrom(baos.toByteArray());
+    ByteString quotedValue = ByteStringer.wrap(baos.toByteArray());
     return RowFilter.newBuilder()
         .setRowKeyRegexFilter(quotedValue)
         .build();

--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/QualifierFilterAdapter.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/QualifierFilterAdapter.java
@@ -15,18 +15,19 @@
  */
 package com.google.cloud.bigtable.hbase.adapters.filters;
 
-import com.google.bigtable.v1.ColumnRange;
-import com.google.bigtable.v1.RowFilter;
-import com.google.bigtable.v1.RowFilter.Interleave;
-import com.google.cloud.bigtable.hbase.adapters.ReaderExpressionHelper;
-import com.google.protobuf.ByteString;
+import java.io.IOException;
 
 import org.apache.hadoop.hbase.filter.BinaryComparator;
 import org.apache.hadoop.hbase.filter.CompareFilter.CompareOp;
 import org.apache.hadoop.hbase.filter.QualifierFilter;
 import org.apache.hadoop.hbase.filter.RegexStringComparator;
 
-import java.io.IOException;
+import com.google.bigtable.v1.ColumnRange;
+import com.google.bigtable.v1.RowFilter;
+import com.google.bigtable.v1.RowFilter.Interleave;
+import com.google.cloud.bigtable.hbase.adapters.ReaderExpressionHelper;
+import com.google.cloud.bigtable.util.ByteStringer;
+import com.google.protobuf.ByteString;
 
 /**
  * Adapter for qualifier filters.
@@ -63,7 +64,7 @@ public class QualifierFilterAdapter implements TypedFilterAdapter<QualifierFilte
       FilterAdapterContext context, CompareOp compareOp, BinaryComparator comparator)
       throws IOException {
     byte[] quoted = ReaderExpressionHelper.quoteRegularExpression(comparator.getValue());
-    ByteString quotedValue = ByteString.copyFrom(quoted);
+    ByteString quotedValue = ByteStringer.wrap(quoted);
     switch (compareOp) {
       case LESS:
         return RowFilter.newBuilder()

--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/RowFilterAdapter.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/RowFilterAdapter.java
@@ -26,7 +26,7 @@ import org.apache.hadoop.hbase.filter.RegexStringComparator;
 import com.google.bigtable.v1.RowFilter;
 import com.google.bigtable.v1.RowFilter.Builder;
 import com.google.cloud.bigtable.hbase.adapters.ReaderExpressionHelper;
-import com.google.protobuf.ByteString;
+import com.google.cloud.bigtable.util.ByteStringer;
 
 /**
  * An adapter for row key filters using comparators and operators. 
@@ -53,12 +53,11 @@ public class RowFilterAdapter implements
     if (comparator == null) {
       throw new IllegalStateException("Comparator cannot be null"); 
     } else if (comparator instanceof RegexStringComparator) {
-      ByteString rawValue = ByteString.copyFrom(comparator.getValue());
-      builder.setRowKeyRegexFilter(rawValue);
+      builder.setRowKeyRegexFilter(ByteStringer.wrap(comparator.getValue()));
     } else if (comparator instanceof BinaryComparator) {
       byte[] quotedRegularExpression =
           ReaderExpressionHelper.quoteRegularExpression(comparator.getValue());
-      builder.setRowKeyRegexFilter(ByteString.copyFrom(quotedRegularExpression));
+      builder.setRowKeyRegexFilter(ByteStringer.wrap(quotedRegularExpression));
     } else {
       throw new IllegalStateException(String.format("Cannot adapt comparator %s", comparator
           .getClass().getCanonicalName()));

--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/SingleColumnValueExcludeFilterAdapter.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/SingleColumnValueExcludeFilterAdapter.java
@@ -15,17 +15,18 @@
  */
 package com.google.cloud.bigtable.hbase.adapters.filters;
 
-import com.google.bigtable.v1.ColumnRange;
-import com.google.bigtable.v1.RowFilter;
-import com.google.bigtable.v1.RowFilter.Chain;
-import com.google.bigtable.v1.RowFilter.Interleave;
-import com.google.protobuf.ByteString;
+import java.io.IOException;
 
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.filter.SingleColumnValueExcludeFilter;
 import org.apache.hadoop.hbase.util.Bytes;
 
-import java.io.IOException;
+import com.google.bigtable.v1.ColumnRange;
+import com.google.bigtable.v1.RowFilter;
+import com.google.bigtable.v1.RowFilter.Chain;
+import com.google.bigtable.v1.RowFilter.Interleave;
+import com.google.cloud.bigtable.util.ByteStringer;
+import com.google.protobuf.ByteString;
 
 /**
  * Adapter for the {@link org.apache.hadoop.hbase.filter.SingleColumnValueFilter}
@@ -61,7 +62,7 @@ public class SingleColumnValueExcludeFilterAdapter
   private RowFilter makeExcludeMatchColumnFilter(
       Scan scan, SingleColumnValueExcludeFilter filter) {
     String family = Bytes.toString(scan.getFamilies()[0]);
-    ByteString qualifier = ByteString.copyFrom(filter.getQualifier());
+    ByteString qualifier = ByteStringer.wrap(filter.getQualifier());
     return RowFilter.newBuilder()
         .setInterleave(
             Interleave.newBuilder()

--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/SingleColumnValueFilterAdapter.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/SingleColumnValueFilterAdapter.java
@@ -26,7 +26,7 @@ import org.apache.hadoop.hbase.util.Bytes;
 import com.google.bigtable.v1.RowFilter;
 import com.google.bigtable.v1.RowFilter.Chain;
 import com.google.bigtable.v1.RowFilter.Condition;
-import com.google.protobuf.ByteString;
+import com.google.cloud.bigtable.util.ByteStringer;
 
 /**
  * Adapt SingleColumnValueFilter instances into bigtable RowFilters.
@@ -69,7 +69,7 @@ public class SingleColumnValueFilterAdapter implements TypedFilterAdapter<Single
                     Bytes.toString(quoteRegularExpression(filter.getFamily()))))
             .addFilters(RowFilter.newBuilder()
                 .setColumnQualifierRegexFilter(
-                    ByteString.copyFrom(quoteRegularExpression(filter.getQualifier()))))
+                    ByteStringer.wrap(quoteRegularExpression(filter.getQualifier()))))
             .addFilters(createVersionLimitFilter(filter)))
         .build();
   }

--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/ValueFilterAdapter.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/ValueFilterAdapter.java
@@ -19,6 +19,7 @@ import com.google.bigtable.v1.RowFilter;
 import com.google.bigtable.v1.RowFilter.Interleave;
 import com.google.bigtable.v1.ValueRange;
 import com.google.cloud.bigtable.hbase.adapters.ReaderExpressionHelper;
+import com.google.cloud.bigtable.util.ByteStringer;
 import com.google.protobuf.ByteString;
 
 import org.apache.hadoop.hbase.filter.BinaryComparator;
@@ -64,7 +65,7 @@ public class ValueFilterAdapter implements TypedFilterAdapter<ValueFilter> {
 
   private RowFilter adaptBinaryComparator(
       CompareOp compareOp, BinaryComparator comparator) throws IOException {
-    ByteString value = ByteString.copyFrom(comparator.getValue());
+    ByteString value = ByteStringer.wrap(comparator.getValue());
     switch (compareOp) {
       case LESS:
         return createRowFilter(ValueRange.newBuilder().setEndValueExclusive(value));
@@ -73,7 +74,7 @@ public class ValueFilterAdapter implements TypedFilterAdapter<ValueFilter> {
       case EQUAL:
         byte[] quotedBytes = ReaderExpressionHelper.quoteRegularExpression(comparator.getValue());
         return RowFilter.newBuilder()
-            .setValueRegexFilter(ByteString.copyFrom(quotedBytes))
+            .setValueRegexFilter(ByteStringer.wrap(quotedBytes))
             .build();
       case NOT_EQUAL:
         // This strictly less than + strictly greater than:


### PR DESCRIPTION
Also removing ByteStringer.wrap() that takes in an array, offset and size; ByteString.copy() is more efficient in that case.