### PR TITLE
Improving use of ClientCall.request() for scanning.

### DIFF
--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/RetryOptions.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/RetryOptions.java
@@ -28,7 +28,7 @@ import com.google.common.annotations.VisibleForTesting;
  */
 public class RetryOptions {
 
-  public static int DEFAULT_STREAMING_BUFFER_SIZE = 32;
+  public static int DEFAULT_STREAMING_BUFFER_SIZE = 60;
 
   /**
    * Flag indicating whether or not grpc retries should be enabled.

--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ResponseQueueReader.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ResponseQueueReader.java
@@ -15,10 +15,14 @@
  */
 package com.google.cloud.bigtable.grpc.scanner;
 
+import io.grpc.ClientCall;
+
 import java.io.IOException;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import com.google.bigtable.v1.ReadRowsResponse;
 import com.google.bigtable.v1.Row;
@@ -28,14 +32,24 @@ import com.google.common.base.Preconditions;
  * Helper to read a queue of ResultQueueEntries and use the RowMergers to reconstruct
  * complete Row objects from the partial ReadRowsResponse objects.
  */
-class ResponseQueueReader {
+public class ResponseQueueReader {
   private final BlockingQueue<ResultQueueEntry<ReadRowsResponse>> resultQueue;
   private final int readPartialRowTimeoutMillis;
   private boolean lastResponseProcessed = false;
+  private AtomicBoolean completionMarkerFound = new AtomicBoolean(false);
+  private final int capacityCap;
+  private final int batchRequestSize;
+  private AtomicInteger outstandingRequestCount;
+  private final ClientCall<?, ReadRowsResponse> call;
 
-  public ResponseQueueReader(int capacity, int readPartialRowTimeoutMillis) {
-    this.resultQueue = new LinkedBlockingQueue<>(capacity);
+  public ResponseQueueReader(int readPartialRowTimeoutMillis, int capacityCap,
+      int outstandingRequestCount, int batchRequestSize, ClientCall<?, ReadRowsResponse> call) {
+    this.resultQueue = new LinkedBlockingQueue<>();
     this.readPartialRowTimeoutMillis = readPartialRowTimeoutMillis;
+    this.capacityCap = capacityCap;
+    this.outstandingRequestCount = new AtomicInteger(outstandingRequestCount);
+    this.batchRequestSize = batchRequestSize;
+    this.call = call;
   }
 
   /**
@@ -66,16 +80,22 @@ class ResponseQueueReader {
       }
     }
 
-    Preconditions.checkState(
-        builder == null,
-        "End of stream marker encountered while merging a row.");
-    Preconditions.checkState(
-        lastResponseProcessed,
-        "Should only exit merge loop with by returning a complete Row or hitting end of stream.");
+    Preconditions.checkState(builder == null,
+      "End of stream marker encountered while merging a row.");
+    Preconditions.checkState(lastResponseProcessed,
+      "Should only exit merge loop with by returning a complete Row or hitting end of stream.");
     return null;
   }
 
   private ResultQueueEntry<ReadRowsResponse> getNext() throws IOException {
+
+    // If there are currently less than or equal to the batch request size, then ask gRPC to
+    // request more results in a batch. Batch requests are more efficient that reading one at
+    // a time.
+    while (!completionMarkerFound.get() && moreCanBeRequested()) {
+      call.request(batchRequestSize);
+      outstandingRequestCount.addAndGet(batchRequestSize);
+    }
     ResultQueueEntry<ReadRowsResponse> queueEntry;
     try {
       queueEntry = resultQueue.poll(readPartialRowTimeoutMillis, TimeUnit.MILLISECONDS);
@@ -86,14 +106,27 @@ class ResponseQueueReader {
     if (queueEntry == null) {
       throw new ScanTimeoutException("Timeout while merging responses.");
     }
+
     return queueEntry;
   }
-  
+
+  /**
+   * Calculates whether or not a new batch should be requested.
+   * @return true if a new batch should be requested.
+   */
+  private boolean moreCanBeRequested() {
+    return outstandingRequestCount.get() + resultQueue.size() <= capacityCap - batchRequestSize;
+  }
+
   public int available() {
     return resultQueue.size();
   }
 
   public void add(ResultQueueEntry<ReadRowsResponse> entry) throws InterruptedException {
+    if (entry.isCompletionMarker()) {
+      completionMarkerFound.set(true);
+    }
+    outstandingRequestCount.decrementAndGet();
     resultQueue.put(entry);
   }
 }

--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ResultQueueEntry.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ResultQueueEntry.java
@@ -4,9 +4,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,6 +16,7 @@
 package com.google.cloud.bigtable.grpc.scanner;
 
 import com.google.cloud.bigtable.grpc.io.IOExceptionWithStatus;
+import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 
@@ -71,10 +72,21 @@ class ResultQueueEntry<T> {
         }
       }
       throw new IOException(EXCEPTION_MESSAGE, throwable);
-    }
-    if (isCompletionMarker()) {
+    } else if (isComplete) {
       throw new IOException("Attempt to interpret a result stream completion marker as a result");
     }
     return response;
+  }
+
+  @Override
+  @SuppressWarnings("rawtypes")
+  public boolean equals(Object obj) {
+    if (!(obj instanceof ResultQueueEntry) || obj == null){
+      return false;
+    }
+    ResultQueueEntry other = (ResultQueueEntry) obj;
+    return Objects.equal(throwable, other.throwable)
+        && Objects.equal(response, other.response)
+        && Objects.equal(isComplete, other.isComplete);
   }
 }

--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/StreamingBigtableResultScanner.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/StreamingBigtableResultScanner.java
@@ -33,13 +33,13 @@ public class StreamingBigtableResultScanner extends AbstractBigtableResultScanne
   private final PooledChannel reservedChannel;
 
   public StreamingBigtableResultScanner(
-      PooledChannel reservedChannel, int capacity, int readPartialRowTimeoutMillis,
+      PooledChannel reservedChannel,
+      ResponseQueueReader responseQueueReader,
       CancellationToken cancellationToken) {
     Preconditions.checkArgument(cancellationToken != null, "cancellationToken cannot be null");
-    Preconditions.checkArgument(capacity > 0, "capacity must be a positive integer");
     this.reservedChannel = reservedChannel;
     this.cancellationToken = cancellationToken;
-    this.responseQueueReader = new ResponseQueueReader(capacity, readPartialRowTimeoutMillis);
+    this.responseQueueReader = responseQueueReader;
   }
 
   private void add(ResultQueueEntry<ReadRowsResponse> entry) {
@@ -57,12 +57,12 @@ public class StreamingBigtableResultScanner extends AbstractBigtableResultScanne
 
   public void setError(Throwable error) {
     reservedChannel.returnToPool();
-    add(ResultQueueEntry.<ReadRowsResponse>newThrowable(error));
+    add(ResultQueueEntry.<ReadRowsResponse> newThrowable(error));
   }
 
   public void complete() {
     reservedChannel.returnToPool();
-    add(ResultQueueEntry.<ReadRowsResponse>newCompletionMarker());
+    add(ResultQueueEntry.<ReadRowsResponse> newCompletionMarker());
   }
 
   @Override

--- a/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestHeapSizeManager.java
+++ b/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestHeapSizeManager.java
@@ -23,7 +23,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/scanner/StreamingBigtableResultScannerTest.java
+++ b/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/scanner/StreamingBigtableResultScannerTest.java
@@ -15,524 +15,84 @@
  */
 package com.google.cloud.bigtable.grpc.scanner;
 
-import static com.google.cloud.bigtable.grpc.scanner.ReadRowTestUtils.createContentChunk;
-import static com.google.cloud.bigtable.grpc.scanner.ReadRowTestUtils.createReadRowsResponse;
-import static com.google.cloud.bigtable.grpc.scanner.ReadRowTestUtils.extractRowsWithKeys;
-import static com.google.cloud.bigtable.grpc.scanner.ReadRowTestUtils.generateReadRowsResponses;
-import static com.google.cloud.bigtable.grpc.scanner.ReadRowTestUtils.randomBytes;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.BrokenBarrierException;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.CyclicBarrier;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
 
-import org.hamcrest.BaseMatcher;
-import org.hamcrest.Description;
-import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import com.google.bigtable.v1.Column;
-import com.google.bigtable.v1.Family;
 import com.google.bigtable.v1.ReadRowsResponse;
-import com.google.bigtable.v1.ReadRowsResponse.Chunk;
-import com.google.bigtable.v1.Row;
 import com.google.cloud.bigtable.grpc.io.CancellationToken;
 import com.google.cloud.bigtable.grpc.io.ChannelPool.PooledChannel;
-import com.google.common.collect.Lists;
-import com.google.protobuf.ByteString;
 
 @RunWith(JUnit4.class)
 public class StreamingBigtableResultScannerTest {
 
-  /**
-   * A matcher that requires the message of a causing exception to match a given substring
-   */
-  public static class CausedByMessage extends BaseMatcher<Throwable> {
-    private String capturedExceptionMessage;
-    private final String expectedCausedByMessage;
-
-    public CausedByMessage(String expectedCausedByMessageSubstring) {
-      this.expectedCausedByMessage = expectedCausedByMessageSubstring;
-    }
-
-    @Override
-    public boolean matches(Object o) {
-      if (o instanceof Throwable) {
-        Throwable exception = (Throwable) o;
-        Throwable causedBy = exception.getCause();
-        if (causedBy == null) {
-          capturedExceptionMessage = "(null getCause())";
-          return false;
-        }
-        capturedExceptionMessage = causedBy.getMessage();
-        return capturedExceptionMessage.contains(expectedCausedByMessage);
-      }
-      return false;
-    }
-
-    @Override
-    public void describeTo(Description description) {
-      description.appendText(
-          String.format(
-              "Expected a caused by exception message containing '%s', but found '%s'",
-              expectedCausedByMessage,
-              capturedExceptionMessage));
-    }
-  }
-
-  static void addResponsesToScanner(
-      StreamingBigtableResultScanner scanner,
-      Iterator<ReadRowsResponse> responses) {
-    while (responses.hasNext()) {
-      scanner.addResult(responses.next());
-    }
-  }
-
-  static void assertScannerContains(
-      StreamingBigtableResultScanner scanner, Iterable<Row> rows)
-      throws IOException {
-    Iterator<Row> iterator = rows.iterator();
-    while (iterator.hasNext()) {
-      Assert.assertEquals(iterator.next().getKey(), scanner.next().getKey());
-    }
-  }
-
-  static void assertScannerEmpty(StreamingBigtableResultScanner scanner) throws IOException {
-    Assert.assertNull(scanner.next());
-  }
-
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
-  private int defaultTimeout = (int) TimeUnit.MILLISECONDS.convert(10, TimeUnit.SECONDS);
-
   @Mock
   PooledChannel channel;
+
+  @Mock
+  ResponseQueueReader reader;
+
+  @Mock
+  CancellationToken cancellationToken;
+
+  StreamingBigtableResultScanner scanner;
 
   @Before
   public void setup(){
     MockitoAnnotations.initMocks(this);
+    scanner = new StreamingBigtableResultScanner(channel, reader, cancellationToken);
   }
 
   @Test
-  public void resultsAreReadable() throws IOException {
-    CancellationToken cancellationToken = new CancellationToken();
-    StreamingBigtableResultScanner scanner =
-        new StreamingBigtableResultScanner(channel, 10, defaultTimeout, cancellationToken);
-
-    List<ReadRowsResponse> responses =
-        generateReadRowsResponses("rowKey-%s", 3);
-
-    addResponsesToScanner(scanner, responses.iterator());
-    scanner.complete();
-
-    assertScannerContains(scanner, extractRowsWithKeys(responses));
-    assertScannerEmpty(scanner);
-    assertChannelReturned();
+  public void testAddResult() throws IOException, InterruptedException {
+    ReadRowsResponse response = ReadRowsResponse.getDefaultInstance();
+    scanner.addResult(response);
+    verify(reader, times(1)).add(eq(ResultQueueEntry.newResult(response)));
+    assertChannelReturned(0);
+    scanner.close();
   }
 
-  private void assertChannelReturned() {
+  @Test
+  public void testSetException() throws IOException, InterruptedException {
+    IOException e = new IOException("Some exception");
+    scanner.setError(e);
+    verify(reader, times(1)).add(eq(ResultQueueEntry.<ReadRowsResponse> newThrowable(e)));
     assertChannelReturned(1);
+    scanner.close();
+  }
+
+  @Test
+  public void testComplete() throws IOException, InterruptedException {
+    scanner.complete();
+    verify(reader, times(1)).add(eq(ResultQueueEntry.<ReadRowsResponse> newCompletionMarker()));
+    assertChannelReturned(1);
+    scanner.close();
+  }
+
+  @Test
+  public void cancellationIsSignalled() throws IOException, InterruptedException {
+    scanner.close();
+    assertChannelReturned(1);
+    verify(cancellationToken, times(1)).cancel();
+  }
+
+  @Test
+  public void testNext() throws IOException, InterruptedException {
+    scanner.next();
+    verify(reader, times(1)).getNextMergedRow();
+    scanner.close();
   }
 
   private void assertChannelReturned(int times) {
     verify(channel, times(times)).returnToPool();
   }
-
-  @Test
-  public void cancellationIsSignalled() throws IOException, InterruptedException {
-    final CountDownLatch countDownLatch = new CountDownLatch(1);
-    CancellationToken cancellationToken = new CancellationToken();
-    cancellationToken.addListener(new Runnable() {
-      @Override
-      public void run() {
-        countDownLatch.countDown();
-      }
-    }, Executors.newCachedThreadPool());
-
-    StreamingBigtableResultScanner scanner =
-        new StreamingBigtableResultScanner(channel, 10, defaultTimeout, cancellationToken);
-
-    scanner.close();
-    // Verify that we've in fact finished.
-    Assert.assertTrue("Waited 10ms for cancellation, but it was not triggered.",
-        countDownLatch.await(10, TimeUnit.MILLISECONDS));
-    assertChannelReturned();
-  }
-
-  @Test
-  public void throwablesAreThrownWhenRead() throws IOException {
-    CancellationToken cancellationToken = new CancellationToken();
-    StreamingBigtableResultScanner scanner =
-        new StreamingBigtableResultScanner(channel, 10, defaultTimeout, cancellationToken);
-
-    List<ReadRowsResponse> responses = generateReadRowsResponses("rowKey-%s", 2);
-    final String innerExceptionMessage = "This message is the causedBy message";
-    addResponsesToScanner(scanner, responses.iterator());
-    scanner.setError(new IOException(innerExceptionMessage));
-
-    assertScannerContains(scanner, extractRowsWithKeys(responses));
-    assertChannelReturned();
-
-    // The next call to next() should throw the exception:
-    expectedException.expect(IOException.class);
-    // Our exception is wrapped in another IOException so this is the expected outer message:
-    expectedException.expectMessage("Error in response stream");
-    expectedException.expect(new CausedByMessage(innerExceptionMessage));
-    scanner.next();
-  }
-
-  @Test
-  public void multipleResponsesAreReturnedAtOnce() throws IOException {
-    int generatedResponseCount = 3;
-    CancellationToken cancellationToken = new CancellationToken();
-    StreamingBigtableResultScanner scanner =
-        new StreamingBigtableResultScanner(channel, 10, defaultTimeout, cancellationToken);
-
-    List<ReadRowsResponse> responses = generateReadRowsResponses(
-        "rowKey-%s", generatedResponseCount);
-    List<Row> rows = Lists.newArrayList(extractRowsWithKeys(responses));
-    addResponsesToScanner(scanner, responses.iterator());
-    scanner.complete();
-
-    Row[] readRows = scanner.next(generatedResponseCount + 1);
-    for (int idx = 0; idx < generatedResponseCount; idx++) {
-      Assert.assertEquals(rows.get(idx).getKey(), readRows[idx].getKey());
-    }
-    Assert.assertEquals(generatedResponseCount, readRows.length);
-    assertScannerEmpty(scanner);
-    assertChannelReturned();
-  }
-
-  @Test
-  public void multipleChunksAreMerged() throws IOException {
-    String rowKey = "row-1";
-
-    Chunk contentChunk = createContentChunk("Family1", "c1", randomBytes(10), 100L);
-    Chunk contentChunk2 = createContentChunk("Family1", "c2", randomBytes(10), 100L);
-    Chunk contentChunk3 = createContentChunk("Family2", null, null, 0L);
-    Chunk rowCompleteChunk = Chunk.newBuilder().setCommitRow(true).build();
-
-    ReadRowsResponse response = createReadRowsResponse(rowKey, contentChunk);
-    ReadRowsResponse response2 = createReadRowsResponse(rowKey, contentChunk2);
-    ReadRowsResponse response3 = createReadRowsResponse(rowKey, contentChunk3);
-    ReadRowsResponse response4 = createReadRowsResponse(rowKey, rowCompleteChunk);
-
-    CancellationToken cancellationToken = new CancellationToken();
-    StreamingBigtableResultScanner scanner =
-        new StreamingBigtableResultScanner(channel, 10, defaultTimeout, cancellationToken);
-
-    scanner.addResult(response);
-    scanner.addResult(response2);
-    scanner.addResult(response3);
-    scanner.addResult(response4);
-
-    scanner.complete();
-
-    Row resultRow = scanner.next();
-
-    Assert.assertEquals(2, resultRow.getFamiliesCount());
-
-    Map<String, Family> familyMap = new HashMap<>();
-    for (Family family : resultRow.getFamiliesList()) {
-      familyMap.put(family.getName(), family);
-    }
-
-    Family resultFamily1 = familyMap.get("Family1");
-    Assert.assertEquals(2, resultFamily1.getColumnsCount());
-    Assert.assertEquals(ByteString.copyFromUtf8("c1"),
-        resultFamily1.getColumns(0).getQualifier());
-    Assert.assertEquals(ByteString.copyFromUtf8("c2"),
-        resultFamily1.getColumns(1).getQualifier());
-
-    Family resultFamily2 = familyMap.get("Family2");
-    Assert.assertEquals(0, resultFamily2.getColumnsCount());
-
-    assertScannerEmpty(scanner);
-    assertChannelReturned();
-  }
-
-  @Test
-  public void rowsCanBeReset() throws IOException {
-    String rowKey = "row-1";
-
-    Chunk contentChunk = createContentChunk("Family1", "c1", randomBytes(10), 10L);
-    Chunk contentChunk2 = createContentChunk("Family1", "c2", randomBytes(10), 100L);
-
-    Chunk rowResetChunk = Chunk.newBuilder().setResetRow(true).build();
-    Chunk rowCompleteChunk = Chunk.newBuilder().setCommitRow(true).build();
-
-    ReadRowsResponse response = createReadRowsResponse(rowKey, contentChunk);
-    ReadRowsResponse response2 = createReadRowsResponse(rowKey, rowResetChunk);
-    ReadRowsResponse response3 = createReadRowsResponse(rowKey, contentChunk2);
-    ReadRowsResponse response4 = createReadRowsResponse(rowKey, rowCompleteChunk);
-
-    CancellationToken cancellationToken = new CancellationToken();
-    StreamingBigtableResultScanner scanner =
-        new StreamingBigtableResultScanner(channel, 10, defaultTimeout, cancellationToken);
-
-    scanner.addResult(response);
-    scanner.addResult(response2);
-    scanner.addResult(response3);
-    scanner.addResult(response4);
-
-    scanner.complete();
-
-    Row resultRow = scanner.next();
-
-    Assert.assertEquals(1, resultRow.getFamiliesCount());
-
-    Family resultFamily = resultRow.getFamilies(0);
-    Assert.assertEquals("Family1", resultFamily.getName());
-    Assert.assertEquals(1, resultFamily.getColumnsCount());
-    Column resultColumn = resultFamily.getColumns(0);
-    Assert.assertEquals(ByteString.copyFromUtf8("c2"), resultColumn.getQualifier());
-
-    assertScannerEmpty(scanner);
-    assertChannelReturned();
-  }
-
-  @Test
-  public void singleChunkRowsAreRead() throws IOException {
-    String rowKey = "row-1";
-    Chunk rowCompleteChunk = Chunk.newBuilder().setCommitRow(true).build();
-    ReadRowsResponse response = createReadRowsResponse(rowKey, rowCompleteChunk);
-
-    CancellationToken cancellationToken = new CancellationToken();
-    StreamingBigtableResultScanner scanner =
-        new StreamingBigtableResultScanner(channel, 10, defaultTimeout, cancellationToken);
-
-    scanner.addResult(response);
-    scanner.complete();
-
-    Row resultRow = scanner.next();
-    Assert.assertEquals(0, resultRow.getFamiliesCount());
-    Assert.assertEquals(ByteString.copyFromUtf8("row-1"), resultRow.getKey());
-
-    assertScannerEmpty(scanner);
-    assertChannelReturned();
-  }
-
-  @Test
-  public void anEmptyStreamDoesNotThrow() throws IOException {
-    CancellationToken cancellationToken = new CancellationToken();
-    StreamingBigtableResultScanner scanner =
-        new StreamingBigtableResultScanner(channel, 10, defaultTimeout, cancellationToken);
-
-    scanner.complete();
-
-    Row resultRow = scanner.next();
-
-    Assert.assertNull(resultRow);
-    assertScannerEmpty(scanner);
-    assertChannelReturned();
-  }
-
-  @Test
-  public void readingPastEndReturnsNull() throws IOException {
-    CancellationToken cancellationToken = new CancellationToken();
-    StreamingBigtableResultScanner scanner =
-        new StreamingBigtableResultScanner(channel, 10, defaultTimeout, cancellationToken);
-
-    scanner.complete();
-
-    Row resultRow = scanner.next();
-    Assert.assertNull(resultRow);
-    resultRow = scanner.next();
-    Assert.assertNull(resultRow);
-    assertScannerEmpty(scanner);
-    assertChannelReturned();
-  }
-
-  @Test
-  public void endOfStreamMidRowThrows() throws IOException {
-    CancellationToken cancellationToken = new CancellationToken();
-    try (StreamingBigtableResultScanner scanner =
-        new StreamingBigtableResultScanner(channel, 10, defaultTimeout, cancellationToken)) {
-
-      String rowKey = "row-1";
-      Chunk contentChunk = createContentChunk("Family1", "c1", randomBytes(10), 100L);
-      ReadRowsResponse response = createReadRowsResponse(rowKey, contentChunk);
-
-      scanner.addResult(response);
-      scanner.complete();
-
-      expectedException.expectMessage("End of stream marker encountered while merging a row.");
-      expectedException.expect(IllegalStateException.class);
-      @SuppressWarnings("unused")
-      Row resultRow = scanner.next();
-      assertChannelReturned();
-    }
-  }
-
-  @Test
-  public void scannerBlocksWhenFull() throws IOException, InterruptedException {
-    // AtomicLong used as a way to easily return values from a closure:
-    final AtomicLong timeBeforeBlock = new AtomicLong();
-    final AtomicLong timeAfterBlock = new AtomicLong();
-
-    final int queueDepth = 10;
-    final CountDownLatch addProcessDone = new CountDownLatch(1);
-
-    CancellationToken cancellationToken = new CancellationToken();
-    final ExecutorService executorService = Executors.newFixedThreadPool(1);
-    try (final StreamingBigtableResultScanner scanner =
-        new StreamingBigtableResultScanner(channel, queueDepth, defaultTimeout, cancellationToken)) {
-
-      final List<ReadRowsResponse> responses =
-          generateReadRowsResponses("rowKey-%s", queueDepth * 2);
-
-      executorService.submit(new Runnable() {
-        @Override
-        public void run() {
-          for (int i = 0; i < queueDepth; i++) {
-            scanner.addResult(responses.get(i));
-          }
-          // The next addResult will block so start a reader in a second and record the time before
-          // the write and after the write. We'll expect a time greater than 500ms of blocking.
-          timeBeforeBlock.set(System.currentTimeMillis());
-          scanner.addResult(responses.get(queueDepth));
-          timeAfterBlock.set(System.currentTimeMillis());
-          scanner.complete();
-          addProcessDone.countDown();
-        }
-      });
-
-      // Make sure it's blocked.
-      Assert.assertFalse(addProcessDone.await(500, TimeUnit.MILLISECONDS));
-
-      // Other tests validate the contents of the queue, we just care that we blocked.
-      scanner.next();
-      // We buffer queueDepth messages in the queue, one slot is needed for scanner.complete()
-      scanner.next();
-
-      Assert.assertTrue(
-          "Expected add process to complete within 500 ms",
-          addProcessDone.await(500, TimeUnit.MILLISECONDS));
-    }
-    executorService.shutdownNow();
-
-    // Both scanner.complete() and scanner.close() will return the channel to the pool.
-    assertChannelReturned(2);
-  }
-
-  @Test
-  public void readTimeoutOnPartialRows() throws IOException, InterruptedException {
-    CancellationToken cancellationToken = new CancellationToken();
-    try (final StreamingBigtableResultScanner scanner =
-        new StreamingBigtableResultScanner(channel, 10, 10 /* timeout millis */, cancellationToken)) {
-
-      ByteString rowKey = ByteString.copyFromUtf8("rowKey");
-      // Add a single response that does not complete the row or stream:
-      scanner.addResult(ReadRowsResponse.newBuilder().setRowKey(rowKey).build());
-
-      expectedException.expect(ScanTimeoutException.class);
-      expectedException.expectMessage("Timeout while merging responses.");
-
-      scanner.next();
-      assertChannelReturned();
-    }
-  }
-
-  @Test
-  public void threadInterruptStatusIsSetOnInterruptedException()
-      throws BrokenBarrierException, InterruptedException {
-    final AtomicReference<Exception> thrownException = new AtomicReference<>();
-    final AtomicBoolean interruptedSet = new AtomicBoolean(false);
-    // Two parties involved in sync: one for the main thread and one for
-    // the test thread.
-    final CyclicBarrier barrier = new CyclicBarrier(2);
-    Thread testThread = new Thread(new Runnable() {
-      @Override
-      public void run() {
-        CancellationToken cancellationToken = new CancellationToken();
-        try (StreamingBigtableResultScanner scanner =
-            new StreamingBigtableResultScanner(channel, 10, defaultTimeout, cancellationToken)) {
-          try {
-            barrier.await();
-          } catch (InterruptedException | BrokenBarrierException e) {
-            thrownException.set(e);
-            return;
-          }
-          try {
-            scanner.next();
-          } catch (IOException e) {
-            thrownException.set(e);
-            if (Thread.currentThread().isInterrupted()) {
-              interruptedSet.set(true);
-            }
-          }
-        } catch (IOException e) {
-          thrownException.set(e);
-        }
-      }
-    });
-
-    testThread.start();
-    barrier.await();
-    // Even with a barrier, we need to wait for our scanner.next() call to be invoked:
-    // TODO(angusdavis): refactor StreamingBigtableResultScanner to take a queue we
-    // control and can throw InterruptedException from at will.
-    Thread.sleep(50);
-    testThread.interrupt();
-    testThread.join();
-
-    Assert.assertNotNull(
-        "An exception should have been thrown while calling scanner.next()",
-        thrownException.get());
-    Assert.assertTrue(
-        "Interrupted exception set as cause of IOException",
-        thrownException.get().getCause() instanceof InterruptedException);
-
-    Assert.assertTrue(
-        "testThread should have recorded that it was interrupted.",
-        interruptedSet.get());
-  }
-
-  @Test
-  public void availableGivesTheNumberOfBufferedItems() throws IOException, InterruptedException {
-
-    final int queueDepth = 10;
-    CancellationToken cancellationToken = new CancellationToken();
-
-    try (final StreamingBigtableResultScanner scanner =
-        new StreamingBigtableResultScanner(channel, queueDepth, defaultTimeout, cancellationToken)) {
-
-      final List<ReadRowsResponse> responses = generateReadRowsResponses("rowKey-%s", queueDepth);
-
-      for (ReadRowsResponse response: responses) {
-        scanner.addResult(response);
-      }
-
-      Assert.assertEquals(
-          "Expected same number of items in scanner as added", queueDepth, scanner.available());
-
-      scanner.next();
-
-      Assert.assertEquals(
-          "Expected same number of items in scanner as added less one",
-          queueDepth - 1, scanner.available());
-
-    }
-
-  }
-
 }


### PR DESCRIPTION
Calling ClientCall.request(capacity) to request the maximum number of requests from the server at the beginning of a scan.  Calling clientCall.request(1) for every response that's handled by ResponseQueueReader so that the server can send an additional response, since there is now more room in the queue.
Also removing a lot of the tests from StreamingBigtableResultScannerTest.  It no longer needs to test the functionality enacpsulated by a ResponseQueueReader.