### PR TITLE
Removing ByteStringer.wrap() around partial byte arrays.

### DIFF
--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/util/ByteStringer.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/util/ByteStringer.java
@@ -11,12 +11,12 @@ import org.apache.commons.logging.LogFactory;
  */
 public class ByteStringer {
   private static final Log LOG = LogFactory.getLog(ByteStringer.class);
-  
+
   /**
    * Flag set at class loading time.
    */
   private static boolean USE_ZEROCOPYBYTESTRING = true;
-  
+
   // Can I classload HBaseZeroCopyByteString without IllegalAccessError?
   // If we can, use it passing ByteStrings to pb else use native ByteString though more costly
   // because it makes a copy of the passed in array.
@@ -28,26 +28,17 @@ public class ByteStringer {
       LOG.debug("Failed to classload BigtableZeroCopyByteString: " + iae.toString());
     }
   }
-  
+
   private ByteStringer() {
     super();
   }
-  
+
   /**
    * Wraps a byte array in a {@link ByteString} without copying it.
    */
   public static ByteString wrap(final byte[] array) {
     return USE_ZEROCOPYBYTESTRING? BigtableZeroCopyByteStringUtil.wrap(array): ByteString.copyFrom(array);
   }
-  
-  /**
-   * Wraps a subset of a byte array in a {@link ByteString} without copying it.
-   */
-  public static ByteString wrap(final byte[] array, int offset, int length) {
-    return USE_ZEROCOPYBYTESTRING? BigtableZeroCopyByteStringUtil.wrap(array, offset, length):
-      ByteString.copyFrom(array, offset, length);
-  }
-
 
   public static byte[] extract(ByteString buf) {
     return USE_ZEROCOPYBYTESTRING ? BigtableZeroCopyByteStringUtil.zeroCopyGetBytes(buf) : buf

--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/PutAdapter.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/PutAdapter.java
@@ -4,9 +4,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -65,7 +65,7 @@ public class PutAdapter implements OperationAdapter<Put, MutateRowRequest.Builde
         Mutation.Builder modBuilder = result.addMutationsBuilder();
         Builder setCellBuilder = modBuilder.getSetCellBuilder();
 
-        ByteString cellQualifierByteString = ByteStringer.wrap(
+        ByteString cellQualifierByteString = ByteString.copyFrom(
             cell.getQualifierArray(),
             cell.getQualifierOffset(),
             cell.getQualifierLength());
@@ -83,7 +83,7 @@ public class PutAdapter implements OperationAdapter<Put, MutateRowRequest.Builde
         }
 
         setCellBuilder.setValue(
-            ByteStringer.wrap(
+            ByteString.copyFrom(
                 cell.getValueArray(),
                 cell.getValueOffset(),
                 cell.getValueLength()));


### PR DESCRIPTION
The ByteString.copyFrom() turns out to be more efficient.  Removing the ByteStringer.wrap(byte[], int, int) and replacing its uses with BytString.copyFrom(byte[], int, int).