### PR TITLE
Using gRPC 0.10.0-SNAPSHOT for forTarget().

### DIFF
--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableOptions.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableOptions.java
@@ -55,7 +55,6 @@ public class BigtableOptions {
     private String tableAdminHost = BIGTABLE_TABLE_ADMIN_HOST_DEFAULT;
     private String clusterAdminHost = BIGTABLE_CLUSTER_ADMIN_HOST_DEFAULT;
     private int port = DEFAULT_BIGTABLE_PORT;
-    private String overrideIp;
 
     // The default credentials get credential from well known locations, such as the GCE
     // metdata service or gcloud configuration in other environments. A user can also override
@@ -79,15 +78,6 @@ public class BigtableOptions {
 
     public Builder setDataHost(String dataHost) {
       this.dataHost = dataHost;
-      return this;
-    }
-
-    /**
-     * Override IP the for all *Hosts.  This is used for Cloud Bigtable to point to a developer's
-     * Cloud Bigtable server.
-     */
-    public Builder setOverrideIp(String overrideIp) {
-      this.overrideIp = overrideIp;
       return this;
     }
 
@@ -141,7 +131,6 @@ public class BigtableOptions {
           clusterAdminHost,
           tableAdminHost,
           dataHost,
-          overrideIp,
           port,
           projectId,
           zoneId,
@@ -157,7 +146,6 @@ public class BigtableOptions {
   private final String clusterAdminHost;
   private final String tableAdminHost;
   private final String dataHost;
-  private final String overrideIp;
   private final int port;
   private final String projectId;
   private final String zoneId;
@@ -174,7 +162,6 @@ public class BigtableOptions {
       clusterAdminHost = null;
       tableAdminHost = null;
       dataHost = null;
-      overrideIp = null;
       port = 0;
       projectId = null;
       zoneId = null;
@@ -191,7 +178,6 @@ public class BigtableOptions {
       String clusterAdminHost,
       String tableAdminHost,
       String dataHost,
-      String overrideIp,
       int port,
       String projectId,
       String zoneId,
@@ -216,7 +202,6 @@ public class BigtableOptions {
     this.tableAdminHost = Preconditions.checkNotNull(tableAdminHost);
     this.clusterAdminHost = Preconditions.checkNotNull(clusterAdminHost);
     this.dataHost = Preconditions.checkNotNull(dataHost);
-    this.overrideIp = overrideIp;
     this.port = port;
     this.projectId = projectId;
     this.zoneId = zoneId;
@@ -260,14 +245,6 @@ public class BigtableOptions {
 
   public String getClusterAdminHost() {
     return clusterAdminHost;
-  }
-
-  /**
-   * Returns an override IP for all *Hosts.  This is used for Cloud Bigtable to point to a
-   * developer's Cloud Bigtable server.
-   */
-  public String getOverrideIp() {
-    return overrideIp;
   }
 
   public int getPort() {

--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableOptionsFactory.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableOptionsFactory.java
@@ -145,12 +145,6 @@ public class BigtableOptionsFactory {
     bigtableOptionsBuilder.setZoneId(getValue(configuration, ZONE_KEY, "Zone"));
     bigtableOptionsBuilder.setClusterId(getValue(configuration, CLUSTER_KEY, "Cluster"));
 
-    String overrideIp = configuration.get(IP_OVERRIDE_KEY);
-    if (!isNullOrEmpty(overrideIp)) {
-      LOG.debug("Using override IP address %s", overrideIp);
-      bigtableOptionsBuilder.setOverrideIp(overrideIp);
-    }
-
     bigtableOptionsBuilder.setDataHost(
         getHost(configuration, BIGTABLE_HOST_KEY, BIGTABLE_DATA_HOST_DEFAULT, "API Data"));
 

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@ limitations under the License.
         <junit.version>4.11</junit.version>
         <mockito.version>1.9.5</mockito.version>
         <protobuff-java.version>3.0.0-beta-1</protobuff-java.version>
-        <grpc.version>0.9.0</grpc.version>
+        <grpc.version>0.10.0-SNAPSHOT</grpc.version>
         <google.api.client.version>1.19.0</google.api.client.version>
         <!-- For Netty HTTP2/TLS negotiation -->
         <alpn.jdk7.version>7.1.3.v20150130</alpn.jdk7.version>


### PR DESCRIPTION
forTarget() is more abstract that forAddress(), since it will allow gRPC to reconnect when the network topology changes.