### PR TITLE
Fixing issue with integration test project pom.xml.

### DIFF
--- a/bigtable-hbase-integration-tests/pom.xml
+++ b/bigtable-hbase-integration-tests/pom.xml
@@ -31,7 +31,6 @@ limitations under the License.
     </description>
 
     <properties>
-        <google.bigtable.auth.service.account.enable>true</google.bigtable.auth.service.account.enable>
         <hbase.version>1.0.1</hbase.version>
         <google.bigtable.project.under.test>bigtable-hbase-1.0</google.bigtable.project.under.test>
         <google.bigtable.connection.impl>com.google.cloud.bigtable.hbase1_0.BigtableConnection</google.bigtable.connection.impl>
@@ -321,6 +320,14 @@ limitations under the License.
             </extension>
         </extensions>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-eclipse-plugin</artifactId>
+                <version>2.9</version>
+                <configuration>
+                    <useProjectReferences>false</useProjectReferences>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>

--- a/bigtable-hbase-integration-tests/src/test/resources/bigtable-test.xml
+++ b/bigtable-hbase-integration-tests/src/test/resources/bigtable-test.xml
@@ -49,20 +49,4 @@ limitations under the License.
         <name>google.bigtable.cluster.name</name>
         <value>${google.bigtable.cluster.name}</value>
     </property>
-    <property>
-        <name>google.bigtable.auth.service.account.enable</name>
-        <value>${google.bigtable.auth.service.account.enable}</value>
-    </property>
-    <property>
-        <name>google.bigtable.auth.null.credential.enable</name>
-        <value>true</value>
-    </property>
-    <property>
-        <name>google.bigtable.auth.service.account.email</name>
-        <value>${google.bigtable.auth.service.account.email}</value>
-    </property>
-    <property>
-        <name>google.bigtable.auth.service.account.keyfile</name>
-        <value>${google.bigtable.auth.service.account.keyfile}</value>
-    </property>
 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -69,16 +69,11 @@ limitations under the License.
 
         <!-- Values for integration testing. Set these in ~/.m2/settings.xml or
              via command-line -D flags. -->
-        <google.bigtable.auth.service.account.email />
-        <google.bigtable.auth.service.account.keyfile />
         <google.bigtable.cluster.name>cluster</google.bigtable.cluster.name>
         <google.bigtable.zone.name>us-central1-b</google.bigtable.zone.name>
         <google.bigtable.endpoint.host>bigtable.googleapis.com</google.bigtable.endpoint.host>
         <google.bigtable.admin.endpoint.host>bigtabletableadmin.googleapis.com</google.bigtable.admin.endpoint.host>
         <google.bigtable.cluster.admin.endpoint.host>bigtableclusteradmin.googleapis.com</google.bigtable.cluster.admin.endpoint.host>
-        <!-- This is false for unit tests, and overriden to be true in
-             bigtable-hbase-integration-tests/pom.xml -->
-        <google.bigtable.auth.service.account.enable>false</google.bigtable.auth.service.account.enable>
     </properties>
 
     <distributionManagement>


### PR DESCRIPTION
Currently, the integration test project will not work well with eclipse
due to the default behavior of the eclipse plugin (project based
dependency) not working well with our shading plugin.  Also, cleaning up
old properties from bigtable-test.xml