### PR TITLE
Scanning batches should be a bit smaller.

### DIFF
--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataGrpcClient.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataGrpcClient.java
@@ -245,7 +245,7 @@ public class BigtableDataGrpcClient implements BigtableDataClient {
     int timeout = retryOptions.getReadPartialRowTimeoutMillis();
 
     int streamingBufferSize = retryOptions.getStreamingBufferSize();
-    int batchRequestSize = streamingBufferSize / 2;
+    int batchRequestSize = streamingBufferSize / 4;
     ResponseQueueReader responseQueueReader =
         new ResponseQueueReader(timeout, streamingBufferSize, batchRequestSize,
             batchRequestSize, readRowsCall);


### PR DESCRIPTION
This ought to improve scan performance a bit.