### PR TITLE
Using a batch size of 1 for Gets.

### DIFF
--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ResponseQueueReader.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ResponseQueueReader.java
@@ -98,7 +98,7 @@ public class ResponseQueueReader {
     // If there are currently less than or equal to the batch request size, then ask gRPC to
     // request more results in a batch. Batch requests are more efficient that reading one at
     // a time.
-    while (!completionMarkerFound.get() && moreCanBeRequested()) {
+    if (!completionMarkerFound.get() && moreCanBeRequested()) {
       call.request(batchRequestSize);
       outstandingRequestCount.addAndGet(batchRequestSize);
     }


### PR DESCRIPTION
Gets will likely have better performance with smaller batch sizes.  Long
scans will likely have better performance with larger ones.