### PR TITLE
Attempting to fix a classpath problem in managed vm examples.

### DIFF
--- a/bigtable-hbase-1.0/pom.xml
+++ b/bigtable-hbase-1.0/pom.xml
@@ -53,8 +53,8 @@ limitations under the License.
             <artifactId>hbase-common</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>log4j-over-slf4j</artifactId>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
         </dependency>
     </dependencies>
     <build>
@@ -95,7 +95,6 @@ limitations under the License.
                                         <exclude>io.grpc:grpc-all:*</exclude>
                                         <exclude>io.netty:netty-all:*</exclude>
                                         <exclude>io.netty:netty:*</exclude>
-                                        <exclude>log4j:log4j:*</exclude>
                                         <exclude>org.slf4j:lf4j-log4j12:*</exclude>
                                     </excludes>
                                     <includes>

--- a/bigtable-hbase-1.1/pom.xml
+++ b/bigtable-hbase-1.1/pom.xml
@@ -53,8 +53,8 @@ limitations under the License.
             <artifactId>hbase-common</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>log4j-over-slf4j</artifactId>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
         </dependency>
     </dependencies>
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -121,13 +121,6 @@ limitations under the License.
             </dependency>
 
             <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>log4j-over-slf4j</artifactId>
-                <version>1.7.5</version>
-                <scope>runtime</scope>
-            </dependency>
-
-            <dependency>
                 <groupId>javax.validation</groupId>
                 <artifactId>validation-api</artifactId>
                 <version>1.0.0.GA</version>
@@ -290,10 +283,6 @@ limitations under the License.
                         <groupId>org.slf4j</groupId>
                         <artifactId>slf4j-log4j12</artifactId>
                     </exclusion>
-                    <exclusion>
-                        <groupId>log4j</groupId>
-                        <artifactId>log4j</artifactId>
-                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>
@@ -381,10 +370,6 @@ limitations under the License.
                         <groupId>org.slf4j</groupId>
                         <artifactId>slf4j-log4j12</artifactId>
                     </exclusion>
-                    <exclusion>
-                        <groupId>log4j</groupId>
-                        <artifactId>log4j</artifactId>
-                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>
@@ -426,6 +411,10 @@ limitations under the License.
                 <version>${hbase.version}</version>
                 <exclusions>
                     <exclusion>
+                        <groupId>org.apache.zookeeper</groupId>
+                        <artifactId>zookeeper</artifactId>
+                    </exclusion>
+                    <exclusion>
                         <groupId>com.google.protobuf</groupId>
                         <artifactId>protobuf-java</artifactId>
                     </exclusion>
@@ -436,10 +425,6 @@ limitations under the License.
                     <exclusion>
                         <groupId>org.slf4j</groupId>
                         <artifactId>slf4j-log4j12</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>log4j</groupId>
-                        <artifactId>log4j</artifactId>
                     </exclusion>
                     <exclusion>
                         <groupId>org.mortbay.jetty</groupId>


### PR DESCRIPTION
There were some conflicts between the changes in our pom.xml files and
the expectation of the
https://github.com/GoogleCloudPlatform/cloud-bigtable-examples/tree/master/java/managed-vm-gae
pom.xml and the updates we made between cloud-bigtable-client 0.2.1 and
0.2.2.  This change seems to correct some of the issues.