### PR TITLE
Reducing exceptions and logging when gRPC channels don't close.

### DIFF
--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
@@ -399,7 +399,12 @@ public class BigtableSession implements AutoCloseable {
               throw new IOException("Interrupted while sleeping for close", e);
             }
             if (!channelImpl.isTerminated()) {
-              throw new IOException("Could not close the channel after " + timeoutMs + " ms.");
+              // Sometimes, gRPC channels don't close properly. We cannot explain why that happens,
+              // nor can we reproduce the problem reliably. However, that doesn't actually cause
+              // problems. Synchronous RPCs will throw exceptions right away. Buffered Mutator based
+              // async operations are already logged. Direct async operations may have some trouble,
+              // but users should not currently be using them directly.
+              LOG.trace("Could not close the channel after %d ms.", timeoutMs);
             }
           }
         };

--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/ReconnectingChannel.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/ReconnectingChannel.java
@@ -222,7 +222,7 @@ public class ReconnectingChannel extends Channel implements Closeable {
         try {
           factory.createClosable(channel).close();
         } catch (IOException e) {
-          log.log(Level.WARNING, "Could not close a recycled delegate", e);
+          log.log(Level.INFO, "Could not close a recycled delegate", e);
         } finally {
           closingAsynchronously.decrementAndGet();
           synchronized (closingAsynchronously) {


### PR DESCRIPTION
We have some unexplained cases where channels don't terminate.  We can't figure out why that happens, but have not seen any adverse affects.  Any problems with BufferedMutator are already logged.  Reducing the logging, and we'll raise an issue with the gRPC team.