### PR TITLE
Reducing scary warnings on scanner retries.

### DIFF
--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/RetryOptions.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/RetryOptions.java
@@ -94,7 +94,7 @@ public class RetryOptions {
     }
 
     /**
-     * The amount of time in miliiseconds we will wait for our first error retry.
+     * The amount of time in milliseconds we will wait for our first error retry.
      */
     public Builder setInitialBackoffMillis(int initialBackoffMillis) {
       this.initialBackoffMillis = initialBackoffMillis;
@@ -186,7 +186,7 @@ public class RetryOptions {
   }
 
   /**
-   * The amount of time in miliiseconds we will wait for our first error retry.
+   * The amount of time in milliseconds we will wait for our first error retry.
    */
   public int getInitialBackoffMillis() {
     return initialBackoffMillis;


### PR DESCRIPTION
Minor performance improvement (40 nanoseconds) by not constructing Backoffs in ResumingStreamingResultScanner and calling reset on every row.
Comment spelling correction in RetryOptions.