### PR TITLE
Properly consider empty gc expression as keeping all the versions.

### DIFF
--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/ColumnDescriptorAdapter.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/ColumnDescriptorAdapter.java
@@ -194,6 +194,8 @@ public class ColumnDescriptorAdapter {
   private static void convertGarbageCollectionExpression(String gcExpression,
       HColumnDescriptor columnDescriptor) {
     if (Strings.isNullOrEmpty(gcExpression)) {
+      // No GC Expression means keep all versions, MaxVersions = 0.
+      columnDescriptor.setMaxVersions(0);
       return;
     }
     String maxVersionExpression = null;

--- a/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/TestColumnDescriptorAdapter.java
+++ b/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/TestColumnDescriptorAdapter.java
@@ -191,7 +191,10 @@ public class TestColumnDescriptorAdapter {
 
   @Test
   public void testBlankExpression(){
-    HColumnDescriptor result = adapter.adapt("family", asColumnFamily(""));
-    Assert.assertEquals(new HColumnDescriptor("family"), result);
+    // An empty gc expression means keep all versions, which is not supported by HBase.
+    expectedException.expectMessage("Maximum versions must be positive");
+    expectedException.expect(IllegalArgumentException.class);
+
+    adapter.adapt("family", asColumnFamily(""));
   }
 }


### PR DESCRIPTION
Is not supported by HBase and will cause IllegalArgumentException. This
is better than falling back to hbase.column.max.version which is 1 by
default, which makes all the versions except the first one invisible.