### PR TITLE
Dataflow-based HBase sequence file import.

### DIFF
--- a/bigtable-dataflow-import/README.md
+++ b/bigtable-dataflow-import/README.md
@@ -1,0 +1,69 @@
+# HBase Sequence Files to Cloud Bigtable Over Dataflow
+
+This project supports importing HBase Sequence Files to Google Cloud Bigtable using
+Cloud Dataflow.
+
+## Code Sample
+
+The following code may be used to import a HBase Sequence Files into a bigtable:
+
+```
+  public static void main(String[] args) throws Exception {
+    HBaseImportOptions options =
+        PipelineOptionsFactory.fromArgs(args).withValidation().as(HBaseImportOptions.class);
+    Pipeline p = CloudBigtableIO.initializeForWrite(Pipeline.create(options));
+    p
+        .apply("ReadSequenceFile", Read.from(HBaseImportIO.createSource(options)))
+        .apply("ConvertResultToMutations", HBaseImportIO.transformToMutations())
+        .apply("WriteToTable", CloudBigtableIO.writeToTable(
+            CloudBigtableTableConfiguration.fromCBTOptions(options)));
+    p.run();
+  }
+```
+
+## Command Line Arguments
+
+The code sample in the previous section may be run with the following command line arguments:
+
+```
+    -Xbootclasspath/p:${ALPN-JAR} \
+    --runner=... \
+    --stagingLocation=... \
+    --bigtableProjectId=... \
+    --bigtableClusterId=... \
+    --bigtableZoneId=... \
+    --bigtableTableId=... \
+    --filePattern=... \
+    --HBase094DataFormat=...
+```
+
+### ALPN
+
+Follow the [instructions here](https://cloud.google.com/bigtable/docs/installing-hbase-shell#alpn)
+to find out the correct version of alpn for your JRE, then download alpn-boot-${ALPN_VERSION}.jar
+ from the [maven repository](http://central.maven.org/maven2/org/mortbay/jetty/alpn/alpn-boot).
+Replace ${ALPN-JAR} above with the path of the downloaded jar.
+
+### More on Arguments
+
++ runner: sepcifies where dataflow job is run. If the input files are on local file system,
+    use "DirectPipelineRunner". If the input files are on google cloud,
+    "BlockingDataflowPipelineRunner" will lauch the job and waits for its completion.
+
++ stagingLocation: specifies the GCS location where run-files for the dataflow job should be
+    uploaded to.
+
++ bigtableProjectId: id of the bigtable project that has the target table. 
+
++ bigtableClusterId: cluser id of the bigtable project.
+
++ bigtableZoneId: zone id of the bigtable project.
+
++ filePattern: specifies the location of the input file(s). This may be either the path to a
+    directory (e.g., gs://mybucket/my-hbase-sequence-file-foler/) or files (e.g., /tmp/part-m*)
+
++ HBase094DataFormat: optional argument. If input files were exported in HBase 0.94 or earlier,
+    set this argument to 'true' so that the correct deserializer may be chosen.
+    The default is 'false'.
+
+

--- a/bigtable-dataflow-import/pom.xml
+++ b/bigtable-dataflow-import/pom.xml
@@ -1,0 +1,192 @@
+<!--
+Copyright 2015 Google Inc. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.google.cloud.bigtable</groupId>
+        <artifactId>bigtable-client</artifactId>
+        <version>0.2.4-SNAPSHOT</version>
+    </parent>
+
+    <groupId>com.google.cloud.bigtable</groupId>
+    <artifactId>bigtable-dataflow-import</artifactId>
+    <packaging>jar</packaging>
+    <name>${project.groupId}:${project.artifactId}</name>
+    <description>
+       This project contains artifacts that import HBase Sequence Files into Google Cloud Bigtable using Google Cloud Dataflow.
+    </description>
+
+    <properties>
+        <gcsconnector.version>1.4.3-hadoop2</gcsconnector.version>
+        <!-- A guava version that is compatible with both gcs-connector and hadoop2. This overrides
+            guava version specification in parent project. -->
+        <guava.version>15.0</guava.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.cloud.bigtable</groupId>
+            <artifactId>bigtable-hbase-dataflow</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <!-- Keeping guava dependency here so that third party code using this package
+                 does not have to declare it-->
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
+        </dependency>
+        <dependency>
+            <!-- hbase-server jar provides Deserializer for the Result class. It also pulls in
+                 necessary hadoop jars. -->
+            <groupId>org.apache.hbase</groupId>
+            <artifactId>hbase-server</artifactId>
+            <version>${hbase.version}</version>
+        </dependency>
+        <dependency>
+            <!-- For accessing gs buckets from the hadoop SequenceFile reader. -->
+            <groupId>com.google.cloud.bigdataoss</groupId>
+            <artifactId>gcs-connector</artifactId>
+            <version>${gcsconnector.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <profiles>
+        <profile>
+            <id>sequencefileIntegrationTest</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>import-e2e-test</id>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <phase>integration-test</phase>
+                                <configuration>
+                                    <!-- ALPN is needed for SSL engine rewrites -->
+                                    <!-- to enable netty logging, include:
+                                    -Djava.util.logging.config.file=src/test/resources/logging.properties
+                                    -->
+                                    <argLine>
+                                        -Xbootclasspath/p:${settings.localRepository}/org/mortbay/jetty/alpn/alpn-boot/${alpn.version}/alpn-boot-${alpn.version}.jar
+                                    </argLine>
+                                    <forkCount>1</forkCount>
+                                    <includes>
+                                        <include>**/*IntegrationTest.java</include>
+                                    </includes>
+                                    <!-- Use Isolated Classloader so that dataflow can find all files
+                                         that must be staged.
+                                    -->
+                                    <useSystemClassLoader>false</useSystemClassLoader>
+                                    <reportNameSuffix>bigtable-server</reportNameSuffix>
+                                    <systemPropertyVariables>
+                                        <bigtable.test.extra.resources>bigtable-test.xml</bigtable.test.extra.resources>
+                                    </systemPropertyVariables>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <configuration>
+                            <windowtitle>Google Cloud Dataflow + Cloud Bigtable Connector ${project.version} API</windowtitle>
+                            <doctitle>Google Cloud Dataflow + Cloud Bigtable Connector ${project.version} API</doctitle>
+                            <overview>../overview.html</overview>
+                            <bottom><![CDATA[<br>]]></bottom>
+
+                            <offlineLinks>
+                                <offlineLink>
+                                    <url>https://cloud.google.com/dataflow/java-sdk/JavaDoc/</url>
+                                    <location>${basedir}/javadoc/dataflow-docs</location>
+                                </offlineLink>
+                                <offlineLink>
+                                    <url>https://hbase.apache.org/apidocs/</url>
+                                    <location>${basedir}/javadoc/hbase-docs</location>
+                                </offlineLink>
+                            </offlineLinks>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                                <phase>package</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+               </plugins>
+           </build>
+        </profile>
+    </profiles>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-eclipse-plugin</artifactId>
+                <version>2.9</version>
+                <configuration>
+                    <useProjectReferences>false</useProjectReferences>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-test</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/*IntegrationTest.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/bigtable-dataflow-import/src/main/java/com/google/cloud/bigtable/dataflowimport/HBaseImportIO.java
+++ b/bigtable-dataflow-import/src/main/java/com/google/cloud/bigtable/dataflowimport/HBaseImportIO.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.dataflowimport;
+
+import com.google.cloud.bigtable.dataflow.HBaseResultCoder;
+import com.google.cloud.dataflow.sdk.coders.KvCoder;
+import com.google.cloud.dataflow.sdk.io.BoundedSource;
+import com.google.cloud.dataflow.sdk.runners.DirectPipelineRunner;
+import com.google.cloud.dataflow.sdk.transforms.PTransform;
+import com.google.cloud.dataflow.sdk.transforms.ParDo;
+import com.google.cloud.dataflow.sdk.values.KV;
+import com.google.cloud.dataflow.sdk.values.PCollection;
+import com.google.cloud.hadoop.fs.gcs.GoogleHadoopFS;
+import com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
+
+import org.apache.hadoop.hbase.client.Mutation;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
+import org.apache.hadoop.hbase.mapreduce.ResultSerialization;
+import org.apache.hadoop.io.serializer.WritableSerialization;
+import org.apache.hadoop.mapreduce.lib.input.SequenceFileInputFormat;
+
+import java.util.Map;
+
+/**
+ * <p>
+ * {@link com.google.cloud.dataflow.sdk.io.Source} and
+ * {@link com.google.cloud.dataflow.sdk.transforms.PTransform}s for importing HBase Sequence Files
+ * into <a href="https://cloud.google.com/bigtable/">Google Cloud Bigtable</a>.
+ * <p>
+ * User of this class should provide dependency for
+ * {@code org.apache.hadoop.hbase.mapreduce.ResultSerialization}, which may be found in
+ * hbase-server jars.
+ *
+ * The following code snippets sets up and runs an import pipeline:
+ *
+ * <pre>
+ * {@code
+ *   HBaseImportOptions options =
+ *       PipelineOptionsFactory.fromArgs(args).withValidation().as(HBaseImportOptions.class);
+ *   Pipeline p = CloudBigtableIO.initializeForWrite(Pipeline.create(options));
+ *   p
+ *       .apply("ReadSequenceFile", Read.from(HBaseImportIO.createSource(options)))
+ *       .apply("ConvertResultToMutations", HBaseImportIO.transformToMutations())
+ *       .apply("WriteToTable", CloudBigtableIO.writeToTable(
+ *           CloudBigtableTableConfiguration.fromCBTOptions(options)));
+ *   p.run();
+ * }
+ * </pre>
+ */
+public class HBaseImportIO {
+  // Needed for HBase 0.94 format. Copied from ResultSerialization.IMPORT_FORMAT_VER.
+  @VisibleForTesting
+  static final String IMPORT_FORMAT_VER = "hbase.import.version";
+  @VisibleForTesting
+  static final String VERSION_094_STRING = "0.94";
+  @VisibleForTesting
+  static final String IO_SERIALIZATIONS = "io.serializations";
+  @VisibleForTesting
+  static final String FS_GS_IMPL = "fs.gs.impl";
+  @VisibleForTesting
+  static final String FS_ABSTRACT_FILESYSTEM_GS_IMPL = "fs.AbstractFileSystem.gs.impl";
+  @VisibleForTesting
+  static final String FS_GS_PROJECT_ID = "fs.gs.project.id";
+  /**
+   * Constant properties needed by input file readers.The {@code IO_SERIALIZATION} property
+   * specifies the classes that can deserialize objects in HBase Sequence Files and is always
+   * needed. The {@code FS_GS_IMPL} and {@code FS_ABSTRACT_FILESYSTEM_GS_IMPL} specify
+   * implementation of the "gs://" file system. They are needed if the input files are on GCS,
+   * and do no harm if the files are not.
+   */
+  @VisibleForTesting
+  static final Map<String, String> CONST_FILE_READER_PROPERTIES = ImmutableMap.of(
+      IO_SERIALIZATIONS,
+          WritableSerialization.class.getName() + "," + ResultSerialization.class.getName(),
+      FS_GS_IMPL, GoogleHadoopFileSystem.class.getName(),
+      FS_ABSTRACT_FILESYSTEM_GS_IMPL, GoogleHadoopFS.class.getName());
+
+  /**
+   * Returns a {@link BoundedSource} from an HBase Sequence File for an import pipeline.
+   */
+  public static BoundedSource<
+      KV<ImmutableBytesWritable, Result>> createSource(HBaseImportOptions options) {
+    // Tell HadoopFileSource not to access the input files before job is staged on the cloud.
+    // See HadoopFileSource.setIsRemoteFileFromLaunchSite() for detailed explanation. This does
+    // not affect program correctness but improves user experience.
+    HadoopFileSource.setIsRemoteFileFromLaunchSite(
+        options.getRunner() != DirectPipelineRunner.class
+        && options.getFilePattern().startsWith("gs://"));
+    return HadoopFileSource.from(
+        options.getFilePattern(),
+        SequenceFileInputFormat.class,
+        ImmutableBytesWritable.class,
+        Result.class,
+        KvCoder.of(new WritableCoder<>(ImmutableBytesWritable.class), new HBaseResultCoder()),
+        createSerializationProperties(options));
+  }
+
+  /**
+   * Returns a {@link PTransform} that converts {@link Result}s into
+   * {@link Mutation}s.
+   */
+  public static PTransform<
+      PCollection<? extends KV<ImmutableBytesWritable, Result>>,
+      PCollection<Mutation>> transformToMutations() {
+    return ParDo.of(new HBaseResultToMutationFn());
+  }
+
+  private static ImmutableMap<String, String> createSerializationProperties(
+      HBaseImportOptions options) {
+    ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+    builder.putAll(CONST_FILE_READER_PROPERTIES);
+
+    if (!Strings.isNullOrEmpty(options.getProject())) {
+      builder.put(FS_GS_PROJECT_ID, options.getProject());
+    }
+    if (options.isHBase094DataFormat()) {
+      builder.put(IMPORT_FORMAT_VER, VERSION_094_STRING);
+    }
+    return builder.build();
+  }
+}

--- a/bigtable-dataflow-import/src/main/java/com/google/cloud/bigtable/dataflowimport/HBaseImportOptions.java
+++ b/bigtable-dataflow-import/src/main/java/com/google/cloud/bigtable/dataflowimport/HBaseImportOptions.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.dataflowimport;
+
+import com.google.cloud.bigtable.dataflow.CloudBigtableOptions;
+import com.google.cloud.dataflow.sdk.options.Default;
+import com.google.cloud.dataflow.sdk.options.Description;
+
+/**
+ * An extension of {@link CloudBigtableOptions} that contains additional configuration
+ * for importing HBase sequence files into Cloud Bigtable.
+ */
+public interface HBaseImportOptions extends CloudBigtableOptions {
+  @Description("Location of the input file(s). For example, '/path_to_data_dir/part-m*'"
+      + " refers to all local files in the specified directory that match the file name pattern, "
+      + "and gs://gcp_bucket/path_to_data_dir/my_data_file.dat refers to a single data file.")
+  String getFilePattern();
+
+  void setFilePattern(String filePattern);
+
+  @Description("Set to True to indicate that the file format is HBase 0.94 or earlier.")
+  @Default.Boolean(false)
+  boolean isHBase094DataFormat();
+
+  void setHBase094DataFormat(boolean value);
+}

--- a/bigtable-dataflow-import/src/main/java/com/google/cloud/bigtable/dataflowimport/HBaseResultToMutationFn.java
+++ b/bigtable-dataflow-import/src/main/java/com/google/cloud/bigtable/dataflowimport/HBaseResultToMutationFn.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.dataflowimport;
+
+import com.google.cloud.dataflow.sdk.transforms.DoFn;
+import com.google.cloud.dataflow.sdk.values.KV;
+import com.google.common.annotations.VisibleForTesting;
+
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.client.Mutation;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A {@link DoFn} function that converts a {@link Result} in the pipeline input to a
+ * {@link Mutation} for output.
+ */
+class HBaseResultToMutationFn
+    extends DoFn<KV<ImmutableBytesWritable, Result>, Mutation> {
+  private static Logger logger = LoggerFactory.getLogger(HBaseImportIO.class);
+
+  private static final long serialVersionUID = 1L;
+  private static final Cell[] NULL_REPLACEMENT = new Cell[0];
+
+  private transient boolean isEmptyRowWarned;
+
+  @VisibleForTesting
+  static void setLogger(Logger log) {
+    logger = log;
+  }
+
+  @Override
+  public void processElement(ProcessContext context) throws Exception {
+    KV<ImmutableBytesWritable, Result> kv = context.element();
+    Cell[] cells = checkEmptyRow(kv);
+    if (cells.length == 0) {
+      return;
+    }
+    // TODO: Handle DeleteMarkers properly.
+    Put put = new Put(kv.getKey().get());
+    for (Cell cell : cells) {
+      put.add(cell);
+    }
+    context.output(put);
+  }
+
+  // Warns about empty row on first occurrence only and replaces a null array with 0-length one.
+  private Cell[] checkEmptyRow(KV<ImmutableBytesWritable, Result> kv) {
+    Cell[] cells = kv.getValue().rawCells();
+    if (cells == null) {
+      cells = NULL_REPLACEMENT;
+    }
+    if (!isEmptyRowWarned && cells.length == 0) {
+      logger.warn("Encountered empty row. Was input file serialized by HBase 0.94?");
+      isEmptyRowWarned = true;
+    }
+    return cells;
+  }
+}

--- a/bigtable-dataflow-import/src/main/java/com/google/cloud/bigtable/dataflowimport/HadoopFileSource.java
+++ b/bigtable-dataflow-import/src/main/java/com/google/cloud/bigtable/dataflowimport/HadoopFileSource.java
@@ -1,0 +1,575 @@
+/*
+ * Copyright (C) 2015 The Google Cloud Dataflow Hadoop Library Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.bigtable.dataflowimport;
+
+import com.google.cloud.dataflow.sdk.coders.Coder;
+import com.google.cloud.dataflow.sdk.coders.KvCoder;
+import com.google.cloud.dataflow.sdk.coders.VoidCoder;
+import com.google.cloud.dataflow.sdk.io.BoundedSource;
+import com.google.cloud.dataflow.sdk.io.Read;
+import com.google.cloud.dataflow.sdk.options.PipelineOptions;
+import com.google.cloud.dataflow.sdk.values.KV;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Function;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.io.WritableUtils;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.hadoop.mapreduce.RecordReader;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.TaskAttemptID;
+import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
+import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import javax.annotation.Nullable;
+
+/**
+ * Part of third party contribution to Google Dataflow Java SDK
+ * (http://github.com/GoogleCloudPlatform/DataflowJavaSDK/tree/master/contrib/hadoop). Repackaged
+ * with change.
+ *
+ * <p>A {@code BoundedSource} for reading files resident in a Hadoop filesystem using a
+ * Hadoop file-based input format.
+ *
+ * <p>To read a {@link com.google.cloud.dataflow.sdk.values.PCollection} of
+ * {@link com.google.cloud.dataflow.sdk.values.KV} key-value pairs from one or more
+ * Hadoop files, use {@link HadoopFileSource#from} to specify the path(s) of the files to
+ * read, the Hadoop {@link org.apache.hadoop.mapreduce.lib.input.FileInputFormat}, the
+ * key class and the value class.
+ *
+ * <p>A {@code HadoopFileSource} can be read from using the
+ * {@link com.google.cloud.dataflow.sdk.io.Read} transform. For example:
+ *
+ * <pre>
+ * {@code
+ * HadoopFileSource<K, V> source = HadoopFileSource.from(path, MyInputFormat.class,
+ *   MyKey.class, MyValue.class);
+ * PCollection<KV<MyKey, MyValue>> records = Read.from(mySource);
+ * }
+ * </pre>
+ *
+ * <p>The {@link HadoopFileSource#readFrom} method is a convenience method
+ * that returns a read transform. For example:
+ *
+ * <pre>
+ * {@code
+ * PCollection<KV<MyKey, MyValue>> records = HadoopFileSource.readFrom(path,
+ *   MyInputFormat.class, MyKey.class, MyValue.class);
+ * }
+ * </pre>
+ *
+ * Implementation note: Since Hadoop's {@link org.apache.hadoop.mapreduce.lib.input.FileInputFormat}
+ * determines the input splits, this class extends {@link BoundedSource} rather than
+ * {@link com.google.cloud.dataflow.sdk.io.OffsetBasedSource}, since the latter
+ * dictates input splits.
+
+ * @param <K> The type of keys to be read from the source.
+ * @param <V> The type of values to be read from the source.
+ */
+public class HadoopFileSource<K, V> extends BoundedSource<KV<K, V>> {
+  private static final long serialVersionUID = 0L;
+  private static Logger logger = LoggerFactory.getLogger(HadoopFileSource.class);
+
+  // Work-around to suppress confusing warning and stack traces by gcs-connector.
+  // See setIsRemoteFileFromLaunchSite() for more information. This variable
+  // must be static.
+  private static boolean isRemoteFileFromLaunchSite;
+
+  private final String filepattern;
+  private final Class<? extends FileInputFormat<?, ?>> formatClass;
+  private final Class<K> keyClass;
+  private final Class<V> valueClass;
+  private final SerializableSplit serializableSplit;
+  private final Coder<KV<K, V>> overrideOutputCoder;
+  // Deserializer configuration that cannot be put in core-site.xml. E.g., hbase.import.version
+  // needs to be dynamically set depending on the HBase sequence file's format.
+  private final Map<String, String> serializationProperties;
+
+  /**
+   * Creates a {@code Read} transform that will read from an {@code HadoopFileSource}
+   * with the given file name or pattern ("glob") using the given Hadoop
+   * {@link org.apache.hadoop.mapreduce.lib.input.FileInputFormat},
+   * with key-value types specified by the given key class and value class.
+   */
+  public static <K, V, T extends FileInputFormat<K, V>> Read.Bounded<KV<K, V>> readFrom(
+      String filepattern, Class<T> formatClass, Class<K> keyClass, Class<V> valueClass) {
+    return Read.from(from(filepattern, formatClass, keyClass, valueClass));
+  }
+
+  /**
+   * Creates a {@code HadoopFileSource} that reads from the given file name or pattern ("glob")
+   * using the given Hadoop {@link org.apache.hadoop.mapreduce.lib.input.FileInputFormat},
+   * with key-value types specified by the given key class and value class.
+   */
+  public static <K, V, T extends FileInputFormat<K, V>> HadoopFileSource<K, V> from(
+      String filepattern, Class<T> formatClass, Class<K> keyClass, Class<V> valueClass) {
+    @SuppressWarnings("unchecked")
+    HadoopFileSource<K, V> source = (HadoopFileSource<K, V>)
+        new HadoopFileSource(filepattern, formatClass, keyClass, valueClass);
+    return source;
+  }
+
+  /**
+   * Creates a {@code HadoopFileSource} that reads from the given file name or pattern ("glob")
+   * using the given Hadoop {@link org.apache.hadoop.mapreduce.lib.input.FileInputFormat},
+   * with key-value types specified by the given key class and value class. The {@code source}
+   * also returns a user-provided output coder and passes on additonal configuration parameters
+   * to the deserializer.
+   */
+  public static <K, V, T extends FileInputFormat<K, V>> HadoopFileSource<K, V> from(
+      String filepattern, Class<T> formatClass, Class<K> keyClass, Class<V> valueClass,
+      Coder<KV<K, V>> overrideOutputCoder, Map<String, String> serializationProperties) {
+    @SuppressWarnings("unchecked")
+    HadoopFileSource<K, V> source = (HadoopFileSource<K, V>)
+        new HadoopFileSource(filepattern, formatClass, keyClass, valueClass,
+            null /** serializableSplit **/, overrideOutputCoder, serializationProperties);
+    return source;
+  }
+
+  /**
+   * A workaround to suppress confusing warnings and stack traces when this class
+   * is instantiated off the cloud for files on google cloud storage.
+   *
+   * <p>If a dataflow job using files on Google Cloud Storage is launched off the cloud
+   * (e.g., from user's desktop), dataflow causes the source to access the files UNNECESSARILY
+   * from the local host, which is bound to fail because gcs-connector is already configured to
+   * use GCE VM's authenticaton mechanism, which won't work for access from off the cloud. The
+   * resulting warnings are very confusing because it happens right before dataflow task-staging,
+   * which may take a long time. To the user the program may appear to have failed fatally.
+   *
+   * <p>When {@code isRemoteFile} is {@code true}, this class would not try to access
+   * google cloud storage from off the cloud, sidestepping the problem. When the program is staged
+   * on cloud this flag is not carried over and file accesses would be allowed.
+   */
+  public static void setIsRemoteFileFromLaunchSite(boolean isRemoteFile) {
+    isRemoteFileFromLaunchSite = isRemoteFile;
+  }
+
+  /**
+   * Create a {@code HadoopFileSource} based on a file or a file pattern specification.
+   */
+  private HadoopFileSource(String filepattern,
+      Class<? extends FileInputFormat<?, ?>> formatClass, Class<K> keyClass,
+      Class<V> valueClass) {
+    this(filepattern, formatClass, keyClass, valueClass, null /** serializableSplit**/,
+        null /** overrideOutputCoder**/, ImmutableMap.<String, String>of());
+  }
+
+  /**
+   * Create a {@code HadoopFileSource} based on a single Hadoop input split, which won't be
+   * split up further.
+   */
+  private HadoopFileSource(String filepattern,
+      Class<? extends FileInputFormat<?, ?>> formatClass, Class<K> keyClass,
+      Class<V> valueClass, SerializableSplit serializableSplit, Coder<KV<K, V>> overrideOutputCoder,
+      Map<String, String> serializationProperties) {
+    this.filepattern = filepattern;
+    this.formatClass = formatClass;
+    this.keyClass = keyClass;
+    this.valueClass = valueClass;
+    this.serializableSplit = serializableSplit;
+    this.overrideOutputCoder = overrideOutputCoder;
+    this.serializationProperties = serializationProperties == null
+        ? ImmutableMap.<String, String>of() : ImmutableMap.copyOf(serializationProperties);
+  }
+
+  public String getFilepattern() {
+    return filepattern;
+  }
+
+  public Class<? extends FileInputFormat<?, ?>> getFormatClass() {
+    return formatClass;
+  }
+
+  public Class<K> getKeyClass() {
+    return keyClass;
+  }
+
+  public Class<V> getValueClass() {
+    return valueClass;
+  }
+
+  @Override
+  public void validate() {
+    Preconditions.checkNotNull(filepattern,
+        "need to set the filepattern of a HadoopFileSource");
+    Preconditions.checkNotNull(formatClass,
+        "need to set the format class of a HadoopFileSource");
+    Preconditions.checkNotNull(keyClass,
+        "need to set the key class of a HadoopFileSource");
+    Preconditions.checkNotNull(valueClass,
+        "need to set the value class of a HadoopFileSource");
+  }
+
+  @Override
+  public List<? extends BoundedSource<KV<K, V>>> splitIntoBundles(long desiredBundleSizeBytes,
+      PipelineOptions options) throws Exception {
+    if (serializableSplit == null) {
+      return Lists.transform(computeSplits(desiredBundleSizeBytes),
+          new Function<InputSplit, BoundedSource<KV<K, V>>>() {
+        @Nullable @Override
+        public BoundedSource<KV<K, V>> apply(@Nullable InputSplit inputSplit) {
+          return new HadoopFileSource<K, V>(filepattern, formatClass, keyClass,
+              valueClass, new SerializableSplit(inputSplit), overrideOutputCoder,
+              serializationProperties);
+        }
+      });
+    } else {
+      return ImmutableList.of(this);
+    }
+  }
+
+  private FileInputFormat<?, ?> createFormat(Job job) throws IOException, IllegalAccessException,
+      InstantiationException {
+    Path path = new Path(filepattern);
+    FileInputFormat.addInputPath(job, path);
+    return formatClass.newInstance();
+  }
+
+  private List<InputSplit> computeSplits(long desiredBundleSizeBytes) throws IOException,
+      IllegalAccessException, InstantiationException {
+    Job job = Job.getInstance(getDeserializerConfiguration());
+    FileInputFormat.setMinInputSplitSize(job, desiredBundleSizeBytes);
+    FileInputFormat.setMaxInputSplitSize(job, desiredBundleSizeBytes);
+    return createFormat(job).getSplits(job);
+  }
+
+  @Override
+  public BoundedReader<KV<K, V>> createReader(PipelineOptions options) throws IOException {
+    this.validate();
+
+    if (serializableSplit == null) {
+      return new HadoopFileReader<>(this, filepattern, formatClass, serializationProperties);
+    } else {
+      return new HadoopFileReader<>(this, filepattern, formatClass,
+          serializableSplit.getSplit(), serializationProperties);
+    }
+  }
+
+  @Override
+  public Coder<KV<K, V>> getDefaultOutputCoder() {
+    if (overrideOutputCoder != null) {
+      return overrideOutputCoder;
+    }
+    return KvCoder.of(getDefaultCoder(keyClass), getDefaultCoder(valueClass));
+  }
+
+  @SuppressWarnings("unchecked")
+  private <T> Coder<T> getDefaultCoder(Class<T> c) {
+    if (Writable.class.isAssignableFrom(c)) {
+      Class<? extends Writable> writableClass = (Class<? extends Writable>) c;
+      return (Coder<T>) WritableCoder.of(writableClass);
+    } else if (Void.class.equals(c)) {
+      return (Coder<T>) VoidCoder.of();
+    }
+    // TODO: how to use registered coders here?
+    throw new IllegalStateException("Cannot find coder for " + c);
+  }
+
+  private static Configuration getHadoopConfigWithOverrides(Map<String, String> overrides) {
+    Configuration configuration = new Configuration();
+    for (Map.Entry<String, String> entry : overrides.entrySet()) {
+      configuration.set(entry.getKey(), entry.getValue());
+    }
+    return configuration;
+  }
+
+  Configuration getDeserializerConfiguration() {
+    return getHadoopConfigWithOverrides(serializationProperties);
+  }
+
+  // BoundedSource
+
+  @Override
+  public long getEstimatedSizeBytes(PipelineOptions options) {
+    if (isRemoteFileFromLaunchSite) {
+      return 0;
+    }
+    long size = 0;
+    try {
+      Job job = Job.getInstance(getDeserializerConfiguration()); // new instance
+      for (FileStatus st : listStatus(createFormat(job), job)) {
+        size += st.getLen();
+      }
+    } catch (IOException | NoSuchMethodException | InvocationTargetException
+        | IllegalAccessException | InstantiationException e) {
+      // ignore, and return 0
+    }
+    return size;
+  }
+
+  private <K, V> List<FileStatus> listStatus(FileInputFormat<K, V> format,
+      JobContext jobContext) throws NoSuchMethodException, InvocationTargetException,
+      IllegalAccessException {
+    // FileInputFormat#listStatus is protected, so call using reflection
+    Method listStatus = FileInputFormat.class.getDeclaredMethod("listStatus", JobContext.class);
+    listStatus.setAccessible(true);
+    @SuppressWarnings("unchecked")
+    List<FileStatus> stat = (List<FileStatus>) listStatus.invoke(format, jobContext);
+    return stat;
+  }
+
+  @Override
+  public boolean producesSortedKeys(PipelineOptions options) throws Exception {
+    return false;
+  }
+
+  static class HadoopFileReader<K, V> extends BoundedSource.BoundedReader<KV<K, V>> {
+
+    private final BoundedSource<KV<K, V>> source;
+    private final String filepattern;
+    private final Class formatClass;
+    private final Map<String, String> serializationProperties;
+
+    private FileInputFormat<?, ?> format;
+    private TaskAttemptContext attemptContext;
+    private List<InputSplit> splits;
+    private ListIterator<InputSplit> splitsIterator;
+    private Configuration conf;
+    private RecordReader<K, V> currentReader;
+    private KV<K, V> currentPair;
+
+    /**
+     * Create a {@code HadoopFileReader} based on a file or a file pattern specification.
+     */
+    public HadoopFileReader(BoundedSource<KV<K, V>> source, String filepattern,
+        Class<? extends FileInputFormat<?, ?>> formatClass,
+        Map<String, String> serializationProperties) {
+      this(source, filepattern, formatClass, null, serializationProperties);
+    }
+
+    /**
+     * Create a {@code HadoopFileReader} based on a single Hadoop input split.
+     */
+    public HadoopFileReader(BoundedSource<KV<K, V>> source, String filepattern,
+        Class<? extends FileInputFormat<?, ?>> formatClass, InputSplit split,
+        Map<String, String> serializationProperties) {
+      this.source = source;
+      this.filepattern = filepattern;
+      this.formatClass = formatClass;
+      if (split != null) {
+        this.splits = ImmutableList.of(split);
+        this.splitsIterator = splits.listIterator();
+      }
+      this.serializationProperties = serializationProperties == null
+          ? ImmutableMap.<String, String>of() : ImmutableMap.copyOf(serializationProperties);
+    }
+
+    @Override
+    public boolean start() throws IOException {
+      Job job = Job.getInstance(getDeserializerConfiguration());
+      Path path = new Path(filepattern);
+      FileInputFormat.addInputPath(job, path);
+
+      try {
+        @SuppressWarnings("unchecked")
+        FileInputFormat<K, V> f = (FileInputFormat<K, V>) formatClass.newInstance();
+        this.format = f;
+      } catch (InstantiationException | IllegalAccessException e) {
+        throw new IOException("Cannot instantiate file input format " + formatClass, e);
+      }
+      this.attemptContext = new TaskAttemptContextImpl(job.getConfiguration(),
+          new TaskAttemptID());
+
+      if (splitsIterator == null) {
+        this.splits = format.getSplits(job);
+        this.splitsIterator = splits.listIterator();
+      }
+      this.conf = job.getConfiguration();
+      return advance();
+    }
+
+    @Override
+    public boolean advance() throws IOException {
+      try {
+        if (currentReader != null && currentReader.nextKeyValue()) {
+          currentPair = nextPair();
+          return true;
+        } else {
+          while (splitsIterator.hasNext()) {
+            // advance the reader and see if it has records
+            InputSplit nextSplit = splitsIterator.next();
+            @SuppressWarnings("unchecked")
+            RecordReader<K, V> reader =
+                (RecordReader<K, V>) format.createRecordReader(nextSplit, attemptContext);
+            if (currentReader != null) {
+              currentReader.close();
+            }
+            currentReader = reader;
+            currentReader.initialize(nextSplit, attemptContext);
+            if (currentReader.nextKeyValue()) {
+              currentPair = nextPair();
+              return true;
+            }
+            currentReader.close();
+            currentReader = null;
+          }
+          // either no next split or all readers were empty
+          currentPair = null;
+          return false;
+        }
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new IOException(e);
+      }
+    }
+
+    @VisibleForTesting
+    Configuration getDeserializerConfiguration() {
+      return getHadoopConfigWithOverrides(serializationProperties);
+    }
+
+    @SuppressWarnings("unchecked")
+    private KV<K, V> nextPair() throws IOException, InterruptedException {
+      K key = currentReader.getCurrentKey();
+      V value = currentReader.getCurrentValue();
+      // clone Writable objects since they are reused between calls to RecordReader#nextKeyValue
+      if (key instanceof Writable) {
+        key = (K) WritableUtils.clone((Writable) key, conf);
+      }
+      if (value instanceof Writable) {
+        value = (V) WritableUtils.clone((Writable) value, conf);
+      }
+      return KV.of(key, value);
+    }
+
+    @Override
+    public KV<K, V> getCurrent() throws NoSuchElementException {
+      if (currentPair == null) {
+        throw new NoSuchElementException();
+      }
+      return currentPair;
+    }
+
+    @Override
+    public void close() throws IOException {
+      if (currentReader != null) {
+        currentReader.close();
+        currentReader = null;
+      }
+      currentPair = null;
+    }
+
+    @Override
+    public BoundedSource<KV<K, V>> getCurrentSource() {
+      return source;
+    }
+
+    // BoundedReader
+
+    @Override
+    public Double getFractionConsumed() {
+      if (currentReader == null) {
+        return 0.0;
+      }
+      if (splits.isEmpty()) {
+        return 1.0;
+      }
+      int index = splitsIterator.previousIndex();
+      int numReaders = splits.size();
+      if (index == numReaders) {
+        return 1.0;
+      }
+      double before = 1.0 * index / numReaders;
+      double after = 1.0 * (index + 1) / numReaders;
+      Double fractionOfCurrentReader = getProgress();
+      if (fractionOfCurrentReader == null) {
+        return before;
+      }
+      return before + fractionOfCurrentReader * (after - before);
+    }
+
+    private Double getProgress() {
+      try {
+        return (double) currentReader.getProgress();
+      } catch (IOException | InterruptedException e) {
+        return null;
+      }
+    }
+
+    @Override
+    public BoundedSource<KV<K, V>> splitAtFraction(double fraction) {
+      // Not yet supported. To implement this, the sizes of the splits should be used to
+      // calculate the remaining splits that constitute the given fraction, then a
+      // new source backed by those splits should be returned.
+      return null;
+    }
+  }
+
+  /**
+   * A wrapper to allow Hadoop {@link org.apache.hadoop.mapreduce.InputSplit}s to be
+   * serialized using Java's standard serialization mechanisms. Note that the InputSplit
+   * has to be Writable (which most are).
+   */
+  public static class SerializableSplit implements Externalizable {
+    private static final long serialVersionUID = 0L;
+
+    private InputSplit split;
+
+    public SerializableSplit() {
+    }
+
+    public SerializableSplit(InputSplit split) {
+      Preconditions.checkArgument(split instanceof Writable, "Split is not writable: "
+          + split);
+      this.split = split;
+    }
+
+    public InputSplit getSplit() {
+      return split;
+    }
+
+    @Override
+    public void writeExternal(ObjectOutput out) throws IOException {
+      out.writeUTF(split.getClass().getCanonicalName());
+      ((Writable) split).write(out);
+    }
+
+    @Override
+    public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+      String className = in.readUTF();
+      try {
+        split = (InputSplit) Class.forName(className).newInstance();
+        ((Writable) split).readFields(in);
+      } catch (InstantiationException | IllegalAccessException e) {
+        throw new IOException(e);
+      }
+    }
+  }
+
+
+}

--- a/bigtable-dataflow-import/src/main/java/com/google/cloud/bigtable/dataflowimport/WritableCoder.java
+++ b/bigtable-dataflow-import/src/main/java/com/google/cloud/bigtable/dataflowimport/WritableCoder.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2015 The Google Cloud Dataflow Hadoop Library Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.bigtable.dataflowimport;
+
+import com.google.cloud.dataflow.sdk.coders.Coder;
+import com.google.cloud.dataflow.sdk.coders.CoderException;
+import com.google.cloud.dataflow.sdk.coders.StandardCoder;
+import com.google.cloud.dataflow.sdk.util.CloudObject;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.hadoop.io.Writable;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.List;
+
+/**
+ * Part of third party contribution to Google Dataflow Java SDK
+ * (http://github.com/GoogleCloudPlatform/DataflowJavaSDK/tree/master/contrib/hadoop). Repackaged
+ * here for convenience.
+ *
+ * <p>A {@code WritableCoder} is a {@link com.google.cloud.dataflow.sdk.coders.Coder} for a
+ * Java class that implements {@link org.apache.hadoop.io.Writable}.
+ *
+ * <p> To use, specify the coder type on a PCollection:
+ * <pre>
+ * {@code
+ *   PCollection<MyRecord> records =
+ *       foo.apply(...).setCoder(WritableCoder.of(MyRecord.class));
+ * }
+ * </pre>
+ *
+ * @param <T> the type of elements handled by this coder
+ */
+public class WritableCoder<T extends Writable> extends StandardCoder<T> {
+  private static final long serialVersionUID = 0L;
+
+  /**
+   * Returns a {@code WritableCoder} instance for the provided element class.
+   * @param <T> the element type
+   */
+  public static <T extends Writable> WritableCoder<T> of(Class<T> clazz) {
+    return new WritableCoder<>(clazz);
+  }
+
+  @JsonCreator
+  @SuppressWarnings("unchecked")
+  public static WritableCoder<?> of(@JsonProperty("type") String classType)
+      throws ClassNotFoundException {
+    Class<?> clazz = Class.forName(classType);
+    if (!Writable.class.isAssignableFrom(clazz)) {
+      throw new ClassNotFoundException(
+          "Class " + classType + " does not implement Writable");
+    }
+    return of((Class<? extends Writable>) clazz);
+  }
+
+  private final Class<T> type;
+
+  public WritableCoder(Class<T> type) {
+    this.type = type;
+  }
+
+  @Override
+  public void encode(T value, OutputStream outStream, Context context) throws IOException {
+    value.write(new DataOutputStream(outStream));
+  }
+
+  @Override
+  public T decode(InputStream inStream, Context context) throws IOException {
+    try {
+      T t = type.newInstance();
+      t.readFields(new DataInputStream(inStream));
+      return t;
+    } catch (InstantiationException | IllegalAccessException e) {
+      throw new CoderException("unable to deserialize record", e);
+    }
+  }
+
+  @Override
+  public List<Coder<?>> getCoderArguments() {
+    return null;
+  }
+
+  @Override
+  public CloudObject asCloudObject() {
+    CloudObject result = super.asCloudObject();
+    result.put("type", type.getName());
+    return result;
+  }
+
+  @Override
+  public void verifyDeterministic() throws NonDeterministicException {
+    throw new NonDeterministicException(this,
+        "Hadoop Writable may be non-deterministic.");
+  }
+
+}

--- a/bigtable-dataflow-import/src/main/java/com/google/cloud/bigtable/dataflowimport/package-info.java
+++ b/bigtable-dataflow-import/src/main/java/com/google/cloud/bigtable/dataflowimport/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * <p>
+ * Enables you to use <a href="https://cloud.google.com/dataflow/">Google Cloud Dataflow</a> to
+ * import HBase Sequence Files into <a href="https://cloud.google.com/bigtable/">Cloud Bigtable</a>.
+ */
+package com.google.cloud.bigtable.dataflowimport;

--- a/bigtable-dataflow-import/src/test/java/com/google/cloud/bigtable/dataflowimport/HBaseImportIOTest.java
+++ b/bigtable-dataflow-import/src/test/java/com/google/cloud/bigtable/dataflowimport/HBaseImportIOTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.bigtable.dataflowimport;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+import com.google.cloud.bigtable.dataflow.HBaseResultCoder;
+import com.google.cloud.bigtable.dataflowimport.HadoopFileSource.HadoopFileReader;
+import com.google.cloud.bigtable.dataflowimport.testing.SequenceFileIoUtils;
+import com.google.cloud.dataflow.sdk.coders.KvCoder;
+import com.google.cloud.dataflow.sdk.io.BoundedSource;
+import com.google.cloud.dataflow.sdk.io.BoundedSource.BoundedReader;
+import com.google.cloud.dataflow.sdk.values.KV;
+import com.google.common.collect.Sets;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.KeyValue;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.mapreduce.lib.input.SequenceFileInputFormat;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.io.File;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Unit tests for {@link HBaseImportIO}.
+ */
+@RunWith(JUnit4.class)
+public class HBaseImportIOTest {
+  private static final byte[] ROW_KEY = Bytes.toBytes("row_key");
+  private static final byte[] ROW_KEY_2 = Bytes.toBytes("row_key_2");
+  private static final byte[] CF = Bytes.toBytes("column_family");
+
+  private static final String FILE_PATTERN = "file_pattern";
+
+  @Rule
+  public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+  @Mock private HBaseImportOptions importOptions;
+
+  @Before
+  public void setup() {
+    MockitoAnnotations.initMocks(this);
+  }
+
+  @Test
+  public void testCreateSource() throws Exception {
+    HadoopFileSource<ImmutableBytesWritable, Result> source =
+        createSourceAndVerifyBasics(importOptions);
+    // Verify that IMPORT_FORMAT_VER is not set for the deserializer.
+    Configuration deserializerConfigs = getDeserializerConfigurationFromSource(source);
+    assertNull(deserializerConfigs.get(HBaseImportIO.IMPORT_FORMAT_VER));
+  }
+
+  @Test
+  public void testCreateSource_forHBase094() throws Exception {
+    when(importOptions.isHBase094DataFormat()).thenReturn(true);
+    HadoopFileSource<ImmutableBytesWritable, Result> source =
+        createSourceAndVerifyBasics(importOptions);
+    // Verify that IMPORT_FORMAT_VER is set correctly for the deserializer.
+    Configuration deserializerConfigs = getDeserializerConfigurationFromSource(source);
+    assertEquals(
+        deserializerConfigs.get(HBaseImportIO.IMPORT_FORMAT_VER),
+        HBaseImportIO.VERSION_094_STRING);
+  }
+
+  /**
+   * Creates a Sequence File and verifies that a {@code source} created by
+   * {@link HBaseImportIO#createSource(HBaseImportOptions)} can read the file correctly.
+   */
+  @Test
+  public void testReadSequenceFile() throws Exception {
+    File tmpFile = tmpFolder.newFile(UUID.randomUUID().toString());
+    when(importOptions.getFilePattern()).thenReturn(tmpFile.getPath());
+    Set<? extends Cell> keyValues = createFileWithData(tmpFile);
+    assertEquals(
+        keyValues,
+        SequenceFileIoUtils.readCellsFromSource(importOptions));
+  }
+
+  private Configuration getDeserializerConfigurationFromSource(
+      HadoopFileSource<ImmutableBytesWritable, Result> source) throws Exception {
+    BoundedReader<KV<ImmutableBytesWritable, Result>> reader = source.createReader(importOptions);
+    assertTrue(reader instanceof HadoopFileReader);
+    return ((HadoopFileReader) reader).getDeserializerConfiguration();
+  }
+
+  private HadoopFileSource<ImmutableBytesWritable, Result> createSourceAndVerifyBasics(
+      HBaseImportOptions importOptions) throws Exception {
+    when(importOptions.getFilePattern()).thenReturn(FILE_PATTERN);
+    BoundedSource<KV<ImmutableBytesWritable, Result>> boundedSource =
+        HBaseImportIO.createSource(importOptions);
+    assertTrue(boundedSource instanceof HadoopFileSource);
+
+    HadoopFileSource<ImmutableBytesWritable, Result> source =
+        (HadoopFileSource<ImmutableBytesWritable, Result>) boundedSource;
+    assertEquals(source.getFilepattern(), FILE_PATTERN);
+    assertEquals(source.getFormatClass(), SequenceFileInputFormat.class);
+    assertEquals(source.getKeyClass(), ImmutableBytesWritable.class);
+    assertEquals(source.getValueClass(), Result.class);
+
+    // Verify the output coder.
+    assertTrue(source.getDefaultOutputCoder() instanceof KvCoder);
+    assertTrue(((KvCoder) source.getDefaultOutputCoder()).getKeyCoder() instanceof WritableCoder);
+    assertTrue(
+        ((KvCoder) source.getDefaultOutputCoder()).getValueCoder() instanceof HBaseResultCoder);
+
+    // Verify the constant serializer properties
+    Configuration deserializerConfigs = getDeserializerConfigurationFromSource(source);
+    for (Map.Entry<String, String> e : HBaseImportIO.CONST_FILE_READER_PROPERTIES.entrySet()) {
+      assertEquals(deserializerConfigs.get(e.getKey()), e.getValue());
+    }
+    return source;
+  }
+
+  private Set<? extends Cell> createFileWithData(File sequenceFile) throws Exception {
+    Set<? extends Cell> keyValues = Sets.newHashSet(
+        new KeyValue(ROW_KEY, CF, Bytes.toBytes("col1"), 1L, Bytes.toBytes("v1")),
+        new KeyValue(ROW_KEY, CF, Bytes.toBytes("col1"), 2L, Bytes.toBytes("v2")),
+        new KeyValue(ROW_KEY_2, CF, Bytes.toBytes("col2"), 1L, Bytes.toBytes("v3")),
+        new KeyValue(ROW_KEY_2, CF, Bytes.toBytes("col2"), 3L, Bytes.toBytes("v4")));
+    SequenceFileIoUtils.createFileWithData(sequenceFile, keyValues);
+    return keyValues;
+  }
+}

--- a/bigtable-dataflow-import/src/test/java/com/google/cloud/bigtable/dataflowimport/HBaseResultToMutationFnTest.java
+++ b/bigtable-dataflow-import/src/test/java/com/google/cloud/bigtable/dataflowimport/HBaseResultToMutationFnTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.bigtable.dataflowimport;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
+
+import com.google.cloud.dataflow.sdk.transforms.DoFnTester;
+import com.google.cloud.dataflow.sdk.values.KV;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Sets;
+
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.KeyValue;
+import org.apache.hadoop.hbase.client.Mutation;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.slf4j.Logger;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.NavigableMap;
+
+/**
+ * Unit tests for {@link HBaseResultToMutationFn}.
+ */
+@RunWith(JUnit4.class)
+public class HBaseResultToMutationFnTest {
+  private static final byte[] ROW_KEY = Bytes.toBytes("row_key");
+  private static final byte[] ROW_KEY_2 = Bytes.toBytes("row_key_2");
+  private static final byte[] CF = Bytes.toBytes("column_family");
+  private static final byte[] QUALIFIER = Bytes.toBytes("qualifier");
+  private static final byte[] VALUE = Bytes.toBytes("value");
+
+  HBaseResultToMutationFn doFn;
+
+  @Mock private Logger logger;
+
+  @Before
+  public void setup() {
+    MockitoAnnotations.initMocks(this);
+    doFn = new HBaseResultToMutationFn();
+    HBaseResultToMutationFn.setLogger(logger);
+  }
+
+  /**
+   * Verifies that when {@link HBaseResultToMutationFn} is called on a {@link Result}
+   * with a single {@link Cell}, that cell is passed to the output, and
+   * the logger is not invoked.
+   */
+  @Test
+  public void testResultToMutation() throws Exception {
+    DoFnTester<KV<ImmutableBytesWritable, Result>, Mutation> doFnTester = DoFnTester.of(doFn);
+    Cell[] expected = new Cell[] { new KeyValue(ROW_KEY, CF, QUALIFIER, 1L, VALUE)};
+    List<Mutation> outputs = doFnTester.processBatch(
+        KV.of(new ImmutableBytesWritable(ROW_KEY), Result.create(expected)));
+    verifyMutationCells(expected, Iterables.getOnlyElement(outputs));
+    verifyZeroInteractions(logger);
+  }
+
+  /**
+   * Verifies that malformed {@link Result}s with null cell-array cause one warning in the log.
+   */
+  @Test
+  public void testResultToMutation_nullCellsWarnOnce() throws Exception {
+    DoFnTester<KV<ImmutableBytesWritable, Result>, Mutation> doFnTester = DoFnTester.of(doFn);
+    Result resultWithNullCells = new Result();
+    assertNull(resultWithNullCells.rawCells());
+    List<Mutation> outputs = doFnTester.processBatch(
+        KV.of(new ImmutableBytesWritable(ROW_KEY), resultWithNullCells),
+        KV.of(new ImmutableBytesWritable(ROW_KEY_2), resultWithNullCells));
+    assertTrue(outputs == null || outputs.isEmpty());
+    verify(logger, times(1)).warn(anyString());
+    verifyNoMoreInteractions(logger);
+  }
+
+  /**
+   * Verifies that malformed {@link Result}s with empty cell-array cause one warning in the log.
+   */
+  @Test
+  public void testResultToMutation_emptyCellsWarnOnce() throws Exception {
+    DoFnTester<KV<ImmutableBytesWritable, Result>, Mutation> doFnTester = DoFnTester.of(doFn);
+    Result resultWithEmptyCells = Result.create(Collections.EMPTY_LIST);
+    List<Mutation> outputs = doFnTester.processBatch(
+        KV.of(new ImmutableBytesWritable(ROW_KEY), resultWithEmptyCells),
+        KV.of(new ImmutableBytesWritable(ROW_KEY_2), resultWithEmptyCells));
+    assertTrue(outputs == null || outputs.isEmpty());
+    verify(logger, times(1)).warn(anyString());
+    verifyNoMoreInteractions(logger);
+  }
+
+  private void verifyMutationCells(Cell[] expected, Mutation mutation) throws Exception {
+    NavigableMap<byte[], List<Cell>> map = mutation.getFamilyCellMap();
+    assertEquals("Cells", Sets.newHashSet(expected), Sets.newHashSet(map.get(CF)));
+  }
+}

--- a/bigtable-dataflow-import/src/test/java/com/google/cloud/bigtable/dataflowimport/HadoopFileSourceTest.java
+++ b/bigtable-dataflow-import/src/test/java/com/google/cloud/bigtable/dataflowimport/HadoopFileSourceTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.bigtable.dataflowimport;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+import com.google.cloud.bigtable.dataflowimport.HadoopFileSource.HadoopFileReader;
+import com.google.cloud.dataflow.sdk.coders.Coder;
+import com.google.cloud.dataflow.sdk.coders.KvCoder;
+import com.google.cloud.dataflow.sdk.io.BoundedSource.BoundedReader;
+import com.google.cloud.dataflow.sdk.values.KV;
+import com.google.common.collect.ImmutableMap;
+
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.mapreduce.lib.input.SequenceFileInputFormat;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Map;
+
+/**
+ * Unit test for changes made to {@link HadoopFileSource} for HBase Sequence File import.
+ */
+@RunWith(JUnit4.class)
+public class HadoopFileSourceTest {
+  private static final String FILE_PATTERN = "file_pattern";
+  private static final Class<Writable> KEY_CLASS = Writable.class;
+  private static final Class<Text> VALUE_CLASS = Text.class;
+  private static final String SERIALIZER_PROPERTY = "serializer_prop";
+  private static final String SERIALIZER_VALUE = "serializer_value";
+
+  @Mock private HBaseImportOptions importOptions;
+  @Mock private Coder<KV<Writable, Text>> overrideCoder;
+
+  @Before
+  public void setup() {
+    MockitoAnnotations.initMocks(this);
+    when(importOptions.getFilePattern()).thenReturn(FILE_PATTERN);
+  }
+
+  /**
+   * Verifies that a {@link HadoopFileSource} created by the simple factory method
+   * ({@link HadoopFileSource#from(String, Class, Class, Class)}) is initialized correctly.
+   */
+  @Test
+  public void testSimpleFactoryMethod() throws Exception {
+    HadoopFileSource<Writable, Text> source = HadoopFileSource.from(
+        FILE_PATTERN, SequenceFileInputFormat.class, KEY_CLASS, VALUE_CLASS);
+    verifySourceBasics(source);
+    // Verify the output coder.
+    assertTrue(source.getDefaultOutputCoder() instanceof KvCoder);
+    assertTrue(((KvCoder) source.getDefaultOutputCoder()).getKeyCoder() instanceof WritableCoder);
+    assertTrue(((KvCoder) source.getDefaultOutputCoder()).getValueCoder() instanceof WritableCoder);
+    // Verify a reader created by the source.
+    BoundedReader<KV<Writable, Text>> reader = source.createReader(importOptions);
+    assertTrue(reader instanceof HadoopFileReader);
+    assertNull(((HadoopFileReader) reader).getDeserializerConfiguration().get(SERIALIZER_PROPERTY));
+  }
+
+  /**
+   * Verifies that a {@link HadoopFileSource} created by the full factory method
+   * ({@link HadoopFileSource#from(String, Class, Class, Class, Coder, Map)}) is initialized
+   * correctly.
+   */
+  @Test
+  public void testFullFactoryMethod() throws Exception {
+    HadoopFileSource<Writable, Text> source = HadoopFileSource.from(
+        FILE_PATTERN, SequenceFileInputFormat.class, KEY_CLASS, VALUE_CLASS, overrideCoder,
+        ImmutableMap.<String, String>of());
+    verifySourceBasics(source);
+
+    assertEquals(source.getDefaultOutputCoder(), overrideCoder);
+    // Verify a reader created by the source.
+    BoundedReader<KV<Writable, Text>> reader = source.createReader(importOptions);
+    assertTrue(reader instanceof HadoopFileReader);
+    assertNull(((HadoopFileReader) reader).getDeserializerConfiguration().get(SERIALIZER_PROPERTY));
+  }
+
+  /**
+   * Verifies that a {@link HadoopFileSource} created by the full factory method
+   * ({@link HadoopFileSource#from(String, Class, Class, Class, Coder, Map)}) is initialized
+   * correctly when properties for the deserializer are present.
+   */
+  @Test
+  public void testFullFactoryMethod_withSerializerProperty() throws Exception {
+    HadoopFileSource<Writable, Text> source = HadoopFileSource.from(
+        FILE_PATTERN, SequenceFileInputFormat.class, KEY_CLASS, VALUE_CLASS, overrideCoder,
+        ImmutableMap.of(SERIALIZER_PROPERTY, SERIALIZER_VALUE));
+    verifySourceBasics(source);
+
+    assertEquals(source.getDefaultOutputCoder(), overrideCoder);
+    // Verify a reader created by the source.
+    BoundedReader<KV<Writable, Text>> reader = source.createReader(importOptions);
+    assertTrue(reader instanceof HadoopFileReader);
+    assertEquals(
+        ((HadoopFileReader) reader).getDeserializerConfiguration().get(SERIALIZER_PROPERTY),
+        SERIALIZER_VALUE);
+  }
+
+  private void verifySourceBasics(HadoopFileSource<Writable, Text> source) throws Exception {
+    // Verify that constructor parameters are assigned properly.
+    assertEquals(source.getFilepattern(), FILE_PATTERN);
+    assertEquals(source.getFormatClass(), SequenceFileInputFormat.class);
+    assertEquals(source.getKeyClass(), KEY_CLASS);
+    assertEquals(source.getValueClass(), VALUE_CLASS);
+  }
+}

--- a/bigtable-dataflow-import/src/test/java/com/google/cloud/bigtable/dataflowimport/ImportIntegrationTest.java
+++ b/bigtable-dataflow-import/src/test/java/com/google/cloud/bigtable/dataflowimport/ImportIntegrationTest.java
@@ -1,0 +1,339 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.bigtable.dataflowimport;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
+
+import com.google.cloud.bigtable.dataflow.CloudBigtableIO;
+import com.google.cloud.bigtable.dataflow.CloudBigtableTableConfiguration;
+import com.google.cloud.bigtable.dataflowimport.testing.BigtableTableUtils.BigtableTableUtilsFactory;
+import com.google.cloud.bigtable.hbase.BigtableOptionsFactory;
+import com.google.cloud.bigtable.dataflowimport.testing.BigtableTableUtils;
+import com.google.cloud.bigtable.dataflowimport.testing.SequenceFileIoUtils;
+import com.google.cloud.dataflow.sdk.Pipeline;
+import com.google.cloud.dataflow.sdk.io.Read;
+import com.google.cloud.dataflow.sdk.options.PipelineOptionsFactory;
+import com.google.cloud.dataflow.sdk.runners.BlockingDataflowPipelineRunner;
+import com.google.cloud.dataflow.sdk.runners.DirectPipelineRunner;
+import com.google.cloud.dataflow.sdk.testing.TestPipeline;
+import com.google.common.base.Function;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Sets;
+
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.KeyValue;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Integration tests for importing HBase Sequence Files into Cloud Bigtable.
+ *
+ * <p>Three test cases are included:
+ * <ul>
+ *   <li>Sequence File in latest format on local file system.
+ *   <li>Sequence File in latest format on Google Cloud Storage (GCS).
+ *   <li>Sequence File in HBase 0.94 format on GCS.
+ * </ul>
+ *
+ * <p>To run this test, the following system properties must be defined:
+ * <ul>
+ *   <li>google.bigtable.project.id
+ *   <li>google.bigtable.cluster.name
+ *   <li>google.bigtable.zone.name
+ *   <li>google.dataflow.stagingLocation
+ *   <li>google.cloud.auth.service.account.email (for on-cloud tests)
+ *   <li>cloud.test.data.folder (on-cloud test data location)
+ * </ul>
+ *
+ * <p>Because {@link TestPipeline} is used for both local and on-cloud runs, tests
+ * in this classes must run sequentially (in arbitrary order). This is because {@code TestPipeline}
+ * use the {@code "runIntegrationTestOnService"} system property to choose the type of
+ * pipeline to create.
+ *
+ * <p>It is possible to use regular pipelines in these tests, e.g.,
+ * {@link com.google.cloud.dataflow.sdk.runners.DirectPipeline} or
+ * {@link BlockingDataflowPipelineRunner}, but
+ * <a href="https://cloud.google.com/dataflow/pipelines/testing-your-pipeline">Dataflow Testing
+ * Guide</a> recommends {@code TestPipeline}.
+ */
+@RunWith(JUnit4.class)
+public class ImportIntegrationTest {
+
+  // Location of test data hosted on Google Cloud Storage, for on-cloud dataflow tests.
+  private static final String CLOUD_TEST_DATA_FOLDER = "cloud.test.data.folder";
+  private static final String HBASE_094_SUBFOLDER = "hbase094";
+  private static final String HBASE_CURRENT_SUBFOLDER = "post-hbase094";
+
+  // Column family name used in all test bigtables.
+  private static final byte[] CF = Bytes.toBytes("column_family");
+
+  /**
+   * Specifies if test pipeline runs locally or on cloud. See {@link TestPipeline} for more
+   * information.
+   */
+  private static final String RUN_INTEGRATION_TEST_ON_SERVICE = "runIntegrationTestOnService";
+  /**
+   * A json string containg configurations for the test pipeline. See {@link TestPipeline} for more
+   * information.
+   */
+  private static final String TEST_PIPELINE_OPTIONS = "dataflowOptions";
+  // Full path of the gcs folder where dataflow jars are uploaded to.
+  public static final String GOOGLE_DATAFLOW_STAGING_LOCATION = "google.dataflow.stagingLocation";
+
+  private HBaseImportOptions commonOptions;
+  private String cloudTestDataFolder;
+  private BigtableTableUtilsFactory tableUtilsFactory;
+
+  @Rule
+  public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+  @Before
+  public void setup() throws Exception {
+    commonOptions = PipelineOptionsFactory.as(HBaseImportOptions.class);
+    commonOptions.setBigtableProjectId(
+        checkNotNull(System.getProperty(BigtableOptionsFactory.PROJECT_ID_KEY),
+            "Required property missing: " + BigtableOptionsFactory.PROJECT_ID_KEY));
+    commonOptions.setBigtableClusterId(
+        checkNotNull(System.getProperty(BigtableOptionsFactory.CLUSTER_KEY),
+            "Required property missing: " + BigtableOptionsFactory.CLUSTER_KEY));
+    commonOptions.setBigtableZoneId(
+        checkNotNull(System.getProperty(BigtableOptionsFactory.ZONE_KEY),
+            "Required property missing: " + BigtableOptionsFactory.ZONE_KEY));
+    commonOptions.setStagingLocation(
+        checkNotNull(System.getProperty(GOOGLE_DATAFLOW_STAGING_LOCATION),
+            "Required property missing: " + GOOGLE_DATAFLOW_STAGING_LOCATION));
+    commonOptions.setMaxNumWorkers(1);
+
+    cloudTestDataFolder =
+        checkNotNull(System.getProperty(CLOUD_TEST_DATA_FOLDER), CLOUD_TEST_DATA_FOLDER);
+    if (!cloudTestDataFolder.endsWith(File.separator)) {
+      cloudTestDataFolder = cloudTestDataFolder + File.separator;
+    }
+    tableUtilsFactory = BigtableTableUtilsFactory.from(commonOptions);
+  }
+
+  @After
+  public void teardown() throws IOException {
+    if (tableUtilsFactory != null) {
+      tableUtilsFactory.close();
+    }
+  }
+
+  private HBaseImportOptions createImportOptions(
+      String importFilePath, String tableName, boolean isHBase094Format) {
+    HBaseImportOptions importOptions = commonOptions.as(HBaseImportOptions.class);
+    importOptions.setFilePattern(importFilePath);
+    importOptions.setBigtableTableId(tableName);
+    importOptions.setHBase094DataFormat(isHBase094Format);
+    if (importFilePath.startsWith("gs://")) {
+      importOptions.setRunner(BlockingDataflowPipelineRunner.class);
+    } else {
+      importOptions.setRunner(DirectPipelineRunner.class);
+    }
+    return importOptions;
+  }
+
+  @Test
+  public void testImportSequenceFile_fromLocalFs() throws Exception {
+    String tableId = "test_" + UUID.randomUUID().toString();
+    File sequenceFile = tmpFolder.newFile(tableId);
+    Set<? extends Cell> expected = getTestData();
+    SequenceFileIoUtils.createFileWithData(sequenceFile, expected);
+
+    HBaseImportOptions options = createImportOptions(
+        sequenceFile.getPath(), tableId, false /** isHBase094Format **/);
+    try (BigtableTableUtils tableUtils = tableUtilsFactory.createBigtableTableUtils(
+        tableId, Bytes.toString(CF))) {
+      tableUtils.createEmptyTable();
+      assertEquals(Collections.EMPTY_SET, tableUtils.readAllCellsFromTable());
+      doImport(options);
+      assertCellSetsEqual(expected, tableUtils.readAllCellsFromTable());
+    }
+  }
+
+  /**
+   * Verifies that a Sequence File on Google Cloud Storage (GCS) can be imported
+   * into Google Cloud Bigtable.
+   *
+   * <p>This method creates a local Sequence File, copies it to the stagingLocation folder
+   * on GCS, then imports the GCS file. The GCS file is not removed by post-test cleanup.
+   */
+  @Test
+  public void testImportSequenceFile_fromGcs() throws Exception {
+    runImportFileTestFromGcs(false /** isHBase094Format **/);
+  }
+
+  @Test
+  public void testImportSequenceFile_fromGcsWithHBase094Format() throws Exception {
+    runImportFileTestFromGcs(true /** isHBase094Format **/);
+  }
+
+  private void runImportFileTestFromGcs(boolean isHBase094Format) throws Exception {
+    String tableId = "test_" + UUID.randomUUID().toString();
+    // For this test input files already exist on GCS. getTestData() returns
+    // all data that we know are in the file. See java doc for that method for more information.
+    // TODO Generate and upload input sequence files for on-cloud tests and remove once done.
+    Set<? extends Cell> expected = getTestData();
+
+    HBaseImportOptions options = createImportOptions(
+        getCloudTestDataFolder(isHBase094Format), tableId, isHBase094Format);
+    options.setFilePattern(options.getFilePattern());
+    try (BigtableTableUtils tableUtils = tableUtilsFactory.createBigtableTableUtils(
+        tableId, Bytes.toString(CF))) {
+      tableUtils.createEmptyTable();
+      assertEquals(Collections.EMPTY_SET, tableUtils.readAllCellsFromTable());
+      doImport(options);
+      assertCellSetsEqual(expected, tableUtils.readAllCellsFromTable());
+    }
+  }
+
+  @Test
+  public void testImportSequenceFile_currentFormatWithHBase094Deserializer() throws Exception {
+    String tableId = "test_" + UUID.randomUUID().toString();
+    File sequenceFile = tmpFolder.newFile(tableId);
+    SequenceFileIoUtils.createFileWithData(sequenceFile, getTestData());
+
+    HBaseImportOptions options = createImportOptions(
+        sequenceFile.getPath(), tableId, true /** isHBase094Format **/);
+    options.setFilePattern(options.getFilePattern());
+    try (BigtableTableUtils tableUtils = tableUtilsFactory.createBigtableTableUtils(
+        tableId, Bytes.toString(CF))) {
+      assertFalse(tableUtils.isTableExists());
+      tableUtils.createEmptyTable();
+      try {
+        doImport(options);
+        fail("Expecting failure.");
+      } catch (Throwable expected) {
+        // In HBase 0.94 and earlier row data was serialized using length-value encoding.
+        // When a 0.94 deserializer is used on a newer file, the error dependends on the data
+        // in file. So far we've seen EOFException and OutOfMemoryError.
+      }
+    }
+    // Verify table is removed.
+    assertFalse(tableUtilsFactory.createBigtableTableUtils(
+        tableId, Bytes.toString(CF)).isTableExists());
+  }
+
+  @Test
+  public void testImportSequenceFile_HBase094FormatWithCurrentDeserializer() throws Exception {
+    String tableId = "test_" + UUID.randomUUID().toString();
+
+    // Use data on GCS because we cannot programmatically create input in old format.
+    HBaseImportOptions options = createImportOptions(
+        getCloudTestDataFolder(true), tableId, false  /** isHBase094Format **/);
+    options.setFilePattern(options.getFilePattern());
+    try (BigtableTableUtils tableUtils = tableUtilsFactory.createBigtableTableUtils(
+        tableId, Bytes.toString(CF))) {
+      tableUtils.createEmptyTable();
+      doImport(options);
+      assertCellSetsEqual(Collections.EMPTY_SET, tableUtils.readAllCellsFromTable());
+    }
+  }
+
+  private String getCloudTestDataFolder(boolean isHBase094Format) {
+    return cloudTestDataFolder + (isHBase094Format ? HBASE_094_SUBFOLDER : HBASE_CURRENT_SUBFOLDER);
+  }
+
+  /**
+   * Returns test data for import.
+   *
+   * <p>Currently for on-cloud tests, test sequence files are manually created and uploaded
+   * to Google Cloud Storage. If this method changes, the test files must be updated. The files
+   * currently in use are created as follows:
+   *
+   *<p>First, run the following commands in HBase shell:
+   * <pre>
+   *   create 'integration-test', { NAME => 'column_family', VERSIONS=>5}
+   *   put 'integration-test', 'row_key_1', 'column_family:col1', 'v1', 1
+   *   put 'integration-test', 'row_key_1', 'column_family:col1', 'v2', 2
+   *   put 'integration-test', 'row_key_2', 'column_family:col2', 'v3', 1
+   *   put 'integration-test', 'row_key_2', 'column_family:col2', 'v4', 3
+   * </pre>
+   *
+   * <p>Next, run the export command in the HBase home directory:
+   * <pre>
+   *   bin/hbase org.apache.hadoop.hbase.mapreduce.Export integration-test TARGET_DIR 5
+   * </pre>
+   */
+  private Set<? extends Cell> getTestData() throws Exception {
+    final byte[] rowKey1 = Bytes.toBytes("row_key_1");
+    final byte[] rowKey2 = Bytes.toBytes("row_key_2");
+    final byte[] col1 = Bytes.toBytes("col1");
+    final byte[] col2 = Bytes.toBytes("col2");
+    Set<? extends Cell> keyValues = Sets.newHashSet(
+        new KeyValue(rowKey1, CF, col1, 1L, Bytes.toBytes("v1")),
+        new KeyValue(rowKey1, CF, col1, 2L, Bytes.toBytes("v2")),
+        new KeyValue(rowKey2, CF, col2, 1L, Bytes.toBytes("v3")),
+        new KeyValue(rowKey2, CF, col2, 3L, Bytes.toBytes("v4")));
+    return keyValues;
+  }
+
+  private void doImport(HBaseImportOptions options) {
+    // Configure the TestPipeline for on- or off-cloud service.
+    if (options.getFilePattern().startsWith("gs://")) {
+      // Pipeline should be staged on cloud.
+      System.setProperty(RUN_INTEGRATION_TEST_ON_SERVICE, "true");
+      System.setProperty(TEST_PIPELINE_OPTIONS,
+          String.format("[ \"%s=%s\", \"%s=%s\", \"%s=%s\" ]",
+              "--runner", BlockingDataflowPipelineRunner.class.getSimpleName(),
+              "--project", options.getProject(),
+              "--stagingLocation", options.getStagingLocation()));
+    } else {
+      // Pipeline should run locally.
+      System.clearProperty(RUN_INTEGRATION_TEST_ON_SERVICE);
+    }
+
+    Pipeline p = CloudBigtableIO.initializeForWrite(TestPipeline.create());
+    p
+        .apply("ReadSequenceFile", Read.from(HBaseImportIO.createSource(options)))
+        .apply("ConvertResultToMutations", HBaseImportIO.transformToMutations())
+        .apply("WriteToTable", CloudBigtableIO.writeToTable(
+            CloudBigtableTableConfiguration.fromCBTOptions(options)));
+
+    p.run();
+  }
+
+  /**
+   * Compare two {@link Set}s of cells. Cells are converted to {@link KeyValue} if necessary
+   * to take advantage the {@link KeyValue#equals} method.
+   */
+  private static void assertCellSetsEqual(
+      Set<? extends Cell> expected, Set<? extends Cell> actual) {
+    Function<Cell, KeyValue> keyValueFunc = new Function<Cell, KeyValue>() {
+          @Override
+          public KeyValue apply(Cell cell) {
+            return cell instanceof KeyValue ? (KeyValue) cell : new KeyValue(cell);
+          }
+        };
+    assertEquals(Sets.newHashSet(Iterables.transform(expected, keyValueFunc)),
+        Sets.newHashSet(Iterables.transform(actual, keyValueFunc)));
+  }
+}

--- a/bigtable-dataflow-import/src/test/java/com/google/cloud/bigtable/dataflowimport/testing/BigtableTableUtils.java
+++ b/bigtable-dataflow-import/src/test/java/com/google/cloud/bigtable/dataflowimport/testing/BigtableTableUtils.java
@@ -1,0 +1,118 @@
+package com.google.cloud.bigtable.dataflowimport.testing;
+
+import com.google.cloud.bigtable.hbase.BigtableConfiguration;
+import com.google.cloud.bigtable.dataflowimport.HBaseImportOptions;
+import com.google.common.collect.Sets;
+
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Admin;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.ResultScanner;
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.client.Table;
+
+import java.io.IOException;
+import java.util.Set;
+
+/**
+ * Helper for creating, deleting and reading a Cloud Bigtable during tests. Each instance manages
+ * a specific table that has one column family.
+ */
+public class BigtableTableUtils implements AutoCloseable {
+  private static final int MAX_VERSISON = 5;
+
+  private final Connection connection;
+  private final Admin admin;
+  private final TableName tableName;
+  private final String columnFamilyName;
+
+  private BigtableTableUtils(
+      Connection connection, Admin admin, String tableName, String columnFamilyName)
+      throws IOException {
+    this.connection = connection;
+    this.admin = admin;
+    this.tableName = TableName.valueOf(tableName);
+    this.columnFamilyName = columnFamilyName;
+  }
+
+  /**
+   * Creates an empty table with a single column family as specified by {@code columnFamily}.
+   * If table already exists, it is removed and recreated.
+   */
+  public void createEmptyTable() throws IOException {
+    if (admin.tableExists(tableName)) {
+      admin.disableTable(tableName);
+      admin.deleteTable(tableName);
+    }
+    HTableDescriptor tableDescriptor = new HTableDescriptor(tableName);
+    tableDescriptor.addFamily(new HColumnDescriptor(columnFamilyName).setMaxVersions(MAX_VERSISON));
+    admin.createTable(tableDescriptor);
+  }
+
+  /**
+   * Returns true if table already exists.
+   */
+  public boolean isTableExists() throws IOException {
+    return admin.tableExists(tableName);
+  }
+
+  /**
+   * Drops the table.
+   */
+  @Override
+  public void close() throws IOException {
+    if (admin.tableExists(tableName)) {
+      admin.disableTable(tableName);
+      admin.deleteTable(tableName);
+    }
+  }
+
+  /**
+   * Returns the content of the table as a {@link Set} of {@link Cell}s. This is only suitable
+   * for small tables.
+   */
+  public Set<? extends Cell> readAllCellsFromTable() throws IOException {
+    Table table = connection.getTable(tableName);
+    Scan scan = new Scan().setMaxVersions().setCacheBlocks(false);
+    ResultScanner resultScanner = table.getScanner(scan);
+    Set<Cell> cells = Sets.newHashSet();
+    for (Result result : resultScanner) {
+      cells.addAll(result.listCells());
+    }
+    return cells;
+  }
+
+  public static class BigtableTableUtilsFactory {
+    private final Connection connection;
+    private final Admin admin;
+
+    private BigtableTableUtilsFactory(Connection connection) throws IOException {
+      this.connection = connection;
+      this.admin = connection.getAdmin();
+    }
+
+    /**
+     * Creates a {@link BigtableTableUtils} instance that manages a table named {@code tableName}.
+     * This table will have a single column family named {@code columnFamilyName}.
+     */
+    public BigtableTableUtils createBigtableTableUtils(String tableName, String columnFamilyName)
+        throws IOException {
+      return new BigtableTableUtils(connection, admin, tableName, columnFamilyName);
+    }
+
+    public void close() throws IOException {
+      this.connection.close();
+    }
+
+    public static BigtableTableUtilsFactory from(HBaseImportOptions options) throws IOException {
+      return new BigtableTableUtilsFactory(BigtableConfiguration.connect(
+          options.getBigtableProjectId(),
+          options.getBigtableZoneId(),
+          options.getBigtableClusterId()));
+    }
+  }
+}

--- a/bigtable-dataflow-import/src/test/java/com/google/cloud/bigtable/dataflowimport/testing/SequenceFileIoUtils.java
+++ b/bigtable-dataflow-import/src/test/java/com/google/cloud/bigtable/dataflowimport/testing/SequenceFileIoUtils.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.dataflowimport.testing;
+
+import com.google.cloud.bigtable.dataflowimport.HBaseImportIO;
+import com.google.cloud.bigtable.dataflowimport.HBaseImportOptions;
+import com.google.cloud.dataflow.sdk.io.BoundedSource;
+import com.google.cloud.dataflow.sdk.options.PipelineOptionsFactory;
+import com.google.cloud.dataflow.sdk.testing.SourceTestUtils;
+import com.google.cloud.dataflow.sdk.values.KV;
+import com.google.common.base.Function;
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Multimaps;
+import com.google.common.collect.Sets;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.CellUtil;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
+import org.apache.hadoop.hbase.mapreduce.ResultSerialization;
+import org.apache.hadoop.io.SequenceFile;
+import org.apache.hadoop.io.SequenceFile.Writer;
+import org.apache.hadoop.io.serializer.WritableSerialization;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Helper methods for creating and reading HBase Sequence Files in tests.
+ */
+public class SequenceFileIoUtils {
+
+  /**
+   * Creates a Sequence File and writes the content of {@code keyValues} to it.
+   */
+  public static void createFileWithData(File sequenceFile, Collection<? extends Cell> keyValues)
+      throws IOException {
+    Configuration configuration = new Configuration();
+    // Configure serializers for Sequence File writer.
+    configuration.set("io.serializations",
+        WritableSerialization.class.getName() + "," + ResultSerialization.class.getName());
+    // Group cells by rowKey.
+    ImmutableListMultimap<byte[], ? extends Cell> records =
+        Multimaps.index(keyValues, new Function<Cell, byte[]>() {
+          @Override
+          public byte[] apply(Cell cell) {
+            return CellUtil.cloneRow(cell);
+          }
+        });
+    try (Writer writer = SequenceFile.createWriter(
+        configuration,
+        Writer.keyClass(ImmutableBytesWritable.class),
+        Writer.valueClass(Result.class),
+        Writer.file(new Path(sequenceFile.toURI())))) {
+
+      for (Collection<? extends Cell> cells : records.asMap().values()) {
+        Result row = Result.create(cells.toArray(new Cell[cells.size()]));
+        writer.append(new ImmutableBytesWritable(row.getRow()), row);
+      }
+      writer.close();
+    }
+  }
+
+  /**
+   * Returns a {@link Set} of {@link Cell}s from the content of a Sequence File.
+   */
+  public static Set<? extends Cell> readCellsFromSource(HBaseImportOptions importOptions)
+      throws IOException {
+    BoundedSource<KV<ImmutableBytesWritable, Result>> source =
+        HBaseImportIO.createSource(importOptions);
+    Iterable<List<Cell>> cellsByRow =
+        Iterables.transform(
+            SourceTestUtils.readFromSource(source, PipelineOptionsFactory.create()),
+            new Function<KV<ImmutableBytesWritable, Result>, List<Cell>>() {
+              @Override
+              public List<Cell> apply(KV<ImmutableBytesWritable, Result> kv) {
+                return kv.getValue().listCells();
+              }
+            });
+    Set<Cell> cells = Sets.newHashSet();
+    for (List<Cell> rowCells: cellsByRow) {
+      cells.addAll(rowCells);
+    }
+    return cells;
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@ limitations under the License.
     <modules>
         <module>bigtable-protos</module>
         <module>bigtable-client-core</module>
+        <module>bigtable-dataflow-import</module>
         <module>bigtable-hbase</module>
         <module>bigtable-hbase-1.0</module>
         <module>bigtable-hbase-1.1</module>


### PR DESCRIPTION
First iteration of data-flow based support for importing HBase sequence files. 
- Supports older format (HBase 0.94 and before)
- TODO in this release: import file with Delete Marker.
- Missing features from HBase import (may be deferred to another realse): Column-family renaming and Filter definition on command line

An example using this change can be found at https://github.com/weiminyu-personal/cloud-bigtable-examples/commit/89d77a68b30d89edfdc3d99a67f4e38ecdb09f71
