### PR TITLE
Moving the BigtableOptions checks into BigtableSession.

### DIFF
--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableOptions.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableOptions.java
@@ -15,15 +15,15 @@
  */
 package com.google.cloud.bigtable.config;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.api.client.util.Objects;
-import com.google.api.client.util.Strings;
-import com.google.cloud.bigtable.grpc.BigtableClusterName;
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Preconditions;
-
 import java.io.Serializable;
 import java.util.concurrent.TimeUnit;
+
+import com.google.api.client.util.Objects;
+import com.google.cloud.bigtable.grpc.BigtableClusterName;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 
 /**
  * An immutable class providing access to configuration options for Bigtable.
@@ -225,14 +225,6 @@ public class BigtableOptions implements Serializable {
       RetryOptions retryOptions,
       int timeoutMs,
       int channelCount) {
-    Preconditions.checkArgument(
-        !Strings.isNullOrEmpty(projectId), "ProjectId must not be empty or null.");
-    Preconditions.checkArgument(
-        !Strings.isNullOrEmpty(zoneId), "ZoneId must not be empty or null.");
-    Preconditions.checkArgument(
-        !Strings.isNullOrEmpty(clusterId), "ClusterId must not be empty or null.");
-    Preconditions.checkArgument(!Strings.isNullOrEmpty(userAgent),
-        "UserAgent must not be empty or null");
     Preconditions.checkArgument(channelCount > 0, "Channel count has to be at least 1.");
     Preconditions.checkArgument(timeoutMs >= -1,
       "ChannelTimeoutMs has to be positive, or -1 for none.");
@@ -250,7 +242,14 @@ public class BigtableOptions implements Serializable {
     this.retryOptions = retryOptions;
     this.timeoutMs = timeoutMs;
     this.dataChannelCount = channelCount;
-    this.clusterName = new BigtableClusterName(getProjectId(), getZoneId(), getClusterId());
+
+    if (!Strings.isNullOrEmpty(projectId)
+        && !Strings.isNullOrEmpty(zoneId)
+        && !Strings.isNullOrEmpty(clusterId)) {
+      this.clusterName = new BigtableClusterName(getProjectId(), getZoneId(), getClusterId());
+    } else {
+      this.clusterName = null;
+    }
 
     LOG.debug("Connection Configuration: projectId: %s, zoneId: %s, clusterId: %s, data host %s, "
         + "table admin host %s, cluster admin host %s.",

--- a/bigtable-client-core/src/test/java/com/google/cloud/bigtable/config/TestBigtableOptions.java
+++ b/bigtable-client-core/src/test/java/com/google/cloud/bigtable/config/TestBigtableOptions.java
@@ -82,4 +82,9 @@ public class TestBigtableOptions {
     BigtableOptions deserialized = (BigtableOptions) iis.readObject();
     Assert.assertEquals(options, deserialized);
   }
+
+  @Test
+  public void testNullStringsDontThrowExceptions() {
+     new BigtableOptions.Builder().build();
+  }
 }

--- a/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestBigtableSession.java
+++ b/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestBigtableSession.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.bigtable.grpc;
+
+import java.io.IOException;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import com.google.cloud.bigtable.config.BigtableOptions;
+
+@SuppressWarnings({"resource","unused"})
+public class TestBigtableSession {
+
+  private static final String PROJECT_ID = "project_id";
+  private static final String ZONE_ID = "zone_id";
+  private static final String CLUSTER_ID = "cluster_id";
+  private static final String USER_AGENT = "user_agent";
+
+  private static void createSession(
+      String projectId, String zoneId, String clusterId, String userAgent) throws IOException {
+    BigtableSession ignored =
+        new BigtableSession(new BigtableOptions.Builder()
+          .setProjectId(projectId)
+          .setZoneId(zoneId)
+          .setClusterId(clusterId)
+          .setUserAgent(userAgent)
+          .build(), null, null, null);
+  }
+
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+
+  @Test
+  public void testNoProjectIdBigtableOptions() throws IOException {
+    expectedException.expect(IllegalArgumentException.class);
+    expectedException.expectMessage(BigtableSession.PROJECT_ID_EMPTY_OR_NULL);
+    createSession(null, ZONE_ID, CLUSTER_ID, USER_AGENT);
+  }
+
+  @Test
+  public void testNoZoneIdBigtableOptions() throws IOException {
+    expectedException.expect(IllegalArgumentException.class);
+    expectedException.expectMessage(BigtableSession.ZONE_ID_EMPTY_OR_NULL);
+    createSession(PROJECT_ID, null, CLUSTER_ID, USER_AGENT);
+  }
+
+  @Test
+  public void testNoClusterIdBigtableOptions() throws IOException {
+    expectedException.expect(IllegalArgumentException.class);
+    expectedException.expectMessage(BigtableSession.CLUSTER_ID_EMPTY_OR_NULL);
+    createSession(PROJECT_ID, ZONE_ID, null, USER_AGENT);
+  }
+
+  @Test
+  public void testNoUserAgentBigtableOptions() throws IOException {
+    expectedException.expect(IllegalArgumentException.class);
+    expectedException.expectMessage(BigtableSession.USER_AGENT_EMPTY_OR_NULL);
+    createSession(PROJECT_ID, ZONE_ID, CLUSTER_ID, null);
+  }
+
+}


### PR DESCRIPTION
There are cases where BigtableOptions may be partially configured.  We
should defer checking for a complete BigtableOptions until we actually
use it.