### PR TITLE
Shading com.google.thirdparty.

### DIFF
--- a/bigtable-hbase-1.0/pom.xml
+++ b/bigtable-hbase-1.0/pom.xml
@@ -178,6 +178,10 @@ limitations under the License.
                                     <shadedPattern>com.google.bigtable.repackaged.com.google.common</shadedPattern>
                                 </relocation>
                                 <relocation>
+                                    <pattern>com.google.thirdparty</pattern>
+                                    <shadedPattern>com.google.bigtable.repackaged.com.google.thirdparty</shadedPattern>
+                                </relocation>
+                                <relocation>
                                     <pattern>com.google.protobuf</pattern>
                                     <shadedPattern>com.google.bigtable.repackaged.com.google.protobuf</shadedPattern>
                                 </relocation>

--- a/bigtable-hbase-1.1/pom.xml
+++ b/bigtable-hbase-1.1/pom.xml
@@ -147,6 +147,10 @@ limitations under the License.
                                     <shadedPattern>com.google.bigtable.repackaged.com.google.common</shadedPattern>
                                 </relocation>
                                 <relocation>
+                                    <pattern>com.google.thirdparty</pattern>
+                                    <shadedPattern>com.google.bigtable.repackaged.com.google.thirdparty</shadedPattern>
+                                </relocation>
+                                <relocation>
                                     <pattern>com.google.protobuf</pattern>
                                     <shadedPattern>com.google.bigtable.repackaged.com.google.protobuf</shadedPattern>
                                 </relocation>


### PR DESCRIPTION
com.google.thirdparty is part of the guava jar that until now was
only partially renamed.  This was causing a user a problem in #605.