### PR TITLE
Fixing some issues with HeapSizeManager.

### DIFF
--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AsyncExecutor.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AsyncExecutor.java
@@ -15,7 +15,6 @@
  */
 package com.google.cloud.bigtable.grpc.async;
 
-import java.io.IOException;
 import java.util.List;
 
 import com.google.bigtable.v1.CheckAndMutateRowRequest;
@@ -128,10 +127,10 @@ public class AsyncExecutor {
     return future;
   }
 
-  public void flush() throws IOException {
+  public void flush() {
     LOG.trace("Flushing");
     try {
-      sizeManager.waitUntilAllOperationsAreDone();
+      sizeManager.flush();
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
     }


### PR DESCRIPTION
Using a wait/notify mechanism for HeapSizeManager flushes that waits for all completions to happen rather than reacting to each completion, which causes thread thrashing.

This is the same code as #614.  Something bad happened on the github side with all of the forced updates.