### PR TITLE
Fix a String format exception

### DIFF
--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
@@ -248,7 +248,7 @@ public class BigtableSession implements AutoCloseable {
         options.getDataHost(), options.getTableAdminHost());
     if(!isAlpnProviderEnabled()) {
       LOG.error("Neither Jetty ALPN nor OpenSSL are available. " +
-          "OpenSSL unavailability cause:\n%s", OpenSsl.unavailabilityCause());
+          "OpenSSL unavailability cause:\n%s", OpenSsl.unavailabilityCause().toString());
       throw new IllegalStateException("Neither Jetty ALPN nor OpenSSL via " +
           "netty-tcnative were properly configured.");
     }


### PR DESCRIPTION
The `%s` is not tied to anything, because the return value of [`unavailabilityCause`](http://netty.io/4.0/api/io/netty/handler/ssl/OpenSsl.html#unavailabilityCause()) is a `Throwable` and hence is treated specially by the logging framework. Thus, this error is emitted:

```
java.util.MissingFormatArgumentException: Format specifier '%s'
	at java.util.Formatter.format(Formatter.java:2519)
	at java.util.Formatter.format(Formatter.java:2455)
	at java.lang.String.format(String.java:2940)
	at com.google.cloud.bigtable.config.Logger.error(Logger.java:69)
	at com.google.cloud.bigtable.grpc.BigtableSession.<init>(BigtableSession.java:250)
	at com.google.cloud.bigtable.grpc.BigtableSession.<init>(BigtableSession.java:235)
	at com.google.cloud.dataflow.sdk.io.BigtableIO$BigtableWriter.open(BigtableIO.java:730)
	at com.google.cloud.dataflow.sdk.io.Write$Bound$2.processElement(Write.java:165)
```

Fix this by running `toString()` on the cause, which is presumably what was intended.