### PR TITLE
Adding better default configuration for bigtable buffered mutator.

### DIFF
--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableOptions.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableOptions.java
@@ -39,11 +39,18 @@ public class BigtableOptions implements Serializable {
   public static final String BIGTABLE_DATA_HOST_DEFAULT = "bigtable.googleapis.com";
   public static final int DEFAULT_BIGTABLE_PORT = 443;
 
-  public static final int BIGTABLE_DATA_CHANNEL_COUNT_DEFAULT = 6;
+  public static final int BIGTABLE_DATA_CHANNEL_COUNT_DEFAULT = getDefaultDataChannelCount();
   public static final int BIGTABLE_CHANNEL_TIMEOUT_MS_DEFAULT =
       (int) TimeUnit.MILLISECONDS.convert(30, TimeUnit.MINUTES);
 
   private static final Logger LOG = new Logger(BigtableOptions.class);
+
+  private static int getDefaultDataChannelCount() {
+    // 10 Channels seemed to work well on a 4 CPU machine, and this seems to scale well for higher
+    // CPU machines. Use no more than 250 Channels by default.
+    int availableProcessors = Runtime.getRuntime().availableProcessors();
+    return (int) Math.min(250, Math.max(1, Math.ceil(availableProcessors * 2.5d)));
+  }
 
   /**
    * A mutable builder for BigtableConnectionOptions.

--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AsyncExecutor.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AsyncExecutor.java
@@ -42,8 +42,9 @@ public class AsyncExecutor {
   public static final int MAX_INFLIGHT_RPCS_DEFAULT = 50;
 
   // This is the maximum accumulated size of uncompleted requests that we allow before throttling.
-  // Default to 32MB.
-  public static final long ASYNC_MUTATOR_MAX_MEMORY_DEFAULT = 16 * 2097152;
+  // Default to 10% of available memory with a max of 1GB.
+  public static final long ASYNC_MUTATOR_MAX_MEMORY_DEFAULT =
+      (long) Math.min(1 << 30, (Runtime.getRuntime().maxMemory() * 0.1d));
 
   protected static final Logger LOG = new Logger(AsyncExecutor.class);
 

--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/HeapSizeManager.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/HeapSizeManager.java
@@ -62,6 +62,10 @@ public class HeapSizeManager {
   public long getMaxHeapSize() {
     return maxHeapSize;
   }
+  
+  public int getMaxInFlightRpcs() {
+    return maxInFlightRpcs;
+  }
 
   public synchronized void flush() throws InterruptedException {
     boolean performedWarning = false;

--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutator.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutator.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.RetriesExhaustedWithDetailsException;
 import org.apache.hadoop.hbase.client.Row;
 
+import com.google.cloud.bigtable.config.BigtableOptions;
 import com.google.cloud.bigtable.config.Logger;
 import com.google.cloud.bigtable.grpc.BigtableDataClient;
 import com.google.cloud.bigtable.grpc.async.AsyncExecutor;
@@ -87,14 +88,20 @@ public class BigtableBufferedMutator implements BufferedMutator {
       BigtableDataClient client,
       HBaseRequestAdapter adapter,
       Configuration configuration,
-      String dataHost,
+      BigtableOptions options,
       BufferedMutator.ExceptionListener listener,
       HeapSizeManager heapSizeManager) {
     this.adapter = adapter;
     this.configuration = configuration;
     this.exceptionListener = listener;
-    this.host = dataHost;
+    this.host = options.getDataHost().toString();
     this.asyncExecutor = new AsyncExecutor(client, heapSizeManager);
+    LOG.info(
+        "Initializing BigtableBufferd Mutator with %d channels, %,d byte heap size"
+        + " and %d concurrent requests.",
+        options.getChannelCount(),
+        heapSizeManager.getMaxHeapSize(),
+        heapSizeManager.getMaxInFlightRpcs());
   }
 
   @Override

--- a/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableConnection.java
+++ b/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableConnection.java
@@ -162,6 +162,7 @@ public abstract class AbstractBigtableConnection implements Connection, Closeabl
     long maxHeapSize = params.getWriteBufferSize();
     if (maxHeapSize == BufferedMutatorParams.UNSET) {
       params.writeBufferSize(tableConfig.getWriteBufferSize());
+      maxHeapSize = params.getWriteBufferSize();
     }
 
     int defaultRpcCount = AsyncExecutor.MAX_INFLIGHT_RPCS_DEFAULT * options.getChannelCount();
@@ -173,7 +174,7 @@ public abstract class AbstractBigtableConnection implements Connection, Closeabl
         session.getDataClient(),
         createAdapter(tableName),
         conf,
-        options.getDataHost().toString(),
+        options,
         params.getListener(),
         new HeapSizeManager(maxHeapSize, maxInflightRpcs)) {
       @Override

--- a/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableBufferedMutator.java
+++ b/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableBufferedMutator.java
@@ -39,6 +39,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import com.google.bigtable.v1.MutateRowRequest;
+import com.google.cloud.bigtable.config.BigtableOptions;
 import com.google.cloud.bigtable.grpc.BigtableClusterName;
 import com.google.cloud.bigtable.grpc.BigtableDataClient;
 import com.google.cloud.bigtable.grpc.async.AsyncExecutor;
@@ -92,7 +93,7 @@ public class TestBigtableBufferedMutator {
       client,
       adapter,
       configuration,
-      null,
+      new BigtableOptions.Builder().build(),
       listener,
       heapSizeManager);
   }


### PR DESCRIPTION
Also logging settings in bigtable buffered mutator.

The implementation:
- default channel count: 2.5 * available processors (i.e. 4 CPUs would mean 10 channels)
- default rpc count: 50 * channel count -- this wasn't changed
- default max heap: 10% of available memory.