### PR TITLE
BigtableBufferdMutator rpc calls are done asynchronously

### DIFF
--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableOptions.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableOptions.java
@@ -37,11 +37,12 @@ public class BigtableOptions implements Serializable {
   public static final String BIGTABLE_CLUSTER_ADMIN_HOST_DEFAULT =
       "bigtableclusteradmin.googleapis.com";
   public static final String BIGTABLE_DATA_HOST_DEFAULT = "bigtable.googleapis.com";
-  public static final int DEFAULT_BIGTABLE_PORT = 443;
+  public static final int BIGTABLE_PORT_DEFAULT = 443;
 
   public static final int BIGTABLE_DATA_CHANNEL_COUNT_DEFAULT = getDefaultDataChannelCount();
   public static final int BIGTABLE_CHANNEL_TIMEOUT_MS_DEFAULT =
       (int) TimeUnit.MILLISECONDS.convert(30, TimeUnit.MINUTES);
+  public static final int BIGTABLE_ASYNC_MUTATOR_COUNT_DEFAULT = 2;
 
   private static final Logger LOG = new Logger(BigtableOptions.class);
 
@@ -56,7 +57,7 @@ public class BigtableOptions implements Serializable {
    * A mutable builder for BigtableConnectionOptions.
    */
   public static class Builder {
-     // Configuration that a user is required to set.
+    // Configuration that a user is required to set.
     private String projectId;
     private String zoneId;
     private String clusterId;
@@ -66,7 +67,7 @@ public class BigtableOptions implements Serializable {
     private String dataHost = BIGTABLE_DATA_HOST_DEFAULT;
     private String tableAdminHost = BIGTABLE_TABLE_ADMIN_HOST_DEFAULT;
     private String clusterAdminHost = BIGTABLE_CLUSTER_ADMIN_HOST_DEFAULT;
-    private int port = DEFAULT_BIGTABLE_PORT;
+    private int port = BIGTABLE_PORT_DEFAULT;
     private String overrideIp;
 
     // The default credentials get credential from well known locations, such as the GCE
@@ -78,6 +79,7 @@ public class BigtableOptions implements Serializable {
     private RetryOptions retryOptions = new RetryOptions.Builder().build();
     private int timeoutMs = BIGTABLE_CHANNEL_TIMEOUT_MS_DEFAULT;
     private int dataChannelCount = BIGTABLE_DATA_CHANNEL_COUNT_DEFAULT;
+    private int asyncMutatorCount = BIGTABLE_ASYNC_MUTATOR_COUNT_DEFAULT;
 
     public Builder() {
     }
@@ -96,6 +98,7 @@ public class BigtableOptions implements Serializable {
       this.retryOptions = original.retryOptions;
       this.timeoutMs = original.timeoutMs;
       this.dataChannelCount = original.dataChannelCount;
+      this.asyncMutatorCount = original.asyncMutatorCount;
     }
 
     public Builder setTableAdminHost(String tableAdminHost) {
@@ -167,6 +170,13 @@ public class BigtableOptions implements Serializable {
       return this;
     }
 
+    public Builder setAsyncMutatorWorkerCount(int asyncMutatorCount) {
+      Preconditions.checkArgument(
+          asyncMutatorCount > 0, "asyncMutatorCount must be greater than 0.");
+      this.asyncMutatorCount = asyncMutatorCount;
+      return this;
+    }
+
     public BigtableOptions build() {
       return new BigtableOptions(
           clusterAdminHost,
@@ -181,7 +191,8 @@ public class BigtableOptions implements Serializable {
           userAgent,
           retryOptions,
           timeoutMs,
-          dataChannelCount);
+          dataChannelCount,
+          asyncMutatorCount);
     }
   }
 
@@ -199,6 +210,7 @@ public class BigtableOptions implements Serializable {
   private final int timeoutMs;
   private final int dataChannelCount;
   private final BigtableClusterName clusterName;
+  private final int asyncMutatorCount;
 
   @VisibleForTesting
   BigtableOptions() {
@@ -216,6 +228,7 @@ public class BigtableOptions implements Serializable {
       timeoutMs = 0;
       dataChannelCount = 1;
       clusterName = null;
+      asyncMutatorCount = 1;
   }
 
   private BigtableOptions(
@@ -231,7 +244,8 @@ public class BigtableOptions implements Serializable {
       String userAgent,
       RetryOptions retryOptions,
       int timeoutMs,
-      int channelCount) {
+      int channelCount,
+      int asyncMutatorCount) {
     Preconditions.checkArgument(channelCount > 0, "Channel count has to be at least 1.");
     Preconditions.checkArgument(timeoutMs >= -1,
       "ChannelTimeoutMs has to be positive, or -1 for none.");
@@ -249,6 +263,7 @@ public class BigtableOptions implements Serializable {
     this.retryOptions = retryOptions;
     this.timeoutMs = timeoutMs;
     this.dataChannelCount = channelCount;
+    this.asyncMutatorCount = asyncMutatorCount;
 
     if (!Strings.isNullOrEmpty(projectId)
         && !Strings.isNullOrEmpty(zoneId)
@@ -343,6 +358,10 @@ public class BigtableOptions implements Serializable {
     return clusterName;
   }
 
+  public int getAsyncMutatorCount() {
+    return asyncMutatorCount;
+  }
+
   @Override
   public boolean equals(Object obj) {
     if (obj == null || obj.getClass() != BigtableOptions.class) {
@@ -352,8 +371,10 @@ public class BigtableOptions implements Serializable {
       return true;
     }
     BigtableOptions other = (BigtableOptions) obj;
-    return (port == other.port) && (timeoutMs == other.timeoutMs)
+    return (port == other.port)
+        && (timeoutMs == other.timeoutMs)
         && (dataChannelCount == other.dataChannelCount)
+        && (asyncMutatorCount == other.asyncMutatorCount)
         && Objects.equal(clusterAdminHost, other.clusterAdminHost)
         && Objects.equal(tableAdminHost, other.tableAdminHost)
         && Objects.equal(dataHost, other.dataHost)
@@ -379,10 +400,15 @@ public class BigtableOptions implements Serializable {
         .add("clusterId", clusterId)
         .add("userAgent", userAgent)
         .add("credentialType", credentialOptions.getCredentialType())
+        .add("port", port)
+        .add("timeoutMs", timeoutMs)
+        .add("dataChannelCount", dataChannelCount)
+        .add("asyncMutatorCount", asyncMutatorCount)
         .toString();
   }
 
   public Builder toBuilder() {
     return new Builder(this);
   }
+
 }

--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AsyncExecutor.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AsyncExecutor.java
@@ -32,7 +32,7 @@ import com.google.protobuf.Empty;
 import com.google.protobuf.GeneratedMessage;
 
 /**
- * This class provides management of asynchronous Bigtable RPCs.  It ensures that there aren't too
+ * This class provides management of asynchronous Bigtable RPCs. It ensures that there aren't too
  * many concurrent, in flight asynchronous RPCs and also makes sure that the memory used by the
  * requests doesn't exceed a threshold.
  */
@@ -52,6 +52,9 @@ public class AsyncExecutor {
     ListenableFuture<ResponseT> call(BigtableDataClient client, RequestT request);
   }
 
+  /**
+   * Calls {@link BigtableDataClient#mutateRowAsync(MutateRowRequest)}.
+   */
   protected static AsyncCall<MutateRowRequest, Empty> MUTATE_ASYNC =
       new AsyncCall<MutateRowRequest, Empty>() {
         @Override
@@ -60,6 +63,9 @@ public class AsyncExecutor {
         }
       };
 
+  /**
+   * Calls {@link BigtableDataClient#readModifyWriteRowAsync(ReadModifyWriteRowRequest)}.
+   */
   protected static AsyncCall<ReadModifyWriteRowRequest, Row> READ_MODIFY_WRITE_ASYNC =
       new AsyncCall<ReadModifyWriteRowRequest, Row>() {
         @Override
@@ -69,6 +75,9 @@ public class AsyncExecutor {
         }
       };
 
+  /**
+   * Calls {@link BigtableDataClient#checkAndMutateRowAsync(CheckAndMutateRowRequest)}.
+   */
   protected static AsyncCall<CheckAndMutateRowRequest, CheckAndMutateRowResponse> CHECK_AND_MUTATE_ASYNC =
       new AsyncCall<CheckAndMutateRowRequest, CheckAndMutateRowResponse>() {
         @Override
@@ -78,6 +87,9 @@ public class AsyncExecutor {
         }
       };
 
+  /**
+   * Calls {@link BigtableDataClient#readRowsAsync(ReadRowsRequest))}.
+   */
   protected static AsyncCall<ReadRowsRequest, List<Row>> READ_ROWS_ASYNC =
       new AsyncCall<ReadRowsRequest, List<Row>>() {
         @Override
@@ -94,22 +106,121 @@ public class AsyncExecutor {
     this.sizeManager = heapSizeManager;
   }
 
+  /**
+   * Performs a {@link BigtableDataClient#mutateRowAsync(MutateRowRequest)} on the
+   * {@link MutateRowRequest} given an operationId generated from
+   * {@link HeapSizeManager#registerOperationWithHeapSize(long)}.
+   *
+   * @param request The {@link MutateRowRequest} to send.
+   * @param operationId The Id generated from
+   *          {@link HeapSizeManager#registerOperationWithHeapSize(long)} that will be released when
+   *          the mutate operation is completed.
+   *
+   * @return a {@link ListenableFuture} which can be listened to for completion events.
+   */
+  public ListenableFuture<Empty> mutateRowAsync(MutateRowRequest request, long operationId) {
+    return call(MUTATE_ASYNC, request, operationId);
+  }
+
+  /**
+   * Performs a {@link BigtableDataClient#checkAndMutateRowAsync(CheckAndMutateRowRequest)} on the
+   * {@link CheckAndMutateRowRequest} given an operationId generated from
+   * {@link HeapSizeManager#registerOperationWithHeapSize(long)}.
+   *
+   * @param request The {@link CheckAndMutateRowRequest} to send.
+   * @param operationId The Id generated from
+   *          {@link HeapSizeManager#registerOperationWithHeapSize(long)} that will be released when
+   *          the checkAndMutateRow operation is completed.
+   *
+   * @return a {@link ListenableFuture} which can be listened to for completion events.
+   */
+  public ListenableFuture<CheckAndMutateRowResponse> checkAndMutateRowAsync(
+      CheckAndMutateRowRequest request, long operationId) {
+    return call(CHECK_AND_MUTATE_ASYNC, request, operationId);
+  }
+
+  /**
+   * Performs a {@link BigtableDataClient#readModifyWriteRowAsync(ReadModifyWriteRowRequest))} on the
+   * {@link ReadModifyWriteRowRequest} given an operationId generated from
+   * {@link HeapSizeManager#registerOperationWithHeapSize(long)}.
+   *
+   * @param request The {@link ReadModifyWriteRowRequest} to send.
+   * @param operationId The Id generated from
+   *          {@link HeapSizeManager#registerOperationWithHeapSize(long)} that will be released when
+   *          the readModifyWriteRowAsync operation is completed.
+   *
+   * @return a {@link ListenableFuture} which can be listened to for completion events.
+   */
+  public ListenableFuture<Row> readModifyWriteRowAsync(ReadModifyWriteRowRequest request,
+      long operationId)  {
+    return call(READ_MODIFY_WRITE_ASYNC, request, operationId);
+  }
+
+  /**
+   * Performs a {@link BigtableDataClient#readRowsAsync(ReadRowsRequest))} on the
+   * {@link ReadRowsRequest} given an operationId generated from
+   * {@link HeapSizeManager#registerOperationWithHeapSize(long)}.
+   *
+   * @param request The {@link ReadRowsRequest} to send.
+   *
+   * @return a {@link ListenableFuture} which can be listened to for completion events.
+   */
+  public ListenableFuture<List<Row>> readRowsAsync(ReadRowsRequest request, long operationId) {
+    return call(READ_ROWS_ASYNC, request, operationId);
+  }
+
+  /**
+   * Performs a {@link BigtableDataClient#mutateRowAsync(MutateRowRequest)} on the
+   * {@link MutateRowRequest}. This method may block if
+   * {@link HeapSizeManager#registerOperationWithHeapSize(long)} blocks.
+   *
+   * @param request The {@link MutateRowRequest} to send.
+   *
+   * @return a {@link ListenableFuture} which can be listened to for completion events.
+   */
   public ListenableFuture<Empty> mutateRowAsync(MutateRowRequest request)
       throws InterruptedException {
     return call(MUTATE_ASYNC, request);
   }
 
+  /**
+   * Performs a {@link BigtableDataClient#checkAndMutateRowAsync(CheckAndMutateRowRequest))} on the
+   * {@link CheckAndMutateRowRequest}. This method may block if
+   * {@link HeapSizeManager#registerOperationWithHeapSize(long)} blocks.
+   *
+   * @param request The {@link CheckAndMutateRowRequest} to send.
+   *
+   * @return a {@link ListenableFuture} which can be listened to for completion events.
+   */
   public ListenableFuture<CheckAndMutateRowResponse> checkAndMutateRowAsync(
       CheckAndMutateRowRequest request) throws InterruptedException {
     return call(CHECK_AND_MUTATE_ASYNC, request);
   }
 
+  /**
+   * Performs a {@link BigtableDataClient#readModifyWriteRow(ReadModifyWriteRowRequest)} on the
+   * {@link ReadModifyWriteRowRequest}. This method may block if
+   * {@link HeapSizeManager#registerOperationWithHeapSize(long)} blocks.
+   *
+   * @param request The {@link ReadModifyWriteRowRequest} to send.
+   *
+   * @return a {@link ListenableFuture} which can be listened to for completion events.
+   */
   public ListenableFuture<Row> readModifyWriteRowAsync(ReadModifyWriteRowRequest request)
       throws InterruptedException {
     return call(READ_MODIFY_WRITE_ASYNC, request);
   }
 
-  public ListenableFuture<List<com.google.bigtable.v1.Row>> readRowsAsync(ReadRowsRequest request)
+  /**
+   * Performs a {@link BigtableDataClient#readRowsAsync(ReadRowsRequest)} on the
+   * {@link ReadRowsRequest}. This method may block if
+   * {@link HeapSizeManager#registerOperationWithHeapSize(long)} blocks.
+   *
+   * @param request The {@link ReadRowsRequest} to send.
+   *
+   * @return a {@link ListenableFuture} which can be listened to for completion events.
+   */
+  public ListenableFuture<List<Row>> readRowsAsync(ReadRowsRequest request)
       throws InterruptedException {
     return call(READ_ROWS_ASYNC, request);
   }
@@ -119,6 +230,11 @@ public class AsyncExecutor {
     // Wait until both the memory and rpc count maximum requirements are achieved before getting a
     // unique id used to track this request.
     long id = sizeManager.registerOperationWithHeapSize(request.getSerializedSize());
+    return call(rpc, request, id);
+  }
+
+  private <ResponseT, RequestT extends GeneratedMessage> ListenableFuture<ResponseT>
+      call(AsyncCall<RequestT, ResponseT> rpc, RequestT request, long id) {
     ListenableFuture<ResponseT> future;
     try {
       future = rpc.call(client, request);
@@ -129,6 +245,12 @@ public class AsyncExecutor {
     return future;
   }
 
+  /**
+   * Waits until all operations managed by the {@link HeapSizeManager} complete. See
+   * {@link HeapSizeManager#flush()} for more information.
+   *
+   * @throws IOException if something goes wrong.
+   */
   public void flush() throws IOException {
     LOG.trace("Flushing");
     try {

--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableOptionsFactory.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableOptionsFactory.java
@@ -19,7 +19,8 @@ import static com.google.api.client.util.Strings.isNullOrEmpty;
 import static com.google.cloud.bigtable.config.BigtableOptions.BIGTABLE_CLUSTER_ADMIN_HOST_DEFAULT;
 import static com.google.cloud.bigtable.config.BigtableOptions.BIGTABLE_DATA_HOST_DEFAULT;
 import static com.google.cloud.bigtable.config.BigtableOptions.BIGTABLE_TABLE_ADMIN_HOST_DEFAULT;
-import static com.google.cloud.bigtable.config.BigtableOptions.DEFAULT_BIGTABLE_PORT;
+import static com.google.cloud.bigtable.config.BigtableOptions.BIGTABLE_PORT_DEFAULT;
+import static com.google.cloud.bigtable.config.BigtableOptions.BIGTABLE_ASYNC_MUTATOR_COUNT_DEFAULT;
 
 import com.google.cloud.bigtable.config.BigtableOptions;
 import com.google.cloud.bigtable.config.CredentialOptions;
@@ -130,11 +131,18 @@ public class BigtableOptionsFactory {
    * The number of grpc channels to open for asynchronous processing such as puts.
    */
   public static final String BIGTABLE_DATA_CHANNEL_COUNT_KEY = "google.bigtable.grpc.channel.count";
+
   /**
    * The maximum length of time to keep a Bigtable grpc channel open.
    */
   public static final String BIGTABLE_CHANNEL_TIMEOUT_MS_KEY =
       "google.bigtable.grpc.channel.timeout.ms";
+
+  /**
+   * The number of asynchronous workers to use for buffered mutator operations.
+   */
+  public static final String BIGTABLE_ASYNC_MUTATOR_COUNT_KEY =
+      "google.bigtable.buffered.mutator.async.worker.count";
 
   public static BigtableOptions fromConfiguration(final Configuration configuration)
       throws IOException {
@@ -161,9 +169,13 @@ public class BigtableOptionsFactory {
     bigtableOptionsBuilder.setClusterAdminHost(getHost(configuration,
         BIGTABLE_CLUSTER_ADMIN_HOST_KEY, BIGTABLE_CLUSTER_ADMIN_HOST_DEFAULT, "Cluster Admin"));
 
-    int port = configuration.getInt(BIGTABLE_PORT_KEY, DEFAULT_BIGTABLE_PORT);
+    int port = configuration.getInt(BIGTABLE_PORT_KEY, BIGTABLE_PORT_DEFAULT);
     bigtableOptionsBuilder.setPort(port);
     setChannelOptions(bigtableOptionsBuilder, configuration);
+    
+    int asyncMutatorCount = configuration.getInt(
+        BIGTABLE_ASYNC_MUTATOR_COUNT_KEY, BIGTABLE_ASYNC_MUTATOR_COUNT_DEFAULT);
+    bigtableOptionsBuilder.setAsyncMutatorWorkerCount(asyncMutatorCount);
 
     return bigtableOptionsBuilder.build();
   }

--- a/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableBufferedMutator.java
+++ b/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableBufferedMutator.java
@@ -105,9 +105,11 @@ public class TestBigtableBufferedMutator {
 
   @SuppressWarnings("unchecked")
   @Test
-  public void testMutation() throws IOException {
+  public void testMutation() throws IOException, InterruptedException {
     when(client.mutateRowAsync(any(MutateRowRequest.class))).thenReturn(future);
     underTest.mutate(SIMPLE_PUT);
+    // Leave some time for the async worker to handle the request.
+    Thread.sleep(100);
     verify(client, times(1)).mutateRowAsync(any(MutateRowRequest.class));
     Assert.assertTrue(underTest.hasInflightRequests());
     completeCall();
@@ -118,6 +120,8 @@ public class TestBigtableBufferedMutator {
   public void testInvalidPut() throws Exception {
     when(client.mutateRowAsync(any(MutateRowRequest.class))).thenThrow(new RuntimeException());
     underTest.mutate(SIMPLE_PUT);
+    // Leave some time for the async worker to handle the request.
+    Thread.sleep(100);
     verify(listener, times(0)).onException(any(RetriesExhaustedWithDetailsException.class),
         same(underTest));
     completeCall();


### PR DESCRIPTION
The adapter from hbase to bigtable proto can take a microsecond or so,
depending on the size.  The initiation of the RPC can also take some
time.  This PR does those two things in worker threads rather than
running in the main thread.  This increases throughput and better
utilizes machine resources.