### PR TITLE
Cleaning up warnings.

### DIFF
--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableTableName.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableTableName.java
@@ -27,6 +27,7 @@ public class BigtableTableName {
     this.tableName = tableName;
   }
 
+  @Override
   public String toString() {
     return tableName;
   }

--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AsyncExecutor.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AsyncExecutor.java
@@ -134,6 +134,7 @@ public class AsyncExecutor {
       sizeManager.flush();
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
+      throw new IOException("Batch operations were interrupted.");
     }
     LOG.trace("Done flushing");
   }

--- a/bigtable-client-core/src/test/java/com/google/cloud/bigtable/config/TestBigtableOptions.java
+++ b/bigtable-client-core/src/test/java/com/google/cloud/bigtable/config/TestBigtableOptions.java
@@ -27,7 +27,7 @@ import org.junit.Test;
 public class TestBigtableOptions {
 
   @Test
-  public void testEquals() throws IOException, ClassNotFoundException {
+  public void testEquals() {
     BigtableOptions options1 = new BigtableOptions.Builder()
         .setProjectId("project")
         .setZoneId("zone")

--- a/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/BigtableDataGrpcClientTests.java
+++ b/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/BigtableDataGrpcClientTests.java
@@ -106,7 +106,7 @@ public class BigtableDataGrpcClientTests {
   }
 
   @Test
-  public void testRetyableMutateRowAsync() throws ServiceException {
+  public void testRetyableMutateRowAsync() {
     MutateRowRequest request = MutateRowRequest.getDefaultInstance();
     underTest.mutateRowAsync(request);
     verify(clientCallService).listenableAsyncCall(any(RetryingCall.class), same(request));
@@ -120,7 +120,7 @@ public class BigtableDataGrpcClientTests {
   }
 
   @Test
-  public void testRetyableCheckAndMutateRowAsync() throws ServiceException {
+  public void testRetyableCheckAndMutateRowAsync() {
     CheckAndMutateRowRequest request = CheckAndMutateRowRequest.getDefaultInstance();
     underTest.checkAndMutateRowAsync(request);
     verify(clientCallService).listenableAsyncCall(any(RetryingCall.class), same(request));

--- a/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestAsyncExecutor.java
+++ b/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestAsyncExecutor.java
@@ -18,7 +18,6 @@ package com.google.cloud.bigtable.grpc.async;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -83,12 +82,12 @@ public class TestAsyncExecutor {
   }
 
   @Test
-  public void testNoMutation() throws IOException {
+  public void testNoMutation() {
     Assert.assertFalse(underTest.hasInflightRequests());
   }
 
   @Test
-  public void testMutation() throws IOException, InterruptedException {
+  public void testMutation() throws InterruptedException {
     when(client.mutateRowAsync(any(MutateRowRequest.class))).thenReturn(future);
     underTest.mutateRowAsync(MutateRowRequest.getDefaultInstance());
     Assert.assertTrue(underTest.hasInflightRequests());
@@ -97,7 +96,7 @@ public class TestAsyncExecutor {
   }
 
   @Test
-  public void testCheckAndMutate() throws IOException, InterruptedException {
+  public void testCheckAndMutate() throws InterruptedException {
     when(client.checkAndMutateRowAsync(any(CheckAndMutateRowRequest.class))).thenReturn(future);
     underTest.checkAndMutateRowAsync(CheckAndMutateRowRequest.getDefaultInstance());
     Assert.assertTrue(underTest.hasInflightRequests());
@@ -106,7 +105,7 @@ public class TestAsyncExecutor {
   }
 
   @Test
-  public void testReadWriteModify() throws IOException, InterruptedException {
+  public void testReadWriteModify() throws InterruptedException {
     when(client.readModifyWriteRowAsync(any(ReadModifyWriteRowRequest.class))).thenReturn(future);
     underTest.readModifyWriteRowAsync(ReadModifyWriteRowRequest.getDefaultInstance());
     Assert.assertTrue(underTest.hasInflightRequests());
@@ -115,7 +114,7 @@ public class TestAsyncExecutor {
   }
 
   @Test
-  public void testReadRowsAsync() throws IOException, InterruptedException {
+  public void testReadRowsAsync() throws InterruptedException {
     when(client.readRowsAsync(any(ReadRowsRequest.class))).thenReturn(future);
     underTest.readRowsAsync(ReadRowsRequest.getDefaultInstance());
     Assert.assertTrue(underTest.hasInflightRequests());

--- a/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/scanner/RowMergerTest.java
+++ b/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/scanner/RowMergerTest.java
@@ -21,7 +21,6 @@ import static com.google.cloud.bigtable.grpc.scanner.ReadRowTestUtils.generateRe
 import static com.google.cloud.bigtable.grpc.scanner.ReadRowTestUtils.randomBytes;
 import static com.google.cloud.bigtable.grpc.scanner.RowMatcher.matchesRow;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -54,7 +53,7 @@ public class RowMergerTest {
   public ExpectedException expectedException = ExpectedException.none();
 
   @Test
-  public void resultsAreReadable() throws IOException {
+  public void resultsAreReadable() {
     List<ReadRowsResponse> responses = generateReadRowsResponses("rowKey-%s", 3);
     List<Row> rows = new ArrayList<>();
     Iterator<ReadRowsResponse> iterator = responses.iterator();
@@ -86,7 +85,7 @@ public class RowMergerTest {
   }
 
   @Test
-  public void multipleChunksAreMerged() throws IOException {
+  public void multipleChunksAreMerged() {
     matchResponses(
         new ReadRowsResponse[]{
             createReadRowsResponse("row-1", Family1_c1_CHUNK),
@@ -104,7 +103,7 @@ public class RowMergerTest {
   }
 
   @Test
-  public void rowsMultipleChunks() throws IOException {
+  public void rowsMultipleChunks() {
     matchResponses(
         new ReadRowsResponse[]{
             createReadRowsResponse("row-1", Family1_c1_CHUNK, Family1_c2_CHUNK, COMPLETE_CHUNK)
@@ -117,7 +116,7 @@ public class RowMergerTest {
   }
 
   @Test
-  public void readMultipleRows() throws IOException {
+  public void readMultipleRows() {
     matchResponses(
         new ReadRowsResponse[]{
             createReadRowsResponse("row-1", Family1_c1_CHUNK, COMPLETE_CHUNK),
@@ -130,7 +129,7 @@ public class RowMergerTest {
   }
 
   @Test
-  public void rowsCanBeReset() throws IOException {
+  public void rowsCanBeReset() {
     matchResponses(
         new ReadRowsResponse[]{
             createReadRowsResponse("row-1", Family1_c1_CHUNK),
@@ -157,7 +156,7 @@ public class RowMergerTest {
   }
 
   @Test
-  public void rowsCanBeResetMultipleTimes() throws IOException {
+  public void rowsCanBeResetMultipleTimes() {
     matchResponses(
         new ReadRowsResponse[]{
             createReadRowsResponse("row-1", Family1_c1_CHUNK),
@@ -176,7 +175,7 @@ public class RowMergerTest {
   }
 
   @Test
-  public void resetCompleteRowsAreRead() throws IOException {
+  public void resetCompleteRowsAreRead() {
     // All of these responses indicate a delete. RowMerger should not return any Row objects for
     // these cases
     matchResponses(
@@ -200,7 +199,7 @@ public class RowMergerTest {
   }
 
   @Test
-  public void endOfStreamMidRowThrows() throws IOException {
+  public void endOfStreamMidRowThrows() {
     String rowKey = "row-1";
     ReadRowsResponse response = createReadRowsResponse(rowKey, Family1_c1_CHUNK);
 
@@ -211,7 +210,7 @@ public class RowMergerTest {
   }
 
   @Test
-  public void oneRowPlusEndofStreamMidRowThrows() throws IOException {
+  public void oneRowPlusEndofStreamMidRowThrows() {
     String rowKey = "row-1";
     ReadRowsResponse response = createReadRowsResponse(rowKey, Family1_c1_CHUNK, COMPLETE_CHUNK);
     ReadRowsResponse response2 = createReadRowsResponse(rowKey, Family1_c2_CHUNK);

--- a/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/scanner/StreamingBigtableResultScannerTest.java
+++ b/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/scanner/StreamingBigtableResultScannerTest.java
@@ -72,13 +72,13 @@ public class StreamingBigtableResultScannerTest {
   }
 
   @Test
-  public void cancellationIsSignalled() throws IOException, InterruptedException {
+  public void cancellationIsSignalled() throws IOException {
     scanner.close();
     verify(cancellationToken, times(1)).cancel();
   }
 
   @Test
-  public void testNext() throws IOException, InterruptedException {
+  public void testNext() throws IOException {
     scanner.next();
     verify(reader, times(1)).getNextMergedRow();
     scanner.close();

--- a/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/CloudBigtableConnectionPool.java
+++ b/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/CloudBigtableConnectionPool.java
@@ -35,7 +35,7 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 /**
  * Pubsub and other windowed sources can have a large quantity of bundles in short amounts of time.
- * {@link CloudBigtableIO.AbstractCloudBigtableTableDoFn} should not create a connection per
+ * {@link AbstractCloudBigtableTableDoFn} should not create a connection per
  * bundle, since that could happen ever few milliseconds. Rather, it should rely on a connection
  * pool to better manage connection life-cycles.
  */
@@ -134,7 +134,7 @@ public class CloudBigtableConnectionPool {
     return new PoolEntry(key, new BigtableConnection(config));
   }
 
-  public synchronized void returnConnection(PoolEntry entry) throws IOException {
+  public synchronized void returnConnection(PoolEntry entry) {
     if (entry.isExpired()) {
       closeAsynchronously(entry);
     } else {
@@ -142,7 +142,7 @@ public class CloudBigtableConnectionPool {
     }
   }
 
-  private void closeAsynchronously(final PoolEntry entry) throws IOException {
+  private void closeAsynchronously(final PoolEntry entry) {
     connectionCloseExecutor.submit(new Callable<Void>() {
       @Override
       public Void call() throws Exception {

--- a/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/CloudBigtableIO.java
+++ b/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/CloudBigtableIO.java
@@ -362,16 +362,16 @@ public class CloudBigtableIO {
     /**
      * Splits the table based on keys that belong to tablets, known as "regions" in the HBase API.
      * The current implementation uses the HBase {@link RegionLocator} interface, which calls
-     * {@link BigtableService#sampleRowKeys(com.google.bigtable.v1.SampleRowKeysRequest,
-     * io.grpc.stub.StreamObserver)} under the covers. A {@link SourceWithKeys} may correspond to a
-     * single region or a portion of a region.
-     * 
+     * {@link BigtableService#sampleRowKeys(SampleRowKeysRequest,
+     * com.google.bigtable.repackaged.io.grpc.stub.StreamObserver)} under the covers. 
+     * A {@link SourceWithKeys} may correspond to a single region or a portion of a region.
+     *
      * <p>
      * If a split is smaller than a single region, the split is calculated based on the assumption
      * that the data is distributed evenly between the region's startKey and stopKey. That
      * assumption may not be correct for any specific start/stop key combination.
      * </p>
-     * 
+     *
      * <p>This method is called internally by Cloud Dataflow. Do not call it directly.</p>
      *
      * @param desiredBundleSizeBytes The desired size for each bundle, in bytes.

--- a/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/HBaseMutationCoder.java
+++ b/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/HBaseMutationCoder.java
@@ -29,7 +29,6 @@ import org.apache.hadoop.hbase.protobuf.generated.ClientProtos.MutationProto.Mut
 
 import com.google.cloud.dataflow.sdk.Pipeline;
 import com.google.cloud.dataflow.sdk.coders.AtomicCoder;
-import com.google.cloud.dataflow.sdk.coders.Coder;
 import com.google.cloud.dataflow.sdk.coders.CoderException;
 
 /**

--- a/bigtable-hbase-dataflow/src/test/java/com/google/cloud/bigtable/dataflow/CloudBigtableScanConfigurationTest.java
+++ b/bigtable-hbase-dataflow/src/test/java/com/google/cloud/bigtable/dataflow/CloudBigtableScanConfigurationTest.java
@@ -22,7 +22,6 @@ import org.junit.Test;
 import com.google.cloud.bigtable.dataflow.CloudBigtableScanConfiguration;
 import com.google.cloud.dataflow.sdk.util.SerializableUtils;
 
-import java.io.IOException;
 import java.util.Collections;
 
 /**
@@ -39,7 +38,7 @@ public class CloudBigtableScanConfigurationTest {
   public static final byte[] STOP_ROW = "zz".getBytes();
 
   @Test
-  public void testSerialization() throws IOException, ClassNotFoundException{
+  public void testSerialization() {
     CloudBigtableScanConfiguration config = new CloudBigtableScanConfiguration.Builder()
       .withProjectId(PROJECT)
       .withZoneId(ZONE)

--- a/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/AbstractTest.java
+++ b/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/AbstractTest.java
@@ -74,10 +74,12 @@ public abstract class AbstractTest {
   }
 
   /** Hook to setup class level resources after the connection is created. */
+  @SuppressWarnings("unused")
   protected void setup() throws IOException {
   }
 
   /** Hook to remove class level resources after the connection is created. */
+  @SuppressWarnings("unused")
   protected void tearDown() throws IOException {
   }
 

--- a/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestBatch.java
+++ b/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestBatch.java
@@ -276,7 +276,7 @@ public class TestBatch extends AbstractTest {
    */
   @Test
   @Category(KnownGap.class)
-  public void testRowMutations() throws IOException, InterruptedException {
+  public void testRowMutations() throws IOException {
     // Initialize data
     Table table = getConnection().getTable(TABLE_NAME);
     byte[] rowKey = dataHelper.randomData("testrow-");

--- a/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestIncrement.java
+++ b/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestIncrement.java
@@ -284,7 +284,7 @@ public class TestIncrement extends AbstractTest {
 
   @Test
   @Category(KnownGap.class)
-  public void testIncrementWithMaxVersions() throws IOException, InterruptedException {
+  public void testIncrementWithMaxVersions() throws IOException {
     // Initialize data
     byte[] incrementFamily = Bytes.toBytes("i");
     byte[] incrementTable = Bytes.toBytes("increment_table");

--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableTable.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableTable.java
@@ -488,12 +488,14 @@ public class BigtableTable implements Table {
     throw new UnsupportedOperationException();  // TODO
   }
 
+  @Deprecated
   @Override
   public long getWriteBufferSize() {
     LOG.error("Unsupported getWriteBufferSize() called");
     throw new UnsupportedOperationException();  // TODO
   }
 
+  @Deprecated
   @Override
   public void setWriteBufferSize(long writeBufferSize) throws IOException {
     LOG.error("Unsupported getWriteBufferSize() called");

--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/DefaultReadHooks.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/DefaultReadHooks.java
@@ -24,6 +24,7 @@ import com.google.common.base.Functions;
  */
 public class DefaultReadHooks implements ReadHooks {
   private Function<ReadRowsRequest, ReadRowsRequest> preSendHook = Functions.identity();
+  @Override
   public void composePreSendHook(Function<ReadRowsRequest, ReadRowsRequest> newHook) {
     preSendHook = Functions.compose(newHook, preSendHook);
   }

--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/ReaderExpressionHelper.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/ReaderExpressionHelper.java
@@ -45,8 +45,6 @@ public class ReaderExpressionHelper {
    *
    * @param unquoted A byte-array, possibly containing bytes outside of the ASCII
    * @param outputStream A stream to write quoted output to
-   * @param unquoted
-   * @param outputStream
    */
   public static void writeFilterQuotedExpression(byte[] unquoted, OutputStream outputStream)
       throws IOException{

--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/RowCell.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/RowCell.java
@@ -99,6 +99,7 @@ public class RowCell implements Cell {
     return Type.Put.getCode();
   }
 
+  @Deprecated
   @Override
   public long getMvccVersion() {
     return 0;
@@ -139,21 +140,25 @@ public class RowCell implements Cell {
     return 0;
   }
 
+  @Deprecated
   @Override
   public byte[] getValue() {
     return Bytes.copy(this.valueArray);
   }
 
+  @Deprecated
   @Override
   public byte[] getFamily() {
     return Bytes.copy(this.familyArray);
   }
 
+  @Deprecated
   @Override
   public byte[] getQualifier() {
     return Bytes.copy(this.qualifierArray);
   }
 
+  @Deprecated
   @Override
   public byte[] getRow() {
     return Bytes.copy(this.rowArray);

--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/MultipleColumnPrefixFilterAdapter.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/MultipleColumnPrefixFilterAdapter.java
@@ -19,7 +19,6 @@ import com.google.bigtable.v1.RowFilter;
 import com.google.bigtable.v1.RowFilter.Interleave;
 import com.google.cloud.bigtable.hbase.adapters.ReaderExpressionHelper;
 import com.google.cloud.bigtable.util.ByteStringer;
-import com.google.protobuf.ByteString;
 
 import org.apache.hadoop.hbase.filter.MultipleColumnPrefixFilter;
 

--- a/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableAdmin.java
+++ b/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableAdmin.java
@@ -163,6 +163,7 @@ public abstract class AbstractBigtableAdmin implements Admin {
 
   // Used by the Hbase shell but not defined by Admin. Will be removed once the
   // shell is switch to use the methods defined in the interface.
+  @Override
   @Deprecated
   public TableName[] listTableNames(String patternStr) throws IOException {
     return listTableNames(Pattern.compile(patternStr));
@@ -569,6 +570,7 @@ public abstract class AbstractBigtableAdmin implements Admin {
     return regionInfos;
   }
 
+  @Override
   public void close() throws IOException {
     // no-op
   }

--- a/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableConnection.java
+++ b/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableConnection.java
@@ -105,6 +105,20 @@ public abstract class AbstractBigtableConnection implements Connection, Closeabl
     this(conf, false, null, null);
   }
 
+  /**
+   * The constructor called from {@link ConnectionFactory#createConnection(Configuration)} and
+   * in its many forms via reflection with this specific signature.
+   *
+   * @param conf The configuration for this channel. See {@link BigtableOptionsFactory} for more details.
+   * @param managed This should always be false. It's an artifact of old HBase behavior.
+   * @param pool An {@link ExecutorService} to run HBase/Bigtable object conversions on. The RPCs
+   *             themselves run via NIO, and not on a waiting thread
+   * @param user This is an artifact of HBase which Cloud Bigtable ignores. User information is
+   * captured in the Credentials configuration in conf.
+   *
+   * @throws IOException if the setup is not correct. The most likely issue is ALPN or OpenSSL 
+   * misconfiguration.
+   */
   protected AbstractBigtableConnection(Configuration conf, boolean managed, ExecutorService pool,
       User user) throws IOException {
     if (managed) {
@@ -345,7 +359,7 @@ public abstract class AbstractBigtableConnection implements Connection, Closeabl
   public abstract Admin getAdmin() throws IOException;
 
   /* Methods needed to construct a Bigtable Admin implementation: */
-  protected BigtableTableAdminClient getBigtableTableAdminClient() throws IOException {
+  protected BigtableTableAdminClient getBigtableTableAdminClient() {
     return session.getTableAdminClient();
   }
 

--- a/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/TestAppendAdapter.java
+++ b/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/TestAppendAdapter.java
@@ -27,7 +27,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-import java.io.IOException;
 import java.util.List;
 
 @RunWith(JUnit4.class)
@@ -36,7 +35,7 @@ public class TestAppendAdapter {
   protected DataGenerationHelper dataHelper = new DataGenerationHelper();
 
   @Test
-  public void testBasicRowKeyAppend() throws IOException {
+  public void testBasicRowKeyAppend() {
     byte[] rowKey = dataHelper.randomData("rk1-");
     Append append = new Append(rowKey);
     ReadModifyWriteRowRequest request = appendAdapter.adapt(append).build();
@@ -45,7 +44,7 @@ public class TestAppendAdapter {
   }
 
   @Test
-  public void testMultipleAppends() throws IOException {
+  public void testMultipleAppends() {
     byte[] rowKey = dataHelper.randomData("rk1-");
 
     byte[] family1 = Bytes.toBytes("family1");
@@ -74,7 +73,7 @@ public class TestAppendAdapter {
   }
 
   @Test
-  public void testMultipleAppendsWithDuplicates() throws IOException {
+  public void testMultipleAppendsWithDuplicates() {
     byte[] rowKey = dataHelper.randomData("rk1-");
 
     byte[] family1 = Bytes.toBytes("family1");

--- a/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/TestIncrementAdapter.java
+++ b/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/TestIncrementAdapter.java
@@ -40,7 +40,7 @@ public class TestIncrementAdapter {
   protected DataGenerationHelper dataHelper = new DataGenerationHelper();
 
   @Test
-  public void testBasicRowKeyIncrement() throws IOException {
+  public void testBasicRowKeyIncrement() {
     byte[] rowKey = dataHelper.randomData("rk1-");
     Increment incr = new Increment(rowKey);
     ReadModifyWriteRowRequest.Builder requestBuilder = incrementAdapter.adapt(incr);
@@ -49,7 +49,7 @@ public class TestIncrementAdapter {
   }
 
   @Test
-  public void testSingleIncrement() throws IOException {
+  public void testSingleIncrement() {
     byte[] rowKey = dataHelper.randomData("rk1-");
     byte[] family = Bytes.toBytes("family");
     byte[] qualifier = Bytes.toBytes("qualifier");
@@ -69,7 +69,7 @@ public class TestIncrementAdapter {
   }
 
   @Test
-  public void testMultipleIncrement() throws IOException {
+  public void testMultipleIncrement() {
     byte[] rowKey = dataHelper.randomData("rk1-");
 
     byte[] family1 = Bytes.toBytes("family1");
@@ -100,7 +100,7 @@ public class TestIncrementAdapter {
 
 
   @Test
-  public void testMultipleIncrementWithDuplicateQualifier() throws IOException {
+  public void testMultipleIncrementWithDuplicateQualifier() {
     byte[] rowKey = dataHelper.randomData("rk1-");
 
     byte[] family1 = Bytes.toBytes("family1");

--- a/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/TestScanAdapter.java
+++ b/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/TestScanAdapter.java
@@ -29,8 +29,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-import java.io.IOException;
-
 /**
  * Lightweight tests for the ScanAdapter. Many of the methods, such as filter building are
  * already tested in {@link TestGetAdapter}.
@@ -65,7 +63,7 @@ public class TestScanAdapter {
   }
 
   @Test
-  public void maxVersionsIsSet() throws IOException {
+  public void maxVersionsIsSet() {
     Scan scan = new Scan();
     scan.setMaxVersions(10);
     ReadRowsRequest.Builder rowRequestBuilder = scanAdapter.adapt(scan, throwingReadHooks);

--- a/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestColumnRangeFilterAdapter.java
+++ b/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestColumnRangeFilterAdapter.java
@@ -35,7 +35,7 @@ public class TestColumnRangeFilterAdapter {
   FilterAdapterContext emptyScanContext = new FilterAdapterContext(emptyScan, null);
 
   @Test
-  public void testColumnRangeFilterThrowsWithNoFamilies() throws IOException {
+  public void testColumnRangeFilterThrowsWithNoFamilies() {
     ColumnRangeFilter filter = new ColumnRangeFilter(
         Bytes.toBytes("a"), true, Bytes.toBytes("b"), true);
     Assert.assertFalse(filterAdapter.isFilterSupported(emptyScanContext, filter).isSupported());

--- a/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestRowFilterAdapter.java
+++ b/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestRowFilterAdapter.java
@@ -108,7 +108,7 @@ public class TestRowFilterAdapter {
   }
 
   @Test
-  public void testNotSupported_RegexNotEquals() throws IOException {
+  public void testNotSupported_RegexNotEquals() {
     String regexp = "^.*hello world.*$";
     RegexStringComparator comparator = new RegexStringComparator(regexp);
     org.apache.hadoop.hbase.filter.RowFilter filter =
@@ -118,7 +118,7 @@ public class TestRowFilterAdapter {
   }
 
   @Test
-  public void testSupported_BinaryComparatorEquals() throws IOException {
+  public void testSupported_BinaryComparatorEquals() {
     BinaryComparator comparator = new BinaryComparator(new byte[] { 0, 1, 2 });
     org.apache.hadoop.hbase.filter.RowFilter filter =
         new org.apache.hadoop.hbase.filter.RowFilter(
@@ -127,7 +127,7 @@ public class TestRowFilterAdapter {
   }
 
   @Test
-  public void testNotSupported_BinaryNotEquals() throws IOException {
+  public void testNotSupported_BinaryNotEquals() {
     BinaryComparator comparator = new BinaryComparator(new byte[] { 0, 1, 2 });
     org.apache.hadoop.hbase.filter.RowFilter filter =
         new org.apache.hadoop.hbase.filter.RowFilter(
@@ -136,7 +136,7 @@ public class TestRowFilterAdapter {
   }
 
   @Test
-  public void testNotSupported_OtherComparator () throws IOException {
+  public void testNotSupported_OtherComparator () {
     ByteArrayComparable comparator = new LongComparator(1L);
     org.apache.hadoop.hbase.filter.RowFilter filter =
         new org.apache.hadoop.hbase.filter.RowFilter(

--- a/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestValueFilterAdapter.java
+++ b/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestValueFilterAdapter.java
@@ -54,7 +54,7 @@ public class TestValueFilterAdapter {
   }
 
   @Test
-  public void testValueFilterFiltersOnValue() throws IOException {
+  public void testValueFilterFiltersOnValue() {
 
   }
 


### PR DESCRIPTION
There are a whole bunch of declared Exceptions that were not thrown.  There were some javadoc issues fixed.  Some methods were deprecated in hbase, but not marked as @Deprected in Bigtable.