### PR TITLE
Using a single Connection for CloudBigtableConnectionPool.

### DIFF
--- a/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/AbstractCloudBigtableTableDoFn.java
+++ b/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/AbstractCloudBigtableTableDoFn.java
@@ -38,26 +38,17 @@ public abstract class AbstractCloudBigtableTableDoFn<In, Out> extends DoFn<In, O
 
   protected final Logger DOFN_LOG = LoggerFactory.getLogger(getClass());
   protected CloudBigtableConfiguration config;
-  protected transient volatile CloudBigtableConnectionPool.PoolEntry connectionEntry;
+  protected Connection connection;
 
   public AbstractCloudBigtableTableDoFn(CloudBigtableConfiguration config) {
     this.config = config;
   }
 
   protected synchronized Connection getConnection() throws IOException {
-    if (connectionEntry == null) {
-      connectionEntry = pool.getConnection(config.toHBaseConfig());
+    if (connection == null) {
+      connection = pool.getConnection(config.toHBaseConfig());
     }
-    return connectionEntry.getConnection();
-  }
-
-  @Override
-  public synchronized void finishBundle(DoFn<In, Out>.Context c) throws Exception {
-    DOFN_LOG.debug("Closing the Bigtable connection.");
-    if (connectionEntry != null) {
-      pool.returnConnection(connectionEntry);
-      connectionEntry = null;
-    }
+    return connection;
   }
 
   /**

--- a/bigtable-hbase-dataflow/src/test/java/com/google/cloud/bigtable/dataflow/CloudBigtableConnectionPoolTest.java
+++ b/bigtable-hbase-dataflow/src/test/java/com/google/cloud/bigtable/dataflow/CloudBigtableConnectionPoolTest.java
@@ -15,14 +15,10 @@
  */
 package com.google.cloud.bigtable.dataflow;
 
-import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutorService;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.client.Connection;
@@ -30,83 +26,43 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-import com.google.cloud.bigtable.dataflow.CloudBigtableConnectionPool.PoolEntry;
-import com.google.common.util.concurrent.MoreExecutors;
-
 /**
  * Tests for {@link CloudBigtableConnectionPool}.
  */
 @RunWith(JUnit4.class)
+@SuppressWarnings("deprecation")
 public class CloudBigtableConnectionPoolTest {
 
   private static Configuration config = new Configuration();
-  private static ExecutorService executorService = MoreExecutors.newDirectExecutorService();
 
   private static class TestCloudbigtableConnectionPool extends CloudBigtableConnectionPool {
-    private long expireTime = System.currentTimeMillis() + 100000;
-
-    public TestCloudbigtableConnectionPool() {
-      super(executorService);
-    }
-
     @Override
-    protected PoolEntry createConnection(Configuration config, String key) throws IOException {
-      return new PoolEntry(key, mock(Connection.class), expireTime);
+    protected Connection createConnection(Configuration config) throws IOException {
+      return mock(Connection.class);
     }
   }
 
   @Test
   public void testConnectionIsPooled() throws IOException{
     TestCloudbigtableConnectionPool pool = new TestCloudbigtableConnectionPool();
-    PoolEntry entry = pool.getConnection(config, "key");
-    pool.returnConnection(entry);
+    Connection entry = pool.getConnection(config, "key");
     for (int i = 0; i < 100; i++) {
-      PoolEntry newEntry = pool.getConnection(config, "key");
+      Connection newEntry = pool.getConnection(config, "key");
       assertSame(entry, newEntry);
-      pool.returnConnection(newEntry);
-    }
-  }
-
-  @Test
-  public void testExpiredConnectionIsRemoved() throws IOException{
-    TestCloudbigtableConnectionPool pool = new TestCloudbigtableConnectionPool();
-    pool.expireTime = System.currentTimeMillis() - 10;
-    PoolEntry entry = pool.getConnection(config, "key");
-    pool.returnConnection(entry);
-    assertNotSame(entry, pool.getConnection(config, "key"));
-    verify(entry.getConnection(), times(1)).close();
-  }
-
-  @Test
-  public void testConnectionsGetCycled() throws IOException{
-    TestCloudbigtableConnectionPool pool = new TestCloudbigtableConnectionPool();
-    PoolEntry entry1 = pool.getConnection(config, "key");
-    PoolEntry entry2 = pool.getConnection(config, "key");
-    assertNotSame(entry1, entry2);
-    pool.returnConnection(entry1);
-    pool.returnConnection(entry2);
-    for (int i = 0; i < 100; i++) {
-      PoolEntry newEntry = pool.getConnection(config, "key");
-      assertSame(i % 2 == 0 ? entry1 : entry2, newEntry);
-      pool.returnConnection(newEntry);
     }
   }
 
   @Test
   public void testDifferentKeys() throws IOException{
     TestCloudbigtableConnectionPool pool = new TestCloudbigtableConnectionPool();
-    PoolEntry entry1 = pool.getConnection(config, "key1");
-    PoolEntry entry2 = pool.getConnection(config, "key2");
-    pool.returnConnection(entry1);
-    pool.returnConnection(entry2);
+    Connection entry1 = pool.getConnection(config, "key1");
+    Connection entry2 = pool.getConnection(config, "key2");
     for (int i = 0; i < 100; i++) {
-      PoolEntry newEntry1 = pool.getConnection(config, "key1");
+      Connection newEntry1 = pool.getConnection(config, "key1");
       assertSame(entry1, newEntry1);
-      pool.returnConnection(newEntry1);
 
-      PoolEntry newEntry2 = pool.getConnection(config, "key2");
+      Connection newEntry2 = pool.getConnection(config, "key2");
       assertSame(entry2, newEntry2);
-      pool.returnConnection(newEntry2);
     }
   }
 }


### PR DESCRIPTION
Moving the BigtableBufferedMutator offer() method.  This should also fix some of the issues in #630.  Each Connection opens up multiple channgles