### PR TITLE
Removing the buffered mutator "worker" behavior from dataflow.

### DIFF
--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableOptions.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableOptions.java
@@ -172,7 +172,7 @@ public class BigtableOptions implements Serializable {
 
     public Builder setAsyncMutatorWorkerCount(int asyncMutatorCount) {
       Preconditions.checkArgument(
-          asyncMutatorCount > 0, "asyncMutatorCount must be greater than 0.");
+          asyncMutatorCount >= 0, "asyncMutatorCount must be greater or equal to 0.");
       this.asyncMutatorCount = asyncMutatorCount;
       return this;
     }

--- a/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/CloudBigtableConfiguration.java
+++ b/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/CloudBigtableConfiguration.java
@@ -178,6 +178,13 @@ public class CloudBigtableConfiguration implements Serializable {
    */
   public Configuration toHBaseConfig() {
     Configuration config = new Configuration();
+
+    // This setting can potentially decrease performance for large scale writes. However, this
+    // setting prevents problems that occur when streaming Sources, such as PubSub, are used.
+    // To override this behavior, call:
+    //    Builder.withConfiguration(BigtableOptionsFactory.BIGTABLE_ASYNC_MUTATOR_COUNT_KEY, 
+    //                              BigtableOptions.BIGTABLE_ASYNC_MUTATOR_COUNT_DEFAULT);
+    config.set(BigtableOptionsFactory.BIGTABLE_ASYNC_MUTATOR_COUNT_KEY, "0");
     for (Entry<String, String> entry : configuration.entrySet()) {
       config.set(entry.getKey(), entry.getValue());
     }

--- a/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableBufferedMutator.java
+++ b/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableBufferedMutator.java
@@ -40,7 +40,6 @@ import org.mockito.MockitoAnnotations;
 
 import com.google.bigtable.v1.MutateRowRequest;
 import com.google.cloud.bigtable.config.BigtableOptions;
-import com.google.cloud.bigtable.grpc.BigtableClusterName;
 import com.google.cloud.bigtable.grpc.BigtableDataClient;
 import com.google.cloud.bigtable.grpc.async.AsyncExecutor;
 import com.google.cloud.bigtable.grpc.async.HeapSizeManager;
@@ -67,14 +66,14 @@ public class TestBigtableBufferedMutator {
   @Mock
   private BufferedMutator.ExceptionListener listener;
 
-  private BigtableBufferedMutator underTest;
   private List<FutureCallback<?>> callbacks = new ArrayList<>();
 
   @Before
   public void setUp() {
     MockitoAnnotations.initMocks(this);
-    BigtableClusterName clusterName = new BigtableClusterName("project", "zone", "cluster");
-    Configuration configuration = new Configuration();
+  }
+
+  private BigtableBufferedMutator createMutator(Configuration configuration) throws IOException {
     HeapSizeManager heapSizeManager =
         new HeapSizeManager(AsyncExecutor.ASYNC_MUTATOR_MAX_MEMORY_DEFAULT,
             AsyncExecutor.MAX_INFLIGHT_RPCS_DEFAULT) {
@@ -86,20 +85,26 @@ public class TestBigtableBufferedMutator {
           }
         };
 
-    HBaseRequestAdapter adapter =
-        new HBaseRequestAdapter(clusterName, TableName.valueOf("TABLE"), configuration);
+    configuration.set(BigtableOptionsFactory.PROJECT_ID_KEY, "project");
+    configuration.set(BigtableOptionsFactory.ZONE_KEY, "zone");
+    configuration.set(BigtableOptionsFactory.CLUSTER_KEY, "cluster");
 
-    underTest = new BigtableBufferedMutator(
+    BigtableOptions options = BigtableOptionsFactory.fromConfiguration(configuration);
+    HBaseRequestAdapter adapter = new HBaseRequestAdapter(
+        options.getClusterName(), TableName.valueOf("TABLE"), configuration);
+
+    return new BigtableBufferedMutator(
       client,
       adapter,
       configuration,
-      new BigtableOptions.Builder().build(),
+      options,
       listener,
       heapSizeManager);
   }
 
   @Test
-  public void testNoMutation() {
+  public void testNoMutation() throws IOException {
+    BigtableBufferedMutator underTest = createMutator(new Configuration());
     Assert.assertFalse(underTest.hasInflightRequests());
   }
 
@@ -107,27 +112,46 @@ public class TestBigtableBufferedMutator {
   @Test
   public void testMutation() throws IOException, InterruptedException {
     when(client.mutateRowAsync(any(MutateRowRequest.class))).thenReturn(future);
-    underTest.mutate(SIMPLE_PUT);
-    // Leave some time for the async worker to handle the request.
-    Thread.sleep(100);
-    verify(client, times(1)).mutateRowAsync(any(MutateRowRequest.class));
-    Assert.assertTrue(underTest.hasInflightRequests());
-    completeCall();
-    Assert.assertFalse(underTest.hasInflightRequests());
+    try (BigtableBufferedMutator underTest = createMutator(new Configuration())) {
+      underTest.mutate(SIMPLE_PUT);
+      // Leave some time for the async worker to handle the request.
+      Thread.sleep(100);
+      verify(client, times(1)).mutateRowAsync(any(MutateRowRequest.class));
+      Assert.assertTrue(underTest.hasInflightRequests());
+      completeCall();
+      Assert.assertFalse(underTest.hasInflightRequests());
+    }
   }
 
   @Test
   public void testInvalidPut() throws Exception {
     when(client.mutateRowAsync(any(MutateRowRequest.class))).thenThrow(new RuntimeException());
-    underTest.mutate(SIMPLE_PUT);
-    // Leave some time for the async worker to handle the request.
-    Thread.sleep(100);
-    verify(listener, times(0)).onException(any(RetriesExhaustedWithDetailsException.class),
-        same(underTest));
-    completeCall();
-    underTest.mutate(SIMPLE_PUT);
-    verify(listener, times(1)).onException(any(RetriesExhaustedWithDetailsException.class),
-        same(underTest));
+    try (BigtableBufferedMutator underTest = createMutator(new Configuration())) {
+      underTest.mutate(SIMPLE_PUT);
+      // Leave some time for the async worker to handle the request.
+      Thread.sleep(100);
+      verify(listener, times(0)).onException(any(RetriesExhaustedWithDetailsException.class),
+          same(underTest));
+      completeCall();
+      underTest.mutate(SIMPLE_PUT);
+      verify(listener, times(1)).onException(any(RetriesExhaustedWithDetailsException.class),
+          same(underTest));
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void testZeroWorkers() throws Exception {
+    when(client.mutateRowAsync(any(MutateRowRequest.class))).thenReturn(future);
+    Configuration config = new Configuration();
+    config.set(BigtableOptionsFactory.BIGTABLE_ASYNC_MUTATOR_COUNT_KEY, "0");
+    try (BigtableBufferedMutator underTest = createMutator(config)) {
+      underTest.mutate(SIMPLE_PUT);
+      verify(client, times(1)).mutateRowAsync(any(MutateRowRequest.class));
+      Assert.assertTrue(underTest.hasInflightRequests());
+      completeCall();
+      Assert.assertFalse(underTest.hasInflightRequests());
+    }
   }
 
   private void completeCall() {


### PR DESCRIPTION
This is the quickest way to fix #630.  It will have some potentially
negative performance impacts on dataflow writes compared to what
performance could be.  That said, there are other issues with
dataflow/bigtable that need solving in bigtable/dataflow that need
solving first.