### PR TITLE
Making sure BatchExecutor doesn't hang when a connection is closed.

### DIFF
--- a/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestBatch.java
+++ b/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestBatch.java
@@ -15,11 +15,20 @@
  */
 package com.google.cloud.bigtable.hbase;
 
-import static com.google.cloud.bigtable.hbase.IntegrationTests.*;
+import static com.google.cloud.bigtable.hbase.IntegrationTests.COLUMN_FAMILY;
+import static com.google.cloud.bigtable.hbase.IntegrationTests.TABLE_NAME;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
 
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.hadoop.hbase.CellUtil;
 import org.apache.hadoop.hbase.client.Append;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.ConnectionFactory;
 import org.apache.hadoop.hbase.client.Delete;
 import org.apache.hadoop.hbase.client.Get;
 import org.apache.hadoop.hbase.client.Increment;
@@ -32,13 +41,10 @@ import org.apache.hadoop.hbase.client.Table;
 import org.apache.hadoop.hbase.regionserver.NoSuchColumnFamilyException;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Random;
+import org.junit.rules.ExpectedException;
 
 public class TestBatch extends AbstractTest {
   /**
@@ -365,5 +371,20 @@ public class TestBatch extends AbstractTest {
       CellUtil.cloneValue(((Result) results[1]).getColumnLatestCell(COLUMN_FAMILY, qual2)));
 
     table.close();
+  }
+
+  @Test
+  public void testBatchDoesntHang() throws Exception {
+    Connection closedConnection = ConnectionFactory.createConnection(IntegrationTests.getConfiguration());
+    Table table = closedConnection.getTable(TABLE_NAME);
+    closedConnection.close();
+    try {
+      table.batch(Arrays.asList(new Get(Bytes.toBytes("key"))), new Object[1]);
+      Assert.fail("Expected an exception");
+    } catch(RetriesExhaustedWithDetailsException e) {
+      Assert.assertEquals(1, e.getCauses().size());
+      Assert.assertEquals(IOException.class, e.getCause(0).getClass());
+      Assert.assertTrue(e.getCause(0).getMessage().toLowerCase().contains("closed"));
+    }
   }
 }

--- a/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestBatch.java
+++ b/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestBatch.java
@@ -41,10 +41,8 @@ import org.apache.hadoop.hbase.client.Table;
 import org.apache.hadoop.hbase.regionserver.NoSuchColumnFamilyException;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.Assert;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.junit.rules.ExpectedException;
 
 public class TestBatch extends AbstractTest {
   /**

--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BatchExecutor.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BatchExecutor.java
@@ -153,7 +153,7 @@ public class BatchExecutor {
    * @return A ListenableFuture that will have the result when the RPC completes.
    */
   private <R extends Row, T> ListenableFuture<Result> issueAsyncRowRequest(Row row,
-      Batch.Callback<T> callback, Object[] results, int index) throws InterruptedException {
+      Batch.Callback<T> callback, Object[] results, int index) {
     LOG.trace("issueRowRequest(Row, Batch.Callback, Object[], index");
     SettableFuture<Result> resultFuture = SettableFuture.create();
     RpcResultFutureCallback<T> futureCallback =
@@ -163,8 +163,8 @@ public class BatchExecutor {
       // If the service is shutdown, that means that the connection is shut down. It also means that
       // the line:
       // Futures.addCallback(future, futureCallback, service);
-      // which uses the service will throw a rejected execution exception. A
-      // ConnectionClosedException is more appropriate and informative.
+      // which uses the service will throw a rejected execution exception. In that case, throw an
+      // IOException like HBase does.
       ListenableFuture<? extends GeneratedMessage> failFuture =
           Futures.immediateFailedFuture(new IOException(
               "Cannot perform batch operations when a connection is closed"));
@@ -176,8 +176,7 @@ public class BatchExecutor {
     return resultFuture;
   }
 
-  private ListenableFuture<? extends GeneratedMessage> issueAsyncRequest(Row row)
-      throws InterruptedException {
+  private ListenableFuture<? extends GeneratedMessage> issueAsyncRequest(Row row) {
     try {
       if (row instanceof Get) {
         return Futures.transform(
@@ -235,7 +234,7 @@ public class BatchExecutor {
   }
 
   private <R> List<ListenableFuture<?>> issueAsyncRowRequests(List<? extends Row> actions,
-      Object[] results, Batch.Callback<R> callback) throws InterruptedException {
+      Object[] results, Batch.Callback<R> callback) {
     List<ListenableFuture<?>> resultFutures = new ArrayList<>(actions.size());
     for (int i = 0; i < actions.size(); i++) {
       resultFutures.add(issueAsyncRowRequest(actions.get(i), callback, results, i));


### PR DESCRIPTION
If a connection is closed, async executor will throw an exception, but only after it registered in the HeapSizeManager; the operation doesn't unregister in that case.  That leads to the client hanging forever.  Returning a future that immediately fails solves this problem.  The failure informs the FutureCallable from the HeapSizeManager that an error occured and that the operation can be marked as complete.
This fixes a problem a user found in #638 .