### PR TITLE
Dataflow configs should not load xml files by default.

### DIFF
--- a/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/CloudBigtableConfiguration.java
+++ b/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/CloudBigtableConfiguration.java
@@ -177,7 +177,7 @@ public class CloudBigtableConfiguration implements Serializable {
    * @return The {@link Configuration}.
    */
   public Configuration toHBaseConfig() {
-    Configuration config = new Configuration();
+    Configuration config = new Configuration(false);
 
     // This setting can potentially decrease performance for large scale writes. However, this
     // setting prevents problems that occur when streaming Sources, such as PubSub, are used.

--- a/bigtable-hbase-dataflow/src/test/java/com/google/cloud/bigtable/dataflow/CloudBigtableConnectionPoolTest.java
+++ b/bigtable-hbase-dataflow/src/test/java/com/google/cloud/bigtable/dataflow/CloudBigtableConnectionPoolTest.java
@@ -33,7 +33,7 @@ import org.junit.runners.JUnit4;
 @SuppressWarnings("deprecation")
 public class CloudBigtableConnectionPoolTest {
 
-  private static Configuration config = new Configuration();
+  private static Configuration config = new Configuration(false);
 
   private static class TestCloudbigtableConnectionPool extends CloudBigtableConnectionPool {
     @Override

--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableConfiguration.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableConfiguration.java
@@ -44,7 +44,7 @@ public class BigtableConfiguration {
   }
 
   public static Configuration configure(String projectId, String zoneName, String clusterName) {
-    Configuration config = new Configuration();
+    Configuration config = new Configuration(false);
     config.set(BigtableOptionsFactory.PROJECT_ID_KEY, projectId);
     config.set(BigtableOptionsFactory.ZONE_KEY, zoneName);
     config.set(BigtableOptionsFactory.CLUSTER_KEY, clusterName);

--- a/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableBufferedMutator.java
+++ b/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableBufferedMutator.java
@@ -104,7 +104,7 @@ public class TestBigtableBufferedMutator {
 
   @Test
   public void testNoMutation() throws IOException {
-    BigtableBufferedMutator underTest = createMutator(new Configuration());
+    BigtableBufferedMutator underTest = createMutator(new Configuration(false));
     Assert.assertFalse(underTest.hasInflightRequests());
   }
 
@@ -112,7 +112,7 @@ public class TestBigtableBufferedMutator {
   @Test
   public void testMutation() throws IOException, InterruptedException {
     when(client.mutateRowAsync(any(MutateRowRequest.class))).thenReturn(future);
-    try (BigtableBufferedMutator underTest = createMutator(new Configuration())) {
+    try (BigtableBufferedMutator underTest = createMutator(new Configuration(false))) {
       underTest.mutate(SIMPLE_PUT);
       // Leave some time for the async worker to handle the request.
       Thread.sleep(100);
@@ -126,7 +126,7 @@ public class TestBigtableBufferedMutator {
   @Test
   public void testInvalidPut() throws Exception {
     when(client.mutateRowAsync(any(MutateRowRequest.class))).thenThrow(new RuntimeException());
-    try (BigtableBufferedMutator underTest = createMutator(new Configuration())) {
+    try (BigtableBufferedMutator underTest = createMutator(new Configuration(false))) {
       underTest.mutate(SIMPLE_PUT);
       // Leave some time for the async worker to handle the request.
       Thread.sleep(100);
@@ -143,7 +143,7 @@ public class TestBigtableBufferedMutator {
   @Test
   public void testZeroWorkers() throws Exception {
     when(client.mutateRowAsync(any(MutateRowRequest.class))).thenReturn(future);
-    Configuration config = new Configuration();
+    Configuration config = new Configuration(false);
     config.set(BigtableOptionsFactory.BIGTABLE_ASYNC_MUTATOR_COUNT_KEY, "0");
     try (BigtableBufferedMutator underTest = createMutator(config)) {
       underTest.mutate(SIMPLE_PUT);

--- a/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableOptionsFactory.java
+++ b/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableOptionsFactory.java
@@ -47,7 +47,7 @@ public class TestBigtableOptionsFactory {
 
   @Before
   public void setup() {
-    configuration = new Configuration();
+    configuration = new Configuration(false);
     configuration.set(BigtableOptionsFactory.BIGTABLE_HOST_KEY, TEST_HOST);
     configuration.set(BigtableOptionsFactory.PROJECT_ID_KEY, TEST_PROJECT_ID);
     configuration.set(BigtableOptionsFactory.CLUSTER_KEY, TEST_CLUSTER_NAME);
@@ -56,7 +56,7 @@ public class TestBigtableOptionsFactory {
 
   @Test
   public void testProjectIdIsRequired() throws IOException {
-    Configuration configuration = new Configuration();
+    Configuration configuration = new Configuration(false);
     configuration.unset(BigtableOptionsFactory.PROJECT_ID_KEY);
 
     expectedException.expect(IllegalArgumentException.class);
@@ -65,7 +65,7 @@ public class TestBigtableOptionsFactory {
 
   @Test
   public void testHostIsRequired() throws IOException {
-    Configuration configuration = new Configuration();
+    Configuration configuration = new Configuration(false);
     configuration.unset(BigtableOptionsFactory.BIGTABLE_HOST_KEY);
 
     expectedException.expect(IllegalArgumentException.class);
@@ -74,7 +74,7 @@ public class TestBigtableOptionsFactory {
 
   @Test
   public void testClusterIsRequired() throws IOException {
-    Configuration configuration = new Configuration();
+    Configuration configuration = new Configuration(false);
     configuration.unset(BigtableOptionsFactory.CLUSTER_KEY);
 
     expectedException.expect(IllegalArgumentException.class);
@@ -83,7 +83,7 @@ public class TestBigtableOptionsFactory {
 
   @Test
   public void testZoneIsRequired() throws IOException {
-    Configuration configuration = new Configuration();
+    Configuration configuration = new Configuration(false);
     configuration.unset(BigtableOptionsFactory.ZONE_KEY);
 
     expectedException.expect(IllegalArgumentException.class);

--- a/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableTable.java
+++ b/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableTable.java
@@ -108,7 +108,7 @@ public class TestBigtableTable {
         .setUserAgent("testAgent")
         .build();
 
-    Configuration config = new Configuration();
+    Configuration config = new Configuration(false);
     TableName tableName = TableName.valueOf(TEST_TABLE);
     HBaseRequestAdapter hbaseAdapter =
         new HBaseRequestAdapter(options.getClusterName(), tableName, config);

--- a/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestClusterAPI.java
+++ b/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestClusterAPI.java
@@ -74,7 +74,7 @@ public class TestClusterAPI {
     }
     int clusterSize = Integer.parseInt(System.getProperty("bigtable.test.cluster.size", "3"));
 
-    Configuration configuration = new Configuration();
+    Configuration configuration = new Configuration(false);
     for (Entry<Object, Object> entry : System.getProperties().entrySet()) {
       configuration.set(entry.getKey().toString(), entry.getValue().toString());
     }


### PR DESCRIPTION
Loading the xml files causes look ups in .jar files for .xml files. That causes problems if it's done too often.  Dataflow doesn't have those files anyway, so don't look them up to avoid locking issues found in #630.