### PR TITLE
Simplify the generics declaration by using the diamond operator ("<>"……) to reduce the verbosity of generics code.

### DIFF
--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataGrpcClient.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataGrpcClient.java
@@ -183,7 +183,7 @@ public class BigtableDataGrpcClient implements BigtableDataClient {
   private <ReqT, RespT> ClientCall<ReqT, RespT> createRetryableCall(
       MethodDescriptor<ReqT, RespT> method, Predicate<ReqT> isRetryable, ReqT request) {
     if (retryOptions.enableRetries() && isRetryable.apply(request)) {
-      return new RetryingCall<ReqT, RespT>(channelPool, method, CallOptions.DEFAULT,
+      return new RetryingCall<>(channelPool, method, CallOptions.DEFAULT,
           retryExecutorService, retryOptions);
     } else {
       return channelPool.newCall(method, CallOptions.DEFAULT);

--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/RetryingRpcFunction.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/RetryingRpcFunction.java
@@ -40,7 +40,7 @@ public class RetryingRpcFunction<RequestT, ResponseT>
 
   public static <RequestT, ResponseT> RetryingRpcFunction<RequestT, ResponseT> create(
       RetryOptions retryOptions, RequestT request, RetryableRpc<RequestT, ResponseT> retryableRpc) {
-    return new RetryingRpcFunction<RequestT, ResponseT>(retryOptions, request, retryableRpc);
+    return new RetryingRpcFunction<>(retryOptions, request, retryableRpc);
   }
 
   protected final Log LOG = LogFactory.getLog(RetryingRpcFunction.class);

--- a/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestBatch.java
+++ b/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestBatch.java
@@ -69,7 +69,7 @@ public class TestBatch extends AbstractTest {
 
     Put put1 = new Put(rowKey1).addColumn(COLUMN_FAMILY, qual1, value1);
     Put put2 = new Put(rowKey2).addColumn(COLUMN_FAMILY, qual2, value2);
-    List<Row> batch = new ArrayList<Row>(2);
+    List<Row> batch = new ArrayList<>(2);
     batch.add(put1);
     batch.add(put2);
     Object[] results = new Object[batch.size()];
@@ -144,7 +144,7 @@ public class TestBatch extends AbstractTest {
     // Put
     Put put1 = new Put(rowKey1).addColumn(COLUMN_FAMILY, qual1, Bytes.toBytes(value1));
     Put put2 = new Put(rowKey2).addColumn(COLUMN_FAMILY, qual2, Bytes.toBytes(value2));
-    List<Row> batch = new ArrayList<Row>(2);
+    List<Row> batch = new ArrayList<>(2);
     batch.add(put1);
     batch.add(put2);
     table.batch(batch, null);
@@ -184,7 +184,7 @@ public class TestBatch extends AbstractTest {
     // Put
     Put put1 = new Put(rowKey1).addColumn(COLUMN_FAMILY, qual1, value1_1);
     Put put2 = new Put(rowKey2).addColumn(COLUMN_FAMILY, qual2, value2_1);
-    List<Row> batch = new ArrayList<Row>(2);
+    List<Row> batch = new ArrayList<>(2);
     batch.add(put1);
     batch.add(put2);
     table.batch(batch, null);
@@ -226,7 +226,7 @@ public class TestBatch extends AbstractTest {
     Put put2 = new Put(rowKeys[2]).addColumn(COLUMN_FAMILY, quals[2], values[2]);
     Put put3 = new Put(rowKeys[3]).addColumn(Bytes.toBytes("NO SUCH FAMILY"), quals[3], values[3]);
     Put put4 = new Put(rowKeys[4]).addColumn(COLUMN_FAMILY, quals[4], values[4]);
-    List<Row> batch = new ArrayList<Row>(5);
+    List<Row> batch = new ArrayList<>(5);
     Object[] results = new Object[5];
     batch.add(put0);
     batch.add(put1);  // This one is bad
@@ -256,7 +256,7 @@ public class TestBatch extends AbstractTest {
     Assert.assertTrue("#4 should be a Result", results[4] instanceof Result);
 
     // Check values.  The good puts should have worked.
-    List<Get> gets = new ArrayList<Get>(5);
+    List<Get> gets = new ArrayList<>(5);
     for (int i = 0; i < 5; ++i) {
       gets.add(new Get(rowKeys[i]));
     }
@@ -335,7 +335,7 @@ public class TestBatch extends AbstractTest {
 
     Put put1 = new Put(rowKey1).addColumn(COLUMN_FAMILY, qual1, value1);
     Put put2 = new Put(rowKey2).addColumn(COLUMN_FAMILY, qual2, value2);
-    List<Row> batch = new ArrayList<Row>(2);
+    List<Row> batch = new ArrayList<>(2);
     batch.add(put1);
     batch.add(put2);
     Object[] results = new Object[batch.size()];

--- a/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestGet.java
+++ b/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestGet.java
@@ -262,7 +262,7 @@ public class TestGet extends AbstractTest {
 
     // Insert a bunch of columns.
     Put put = new Put(rowKey);
-    List<QualifierValue> keyValues = new ArrayList<QualifierValue>();
+    List<QualifierValue> keyValues = new ArrayList<>();
     for (int i = 0; i < totalColumns; ++i) {
       put.addColumn(COLUMN_FAMILY, quals[i], timestamps[i], values[i]);
 
@@ -345,7 +345,7 @@ public class TestGet extends AbstractTest {
     byte[][] values = dataHelper.randomData("value-", numValues);
 
     // Insert a bunch of data
-    List<Put> puts = new ArrayList<Put>(numValues);
+    List<Put> puts = new ArrayList<>(numValues);
     for (int i = 0; i < numValues; ++i) {
       Put put = new Put(rowKeys[i]);
       put.addColumn(COLUMN_FAMILY, quals[i], values[0]);
@@ -354,7 +354,7 @@ public class TestGet extends AbstractTest {
     table.put(puts);
 
     // Test just keys, both individually and as batch.
-    List<Get> gets = new ArrayList<Get>(numValues);
+    List<Get> gets = new ArrayList<>(numValues);
     for(int i = 0; i < numValues; ++i) {
       Get get = new Get(rowKeys[i]);
       Assert.assertTrue(table.exists(get));
@@ -470,7 +470,7 @@ public class TestGet extends AbstractTest {
     int numValues = 10;
 
     // Run a control test.
-    List<Get> gets = new ArrayList<Get>(numValues + 1);
+    List<Get> gets = new ArrayList<>(numValues + 1);
     for (int i = 0; i < numValues; ++i) {
       Get get = new Get(dataHelper.randomData("key-"));
       get.addColumn(COLUMN_FAMILY, dataHelper.randomData("qual-"));

--- a/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestPut.java
+++ b/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestPut.java
@@ -63,7 +63,7 @@ public class TestPut extends AbstractTest {
 
     // Construct put with NUM_CELL random qualifier/value combos
     Put put = new Put(rowKey);
-    List<QualifierValue> keyValues = new ArrayList<QualifierValue>(100);
+    List<QualifierValue> keyValues = new ArrayList<>(100);
     for (int i = 0; i < NUM_CELLS; ++i) {
       put.addColumn(COLUMN_FAMILY, quals[i], values[i]);
       keyValues.add(new QualifierValue(quals[i], values[i]));
@@ -105,9 +105,9 @@ public class TestPut extends AbstractTest {
     byte[][] values = dataHelper.randomData("testValue-", NUM_ROWS);
 
     // Do puts
-    List<Put> puts = new ArrayList<Put>(NUM_ROWS);
-    List<String> keys = new ArrayList<String>(NUM_ROWS);
-    Map<String, QualifierValue> insertedKeyValues = new TreeMap<String, QualifierValue>();
+    List<Put> puts = new ArrayList<>(NUM_ROWS);
+    List<String> keys = new ArrayList<>(NUM_ROWS);
+    Map<String, QualifierValue> insertedKeyValues = new TreeMap<>();
     for (int i = 0; i < NUM_ROWS; ++i) {
       Put put = new Put(rowKeys[i]);
       put.addColumn(COLUMN_FAMILY, qualifiers[i], values[i]);
@@ -120,7 +120,7 @@ public class TestPut extends AbstractTest {
     table.put(puts);
 
     // Get
-    List<Get> gets = new ArrayList<Get>(NUM_ROWS);
+    List<Get> gets = new ArrayList<>(NUM_ROWS);
     Collections.shuffle(keys);  // Retrieve in random order
     for (String key : keys) {
       Get get = new Get(Bytes.toBytes(key));
@@ -143,7 +143,7 @@ public class TestPut extends AbstractTest {
     }
 
     // Delete
-    List<Delete> deletes = new ArrayList<Delete>(NUM_ROWS);
+    List<Delete> deletes = new ArrayList<>(NUM_ROWS);
     for (byte[] rowKey : rowKeys) {
       Delete delete = new Delete(rowKey);
       deletes.add(delete);
@@ -343,7 +343,7 @@ public class TestPut extends AbstractTest {
     }
     multiplePutsOneBad(numberOfGoodPuts, goodkeys, badkey);
 
-    List<Get> gets = new ArrayList<Get>();
+    List<Get> gets = new ArrayList<>();
     for (int i = 0; i < numberOfGoodPuts; ++i) {
       Get get = new Get(goodkeys[i]);
       gets.add(get);
@@ -368,8 +368,8 @@ public class TestPut extends AbstractTest {
 
     // Construct put with NUM_CELL random qualifier/value combos
     Put put = new Put(rowKey);
-    List<QualifierValue> family1KeyValues = new ArrayList<QualifierValue>(100);
-    List<QualifierValue> family2KeyValues = new ArrayList<QualifierValue>(100);
+    List<QualifierValue> family1KeyValues = new ArrayList<>(100);
+    List<QualifierValue> family2KeyValues = new ArrayList<>(100);
     for (int i = 0; i < NUM_CELLS; i++) {
       put.addColumn(COLUMN_FAMILY, quals[i], values[i]);
       family1KeyValues.add(new QualifierValue(quals[i], values[i]));
@@ -416,7 +416,7 @@ public class TestPut extends AbstractTest {
   private void multiplePutsOneBad(int numberOfGoodPuts, byte[][] goodkeys, byte[] badkey)
       throws IOException {
     Table table = getConnection().getTable(TABLE_NAME);
-    List<Put> puts = new ArrayList<Put>();
+    List<Put> puts = new ArrayList<>();
     for (int i = 0; i < numberOfGoodPuts; ++i) {
       byte[] qualifier = Bytes.toBytes("testQualifier-" + RandomStringUtils.randomAlphanumeric(8));
       byte[] value = Bytes.toBytes("testValue-" + RandomStringUtils.randomAlphanumeric(8));

--- a/bigtable-hbase-mapreduce/src/main/java/com/google/cloud/bigtable/mapreduce/Import.java
+++ b/bigtable-hbase-mapreduce/src/main/java/com/google/cloud/bigtable/mapreduce/Import.java
@@ -257,7 +257,7 @@ public class Import extends Configured implements Tool {
   }
 
   private static ArrayList<byte[]> toQuotedByteArrays(String... stringArgs) {
-    ArrayList<byte[]> quotedArgs = new ArrayList<byte[]>();
+    ArrayList<byte[]> quotedArgs = new ArrayList<>();
     for (String stringArg : stringArgs) {
       // all the filters' instantiation methods expected quoted args since they are coming from
       // the shell, so add them here, though it shouldn't really be needed :-/
@@ -322,7 +322,7 @@ public class Import extends Configured implements Tool {
       String[] allMappings = allMappingsPropVal.split(",");
       for (String mapping: allMappings) {
         if(cfRenameMap == null) {
-            cfRenameMap = new TreeMap<byte[],byte[]>(Bytes.BYTES_COMPARATOR);
+            cfRenameMap = new TreeMap<>(Bytes.BYTES_COMPARATOR);
         }
         String [] srcAndDest = mapping.split(":");
         if(srcAndDest.length != 2) {

--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BatchExecutor.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BatchExecutor.java
@@ -157,7 +157,7 @@ public class BatchExecutor {
     LOG.trace("issueRowRequest(Row, Batch.Callback, Object[], index");
     SettableFuture<Result> resultFuture = SettableFuture.create();
     RpcResultFutureCallback<T> futureCallback =
-        new RpcResultFutureCallback<T>(row, callback, index, results, resultFuture);
+            new RpcResultFutureCallback<>(row, callback, index, results, resultFuture);
     results[index] = null;
     if (service.isShutdown()) {
       // If the service is shutdown, that means that the connection is shut down. It also means that

--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutator.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutator.java
@@ -105,7 +105,7 @@ public class BigtableBufferedMutator implements BufferedMutator {
   private final ExceptionListener exceptionListener;
 
   private final AtomicBoolean hasExceptions = new AtomicBoolean(false);
-  private final List<MutationException> globalExceptions = new ArrayList<MutationException>();
+  private final List<MutationException> globalExceptions = new ArrayList<>();
 
   private final String host;
 

--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/ColumnDescriptorAdapter.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/ColumnDescriptorAdapter.java
@@ -83,7 +83,7 @@ public class ColumnDescriptorAdapter {
    * Build a list of configuration keys that we don't know how to handle
    */
   public static List<String> getUnknownFeatures(HColumnDescriptor columnDescriptor) {
-    List<String> unknownFeatures = new ArrayList<String>();
+    List<String> unknownFeatures = new ArrayList<>();
     for (Map.Entry<String, String> entry : columnDescriptor.getConfiguration().entrySet()) {
       String key = entry.getKey();
       if (!SUPPORTED_OPTION_KEYS.contains(key)
@@ -99,7 +99,7 @@ public class ColumnDescriptorAdapter {
    * Build a Map of configuration keys and values describing configuration values we don't support.
    */
   public static Map<String, String> getUnsupportedFeatures(HColumnDescriptor columnDescriptor) {
-    Map<String, String> unsupportedConfiguration = new HashMap<String, String>();
+    Map<String, String> unsupportedConfiguration = new HashMap<>();
 
     Map<String, String> configuration = columnDescriptor.getConfiguration();
     for (Map.Entry<String, String> entry : SUPPORTED_OPTION_VALUES.entrySet()) {
@@ -133,7 +133,7 @@ public class ColumnDescriptorAdapter {
   public static void throwIfRequestingUnsupportedFeatures(HColumnDescriptor columnDescriptor) {
     Map<String, String> unsupportedConfiguration = getUnsupportedFeatures(columnDescriptor);
     if (!unsupportedConfiguration.isEmpty()) {
-      List<String> configurationStrings = new ArrayList<String>(unsupportedConfiguration.size());
+      List<String> configurationStrings = new ArrayList<>(unsupportedConfiguration.size());
       for (Map.Entry<String, String> entry : unsupportedConfiguration.entrySet()) {
         configurationStrings.add(String.format("(%s: %s)", entry.getKey(), entry.getValue()));
       }

--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/MutationAdapter.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/MutationAdapter.java
@@ -36,7 +36,7 @@ public class MutationAdapter
 
   static class AdapterInstanceMap {
     private Map<Class<?>, OperationAdapter<?, ?>> unsafeMap =
-        new HashMap<Class<?>, OperationAdapter<?, ?>>();
+            new HashMap<>();
 
     public <S extends Mutation, U extends OperationAdapter<S, MutateRowRequest.Builder>>
     Class<S> put(Class<S> key, U adapter) {

--- a/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableAdmin.java
+++ b/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableAdmin.java
@@ -357,7 +357,7 @@ public abstract class AbstractBigtableAdmin implements Admin {
 
   @Override
   public HTableDescriptor[] deleteTables(Pattern pattern) throws IOException {
-    List<HTableDescriptor> failed = new LinkedList<HTableDescriptor>();
+    List<HTableDescriptor> failed = new LinkedList<>();
     for (HTableDescriptor table : listTables(pattern)) {
       try {
         deleteTable(table.getTableName());

--- a/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableConnection.java
+++ b/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableConnection.java
@@ -326,8 +326,8 @@ public abstract class AbstractBigtableConnection implements Connection, Closeabl
           int minThreads = Math.min(getCoreThreads(), maxThreads);
           long keepAliveTime = conf.getLong("hbase.hconnection.threads.keepalivetime", 60);
           LinkedBlockingQueue<Runnable> workQueue =
-              new LinkedBlockingQueue<Runnable>(128 * conf.getInt("hbase.client.max.total.tasks",
-                200));
+                  new LinkedBlockingQueue<>(128 * conf.getInt("hbase.client.max.total.tasks",
+                          200));
           this.batchPool = new ThreadPoolExecutor(
               minThreads,
               maxThreads,

--- a/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/TestUnsupportedOperationAdapter.java
+++ b/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/TestUnsupportedOperationAdapter.java
@@ -32,7 +32,7 @@ public class TestUnsupportedOperationAdapter {
   @Test
   public void testUnsupportedOperationExceptionIsThrownOnUse() {
     UnsupportedOperationAdapter<Append> unsupportedOperationAdapter =
-        new UnsupportedOperationAdapter<Append>("append");
+            new UnsupportedOperationAdapter<>("append");
 
     expectedException.expect(UnsupportedOperationException.class);
     expectedException.expectMessage("operation is unsupported");

--- a/bigtable-protos/src/generated/java/protos/com/google/api/HttpRule.java
+++ b/bigtable-protos/src/generated/java/protos/com/google/api/HttpRule.java
@@ -148,7 +148,7 @@ public  final class HttpRule extends
           }
           case 90: {
             if (!((mutable_bitField0_ & 0x00000080) == 0x00000080)) {
-              additionalBindings_ = new java.util.ArrayList<com.google.api.HttpRule>();
+              additionalBindings_ = new java.util.ArrayList<>();
               mutable_bitField0_ |= 0x00000080;
             }
             additionalBindings_.add(input.readMessage(com.google.api.HttpRule.parser(), extensionRegistry));
@@ -1688,8 +1688,7 @@ public  final class HttpRule extends
         if (!(patternCase_ == 8)) {
           pattern_ = com.google.api.CustomHttpPattern.getDefaultInstance();
         }
-        customBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-            com.google.api.CustomHttpPattern, com.google.api.CustomHttpPattern.Builder, com.google.api.CustomHttpPatternOrBuilder>(
+        customBuilder_ = new com.google.protobuf.SingleFieldBuilder<>(
                 (com.google.api.CustomHttpPattern) pattern_,
                 getParentForChildren(),
                 isClean());
@@ -1803,7 +1802,7 @@ public  final class HttpRule extends
       java.util.Collections.emptyList();
     private void ensureAdditionalBindingsIsMutable() {
       if (!((bitField0_ & 0x00000080) == 0x00000080)) {
-        additionalBindings_ = new java.util.ArrayList<com.google.api.HttpRule>(additionalBindings_);
+        additionalBindings_ = new java.util.ArrayList<>(additionalBindings_);
         bitField0_ |= 0x00000080;
        }
     }
@@ -2118,8 +2117,7 @@ public  final class HttpRule extends
         com.google.api.HttpRule, com.google.api.HttpRule.Builder, com.google.api.HttpRuleOrBuilder> 
         getAdditionalBindingsFieldBuilder() {
       if (additionalBindingsBuilder_ == null) {
-        additionalBindingsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-            com.google.api.HttpRule, com.google.api.HttpRule.Builder, com.google.api.HttpRuleOrBuilder>(
+        additionalBindingsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<>(
                 additionalBindings_,
                 ((bitField0_ & 0x00000080) == 0x00000080),
                 getParentForChildren(),

--- a/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/cluster/v1/Cluster.java
+++ b/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/cluster/v1/Cluster.java
@@ -826,8 +826,7 @@ public  final class Cluster extends
         com.google.longrunning.Operation, com.google.longrunning.Operation.Builder, com.google.longrunning.OperationOrBuilder> 
         getCurrentOperationFieldBuilder() {
       if (currentOperationBuilder_ == null) {
-        currentOperationBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-            com.google.longrunning.Operation, com.google.longrunning.Operation.Builder, com.google.longrunning.OperationOrBuilder>(
+        currentOperationBuilder_ = new com.google.protobuf.SingleFieldBuilder<>(
                 getCurrentOperation(),
                 getParentForChildren(),
                 isClean());

--- a/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/cluster/v1/CreateClusterMetadata.java
+++ b/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/cluster/v1/CreateClusterMetadata.java
@@ -612,8 +612,7 @@ public  final class CreateClusterMetadata extends
         com.google.bigtable.admin.cluster.v1.CreateClusterRequest, com.google.bigtable.admin.cluster.v1.CreateClusterRequest.Builder, com.google.bigtable.admin.cluster.v1.CreateClusterRequestOrBuilder> 
         getOriginalRequestFieldBuilder() {
       if (originalRequestBuilder_ == null) {
-        originalRequestBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-            com.google.bigtable.admin.cluster.v1.CreateClusterRequest, com.google.bigtable.admin.cluster.v1.CreateClusterRequest.Builder, com.google.bigtable.admin.cluster.v1.CreateClusterRequestOrBuilder>(
+        originalRequestBuilder_ = new com.google.protobuf.SingleFieldBuilder<>(
                 getOriginalRequest(),
                 getParentForChildren(),
                 isClean());
@@ -765,8 +764,7 @@ public  final class CreateClusterMetadata extends
         com.google.protobuf.Timestamp, com.google.protobuf.Timestamp.Builder, com.google.protobuf.TimestampOrBuilder> 
         getRequestTimeFieldBuilder() {
       if (requestTimeBuilder_ == null) {
-        requestTimeBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-            com.google.protobuf.Timestamp, com.google.protobuf.Timestamp.Builder, com.google.protobuf.TimestampOrBuilder>(
+        requestTimeBuilder_ = new com.google.protobuf.SingleFieldBuilder<>(
                 getRequestTime(),
                 getParentForChildren(),
                 isClean());
@@ -918,8 +916,7 @@ public  final class CreateClusterMetadata extends
         com.google.protobuf.Timestamp, com.google.protobuf.Timestamp.Builder, com.google.protobuf.TimestampOrBuilder> 
         getFinishTimeFieldBuilder() {
       if (finishTimeBuilder_ == null) {
-        finishTimeBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-            com.google.protobuf.Timestamp, com.google.protobuf.Timestamp.Builder, com.google.protobuf.TimestampOrBuilder>(
+        finishTimeBuilder_ = new com.google.protobuf.SingleFieldBuilder<>(
                 getFinishTime(),
                 getParentForChildren(),
                 isClean());

--- a/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/cluster/v1/CreateClusterRequest.java
+++ b/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/cluster/v1/CreateClusterRequest.java
@@ -823,8 +823,7 @@ public  final class CreateClusterRequest extends
         com.google.bigtable.admin.cluster.v1.Cluster, com.google.bigtable.admin.cluster.v1.Cluster.Builder, com.google.bigtable.admin.cluster.v1.ClusterOrBuilder> 
         getClusterFieldBuilder() {
       if (clusterBuilder_ == null) {
-        clusterBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-            com.google.bigtable.admin.cluster.v1.Cluster, com.google.bigtable.admin.cluster.v1.Cluster.Builder, com.google.bigtable.admin.cluster.v1.ClusterOrBuilder>(
+        clusterBuilder_ = new com.google.protobuf.SingleFieldBuilder<>(
                 getCluster(),
                 getParentForChildren(),
                 isClean());

--- a/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/cluster/v1/ListClustersResponse.java
+++ b/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/cluster/v1/ListClustersResponse.java
@@ -49,7 +49,7 @@ public  final class ListClustersResponse extends
           }
           case 10: {
             if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
-              clusters_ = new java.util.ArrayList<com.google.bigtable.admin.cluster.v1.Cluster>();
+              clusters_ = new java.util.ArrayList<>();
               mutable_bitField0_ |= 0x00000001;
             }
             clusters_.add(input.readMessage(com.google.bigtable.admin.cluster.v1.Cluster.parser(), extensionRegistry));
@@ -57,7 +57,7 @@ public  final class ListClustersResponse extends
           }
           case 18: {
             if (!((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
-              failedZones_ = new java.util.ArrayList<com.google.bigtable.admin.cluster.v1.Zone>();
+              failedZones_ = new java.util.ArrayList<>();
               mutable_bitField0_ |= 0x00000002;
             }
             failedZones_.add(input.readMessage(com.google.bigtable.admin.cluster.v1.Zone.parser(), extensionRegistry));
@@ -504,7 +504,7 @@ public  final class ListClustersResponse extends
       java.util.Collections.emptyList();
     private void ensureClustersIsMutable() {
       if (!((bitField0_ & 0x00000001) == 0x00000001)) {
-        clusters_ = new java.util.ArrayList<com.google.bigtable.admin.cluster.v1.Cluster>(clusters_);
+        clusters_ = new java.util.ArrayList<>(clusters_);
         bitField0_ |= 0x00000001;
        }
     }
@@ -801,8 +801,7 @@ public  final class ListClustersResponse extends
         com.google.bigtable.admin.cluster.v1.Cluster, com.google.bigtable.admin.cluster.v1.Cluster.Builder, com.google.bigtable.admin.cluster.v1.ClusterOrBuilder> 
         getClustersFieldBuilder() {
       if (clustersBuilder_ == null) {
-        clustersBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-            com.google.bigtable.admin.cluster.v1.Cluster, com.google.bigtable.admin.cluster.v1.Cluster.Builder, com.google.bigtable.admin.cluster.v1.ClusterOrBuilder>(
+        clustersBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<>(
                 clusters_,
                 ((bitField0_ & 0x00000001) == 0x00000001),
                 getParentForChildren(),
@@ -816,7 +815,7 @@ public  final class ListClustersResponse extends
       java.util.Collections.emptyList();
     private void ensureFailedZonesIsMutable() {
       if (!((bitField0_ & 0x00000002) == 0x00000002)) {
-        failedZones_ = new java.util.ArrayList<com.google.bigtable.admin.cluster.v1.Zone>(failedZones_);
+        failedZones_ = new java.util.ArrayList<>(failedZones_);
         bitField0_ |= 0x00000002;
        }
     }
@@ -1113,8 +1112,7 @@ public  final class ListClustersResponse extends
         com.google.bigtable.admin.cluster.v1.Zone, com.google.bigtable.admin.cluster.v1.Zone.Builder, com.google.bigtable.admin.cluster.v1.ZoneOrBuilder> 
         getFailedZonesFieldBuilder() {
       if (failedZonesBuilder_ == null) {
-        failedZonesBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-            com.google.bigtable.admin.cluster.v1.Zone, com.google.bigtable.admin.cluster.v1.Zone.Builder, com.google.bigtable.admin.cluster.v1.ZoneOrBuilder>(
+        failedZonesBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<>(
                 failedZones_,
                 ((bitField0_ & 0x00000002) == 0x00000002),
                 getParentForChildren(),

--- a/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/cluster/v1/ListZonesResponse.java
+++ b/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/cluster/v1/ListZonesResponse.java
@@ -48,7 +48,7 @@ public  final class ListZonesResponse extends
           }
           case 10: {
             if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
-              zones_ = new java.util.ArrayList<com.google.bigtable.admin.cluster.v1.Zone>();
+              zones_ = new java.util.ArrayList<>();
               mutable_bitField0_ |= 0x00000001;
             }
             zones_.add(input.readMessage(com.google.bigtable.admin.cluster.v1.Zone.parser(), extensionRegistry));
@@ -388,7 +388,7 @@ public  final class ListZonesResponse extends
       java.util.Collections.emptyList();
     private void ensureZonesIsMutable() {
       if (!((bitField0_ & 0x00000001) == 0x00000001)) {
-        zones_ = new java.util.ArrayList<com.google.bigtable.admin.cluster.v1.Zone>(zones_);
+        zones_ = new java.util.ArrayList<>(zones_);
         bitField0_ |= 0x00000001;
        }
     }
@@ -685,8 +685,7 @@ public  final class ListZonesResponse extends
         com.google.bigtable.admin.cluster.v1.Zone, com.google.bigtable.admin.cluster.v1.Zone.Builder, com.google.bigtable.admin.cluster.v1.ZoneOrBuilder> 
         getZonesFieldBuilder() {
       if (zonesBuilder_ == null) {
-        zonesBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-            com.google.bigtable.admin.cluster.v1.Zone, com.google.bigtable.admin.cluster.v1.Zone.Builder, com.google.bigtable.admin.cluster.v1.ZoneOrBuilder>(
+        zonesBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<>(
                 zones_,
                 ((bitField0_ & 0x00000001) == 0x00000001),
                 getParentForChildren(),

--- a/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/cluster/v1/UndeleteClusterMetadata.java
+++ b/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/cluster/v1/UndeleteClusterMetadata.java
@@ -545,8 +545,7 @@ public  final class UndeleteClusterMetadata extends
         com.google.protobuf.Timestamp, com.google.protobuf.Timestamp.Builder, com.google.protobuf.TimestampOrBuilder> 
         getRequestTimeFieldBuilder() {
       if (requestTimeBuilder_ == null) {
-        requestTimeBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-            com.google.protobuf.Timestamp, com.google.protobuf.Timestamp.Builder, com.google.protobuf.TimestampOrBuilder>(
+        requestTimeBuilder_ = new com.google.protobuf.SingleFieldBuilder<>(
                 getRequestTime(),
                 getParentForChildren(),
                 isClean());
@@ -698,8 +697,7 @@ public  final class UndeleteClusterMetadata extends
         com.google.protobuf.Timestamp, com.google.protobuf.Timestamp.Builder, com.google.protobuf.TimestampOrBuilder> 
         getFinishTimeFieldBuilder() {
       if (finishTimeBuilder_ == null) {
-        finishTimeBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-            com.google.protobuf.Timestamp, com.google.protobuf.Timestamp.Builder, com.google.protobuf.TimestampOrBuilder>(
+        finishTimeBuilder_ = new com.google.protobuf.SingleFieldBuilder<>(
                 getFinishTime(),
                 getParentForChildren(),
                 isClean());

--- a/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/cluster/v1/UpdateClusterMetadata.java
+++ b/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/cluster/v1/UpdateClusterMetadata.java
@@ -685,8 +685,7 @@ public  final class UpdateClusterMetadata extends
         com.google.bigtable.admin.cluster.v1.Cluster, com.google.bigtable.admin.cluster.v1.Cluster.Builder, com.google.bigtable.admin.cluster.v1.ClusterOrBuilder> 
         getOriginalRequestFieldBuilder() {
       if (originalRequestBuilder_ == null) {
-        originalRequestBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-            com.google.bigtable.admin.cluster.v1.Cluster, com.google.bigtable.admin.cluster.v1.Cluster.Builder, com.google.bigtable.admin.cluster.v1.ClusterOrBuilder>(
+        originalRequestBuilder_ = new com.google.protobuf.SingleFieldBuilder<>(
                 getOriginalRequest(),
                 getParentForChildren(),
                 isClean());
@@ -838,8 +837,7 @@ public  final class UpdateClusterMetadata extends
         com.google.protobuf.Timestamp, com.google.protobuf.Timestamp.Builder, com.google.protobuf.TimestampOrBuilder> 
         getRequestTimeFieldBuilder() {
       if (requestTimeBuilder_ == null) {
-        requestTimeBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-            com.google.protobuf.Timestamp, com.google.protobuf.Timestamp.Builder, com.google.protobuf.TimestampOrBuilder>(
+        requestTimeBuilder_ = new com.google.protobuf.SingleFieldBuilder<>(
                 getRequestTime(),
                 getParentForChildren(),
                 isClean());
@@ -1009,8 +1007,7 @@ public  final class UpdateClusterMetadata extends
         com.google.protobuf.Timestamp, com.google.protobuf.Timestamp.Builder, com.google.protobuf.TimestampOrBuilder> 
         getCancelTimeFieldBuilder() {
       if (cancelTimeBuilder_ == null) {
-        cancelTimeBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-            com.google.protobuf.Timestamp, com.google.protobuf.Timestamp.Builder, com.google.protobuf.TimestampOrBuilder>(
+        cancelTimeBuilder_ = new com.google.protobuf.SingleFieldBuilder<>(
                 getCancelTime(),
                 getParentForChildren(),
                 isClean());
@@ -1162,8 +1159,7 @@ public  final class UpdateClusterMetadata extends
         com.google.protobuf.Timestamp, com.google.protobuf.Timestamp.Builder, com.google.protobuf.TimestampOrBuilder> 
         getFinishTimeFieldBuilder() {
       if (finishTimeBuilder_ == null) {
-        finishTimeBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-            com.google.protobuf.Timestamp, com.google.protobuf.Timestamp.Builder, com.google.protobuf.TimestampOrBuilder>(
+        finishTimeBuilder_ = new com.google.protobuf.SingleFieldBuilder<>(
                 getFinishTime(),
                 getParentForChildren(),
                 isClean());

--- a/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/table/v1/ColumnFamily.java
+++ b/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/table/v1/ColumnFamily.java
@@ -999,8 +999,7 @@ public  final class ColumnFamily extends
         com.google.bigtable.admin.table.v1.GcRule, com.google.bigtable.admin.table.v1.GcRule.Builder, com.google.bigtable.admin.table.v1.GcRuleOrBuilder> 
         getGcRuleFieldBuilder() {
       if (gcRuleBuilder_ == null) {
-        gcRuleBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-            com.google.bigtable.admin.table.v1.GcRule, com.google.bigtable.admin.table.v1.GcRule.Builder, com.google.bigtable.admin.table.v1.GcRuleOrBuilder>(
+        gcRuleBuilder_ = new com.google.protobuf.SingleFieldBuilder<>(
                 getGcRule(),
                 getParentForChildren(),
                 isClean());

--- a/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/table/v1/CreateColumnFamilyRequest.java
+++ b/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/table/v1/CreateColumnFamilyRequest.java
@@ -777,8 +777,7 @@ public  final class CreateColumnFamilyRequest extends
         com.google.bigtable.admin.table.v1.ColumnFamily, com.google.bigtable.admin.table.v1.ColumnFamily.Builder, com.google.bigtable.admin.table.v1.ColumnFamilyOrBuilder> 
         getColumnFamilyFieldBuilder() {
       if (columnFamilyBuilder_ == null) {
-        columnFamilyBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-            com.google.bigtable.admin.table.v1.ColumnFamily, com.google.bigtable.admin.table.v1.ColumnFamily.Builder, com.google.bigtable.admin.table.v1.ColumnFamilyOrBuilder>(
+        columnFamilyBuilder_ = new com.google.protobuf.SingleFieldBuilder<>(
                 getColumnFamily(),
                 getParentForChildren(),
                 isClean());

--- a/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/table/v1/CreateTableRequest.java
+++ b/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/table/v1/CreateTableRequest.java
@@ -932,8 +932,7 @@ public  final class CreateTableRequest extends
         com.google.bigtable.admin.table.v1.Table, com.google.bigtable.admin.table.v1.Table.Builder, com.google.bigtable.admin.table.v1.TableOrBuilder> 
         getTableFieldBuilder() {
       if (tableBuilder_ == null) {
-        tableBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-            com.google.bigtable.admin.table.v1.Table, com.google.bigtable.admin.table.v1.Table.Builder, com.google.bigtable.admin.table.v1.TableOrBuilder>(
+        tableBuilder_ = new com.google.protobuf.SingleFieldBuilder<>(
                 getTable(),
                 getParentForChildren(),
                 isClean());

--- a/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/table/v1/GcRule.java
+++ b/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/table/v1/GcRule.java
@@ -209,7 +209,7 @@ public  final class GcRule extends
             }
             case 10: {
               if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
-                rules_ = new java.util.ArrayList<com.google.bigtable.admin.table.v1.GcRule>();
+                rules_ = new java.util.ArrayList<>();
                 mutable_bitField0_ |= 0x00000001;
               }
               rules_.add(input.readMessage(com.google.bigtable.admin.table.v1.GcRule.parser(), extensionRegistry));
@@ -549,7 +549,7 @@ public  final class GcRule extends
         java.util.Collections.emptyList();
       private void ensureRulesIsMutable() {
         if (!((bitField0_ & 0x00000001) == 0x00000001)) {
-          rules_ = new java.util.ArrayList<com.google.bigtable.admin.table.v1.GcRule>(rules_);
+          rules_ = new java.util.ArrayList<>(rules_);
           bitField0_ |= 0x00000001;
          }
       }
@@ -846,8 +846,7 @@ public  final class GcRule extends
           com.google.bigtable.admin.table.v1.GcRule, com.google.bigtable.admin.table.v1.GcRule.Builder, com.google.bigtable.admin.table.v1.GcRuleOrBuilder> 
           getRulesFieldBuilder() {
         if (rulesBuilder_ == null) {
-          rulesBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-              com.google.bigtable.admin.table.v1.GcRule, com.google.bigtable.admin.table.v1.GcRule.Builder, com.google.bigtable.admin.table.v1.GcRuleOrBuilder>(
+          rulesBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<>(
                   rules_,
                   ((bitField0_ & 0x00000001) == 0x00000001),
                   getParentForChildren(),
@@ -1007,7 +1006,7 @@ public  final class GcRule extends
             }
             case 10: {
               if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
-                rules_ = new java.util.ArrayList<com.google.bigtable.admin.table.v1.GcRule>();
+                rules_ = new java.util.ArrayList<>();
                 mutable_bitField0_ |= 0x00000001;
               }
               rules_.add(input.readMessage(com.google.bigtable.admin.table.v1.GcRule.parser(), extensionRegistry));
@@ -1347,7 +1346,7 @@ public  final class GcRule extends
         java.util.Collections.emptyList();
       private void ensureRulesIsMutable() {
         if (!((bitField0_ & 0x00000001) == 0x00000001)) {
-          rules_ = new java.util.ArrayList<com.google.bigtable.admin.table.v1.GcRule>(rules_);
+          rules_ = new java.util.ArrayList<>(rules_);
           bitField0_ |= 0x00000001;
          }
       }
@@ -1644,8 +1643,7 @@ public  final class GcRule extends
           com.google.bigtable.admin.table.v1.GcRule, com.google.bigtable.admin.table.v1.GcRule.Builder, com.google.bigtable.admin.table.v1.GcRuleOrBuilder> 
           getRulesFieldBuilder() {
         if (rulesBuilder_ == null) {
-          rulesBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-              com.google.bigtable.admin.table.v1.GcRule, com.google.bigtable.admin.table.v1.GcRule.Builder, com.google.bigtable.admin.table.v1.GcRuleOrBuilder>(
+          rulesBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<>(
                   rules_,
                   ((bitField0_ & 0x00000001) == 0x00000001),
                   getParentForChildren(),
@@ -2348,8 +2346,7 @@ public  final class GcRule extends
         if (!(ruleCase_ == 2)) {
           rule_ = com.google.protobuf.Duration.getDefaultInstance();
         }
-        maxAgeBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-            com.google.protobuf.Duration, com.google.protobuf.Duration.Builder, com.google.protobuf.DurationOrBuilder>(
+        maxAgeBuilder_ = new com.google.protobuf.SingleFieldBuilder<>(
                 (com.google.protobuf.Duration) rule_,
                 getParentForChildren(),
                 isClean());
@@ -2510,8 +2507,7 @@ public  final class GcRule extends
         if (!(ruleCase_ == 3)) {
           rule_ = com.google.bigtable.admin.table.v1.GcRule.Intersection.getDefaultInstance();
         }
-        intersectionBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-            com.google.bigtable.admin.table.v1.GcRule.Intersection, com.google.bigtable.admin.table.v1.GcRule.Intersection.Builder, com.google.bigtable.admin.table.v1.GcRule.IntersectionOrBuilder>(
+        intersectionBuilder_ = new com.google.protobuf.SingleFieldBuilder<>(
                 (com.google.bigtable.admin.table.v1.GcRule.Intersection) rule_,
                 getParentForChildren(),
                 isClean());
@@ -2672,8 +2668,7 @@ public  final class GcRule extends
         if (!(ruleCase_ == 4)) {
           rule_ = com.google.bigtable.admin.table.v1.GcRule.Union.getDefaultInstance();
         }
-        unionBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-            com.google.bigtable.admin.table.v1.GcRule.Union, com.google.bigtable.admin.table.v1.GcRule.Union.Builder, com.google.bigtable.admin.table.v1.GcRule.UnionOrBuilder>(
+        unionBuilder_ = new com.google.protobuf.SingleFieldBuilder<>(
                 (com.google.bigtable.admin.table.v1.GcRule.Union) rule_,
                 getParentForChildren(),
                 isClean());

--- a/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/table/v1/ListTablesResponse.java
+++ b/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/table/v1/ListTablesResponse.java
@@ -44,7 +44,7 @@ public  final class ListTablesResponse extends
           }
           case 10: {
             if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
-              tables_ = new java.util.ArrayList<com.google.bigtable.admin.table.v1.Table>();
+              tables_ = new java.util.ArrayList<>();
               mutable_bitField0_ |= 0x00000001;
             }
             tables_.add(input.readMessage(com.google.bigtable.admin.table.v1.Table.parser(), extensionRegistry));
@@ -385,7 +385,7 @@ public  final class ListTablesResponse extends
       java.util.Collections.emptyList();
     private void ensureTablesIsMutable() {
       if (!((bitField0_ & 0x00000001) == 0x00000001)) {
-        tables_ = new java.util.ArrayList<com.google.bigtable.admin.table.v1.Table>(tables_);
+        tables_ = new java.util.ArrayList<>(tables_);
         bitField0_ |= 0x00000001;
        }
     }
@@ -700,8 +700,7 @@ public  final class ListTablesResponse extends
         com.google.bigtable.admin.table.v1.Table, com.google.bigtable.admin.table.v1.Table.Builder, com.google.bigtable.admin.table.v1.TableOrBuilder> 
         getTablesFieldBuilder() {
       if (tablesBuilder_ == null) {
-        tablesBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-            com.google.bigtable.admin.table.v1.Table, com.google.bigtable.admin.table.v1.Table.Builder, com.google.bigtable.admin.table.v1.TableOrBuilder>(
+        tablesBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<>(
                 tables_,
                 ((bitField0_ & 0x00000001) == 0x00000001),
                 getParentForChildren(),

--- a/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/table/v1/Table.java
+++ b/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/table/v1/Table.java
@@ -899,8 +899,7 @@ public  final class Table extends
         com.google.longrunning.Operation, com.google.longrunning.Operation.Builder, com.google.longrunning.OperationOrBuilder> 
         getCurrentOperationFieldBuilder() {
       if (currentOperationBuilder_ == null) {
-        currentOperationBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-            com.google.longrunning.Operation, com.google.longrunning.Operation.Builder, com.google.longrunning.OperationOrBuilder>(
+        currentOperationBuilder_ = new com.google.protobuf.SingleFieldBuilder<>(
                 getCurrentOperation(),
                 getParentForChildren(),
                 isClean());

--- a/bigtable-protos/src/generated/java/protos/com/google/bigtable/v1/CheckAndMutateRowRequest.java
+++ b/bigtable-protos/src/generated/java/protos/com/google/bigtable/v1/CheckAndMutateRowRequest.java
@@ -62,7 +62,7 @@ public  final class CheckAndMutateRowRequest extends
           }
           case 34: {
             if (!((mutable_bitField0_ & 0x00000008) == 0x00000008)) {
-              trueMutations_ = new java.util.ArrayList<com.google.bigtable.v1.Mutation>();
+              trueMutations_ = new java.util.ArrayList<>();
               mutable_bitField0_ |= 0x00000008;
             }
             trueMutations_.add(input.readMessage(com.google.bigtable.v1.Mutation.parser(), extensionRegistry));
@@ -70,7 +70,7 @@ public  final class CheckAndMutateRowRequest extends
           }
           case 42: {
             if (!((mutable_bitField0_ & 0x00000010) == 0x00000010)) {
-              falseMutations_ = new java.util.ArrayList<com.google.bigtable.v1.Mutation>();
+              falseMutations_ = new java.util.ArrayList<>();
               mutable_bitField0_ |= 0x00000010;
             }
             falseMutations_.add(input.readMessage(com.google.bigtable.v1.Mutation.parser(), extensionRegistry));
@@ -1020,8 +1020,7 @@ public  final class CheckAndMutateRowRequest extends
         com.google.bigtable.v1.RowFilter, com.google.bigtable.v1.RowFilter.Builder, com.google.bigtable.v1.RowFilterOrBuilder> 
         getPredicateFilterFieldBuilder() {
       if (predicateFilterBuilder_ == null) {
-        predicateFilterBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-            com.google.bigtable.v1.RowFilter, com.google.bigtable.v1.RowFilter.Builder, com.google.bigtable.v1.RowFilterOrBuilder>(
+        predicateFilterBuilder_ = new com.google.protobuf.SingleFieldBuilder<>(
                 getPredicateFilter(),
                 getParentForChildren(),
                 isClean());
@@ -1034,7 +1033,7 @@ public  final class CheckAndMutateRowRequest extends
       java.util.Collections.emptyList();
     private void ensureTrueMutationsIsMutable() {
       if (!((bitField0_ & 0x00000008) == 0x00000008)) {
-        trueMutations_ = new java.util.ArrayList<com.google.bigtable.v1.Mutation>(trueMutations_);
+        trueMutations_ = new java.util.ArrayList<>(trueMutations_);
         bitField0_ |= 0x00000008;
        }
     }
@@ -1403,8 +1402,7 @@ public  final class CheckAndMutateRowRequest extends
         com.google.bigtable.v1.Mutation, com.google.bigtable.v1.Mutation.Builder, com.google.bigtable.v1.MutationOrBuilder> 
         getTrueMutationsFieldBuilder() {
       if (trueMutationsBuilder_ == null) {
-        trueMutationsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-            com.google.bigtable.v1.Mutation, com.google.bigtable.v1.Mutation.Builder, com.google.bigtable.v1.MutationOrBuilder>(
+        trueMutationsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<>(
                 trueMutations_,
                 ((bitField0_ & 0x00000008) == 0x00000008),
                 getParentForChildren(),
@@ -1418,7 +1416,7 @@ public  final class CheckAndMutateRowRequest extends
       java.util.Collections.emptyList();
     private void ensureFalseMutationsIsMutable() {
       if (!((bitField0_ & 0x00000010) == 0x00000010)) {
-        falseMutations_ = new java.util.ArrayList<com.google.bigtable.v1.Mutation>(falseMutations_);
+        falseMutations_ = new java.util.ArrayList<>(falseMutations_);
         bitField0_ |= 0x00000010;
        }
     }
@@ -1787,8 +1785,7 @@ public  final class CheckAndMutateRowRequest extends
         com.google.bigtable.v1.Mutation, com.google.bigtable.v1.Mutation.Builder, com.google.bigtable.v1.MutationOrBuilder> 
         getFalseMutationsFieldBuilder() {
       if (falseMutationsBuilder_ == null) {
-        falseMutationsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-            com.google.bigtable.v1.Mutation, com.google.bigtable.v1.Mutation.Builder, com.google.bigtable.v1.MutationOrBuilder>(
+        falseMutationsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<>(
                 falseMutations_,
                 ((bitField0_ & 0x00000010) == 0x00000010),
                 getParentForChildren(),

--- a/bigtable-protos/src/generated/java/protos/com/google/bigtable/v1/Column.java
+++ b/bigtable-protos/src/generated/java/protos/com/google/bigtable/v1/Column.java
@@ -54,7 +54,7 @@ public  final class Column extends
           }
           case 18: {
             if (!((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
-              cells_ = new java.util.ArrayList<com.google.bigtable.v1.Cell>();
+              cells_ = new java.util.ArrayList<>();
               mutable_bitField0_ |= 0x00000002;
             }
             cells_.add(input.readMessage(com.google.bigtable.v1.Cell.parser(), extensionRegistry));
@@ -480,7 +480,7 @@ public  final class Column extends
       java.util.Collections.emptyList();
     private void ensureCellsIsMutable() {
       if (!((bitField0_ & 0x00000002) == 0x00000002)) {
-        cells_ = new java.util.ArrayList<com.google.bigtable.v1.Cell>(cells_);
+        cells_ = new java.util.ArrayList<>(cells_);
         bitField0_ |= 0x00000002;
        }
     }
@@ -777,8 +777,7 @@ public  final class Column extends
         com.google.bigtable.v1.Cell, com.google.bigtable.v1.Cell.Builder, com.google.bigtable.v1.CellOrBuilder> 
         getCellsFieldBuilder() {
       if (cellsBuilder_ == null) {
-        cellsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-            com.google.bigtable.v1.Cell, com.google.bigtable.v1.Cell.Builder, com.google.bigtable.v1.CellOrBuilder>(
+        cellsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<>(
                 cells_,
                 ((bitField0_ & 0x00000002) == 0x00000002),
                 getParentForChildren(),

--- a/bigtable-protos/src/generated/java/protos/com/google/bigtable/v1/Family.java
+++ b/bigtable-protos/src/generated/java/protos/com/google/bigtable/v1/Family.java
@@ -55,7 +55,7 @@ public  final class Family extends
           }
           case 18: {
             if (!((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
-              columns_ = new java.util.ArrayList<com.google.bigtable.v1.Column>();
+              columns_ = new java.util.ArrayList<>();
               mutable_bitField0_ |= 0x00000002;
             }
             columns_.add(input.readMessage(com.google.bigtable.v1.Column.parser(), extensionRegistry));
@@ -577,7 +577,7 @@ public  final class Family extends
       java.util.Collections.emptyList();
     private void ensureColumnsIsMutable() {
       if (!((bitField0_ & 0x00000002) == 0x00000002)) {
-        columns_ = new java.util.ArrayList<com.google.bigtable.v1.Column>(columns_);
+        columns_ = new java.util.ArrayList<>(columns_);
         bitField0_ |= 0x00000002;
        }
     }
@@ -874,8 +874,7 @@ public  final class Family extends
         com.google.bigtable.v1.Column, com.google.bigtable.v1.Column.Builder, com.google.bigtable.v1.ColumnOrBuilder> 
         getColumnsFieldBuilder() {
       if (columnsBuilder_ == null) {
-        columnsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-            com.google.bigtable.v1.Column, com.google.bigtable.v1.Column.Builder, com.google.bigtable.v1.ColumnOrBuilder>(
+        columnsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<>(
                 columns_,
                 ((bitField0_ & 0x00000002) == 0x00000002),
                 getParentForChildren(),

--- a/bigtable-protos/src/generated/java/protos/com/google/bigtable/v1/MutateRowRequest.java
+++ b/bigtable-protos/src/generated/java/protos/com/google/bigtable/v1/MutateRowRequest.java
@@ -61,7 +61,7 @@ public  final class MutateRowRequest extends
           }
           case 26: {
             if (!((mutable_bitField0_ & 0x00000004) == 0x00000004)) {
-              mutations_ = new java.util.ArrayList<com.google.bigtable.v1.Mutation>();
+              mutations_ = new java.util.ArrayList<>();
               mutable_bitField0_ |= 0x00000004;
             }
             mutations_.add(input.readMessage(com.google.bigtable.v1.Mutation.parser(), extensionRegistry));
@@ -625,7 +625,7 @@ public  final class MutateRowRequest extends
       java.util.Collections.emptyList();
     private void ensureMutationsIsMutable() {
       if (!((bitField0_ & 0x00000004) == 0x00000004)) {
-        mutations_ = new java.util.ArrayList<com.google.bigtable.v1.Mutation>(mutations_);
+        mutations_ = new java.util.ArrayList<>(mutations_);
         bitField0_ |= 0x00000004;
        }
     }
@@ -958,8 +958,7 @@ public  final class MutateRowRequest extends
         com.google.bigtable.v1.Mutation, com.google.bigtable.v1.Mutation.Builder, com.google.bigtable.v1.MutationOrBuilder> 
         getMutationsFieldBuilder() {
       if (mutationsBuilder_ == null) {
-        mutationsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-            com.google.bigtable.v1.Mutation, com.google.bigtable.v1.Mutation.Builder, com.google.bigtable.v1.MutationOrBuilder>(
+        mutationsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<>(
                 mutations_,
                 ((bitField0_ & 0x00000004) == 0x00000004),
                 getParentForChildren(),

--- a/bigtable-protos/src/generated/java/protos/com/google/bigtable/v1/MutateRowsRequest.java
+++ b/bigtable-protos/src/generated/java/protos/com/google/bigtable/v1/MutateRowsRequest.java
@@ -55,7 +55,7 @@ public  final class MutateRowsRequest extends
           }
           case 18: {
             if (!((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
-              entries_ = new java.util.ArrayList<com.google.bigtable.v1.MutateRowsRequest.Entry>();
+              entries_ = new java.util.ArrayList<>();
               mutable_bitField0_ |= 0x00000002;
             }
             entries_.add(input.readMessage(com.google.bigtable.v1.MutateRowsRequest.Entry.parser(), extensionRegistry));
@@ -207,7 +207,7 @@ public  final class MutateRowsRequest extends
             }
             case 18: {
               if (!((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
-                mutations_ = new java.util.ArrayList<com.google.bigtable.v1.Mutation>();
+                mutations_ = new java.util.ArrayList<>();
                 mutable_bitField0_ |= 0x00000002;
               }
               mutations_.add(input.readMessage(com.google.bigtable.v1.Mutation.parser(), extensionRegistry));
@@ -628,7 +628,7 @@ public  final class MutateRowsRequest extends
         java.util.Collections.emptyList();
       private void ensureMutationsIsMutable() {
         if (!((bitField0_ & 0x00000002) == 0x00000002)) {
-          mutations_ = new java.util.ArrayList<com.google.bigtable.v1.Mutation>(mutations_);
+          mutations_ = new java.util.ArrayList<>(mutations_);
           bitField0_ |= 0x00000002;
          }
       }
@@ -979,8 +979,7 @@ public  final class MutateRowsRequest extends
           com.google.bigtable.v1.Mutation, com.google.bigtable.v1.Mutation.Builder, com.google.bigtable.v1.MutationOrBuilder> 
           getMutationsFieldBuilder() {
         if (mutationsBuilder_ == null) {
-          mutationsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-              com.google.bigtable.v1.Mutation, com.google.bigtable.v1.Mutation.Builder, com.google.bigtable.v1.MutationOrBuilder>(
+          mutationsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<>(
                   mutations_,
                   ((bitField0_ & 0x00000002) == 0x00000002),
                   getParentForChildren(),
@@ -1521,7 +1520,7 @@ public  final class MutateRowsRequest extends
       java.util.Collections.emptyList();
     private void ensureEntriesIsMutable() {
       if (!((bitField0_ & 0x00000002) == 0x00000002)) {
-        entries_ = new java.util.ArrayList<com.google.bigtable.v1.MutateRowsRequest.Entry>(entries_);
+        entries_ = new java.util.ArrayList<>(entries_);
         bitField0_ |= 0x00000002;
        }
     }
@@ -1890,8 +1889,7 @@ public  final class MutateRowsRequest extends
         com.google.bigtable.v1.MutateRowsRequest.Entry, com.google.bigtable.v1.MutateRowsRequest.Entry.Builder, com.google.bigtable.v1.MutateRowsRequest.EntryOrBuilder> 
         getEntriesFieldBuilder() {
       if (entriesBuilder_ == null) {
-        entriesBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-            com.google.bigtable.v1.MutateRowsRequest.Entry, com.google.bigtable.v1.MutateRowsRequest.Entry.Builder, com.google.bigtable.v1.MutateRowsRequest.EntryOrBuilder>(
+        entriesBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<>(
                 entries_,
                 ((bitField0_ & 0x00000002) == 0x00000002),
                 getParentForChildren(),

--- a/bigtable-protos/src/generated/java/protos/com/google/bigtable/v1/MutateRowsResponse.java
+++ b/bigtable-protos/src/generated/java/protos/com/google/bigtable/v1/MutateRowsResponse.java
@@ -48,7 +48,7 @@ public  final class MutateRowsResponse extends
           }
           case 10: {
             if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
-              statuses_ = new java.util.ArrayList<com.google.rpc.Status>();
+              statuses_ = new java.util.ArrayList<>();
               mutable_bitField0_ |= 0x00000001;
             }
             statuses_.add(input.readMessage(com.google.rpc.Status.parser(), extensionRegistry));
@@ -393,7 +393,7 @@ public  final class MutateRowsResponse extends
       java.util.Collections.emptyList();
     private void ensureStatusesIsMutable() {
       if (!((bitField0_ & 0x00000001) == 0x00000001)) {
-        statuses_ = new java.util.ArrayList<com.google.rpc.Status>(statuses_);
+        statuses_ = new java.util.ArrayList<>(statuses_);
         bitField0_ |= 0x00000001;
        }
     }
@@ -708,8 +708,7 @@ public  final class MutateRowsResponse extends
         com.google.rpc.Status, com.google.rpc.Status.Builder, com.google.rpc.StatusOrBuilder> 
         getStatusesFieldBuilder() {
       if (statusesBuilder_ == null) {
-        statusesBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-            com.google.rpc.Status, com.google.rpc.Status.Builder, com.google.rpc.StatusOrBuilder>(
+        statusesBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<>(
                 statuses_,
                 ((bitField0_ & 0x00000001) == 0x00000001),
                 getParentForChildren(),

--- a/bigtable-protos/src/generated/java/protos/com/google/bigtable/v1/Mutation.java
+++ b/bigtable-protos/src/generated/java/protos/com/google/bigtable/v1/Mutation.java
@@ -1664,8 +1664,7 @@ public  final class Mutation extends
           com.google.bigtable.v1.TimestampRange, com.google.bigtable.v1.TimestampRange.Builder, com.google.bigtable.v1.TimestampRangeOrBuilder> 
           getTimeRangeFieldBuilder() {
         if (timeRangeBuilder_ == null) {
-          timeRangeBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-              com.google.bigtable.v1.TimestampRange, com.google.bigtable.v1.TimestampRange.Builder, com.google.bigtable.v1.TimestampRangeOrBuilder>(
+          timeRangeBuilder_ = new com.google.protobuf.SingleFieldBuilder<>(
                   getTimeRange(),
                   getParentForChildren(),
                   isClean());
@@ -3145,8 +3144,7 @@ public  final class Mutation extends
         if (!(mutationCase_ == 1)) {
           mutation_ = com.google.bigtable.v1.Mutation.SetCell.getDefaultInstance();
         }
-        setCellBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-            com.google.bigtable.v1.Mutation.SetCell, com.google.bigtable.v1.Mutation.SetCell.Builder, com.google.bigtable.v1.Mutation.SetCellOrBuilder>(
+        setCellBuilder_ = new com.google.protobuf.SingleFieldBuilder<>(
                 (com.google.bigtable.v1.Mutation.SetCell) mutation_,
                 getParentForChildren(),
                 isClean());
@@ -3307,8 +3305,7 @@ public  final class Mutation extends
         if (!(mutationCase_ == 2)) {
           mutation_ = com.google.bigtable.v1.Mutation.DeleteFromColumn.getDefaultInstance();
         }
-        deleteFromColumnBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-            com.google.bigtable.v1.Mutation.DeleteFromColumn, com.google.bigtable.v1.Mutation.DeleteFromColumn.Builder, com.google.bigtable.v1.Mutation.DeleteFromColumnOrBuilder>(
+        deleteFromColumnBuilder_ = new com.google.protobuf.SingleFieldBuilder<>(
                 (com.google.bigtable.v1.Mutation.DeleteFromColumn) mutation_,
                 getParentForChildren(),
                 isClean());
@@ -3469,8 +3466,7 @@ public  final class Mutation extends
         if (!(mutationCase_ == 3)) {
           mutation_ = com.google.bigtable.v1.Mutation.DeleteFromFamily.getDefaultInstance();
         }
-        deleteFromFamilyBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-            com.google.bigtable.v1.Mutation.DeleteFromFamily, com.google.bigtable.v1.Mutation.DeleteFromFamily.Builder, com.google.bigtable.v1.Mutation.DeleteFromFamilyOrBuilder>(
+        deleteFromFamilyBuilder_ = new com.google.protobuf.SingleFieldBuilder<>(
                 (com.google.bigtable.v1.Mutation.DeleteFromFamily) mutation_,
                 getParentForChildren(),
                 isClean());
@@ -3631,8 +3627,7 @@ public  final class Mutation extends
         if (!(mutationCase_ == 4)) {
           mutation_ = com.google.bigtable.v1.Mutation.DeleteFromRow.getDefaultInstance();
         }
-        deleteFromRowBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-            com.google.bigtable.v1.Mutation.DeleteFromRow, com.google.bigtable.v1.Mutation.DeleteFromRow.Builder, com.google.bigtable.v1.Mutation.DeleteFromRowOrBuilder>(
+        deleteFromRowBuilder_ = new com.google.protobuf.SingleFieldBuilder<>(
                 (com.google.bigtable.v1.Mutation.DeleteFromRow) mutation_,
                 getParentForChildren(),
                 isClean());

--- a/bigtable-protos/src/generated/java/protos/com/google/bigtable/v1/ReadModifyWriteRowRequest.java
+++ b/bigtable-protos/src/generated/java/protos/com/google/bigtable/v1/ReadModifyWriteRowRequest.java
@@ -61,7 +61,7 @@ public  final class ReadModifyWriteRowRequest extends
           }
           case 26: {
             if (!((mutable_bitField0_ & 0x00000004) == 0x00000004)) {
-              rules_ = new java.util.ArrayList<com.google.bigtable.v1.ReadModifyWriteRule>();
+              rules_ = new java.util.ArrayList<>();
               mutable_bitField0_ |= 0x00000004;
             }
             rules_.add(input.readMessage(com.google.bigtable.v1.ReadModifyWriteRule.parser(), extensionRegistry));
@@ -632,7 +632,7 @@ public  final class ReadModifyWriteRowRequest extends
       java.util.Collections.emptyList();
     private void ensureRulesIsMutable() {
       if (!((bitField0_ & 0x00000004) == 0x00000004)) {
-        rules_ = new java.util.ArrayList<com.google.bigtable.v1.ReadModifyWriteRule>(rules_);
+        rules_ = new java.util.ArrayList<>(rules_);
         bitField0_ |= 0x00000004;
        }
     }
@@ -965,8 +965,7 @@ public  final class ReadModifyWriteRowRequest extends
         com.google.bigtable.v1.ReadModifyWriteRule, com.google.bigtable.v1.ReadModifyWriteRule.Builder, com.google.bigtable.v1.ReadModifyWriteRuleOrBuilder> 
         getRulesFieldBuilder() {
       if (rulesBuilder_ == null) {
-        rulesBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-            com.google.bigtable.v1.ReadModifyWriteRule, com.google.bigtable.v1.ReadModifyWriteRule.Builder, com.google.bigtable.v1.ReadModifyWriteRuleOrBuilder>(
+        rulesBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<>(
                 rules_,
                 ((bitField0_ & 0x00000004) == 0x00000004),
                 getParentForChildren(),

--- a/bigtable-protos/src/generated/java/protos/com/google/bigtable/v1/ReadRowsRequest.java
+++ b/bigtable-protos/src/generated/java/protos/com/google/bigtable/v1/ReadRowsRequest.java
@@ -969,8 +969,7 @@ public  final class ReadRowsRequest extends
         if (!(targetCase_ == 3)) {
           target_ = com.google.bigtable.v1.RowRange.getDefaultInstance();
         }
-        rowRangeBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-            com.google.bigtable.v1.RowRange, com.google.bigtable.v1.RowRange.Builder, com.google.bigtable.v1.RowRangeOrBuilder>(
+        rowRangeBuilder_ = new com.google.protobuf.SingleFieldBuilder<>(
                 (com.google.bigtable.v1.RowRange) target_,
                 getParentForChildren(),
                 isClean());
@@ -1147,8 +1146,7 @@ public  final class ReadRowsRequest extends
         if (!(targetCase_ == 8)) {
           target_ = com.google.bigtable.v1.RowSet.getDefaultInstance();
         }
-        rowSetBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-            com.google.bigtable.v1.RowSet, com.google.bigtable.v1.RowSet.Builder, com.google.bigtable.v1.RowSetOrBuilder>(
+        rowSetBuilder_ = new com.google.protobuf.SingleFieldBuilder<>(
                 (com.google.bigtable.v1.RowSet) target_,
                 getParentForChildren(),
                 isClean());
@@ -1311,8 +1309,7 @@ public  final class ReadRowsRequest extends
         com.google.bigtable.v1.RowFilter, com.google.bigtable.v1.RowFilter.Builder, com.google.bigtable.v1.RowFilterOrBuilder> 
         getFilterFieldBuilder() {
       if (filterBuilder_ == null) {
-        filterBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-            com.google.bigtable.v1.RowFilter, com.google.bigtable.v1.RowFilter.Builder, com.google.bigtable.v1.RowFilterOrBuilder>(
+        filterBuilder_ = new com.google.protobuf.SingleFieldBuilder<>(
                 getFilter(),
                 getParentForChildren(),
                 isClean());

--- a/bigtable-protos/src/generated/java/protos/com/google/bigtable/v1/ReadRowsResponse.java
+++ b/bigtable-protos/src/generated/java/protos/com/google/bigtable/v1/ReadRowsResponse.java
@@ -54,7 +54,7 @@ public  final class ReadRowsResponse extends
           }
           case 18: {
             if (!((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
-              chunks_ = new java.util.ArrayList<com.google.bigtable.v1.ReadRowsResponse.Chunk>();
+              chunks_ = new java.util.ArrayList<>();
               mutable_bitField0_ |= 0x00000002;
             }
             chunks_.add(input.readMessage(com.google.bigtable.v1.ReadRowsResponse.Chunk.parser(), extensionRegistry));
@@ -771,8 +771,7 @@ public  final class ReadRowsResponse extends
           if (!(chunkCase_ == 1)) {
             chunk_ = com.google.bigtable.v1.Family.getDefaultInstance();
           }
-          rowContentsBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-              com.google.bigtable.v1.Family, com.google.bigtable.v1.Family.Builder, com.google.bigtable.v1.FamilyOrBuilder>(
+          rowContentsBuilder_ = new com.google.protobuf.SingleFieldBuilder<>(
                   (com.google.bigtable.v1.Family) chunk_,
                   getParentForChildren(),
                   isClean());
@@ -1315,7 +1314,7 @@ public  final class ReadRowsResponse extends
       java.util.Collections.emptyList();
     private void ensureChunksIsMutable() {
       if (!((bitField0_ & 0x00000002) == 0x00000002)) {
-        chunks_ = new java.util.ArrayList<com.google.bigtable.v1.ReadRowsResponse.Chunk>(chunks_);
+        chunks_ = new java.util.ArrayList<>(chunks_);
         bitField0_ |= 0x00000002;
        }
     }
@@ -1612,8 +1611,7 @@ public  final class ReadRowsResponse extends
         com.google.bigtable.v1.ReadRowsResponse.Chunk, com.google.bigtable.v1.ReadRowsResponse.Chunk.Builder, com.google.bigtable.v1.ReadRowsResponse.ChunkOrBuilder> 
         getChunksFieldBuilder() {
       if (chunksBuilder_ == null) {
-        chunksBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-            com.google.bigtable.v1.ReadRowsResponse.Chunk, com.google.bigtable.v1.ReadRowsResponse.Chunk.Builder, com.google.bigtable.v1.ReadRowsResponse.ChunkOrBuilder>(
+        chunksBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<>(
                 chunks_,
                 ((bitField0_ & 0x00000002) == 0x00000002),
                 getParentForChildren(),

--- a/bigtable-protos/src/generated/java/protos/com/google/bigtable/v1/Row.java
+++ b/bigtable-protos/src/generated/java/protos/com/google/bigtable/v1/Row.java
@@ -55,7 +55,7 @@ public  final class Row extends
           }
           case 18: {
             if (!((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
-              families_ = new java.util.ArrayList<com.google.bigtable.v1.Family>();
+              families_ = new java.util.ArrayList<>();
               mutable_bitField0_ |= 0x00000002;
             }
             families_.add(input.readMessage(com.google.bigtable.v1.Family.parser(), extensionRegistry));
@@ -479,7 +479,7 @@ public  final class Row extends
       java.util.Collections.emptyList();
     private void ensureFamiliesIsMutable() {
       if (!((bitField0_ & 0x00000002) == 0x00000002)) {
-        families_ = new java.util.ArrayList<com.google.bigtable.v1.Family>(families_);
+        families_ = new java.util.ArrayList<>(families_);
         bitField0_ |= 0x00000002;
        }
     }
@@ -794,8 +794,7 @@ public  final class Row extends
         com.google.bigtable.v1.Family, com.google.bigtable.v1.Family.Builder, com.google.bigtable.v1.FamilyOrBuilder> 
         getFamiliesFieldBuilder() {
       if (familiesBuilder_ == null) {
-        familiesBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-            com.google.bigtable.v1.Family, com.google.bigtable.v1.Family.Builder, com.google.bigtable.v1.FamilyOrBuilder>(
+        familiesBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<>(
                 families_,
                 ((bitField0_ & 0x00000002) == 0x00000002),
                 getParentForChildren(),

--- a/bigtable-protos/src/generated/java/protos/com/google/bigtable/v1/RowFilter.java
+++ b/bigtable-protos/src/generated/java/protos/com/google/bigtable/v1/RowFilter.java
@@ -350,7 +350,7 @@ public  final class RowFilter extends
             }
             case 10: {
               if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
-                filters_ = new java.util.ArrayList<com.google.bigtable.v1.RowFilter>();
+                filters_ = new java.util.ArrayList<>();
                 mutable_bitField0_ |= 0x00000001;
               }
               filters_.add(input.readMessage(com.google.bigtable.v1.RowFilter.parser(), extensionRegistry));
@@ -700,7 +700,7 @@ public  final class RowFilter extends
         java.util.Collections.emptyList();
       private void ensureFiltersIsMutable() {
         if (!((bitField0_ & 0x00000001) == 0x00000001)) {
-          filters_ = new java.util.ArrayList<com.google.bigtable.v1.RowFilter>(filters_);
+          filters_ = new java.util.ArrayList<>(filters_);
           bitField0_ |= 0x00000001;
          }
       }
@@ -1033,8 +1033,7 @@ public  final class RowFilter extends
           com.google.bigtable.v1.RowFilter, com.google.bigtable.v1.RowFilter.Builder, com.google.bigtable.v1.RowFilterOrBuilder> 
           getFiltersFieldBuilder() {
         if (filtersBuilder_ == null) {
-          filtersBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-              com.google.bigtable.v1.RowFilter, com.google.bigtable.v1.RowFilter.Builder, com.google.bigtable.v1.RowFilterOrBuilder>(
+          filtersBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<>(
                   filters_,
                   ((bitField0_ & 0x00000001) == 0x00000001),
                   getParentForChildren(),
@@ -1305,7 +1304,7 @@ public  final class RowFilter extends
             }
             case 10: {
               if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
-                filters_ = new java.util.ArrayList<com.google.bigtable.v1.RowFilter>();
+                filters_ = new java.util.ArrayList<>();
                 mutable_bitField0_ |= 0x00000001;
               }
               filters_.add(input.readMessage(com.google.bigtable.v1.RowFilter.parser(), extensionRegistry));
@@ -1756,7 +1755,7 @@ public  final class RowFilter extends
         java.util.Collections.emptyList();
       private void ensureFiltersIsMutable() {
         if (!((bitField0_ & 0x00000001) == 0x00000001)) {
-          filters_ = new java.util.ArrayList<com.google.bigtable.v1.RowFilter>(filters_);
+          filters_ = new java.util.ArrayList<>(filters_);
           bitField0_ |= 0x00000001;
          }
       }
@@ -2449,8 +2448,7 @@ public  final class RowFilter extends
           com.google.bigtable.v1.RowFilter, com.google.bigtable.v1.RowFilter.Builder, com.google.bigtable.v1.RowFilterOrBuilder> 
           getFiltersFieldBuilder() {
         if (filtersBuilder_ == null) {
-          filtersBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-              com.google.bigtable.v1.RowFilter, com.google.bigtable.v1.RowFilter.Builder, com.google.bigtable.v1.RowFilterOrBuilder>(
+          filtersBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<>(
                   filters_,
                   ((bitField0_ & 0x00000001) == 0x00000001),
                   getParentForChildren(),
@@ -3246,8 +3244,7 @@ public  final class RowFilter extends
           com.google.bigtable.v1.RowFilter, com.google.bigtable.v1.RowFilter.Builder, com.google.bigtable.v1.RowFilterOrBuilder> 
           getPredicateFilterFieldBuilder() {
         if (predicateFilterBuilder_ == null) {
-          predicateFilterBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-              com.google.bigtable.v1.RowFilter, com.google.bigtable.v1.RowFilter.Builder, com.google.bigtable.v1.RowFilterOrBuilder>(
+          predicateFilterBuilder_ = new com.google.protobuf.SingleFieldBuilder<>(
                   getPredicateFilter(),
                   getParentForChildren(),
                   isClean());
@@ -3408,8 +3405,7 @@ public  final class RowFilter extends
           com.google.bigtable.v1.RowFilter, com.google.bigtable.v1.RowFilter.Builder, com.google.bigtable.v1.RowFilterOrBuilder> 
           getTrueFilterFieldBuilder() {
         if (trueFilterBuilder_ == null) {
-          trueFilterBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-              com.google.bigtable.v1.RowFilter, com.google.bigtable.v1.RowFilter.Builder, com.google.bigtable.v1.RowFilterOrBuilder>(
+          trueFilterBuilder_ = new com.google.protobuf.SingleFieldBuilder<>(
                   getTrueFilter(),
                   getParentForChildren(),
                   isClean());
@@ -3579,8 +3575,7 @@ public  final class RowFilter extends
           com.google.bigtable.v1.RowFilter, com.google.bigtable.v1.RowFilter.Builder, com.google.bigtable.v1.RowFilterOrBuilder> 
           getFalseFilterFieldBuilder() {
         if (falseFilterBuilder_ == null) {
-          falseFilterBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-              com.google.bigtable.v1.RowFilter, com.google.bigtable.v1.RowFilter.Builder, com.google.bigtable.v1.RowFilterOrBuilder>(
+          falseFilterBuilder_ = new com.google.protobuf.SingleFieldBuilder<>(
                   getFalseFilter(),
                   getParentForChildren(),
                   isClean());
@@ -4981,8 +4976,7 @@ public  final class RowFilter extends
         if (!(filterCase_ == 1)) {
           filter_ = com.google.bigtable.v1.RowFilter.Chain.getDefaultInstance();
         }
-        chainBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-            com.google.bigtable.v1.RowFilter.Chain, com.google.bigtable.v1.RowFilter.Chain.Builder, com.google.bigtable.v1.RowFilter.ChainOrBuilder>(
+        chainBuilder_ = new com.google.protobuf.SingleFieldBuilder<>(
                 (com.google.bigtable.v1.RowFilter.Chain) filter_,
                 getParentForChildren(),
                 isClean());
@@ -5151,8 +5145,7 @@ public  final class RowFilter extends
         if (!(filterCase_ == 2)) {
           filter_ = com.google.bigtable.v1.RowFilter.Interleave.getDefaultInstance();
         }
-        interleaveBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-            com.google.bigtable.v1.RowFilter.Interleave, com.google.bigtable.v1.RowFilter.Interleave.Builder, com.google.bigtable.v1.RowFilter.InterleaveOrBuilder>(
+        interleaveBuilder_ = new com.google.protobuf.SingleFieldBuilder<>(
                 (com.google.bigtable.v1.RowFilter.Interleave) filter_,
                 getParentForChildren(),
                 isClean());
@@ -5321,8 +5314,7 @@ public  final class RowFilter extends
         if (!(filterCase_ == 3)) {
           filter_ = com.google.bigtable.v1.RowFilter.Condition.getDefaultInstance();
         }
-        conditionBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-            com.google.bigtable.v1.RowFilter.Condition, com.google.bigtable.v1.RowFilter.Condition.Builder, com.google.bigtable.v1.RowFilter.ConditionOrBuilder>(
+        conditionBuilder_ = new com.google.protobuf.SingleFieldBuilder<>(
                 (com.google.bigtable.v1.RowFilter.Condition) filter_,
                 getParentForChildren(),
                 isClean());
@@ -6067,8 +6059,7 @@ public  final class RowFilter extends
         if (!(filterCase_ == 7)) {
           filter_ = com.google.bigtable.v1.ColumnRange.getDefaultInstance();
         }
-        columnRangeFilterBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-            com.google.bigtable.v1.ColumnRange, com.google.bigtable.v1.ColumnRange.Builder, com.google.bigtable.v1.ColumnRangeOrBuilder>(
+        columnRangeFilterBuilder_ = new com.google.protobuf.SingleFieldBuilder<>(
                 (com.google.bigtable.v1.ColumnRange) filter_,
                 getParentForChildren(),
                 isClean());
@@ -6229,8 +6220,7 @@ public  final class RowFilter extends
         if (!(filterCase_ == 8)) {
           filter_ = com.google.bigtable.v1.TimestampRange.getDefaultInstance();
         }
-        timestampRangeFilterBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-            com.google.bigtable.v1.TimestampRange, com.google.bigtable.v1.TimestampRange.Builder, com.google.bigtable.v1.TimestampRangeOrBuilder>(
+        timestampRangeFilterBuilder_ = new com.google.protobuf.SingleFieldBuilder<>(
                 (com.google.bigtable.v1.TimestampRange) filter_,
                 getParentForChildren(),
                 isClean());
@@ -6448,8 +6438,7 @@ public  final class RowFilter extends
         if (!(filterCase_ == 15)) {
           filter_ = com.google.bigtable.v1.ValueRange.getDefaultInstance();
         }
-        valueRangeFilterBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-            com.google.bigtable.v1.ValueRange, com.google.bigtable.v1.ValueRange.Builder, com.google.bigtable.v1.ValueRangeOrBuilder>(
+        valueRangeFilterBuilder_ = new com.google.protobuf.SingleFieldBuilder<>(
                 (com.google.bigtable.v1.ValueRange) filter_,
                 getParentForChildren(),
                 isClean());

--- a/bigtable-protos/src/generated/java/protos/com/google/bigtable/v1/RowSet.java
+++ b/bigtable-protos/src/generated/java/protos/com/google/bigtable/v1/RowSet.java
@@ -49,7 +49,7 @@ public  final class RowSet extends
           }
           case 10: {
             if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
-              rowKeys_ = new java.util.ArrayList<com.google.protobuf.ByteString>();
+              rowKeys_ = new java.util.ArrayList<>();
               mutable_bitField0_ |= 0x00000001;
             }
             rowKeys_.add(input.readBytes());
@@ -57,7 +57,7 @@ public  final class RowSet extends
           }
           case 18: {
             if (!((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
-              rowRanges_ = new java.util.ArrayList<com.google.bigtable.v1.RowRange>();
+              rowRanges_ = new java.util.ArrayList<>();
               mutable_bitField0_ |= 0x00000002;
             }
             rowRanges_.add(input.readMessage(com.google.bigtable.v1.RowRange.parser(), extensionRegistry));
@@ -462,7 +462,7 @@ public  final class RowSet extends
     private java.util.List<com.google.protobuf.ByteString> rowKeys_ = java.util.Collections.emptyList();
     private void ensureRowKeysIsMutable() {
       if (!((bitField0_ & 0x00000001) == 0x00000001)) {
-        rowKeys_ = new java.util.ArrayList<com.google.protobuf.ByteString>(rowKeys_);
+        rowKeys_ = new java.util.ArrayList<>(rowKeys_);
         bitField0_ |= 0x00000001;
        }
     }
@@ -563,7 +563,7 @@ public  final class RowSet extends
       java.util.Collections.emptyList();
     private void ensureRowRangesIsMutable() {
       if (!((bitField0_ & 0x00000002) == 0x00000002)) {
-        rowRanges_ = new java.util.ArrayList<com.google.bigtable.v1.RowRange>(rowRanges_);
+        rowRanges_ = new java.util.ArrayList<>(rowRanges_);
         bitField0_ |= 0x00000002;
        }
     }
@@ -860,8 +860,7 @@ public  final class RowSet extends
         com.google.bigtable.v1.RowRange, com.google.bigtable.v1.RowRange.Builder, com.google.bigtable.v1.RowRangeOrBuilder> 
         getRowRangesFieldBuilder() {
       if (rowRangesBuilder_ == null) {
-        rowRangesBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-            com.google.bigtable.v1.RowRange, com.google.bigtable.v1.RowRange.Builder, com.google.bigtable.v1.RowRangeOrBuilder>(
+        rowRangesBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<>(
                 rowRanges_,
                 ((bitField0_ & 0x00000002) == 0x00000002),
                 getParentForChildren(),

--- a/bigtable-protos/src/generated/java/protos/com/google/longrunning/ListOperationsResponse.java
+++ b/bigtable-protos/src/generated/java/protos/com/google/longrunning/ListOperationsResponse.java
@@ -49,7 +49,7 @@ public  final class ListOperationsResponse extends
           }
           case 10: {
             if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
-              operations_ = new java.util.ArrayList<com.google.longrunning.Operation>();
+              operations_ = new java.util.ArrayList<>();
               mutable_bitField0_ |= 0x00000001;
             }
             operations_.add(input.readMessage(com.google.longrunning.Operation.parser(), extensionRegistry));
@@ -453,7 +453,7 @@ public  final class ListOperationsResponse extends
       java.util.Collections.emptyList();
     private void ensureOperationsIsMutable() {
       if (!((bitField0_ & 0x00000001) == 0x00000001)) {
-        operations_ = new java.util.ArrayList<com.google.longrunning.Operation>(operations_);
+        operations_ = new java.util.ArrayList<>(operations_);
         bitField0_ |= 0x00000001;
        }
     }
@@ -750,8 +750,7 @@ public  final class ListOperationsResponse extends
         com.google.longrunning.Operation, com.google.longrunning.Operation.Builder, com.google.longrunning.OperationOrBuilder> 
         getOperationsFieldBuilder() {
       if (operationsBuilder_ == null) {
-        operationsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-            com.google.longrunning.Operation, com.google.longrunning.Operation.Builder, com.google.longrunning.OperationOrBuilder>(
+        operationsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<>(
                 operations_,
                 ((bitField0_ & 0x00000001) == 0x00000001),
                 getParentForChildren(),

--- a/bigtable-protos/src/generated/java/protos/com/google/longrunning/Operation.java
+++ b/bigtable-protos/src/generated/java/protos/com/google/longrunning/Operation.java
@@ -893,8 +893,7 @@ public  final class Operation extends
         com.google.protobuf.Any, com.google.protobuf.Any.Builder, com.google.protobuf.AnyOrBuilder> 
         getMetadataFieldBuilder() {
       if (metadataBuilder_ == null) {
-        metadataBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-            com.google.protobuf.Any, com.google.protobuf.Any.Builder, com.google.protobuf.AnyOrBuilder>(
+        metadataBuilder_ = new com.google.protobuf.SingleFieldBuilder<>(
                 getMetadata(),
                 getParentForChildren(),
                 isClean());
@@ -1094,8 +1093,7 @@ public  final class Operation extends
         if (!(resultCase_ == 4)) {
           result_ = com.google.rpc.Status.getDefaultInstance();
         }
-        errorBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-            com.google.rpc.Status, com.google.rpc.Status.Builder, com.google.rpc.StatusOrBuilder>(
+        errorBuilder_ = new com.google.protobuf.SingleFieldBuilder<>(
                 (com.google.rpc.Status) result_,
                 getParentForChildren(),
                 isClean());
@@ -1312,8 +1310,7 @@ public  final class Operation extends
         if (!(resultCase_ == 5)) {
           result_ = com.google.protobuf.Any.getDefaultInstance();
         }
-        responseBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-            com.google.protobuf.Any, com.google.protobuf.Any.Builder, com.google.protobuf.AnyOrBuilder>(
+        responseBuilder_ = new com.google.protobuf.SingleFieldBuilder<>(
                 (com.google.protobuf.Any) result_,
                 getParentForChildren(),
                 isClean());

--- a/bigtable-protos/src/generated/java/protos/com/google/protobuf/Api.java
+++ b/bigtable-protos/src/generated/java/protos/com/google/protobuf/Api.java
@@ -57,7 +57,7 @@ public  final class Api extends
           }
           case 18: {
             if (!((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
-              methods_ = new java.util.ArrayList<com.google.protobuf.Method>();
+              methods_ = new java.util.ArrayList<>();
               mutable_bitField0_ |= 0x00000002;
             }
             methods_.add(input.readMessage(com.google.protobuf.Method.parser(), extensionRegistry));
@@ -65,7 +65,7 @@ public  final class Api extends
           }
           case 26: {
             if (!((mutable_bitField0_ & 0x00000004) == 0x00000004)) {
-              options_ = new java.util.ArrayList<com.google.protobuf.Option>();
+              options_ = new java.util.ArrayList<>();
               mutable_bitField0_ |= 0x00000004;
             }
             options_.add(input.readMessage(com.google.protobuf.Option.parser(), extensionRegistry));
@@ -833,7 +833,7 @@ public  final class Api extends
       java.util.Collections.emptyList();
     private void ensureMethodsIsMutable() {
       if (!((bitField0_ & 0x00000002) == 0x00000002)) {
-        methods_ = new java.util.ArrayList<com.google.protobuf.Method>(methods_);
+        methods_ = new java.util.ArrayList<>(methods_);
         bitField0_ |= 0x00000002;
        }
     }
@@ -1130,8 +1130,7 @@ public  final class Api extends
         com.google.protobuf.Method, com.google.protobuf.Method.Builder, com.google.protobuf.MethodOrBuilder> 
         getMethodsFieldBuilder() {
       if (methodsBuilder_ == null) {
-        methodsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-            com.google.protobuf.Method, com.google.protobuf.Method.Builder, com.google.protobuf.MethodOrBuilder>(
+        methodsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<>(
                 methods_,
                 ((bitField0_ & 0x00000002) == 0x00000002),
                 getParentForChildren(),
@@ -1145,7 +1144,7 @@ public  final class Api extends
       java.util.Collections.emptyList();
     private void ensureOptionsIsMutable() {
       if (!((bitField0_ & 0x00000004) == 0x00000004)) {
-        options_ = new java.util.ArrayList<com.google.protobuf.Option>(options_);
+        options_ = new java.util.ArrayList<>(options_);
         bitField0_ |= 0x00000004;
        }
     }
@@ -1442,8 +1441,7 @@ public  final class Api extends
         com.google.protobuf.Option, com.google.protobuf.Option.Builder, com.google.protobuf.OptionOrBuilder> 
         getOptionsFieldBuilder() {
       if (optionsBuilder_ == null) {
-        optionsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-            com.google.protobuf.Option, com.google.protobuf.Option.Builder, com.google.protobuf.OptionOrBuilder>(
+        optionsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<>(
                 options_,
                 ((bitField0_ & 0x00000004) == 0x00000004),
                 getParentForChildren(),
@@ -1784,8 +1782,7 @@ public  final class Api extends
         com.google.protobuf.SourceContext, com.google.protobuf.SourceContext.Builder, com.google.protobuf.SourceContextOrBuilder> 
         getSourceContextFieldBuilder() {
       if (sourceContextBuilder_ == null) {
-        sourceContextBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-            com.google.protobuf.SourceContext, com.google.protobuf.SourceContext.Builder, com.google.protobuf.SourceContextOrBuilder>(
+        sourceContextBuilder_ = new com.google.protobuf.SingleFieldBuilder<>(
                 getSourceContext(),
                 getParentForChildren(),
                 isClean());

--- a/bigtable-protos/src/generated/java/protos/com/google/protobuf/DescriptorProtos.java
+++ b/bigtable-protos/src/generated/java/protos/com/google/protobuf/DescriptorProtos.java
@@ -85,7 +85,7 @@ public final class DescriptorProtos {
             }
             case 10: {
               if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
-                file_ = new java.util.ArrayList<com.google.protobuf.DescriptorProtos.FileDescriptorProto>();
+                file_ = new java.util.ArrayList<>();
                 mutable_bitField0_ |= 0x00000001;
               }
               file_.add(input.readMessage(com.google.protobuf.DescriptorProtos.FileDescriptorProto.parser(), extensionRegistry));
@@ -421,7 +421,7 @@ public final class DescriptorProtos {
         java.util.Collections.emptyList();
       private void ensureFileIsMutable() {
         if (!((bitField0_ & 0x00000001) == 0x00000001)) {
-          file_ = new java.util.ArrayList<com.google.protobuf.DescriptorProtos.FileDescriptorProto>(file_);
+          file_ = new java.util.ArrayList<>(file_);
           bitField0_ |= 0x00000001;
          }
       }
@@ -646,8 +646,7 @@ public final class DescriptorProtos {
           com.google.protobuf.DescriptorProtos.FileDescriptorProto, com.google.protobuf.DescriptorProtos.FileDescriptorProto.Builder, com.google.protobuf.DescriptorProtos.FileDescriptorProtoOrBuilder> 
           getFileFieldBuilder() {
         if (fileBuilder_ == null) {
-          fileBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-              com.google.protobuf.DescriptorProtos.FileDescriptorProto, com.google.protobuf.DescriptorProtos.FileDescriptorProto.Builder, com.google.protobuf.DescriptorProtos.FileDescriptorProtoOrBuilder>(
+          fileBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<>(
                   file_,
                   ((bitField0_ & 0x00000001) == 0x00000001),
                   getParentForChildren(),
@@ -1118,7 +1117,7 @@ public final class DescriptorProtos {
             }
             case 34: {
               if (!((mutable_bitField0_ & 0x00000020) == 0x00000020)) {
-                messageType_ = new java.util.ArrayList<com.google.protobuf.DescriptorProtos.DescriptorProto>();
+                messageType_ = new java.util.ArrayList<>();
                 mutable_bitField0_ |= 0x00000020;
               }
               messageType_.add(input.readMessage(com.google.protobuf.DescriptorProtos.DescriptorProto.parser(), extensionRegistry));
@@ -1126,7 +1125,7 @@ public final class DescriptorProtos {
             }
             case 42: {
               if (!((mutable_bitField0_ & 0x00000040) == 0x00000040)) {
-                enumType_ = new java.util.ArrayList<com.google.protobuf.DescriptorProtos.EnumDescriptorProto>();
+                enumType_ = new java.util.ArrayList<>();
                 mutable_bitField0_ |= 0x00000040;
               }
               enumType_.add(input.readMessage(com.google.protobuf.DescriptorProtos.EnumDescriptorProto.parser(), extensionRegistry));
@@ -1134,7 +1133,7 @@ public final class DescriptorProtos {
             }
             case 50: {
               if (!((mutable_bitField0_ & 0x00000080) == 0x00000080)) {
-                service_ = new java.util.ArrayList<com.google.protobuf.DescriptorProtos.ServiceDescriptorProto>();
+                service_ = new java.util.ArrayList<>();
                 mutable_bitField0_ |= 0x00000080;
               }
               service_.add(input.readMessage(com.google.protobuf.DescriptorProtos.ServiceDescriptorProto.parser(), extensionRegistry));
@@ -1142,7 +1141,7 @@ public final class DescriptorProtos {
             }
             case 58: {
               if (!((mutable_bitField0_ & 0x00000100) == 0x00000100)) {
-                extension_ = new java.util.ArrayList<com.google.protobuf.DescriptorProtos.FieldDescriptorProto>();
+                extension_ = new java.util.ArrayList<>();
                 mutable_bitField0_ |= 0x00000100;
               }
               extension_.add(input.readMessage(com.google.protobuf.DescriptorProtos.FieldDescriptorProto.parser(), extensionRegistry));
@@ -1176,7 +1175,7 @@ public final class DescriptorProtos {
             }
             case 80: {
               if (!((mutable_bitField0_ & 0x00000008) == 0x00000008)) {
-                publicDependency_ = new java.util.ArrayList<java.lang.Integer>();
+                publicDependency_ = new java.util.ArrayList<>();
                 mutable_bitField0_ |= 0x00000008;
               }
               publicDependency_.add(input.readInt32());
@@ -1186,7 +1185,7 @@ public final class DescriptorProtos {
               int length = input.readRawVarint32();
               int limit = input.pushLimit(length);
               if (!((mutable_bitField0_ & 0x00000008) == 0x00000008) && input.getBytesUntilLimit() > 0) {
-                publicDependency_ = new java.util.ArrayList<java.lang.Integer>();
+                publicDependency_ = new java.util.ArrayList<>();
                 mutable_bitField0_ |= 0x00000008;
               }
               while (input.getBytesUntilLimit() > 0) {
@@ -1197,7 +1196,7 @@ public final class DescriptorProtos {
             }
             case 88: {
               if (!((mutable_bitField0_ & 0x00000010) == 0x00000010)) {
-                weakDependency_ = new java.util.ArrayList<java.lang.Integer>();
+                weakDependency_ = new java.util.ArrayList<>();
                 mutable_bitField0_ |= 0x00000010;
               }
               weakDependency_.add(input.readInt32());
@@ -1207,7 +1206,7 @@ public final class DescriptorProtos {
               int length = input.readRawVarint32();
               int limit = input.pushLimit(length);
               if (!((mutable_bitField0_ & 0x00000010) == 0x00000010) && input.getBytesUntilLimit() > 0) {
-                weakDependency_ = new java.util.ArrayList<java.lang.Integer>();
+                weakDependency_ = new java.util.ArrayList<>();
                 mutable_bitField0_ |= 0x00000010;
               }
               while (input.getBytesUntilLimit() > 0) {
@@ -2747,7 +2746,7 @@ public final class DescriptorProtos {
       private java.util.List<java.lang.Integer> publicDependency_ = java.util.Collections.emptyList();
       private void ensurePublicDependencyIsMutable() {
         if (!((bitField0_ & 0x00000008) == 0x00000008)) {
-          publicDependency_ = new java.util.ArrayList<java.lang.Integer>(publicDependency_);
+          publicDependency_ = new java.util.ArrayList<>(publicDependency_);
           bitField0_ |= 0x00000008;
          }
       }
@@ -2841,7 +2840,7 @@ public final class DescriptorProtos {
       private java.util.List<java.lang.Integer> weakDependency_ = java.util.Collections.emptyList();
       private void ensureWeakDependencyIsMutable() {
         if (!((bitField0_ & 0x00000010) == 0x00000010)) {
-          weakDependency_ = new java.util.ArrayList<java.lang.Integer>(weakDependency_);
+          weakDependency_ = new java.util.ArrayList<>(weakDependency_);
           bitField0_ |= 0x00000010;
          }
       }
@@ -2943,7 +2942,7 @@ public final class DescriptorProtos {
         java.util.Collections.emptyList();
       private void ensureMessageTypeIsMutable() {
         if (!((bitField0_ & 0x00000020) == 0x00000020)) {
-          messageType_ = new java.util.ArrayList<com.google.protobuf.DescriptorProtos.DescriptorProto>(messageType_);
+          messageType_ = new java.util.ArrayList<>(messageType_);
           bitField0_ |= 0x00000020;
          }
       }
@@ -3240,8 +3239,7 @@ public final class DescriptorProtos {
           com.google.protobuf.DescriptorProtos.DescriptorProto, com.google.protobuf.DescriptorProtos.DescriptorProto.Builder, com.google.protobuf.DescriptorProtos.DescriptorProtoOrBuilder> 
           getMessageTypeFieldBuilder() {
         if (messageTypeBuilder_ == null) {
-          messageTypeBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-              com.google.protobuf.DescriptorProtos.DescriptorProto, com.google.protobuf.DescriptorProtos.DescriptorProto.Builder, com.google.protobuf.DescriptorProtos.DescriptorProtoOrBuilder>(
+          messageTypeBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<>(
                   messageType_,
                   ((bitField0_ & 0x00000020) == 0x00000020),
                   getParentForChildren(),
@@ -3255,7 +3253,7 @@ public final class DescriptorProtos {
         java.util.Collections.emptyList();
       private void ensureEnumTypeIsMutable() {
         if (!((bitField0_ & 0x00000040) == 0x00000040)) {
-          enumType_ = new java.util.ArrayList<com.google.protobuf.DescriptorProtos.EnumDescriptorProto>(enumType_);
+          enumType_ = new java.util.ArrayList<>(enumType_);
           bitField0_ |= 0x00000040;
          }
       }
@@ -3480,8 +3478,7 @@ public final class DescriptorProtos {
           com.google.protobuf.DescriptorProtos.EnumDescriptorProto, com.google.protobuf.DescriptorProtos.EnumDescriptorProto.Builder, com.google.protobuf.DescriptorProtos.EnumDescriptorProtoOrBuilder> 
           getEnumTypeFieldBuilder() {
         if (enumTypeBuilder_ == null) {
-          enumTypeBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-              com.google.protobuf.DescriptorProtos.EnumDescriptorProto, com.google.protobuf.DescriptorProtos.EnumDescriptorProto.Builder, com.google.protobuf.DescriptorProtos.EnumDescriptorProtoOrBuilder>(
+          enumTypeBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<>(
                   enumType_,
                   ((bitField0_ & 0x00000040) == 0x00000040),
                   getParentForChildren(),
@@ -3495,7 +3492,7 @@ public final class DescriptorProtos {
         java.util.Collections.emptyList();
       private void ensureServiceIsMutable() {
         if (!((bitField0_ & 0x00000080) == 0x00000080)) {
-          service_ = new java.util.ArrayList<com.google.protobuf.DescriptorProtos.ServiceDescriptorProto>(service_);
+          service_ = new java.util.ArrayList<>(service_);
           bitField0_ |= 0x00000080;
          }
       }
@@ -3720,8 +3717,7 @@ public final class DescriptorProtos {
           com.google.protobuf.DescriptorProtos.ServiceDescriptorProto, com.google.protobuf.DescriptorProtos.ServiceDescriptorProto.Builder, com.google.protobuf.DescriptorProtos.ServiceDescriptorProtoOrBuilder> 
           getServiceFieldBuilder() {
         if (serviceBuilder_ == null) {
-          serviceBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-              com.google.protobuf.DescriptorProtos.ServiceDescriptorProto, com.google.protobuf.DescriptorProtos.ServiceDescriptorProto.Builder, com.google.protobuf.DescriptorProtos.ServiceDescriptorProtoOrBuilder>(
+          serviceBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<>(
                   service_,
                   ((bitField0_ & 0x00000080) == 0x00000080),
                   getParentForChildren(),
@@ -3735,7 +3731,7 @@ public final class DescriptorProtos {
         java.util.Collections.emptyList();
       private void ensureExtensionIsMutable() {
         if (!((bitField0_ & 0x00000100) == 0x00000100)) {
-          extension_ = new java.util.ArrayList<com.google.protobuf.DescriptorProtos.FieldDescriptorProto>(extension_);
+          extension_ = new java.util.ArrayList<>(extension_);
           bitField0_ |= 0x00000100;
          }
       }
@@ -3960,8 +3956,7 @@ public final class DescriptorProtos {
           com.google.protobuf.DescriptorProtos.FieldDescriptorProto, com.google.protobuf.DescriptorProtos.FieldDescriptorProto.Builder, com.google.protobuf.DescriptorProtos.FieldDescriptorProtoOrBuilder> 
           getExtensionFieldBuilder() {
         if (extensionBuilder_ == null) {
-          extensionBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-              com.google.protobuf.DescriptorProtos.FieldDescriptorProto, com.google.protobuf.DescriptorProtos.FieldDescriptorProto.Builder, com.google.protobuf.DescriptorProtos.FieldDescriptorProtoOrBuilder>(
+          extensionBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<>(
                   extension_,
                   ((bitField0_ & 0x00000100) == 0x00000100),
                   getParentForChildren(),
@@ -4079,8 +4074,7 @@ public final class DescriptorProtos {
           com.google.protobuf.DescriptorProtos.FileOptions, com.google.protobuf.DescriptorProtos.FileOptions.Builder, com.google.protobuf.DescriptorProtos.FileOptionsOrBuilder> 
           getOptionsFieldBuilder() {
         if (optionsBuilder_ == null) {
-          optionsBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-              com.google.protobuf.DescriptorProtos.FileOptions, com.google.protobuf.DescriptorProtos.FileOptions.Builder, com.google.protobuf.DescriptorProtos.FileOptionsOrBuilder>(
+          optionsBuilder_ = new com.google.protobuf.SingleFieldBuilder<>(
                   getOptions(),
                   getParentForChildren(),
                   isClean());
@@ -4260,8 +4254,7 @@ public final class DescriptorProtos {
           com.google.protobuf.DescriptorProtos.SourceCodeInfo, com.google.protobuf.DescriptorProtos.SourceCodeInfo.Builder, com.google.protobuf.DescriptorProtos.SourceCodeInfoOrBuilder> 
           getSourceCodeInfoFieldBuilder() {
         if (sourceCodeInfoBuilder_ == null) {
-          sourceCodeInfoBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-              com.google.protobuf.DescriptorProtos.SourceCodeInfo, com.google.protobuf.DescriptorProtos.SourceCodeInfo.Builder, com.google.protobuf.DescriptorProtos.SourceCodeInfoOrBuilder>(
+          sourceCodeInfoBuilder_ = new com.google.protobuf.SingleFieldBuilder<>(
                   getSourceCodeInfo(),
                   getParentForChildren(),
                   isClean());
@@ -4658,7 +4651,7 @@ public final class DescriptorProtos {
             }
             case 18: {
               if (!((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
-                field_ = new java.util.ArrayList<com.google.protobuf.DescriptorProtos.FieldDescriptorProto>();
+                field_ = new java.util.ArrayList<>();
                 mutable_bitField0_ |= 0x00000002;
               }
               field_.add(input.readMessage(com.google.protobuf.DescriptorProtos.FieldDescriptorProto.parser(), extensionRegistry));
@@ -4666,7 +4659,7 @@ public final class DescriptorProtos {
             }
             case 26: {
               if (!((mutable_bitField0_ & 0x00000008) == 0x00000008)) {
-                nestedType_ = new java.util.ArrayList<com.google.protobuf.DescriptorProtos.DescriptorProto>();
+                nestedType_ = new java.util.ArrayList<>();
                 mutable_bitField0_ |= 0x00000008;
               }
               nestedType_.add(input.readMessage(com.google.protobuf.DescriptorProtos.DescriptorProto.parser(), extensionRegistry));
@@ -4674,7 +4667,7 @@ public final class DescriptorProtos {
             }
             case 34: {
               if (!((mutable_bitField0_ & 0x00000010) == 0x00000010)) {
-                enumType_ = new java.util.ArrayList<com.google.protobuf.DescriptorProtos.EnumDescriptorProto>();
+                enumType_ = new java.util.ArrayList<>();
                 mutable_bitField0_ |= 0x00000010;
               }
               enumType_.add(input.readMessage(com.google.protobuf.DescriptorProtos.EnumDescriptorProto.parser(), extensionRegistry));
@@ -4682,7 +4675,7 @@ public final class DescriptorProtos {
             }
             case 42: {
               if (!((mutable_bitField0_ & 0x00000020) == 0x00000020)) {
-                extensionRange_ = new java.util.ArrayList<com.google.protobuf.DescriptorProtos.DescriptorProto.ExtensionRange>();
+                extensionRange_ = new java.util.ArrayList<>();
                 mutable_bitField0_ |= 0x00000020;
               }
               extensionRange_.add(input.readMessage(com.google.protobuf.DescriptorProtos.DescriptorProto.ExtensionRange.parser(), extensionRegistry));
@@ -4690,7 +4683,7 @@ public final class DescriptorProtos {
             }
             case 50: {
               if (!((mutable_bitField0_ & 0x00000004) == 0x00000004)) {
-                extension_ = new java.util.ArrayList<com.google.protobuf.DescriptorProtos.FieldDescriptorProto>();
+                extension_ = new java.util.ArrayList<>();
                 mutable_bitField0_ |= 0x00000004;
               }
               extension_.add(input.readMessage(com.google.protobuf.DescriptorProtos.FieldDescriptorProto.parser(), extensionRegistry));
@@ -4711,7 +4704,7 @@ public final class DescriptorProtos {
             }
             case 66: {
               if (!((mutable_bitField0_ & 0x00000040) == 0x00000040)) {
-                oneofDecl_ = new java.util.ArrayList<com.google.protobuf.DescriptorProtos.OneofDescriptorProto>();
+                oneofDecl_ = new java.util.ArrayList<>();
                 mutable_bitField0_ |= 0x00000040;
               }
               oneofDecl_.add(input.readMessage(com.google.protobuf.DescriptorProtos.OneofDescriptorProto.parser(), extensionRegistry));
@@ -6183,7 +6176,7 @@ public final class DescriptorProtos {
         java.util.Collections.emptyList();
       private void ensureFieldIsMutable() {
         if (!((bitField0_ & 0x00000002) == 0x00000002)) {
-          field_ = new java.util.ArrayList<com.google.protobuf.DescriptorProtos.FieldDescriptorProto>(field_);
+          field_ = new java.util.ArrayList<>(field_);
           bitField0_ |= 0x00000002;
          }
       }
@@ -6408,8 +6401,7 @@ public final class DescriptorProtos {
           com.google.protobuf.DescriptorProtos.FieldDescriptorProto, com.google.protobuf.DescriptorProtos.FieldDescriptorProto.Builder, com.google.protobuf.DescriptorProtos.FieldDescriptorProtoOrBuilder> 
           getFieldFieldBuilder() {
         if (fieldBuilder_ == null) {
-          fieldBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-              com.google.protobuf.DescriptorProtos.FieldDescriptorProto, com.google.protobuf.DescriptorProtos.FieldDescriptorProto.Builder, com.google.protobuf.DescriptorProtos.FieldDescriptorProtoOrBuilder>(
+          fieldBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<>(
                   field_,
                   ((bitField0_ & 0x00000002) == 0x00000002),
                   getParentForChildren(),
@@ -6423,7 +6415,7 @@ public final class DescriptorProtos {
         java.util.Collections.emptyList();
       private void ensureExtensionIsMutable() {
         if (!((bitField0_ & 0x00000004) == 0x00000004)) {
-          extension_ = new java.util.ArrayList<com.google.protobuf.DescriptorProtos.FieldDescriptorProto>(extension_);
+          extension_ = new java.util.ArrayList<>(extension_);
           bitField0_ |= 0x00000004;
          }
       }
@@ -6648,8 +6640,7 @@ public final class DescriptorProtos {
           com.google.protobuf.DescriptorProtos.FieldDescriptorProto, com.google.protobuf.DescriptorProtos.FieldDescriptorProto.Builder, com.google.protobuf.DescriptorProtos.FieldDescriptorProtoOrBuilder> 
           getExtensionFieldBuilder() {
         if (extensionBuilder_ == null) {
-          extensionBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-              com.google.protobuf.DescriptorProtos.FieldDescriptorProto, com.google.protobuf.DescriptorProtos.FieldDescriptorProto.Builder, com.google.protobuf.DescriptorProtos.FieldDescriptorProtoOrBuilder>(
+          extensionBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<>(
                   extension_,
                   ((bitField0_ & 0x00000004) == 0x00000004),
                   getParentForChildren(),
@@ -6663,7 +6654,7 @@ public final class DescriptorProtos {
         java.util.Collections.emptyList();
       private void ensureNestedTypeIsMutable() {
         if (!((bitField0_ & 0x00000008) == 0x00000008)) {
-          nestedType_ = new java.util.ArrayList<com.google.protobuf.DescriptorProtos.DescriptorProto>(nestedType_);
+          nestedType_ = new java.util.ArrayList<>(nestedType_);
           bitField0_ |= 0x00000008;
          }
       }
@@ -6888,8 +6879,7 @@ public final class DescriptorProtos {
           com.google.protobuf.DescriptorProtos.DescriptorProto, com.google.protobuf.DescriptorProtos.DescriptorProto.Builder, com.google.protobuf.DescriptorProtos.DescriptorProtoOrBuilder> 
           getNestedTypeFieldBuilder() {
         if (nestedTypeBuilder_ == null) {
-          nestedTypeBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-              com.google.protobuf.DescriptorProtos.DescriptorProto, com.google.protobuf.DescriptorProtos.DescriptorProto.Builder, com.google.protobuf.DescriptorProtos.DescriptorProtoOrBuilder>(
+          nestedTypeBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<>(
                   nestedType_,
                   ((bitField0_ & 0x00000008) == 0x00000008),
                   getParentForChildren(),
@@ -6903,7 +6893,7 @@ public final class DescriptorProtos {
         java.util.Collections.emptyList();
       private void ensureEnumTypeIsMutable() {
         if (!((bitField0_ & 0x00000010) == 0x00000010)) {
-          enumType_ = new java.util.ArrayList<com.google.protobuf.DescriptorProtos.EnumDescriptorProto>(enumType_);
+          enumType_ = new java.util.ArrayList<>(enumType_);
           bitField0_ |= 0x00000010;
          }
       }
@@ -7128,8 +7118,7 @@ public final class DescriptorProtos {
           com.google.protobuf.DescriptorProtos.EnumDescriptorProto, com.google.protobuf.DescriptorProtos.EnumDescriptorProto.Builder, com.google.protobuf.DescriptorProtos.EnumDescriptorProtoOrBuilder> 
           getEnumTypeFieldBuilder() {
         if (enumTypeBuilder_ == null) {
-          enumTypeBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-              com.google.protobuf.DescriptorProtos.EnumDescriptorProto, com.google.protobuf.DescriptorProtos.EnumDescriptorProto.Builder, com.google.protobuf.DescriptorProtos.EnumDescriptorProtoOrBuilder>(
+          enumTypeBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<>(
                   enumType_,
                   ((bitField0_ & 0x00000010) == 0x00000010),
                   getParentForChildren(),
@@ -7143,7 +7132,7 @@ public final class DescriptorProtos {
         java.util.Collections.emptyList();
       private void ensureExtensionRangeIsMutable() {
         if (!((bitField0_ & 0x00000020) == 0x00000020)) {
-          extensionRange_ = new java.util.ArrayList<com.google.protobuf.DescriptorProtos.DescriptorProto.ExtensionRange>(extensionRange_);
+          extensionRange_ = new java.util.ArrayList<>(extensionRange_);
           bitField0_ |= 0x00000020;
          }
       }
@@ -7368,8 +7357,7 @@ public final class DescriptorProtos {
           com.google.protobuf.DescriptorProtos.DescriptorProto.ExtensionRange, com.google.protobuf.DescriptorProtos.DescriptorProto.ExtensionRange.Builder, com.google.protobuf.DescriptorProtos.DescriptorProto.ExtensionRangeOrBuilder> 
           getExtensionRangeFieldBuilder() {
         if (extensionRangeBuilder_ == null) {
-          extensionRangeBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-              com.google.protobuf.DescriptorProtos.DescriptorProto.ExtensionRange, com.google.protobuf.DescriptorProtos.DescriptorProto.ExtensionRange.Builder, com.google.protobuf.DescriptorProtos.DescriptorProto.ExtensionRangeOrBuilder>(
+          extensionRangeBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<>(
                   extensionRange_,
                   ((bitField0_ & 0x00000020) == 0x00000020),
                   getParentForChildren(),
@@ -7383,7 +7371,7 @@ public final class DescriptorProtos {
         java.util.Collections.emptyList();
       private void ensureOneofDeclIsMutable() {
         if (!((bitField0_ & 0x00000040) == 0x00000040)) {
-          oneofDecl_ = new java.util.ArrayList<com.google.protobuf.DescriptorProtos.OneofDescriptorProto>(oneofDecl_);
+          oneofDecl_ = new java.util.ArrayList<>(oneofDecl_);
           bitField0_ |= 0x00000040;
          }
       }
@@ -7608,8 +7596,7 @@ public final class DescriptorProtos {
           com.google.protobuf.DescriptorProtos.OneofDescriptorProto, com.google.protobuf.DescriptorProtos.OneofDescriptorProto.Builder, com.google.protobuf.DescriptorProtos.OneofDescriptorProtoOrBuilder> 
           getOneofDeclFieldBuilder() {
         if (oneofDeclBuilder_ == null) {
-          oneofDeclBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-              com.google.protobuf.DescriptorProtos.OneofDescriptorProto, com.google.protobuf.DescriptorProtos.OneofDescriptorProto.Builder, com.google.protobuf.DescriptorProtos.OneofDescriptorProtoOrBuilder>(
+          oneofDeclBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<>(
                   oneofDecl_,
                   ((bitField0_ & 0x00000040) == 0x00000040),
                   getParentForChildren(),
@@ -7727,8 +7714,7 @@ public final class DescriptorProtos {
           com.google.protobuf.DescriptorProtos.MessageOptions, com.google.protobuf.DescriptorProtos.MessageOptions.Builder, com.google.protobuf.DescriptorProtos.MessageOptionsOrBuilder> 
           getOptionsFieldBuilder() {
         if (optionsBuilder_ == null) {
-          optionsBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-              com.google.protobuf.DescriptorProtos.MessageOptions, com.google.protobuf.DescriptorProtos.MessageOptions.Builder, com.google.protobuf.DescriptorProtos.MessageOptionsOrBuilder>(
+          optionsBuilder_ = new com.google.protobuf.SingleFieldBuilder<>(
                   getOptions(),
                   getParentForChildren(),
                   isClean());
@@ -9951,8 +9937,7 @@ public final class DescriptorProtos {
           com.google.protobuf.DescriptorProtos.FieldOptions, com.google.protobuf.DescriptorProtos.FieldOptions.Builder, com.google.protobuf.DescriptorProtos.FieldOptionsOrBuilder> 
           getOptionsFieldBuilder() {
         if (optionsBuilder_ == null) {
-          optionsBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-              com.google.protobuf.DescriptorProtos.FieldOptions, com.google.protobuf.DescriptorProtos.FieldOptions.Builder, com.google.protobuf.DescriptorProtos.FieldOptionsOrBuilder>(
+          optionsBuilder_ = new com.google.protobuf.SingleFieldBuilder<>(
                   getOptions(),
                   getParentForChildren(),
                   isClean());
@@ -10600,7 +10585,7 @@ public final class DescriptorProtos {
             }
             case 18: {
               if (!((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
-                value_ = new java.util.ArrayList<com.google.protobuf.DescriptorProtos.EnumValueDescriptorProto>();
+                value_ = new java.util.ArrayList<>();
                 mutable_bitField0_ |= 0x00000002;
               }
               value_.add(input.readMessage(com.google.protobuf.DescriptorProtos.EnumValueDescriptorProto.parser(), extensionRegistry));
@@ -11143,7 +11128,7 @@ public final class DescriptorProtos {
         java.util.Collections.emptyList();
       private void ensureValueIsMutable() {
         if (!((bitField0_ & 0x00000002) == 0x00000002)) {
-          value_ = new java.util.ArrayList<com.google.protobuf.DescriptorProtos.EnumValueDescriptorProto>(value_);
+          value_ = new java.util.ArrayList<>(value_);
           bitField0_ |= 0x00000002;
          }
       }
@@ -11368,8 +11353,7 @@ public final class DescriptorProtos {
           com.google.protobuf.DescriptorProtos.EnumValueDescriptorProto, com.google.protobuf.DescriptorProtos.EnumValueDescriptorProto.Builder, com.google.protobuf.DescriptorProtos.EnumValueDescriptorProtoOrBuilder> 
           getValueFieldBuilder() {
         if (valueBuilder_ == null) {
-          valueBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-              com.google.protobuf.DescriptorProtos.EnumValueDescriptorProto, com.google.protobuf.DescriptorProtos.EnumValueDescriptorProto.Builder, com.google.protobuf.DescriptorProtos.EnumValueDescriptorProtoOrBuilder>(
+          valueBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<>(
                   value_,
                   ((bitField0_ & 0x00000002) == 0x00000002),
                   getParentForChildren(),
@@ -11487,8 +11471,7 @@ public final class DescriptorProtos {
           com.google.protobuf.DescriptorProtos.EnumOptions, com.google.protobuf.DescriptorProtos.EnumOptions.Builder, com.google.protobuf.DescriptorProtos.EnumOptionsOrBuilder> 
           getOptionsFieldBuilder() {
         if (optionsBuilder_ == null) {
-          optionsBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-              com.google.protobuf.DescriptorProtos.EnumOptions, com.google.protobuf.DescriptorProtos.EnumOptions.Builder, com.google.protobuf.DescriptorProtos.EnumOptionsOrBuilder>(
+          optionsBuilder_ = new com.google.protobuf.SingleFieldBuilder<>(
                   getOptions(),
                   getParentForChildren(),
                   isClean());
@@ -12248,8 +12231,7 @@ public final class DescriptorProtos {
           com.google.protobuf.DescriptorProtos.EnumValueOptions, com.google.protobuf.DescriptorProtos.EnumValueOptions.Builder, com.google.protobuf.DescriptorProtos.EnumValueOptionsOrBuilder> 
           getOptionsFieldBuilder() {
         if (optionsBuilder_ == null) {
-          optionsBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-              com.google.protobuf.DescriptorProtos.EnumValueOptions, com.google.protobuf.DescriptorProtos.EnumValueOptions.Builder, com.google.protobuf.DescriptorProtos.EnumValueOptionsOrBuilder>(
+          optionsBuilder_ = new com.google.protobuf.SingleFieldBuilder<>(
                   getOptions(),
                   getParentForChildren(),
                   isClean());
@@ -12415,7 +12397,7 @@ public final class DescriptorProtos {
             }
             case 18: {
               if (!((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
-                method_ = new java.util.ArrayList<com.google.protobuf.DescriptorProtos.MethodDescriptorProto>();
+                method_ = new java.util.ArrayList<>();
                 mutable_bitField0_ |= 0x00000002;
               }
               method_.add(input.readMessage(com.google.protobuf.DescriptorProtos.MethodDescriptorProto.parser(), extensionRegistry));
@@ -12958,7 +12940,7 @@ public final class DescriptorProtos {
         java.util.Collections.emptyList();
       private void ensureMethodIsMutable() {
         if (!((bitField0_ & 0x00000002) == 0x00000002)) {
-          method_ = new java.util.ArrayList<com.google.protobuf.DescriptorProtos.MethodDescriptorProto>(method_);
+          method_ = new java.util.ArrayList<>(method_);
           bitField0_ |= 0x00000002;
          }
       }
@@ -13183,8 +13165,7 @@ public final class DescriptorProtos {
           com.google.protobuf.DescriptorProtos.MethodDescriptorProto, com.google.protobuf.DescriptorProtos.MethodDescriptorProto.Builder, com.google.protobuf.DescriptorProtos.MethodDescriptorProtoOrBuilder> 
           getMethodFieldBuilder() {
         if (methodBuilder_ == null) {
-          methodBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-              com.google.protobuf.DescriptorProtos.MethodDescriptorProto, com.google.protobuf.DescriptorProtos.MethodDescriptorProto.Builder, com.google.protobuf.DescriptorProtos.MethodDescriptorProtoOrBuilder>(
+          methodBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<>(
                   method_,
                   ((bitField0_ & 0x00000002) == 0x00000002),
                   getParentForChildren(),
@@ -13302,8 +13283,7 @@ public final class DescriptorProtos {
           com.google.protobuf.DescriptorProtos.ServiceOptions, com.google.protobuf.DescriptorProtos.ServiceOptions.Builder, com.google.protobuf.DescriptorProtos.ServiceOptionsOrBuilder> 
           getOptionsFieldBuilder() {
         if (optionsBuilder_ == null) {
-          optionsBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-              com.google.protobuf.DescriptorProtos.ServiceOptions, com.google.protobuf.DescriptorProtos.ServiceOptions.Builder, com.google.protobuf.DescriptorProtos.ServiceOptionsOrBuilder>(
+          optionsBuilder_ = new com.google.protobuf.SingleFieldBuilder<>(
                   getOptions(),
                   getParentForChildren(),
                   isClean());
@@ -14481,8 +14461,7 @@ public final class DescriptorProtos {
           com.google.protobuf.DescriptorProtos.MethodOptions, com.google.protobuf.DescriptorProtos.MethodOptions.Builder, com.google.protobuf.DescriptorProtos.MethodOptionsOrBuilder> 
           getOptionsFieldBuilder() {
         if (optionsBuilder_ == null) {
-          optionsBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-              com.google.protobuf.DescriptorProtos.MethodOptions, com.google.protobuf.DescriptorProtos.MethodOptions.Builder, com.google.protobuf.DescriptorProtos.MethodOptionsOrBuilder>(
+          optionsBuilder_ = new com.google.protobuf.SingleFieldBuilder<>(
                   getOptions(),
                   getParentForChildren(),
                   isClean());
@@ -15147,7 +15126,7 @@ public final class DescriptorProtos {
             }
             case 7994: {
               if (!((mutable_bitField0_ & 0x00002000) == 0x00002000)) {
-                uninterpretedOption_ = new java.util.ArrayList<com.google.protobuf.DescriptorProtos.UninterpretedOption>();
+                uninterpretedOption_ = new java.util.ArrayList<>();
                 mutable_bitField0_ |= 0x00002000;
               }
               uninterpretedOption_.add(input.readMessage(com.google.protobuf.DescriptorProtos.UninterpretedOption.parser(), extensionRegistry));
@@ -17330,7 +17309,7 @@ public final class DescriptorProtos {
         java.util.Collections.emptyList();
       private void ensureUninterpretedOptionIsMutable() {
         if (!((bitField0_ & 0x00002000) == 0x00002000)) {
-          uninterpretedOption_ = new java.util.ArrayList<com.google.protobuf.DescriptorProtos.UninterpretedOption>(uninterpretedOption_);
+          uninterpretedOption_ = new java.util.ArrayList<>(uninterpretedOption_);
           bitField0_ |= 0x00002000;
          }
       }
@@ -17627,8 +17606,7 @@ public final class DescriptorProtos {
           com.google.protobuf.DescriptorProtos.UninterpretedOption, com.google.protobuf.DescriptorProtos.UninterpretedOption.Builder, com.google.protobuf.DescriptorProtos.UninterpretedOptionOrBuilder> 
           getUninterpretedOptionFieldBuilder() {
         if (uninterpretedOptionBuilder_ == null) {
-          uninterpretedOptionBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-              com.google.protobuf.DescriptorProtos.UninterpretedOption, com.google.protobuf.DescriptorProtos.UninterpretedOption.Builder, com.google.protobuf.DescriptorProtos.UninterpretedOptionOrBuilder>(
+          uninterpretedOptionBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<>(
                   uninterpretedOption_,
                   ((bitField0_ & 0x00002000) == 0x00002000),
                   getParentForChildren(),
@@ -17943,7 +17921,7 @@ public final class DescriptorProtos {
             }
             case 7994: {
               if (!((mutable_bitField0_ & 0x00000010) == 0x00000010)) {
-                uninterpretedOption_ = new java.util.ArrayList<com.google.protobuf.DescriptorProtos.UninterpretedOption>();
+                uninterpretedOption_ = new java.util.ArrayList<>();
                 mutable_bitField0_ |= 0x00000010;
               }
               uninterpretedOption_.add(input.readMessage(com.google.protobuf.DescriptorProtos.UninterpretedOption.parser(), extensionRegistry));
@@ -18875,7 +18853,7 @@ public final class DescriptorProtos {
         java.util.Collections.emptyList();
       private void ensureUninterpretedOptionIsMutable() {
         if (!((bitField0_ & 0x00000010) == 0x00000010)) {
-          uninterpretedOption_ = new java.util.ArrayList<com.google.protobuf.DescriptorProtos.UninterpretedOption>(uninterpretedOption_);
+          uninterpretedOption_ = new java.util.ArrayList<>(uninterpretedOption_);
           bitField0_ |= 0x00000010;
          }
       }
@@ -19172,8 +19150,7 @@ public final class DescriptorProtos {
           com.google.protobuf.DescriptorProtos.UninterpretedOption, com.google.protobuf.DescriptorProtos.UninterpretedOption.Builder, com.google.protobuf.DescriptorProtos.UninterpretedOptionOrBuilder> 
           getUninterpretedOptionFieldBuilder() {
         if (uninterpretedOptionBuilder_ == null) {
-          uninterpretedOptionBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-              com.google.protobuf.DescriptorProtos.UninterpretedOption, com.google.protobuf.DescriptorProtos.UninterpretedOption.Builder, com.google.protobuf.DescriptorProtos.UninterpretedOptionOrBuilder>(
+          uninterpretedOptionBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<>(
                   uninterpretedOption_,
                   ((bitField0_ & 0x00000010) == 0x00000010),
                   getParentForChildren(),
@@ -19509,7 +19486,7 @@ public final class DescriptorProtos {
             }
             case 7994: {
               if (!((mutable_bitField0_ & 0x00000020) == 0x00000020)) {
-                uninterpretedOption_ = new java.util.ArrayList<com.google.protobuf.DescriptorProtos.UninterpretedOption>();
+                uninterpretedOption_ = new java.util.ArrayList<>();
                 mutable_bitField0_ |= 0x00000020;
               }
               uninterpretedOption_.add(input.readMessage(com.google.protobuf.DescriptorProtos.UninterpretedOption.parser(), extensionRegistry));
@@ -20610,7 +20587,7 @@ public final class DescriptorProtos {
         java.util.Collections.emptyList();
       private void ensureUninterpretedOptionIsMutable() {
         if (!((bitField0_ & 0x00000020) == 0x00000020)) {
-          uninterpretedOption_ = new java.util.ArrayList<com.google.protobuf.DescriptorProtos.UninterpretedOption>(uninterpretedOption_);
+          uninterpretedOption_ = new java.util.ArrayList<>(uninterpretedOption_);
           bitField0_ |= 0x00000020;
          }
       }
@@ -20907,8 +20884,7 @@ public final class DescriptorProtos {
           com.google.protobuf.DescriptorProtos.UninterpretedOption, com.google.protobuf.DescriptorProtos.UninterpretedOption.Builder, com.google.protobuf.DescriptorProtos.UninterpretedOptionOrBuilder> 
           getUninterpretedOptionFieldBuilder() {
         if (uninterpretedOptionBuilder_ == null) {
-          uninterpretedOptionBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-              com.google.protobuf.DescriptorProtos.UninterpretedOption, com.google.protobuf.DescriptorProtos.UninterpretedOption.Builder, com.google.protobuf.DescriptorProtos.UninterpretedOptionOrBuilder>(
+          uninterpretedOptionBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<>(
                   uninterpretedOption_,
                   ((bitField0_ & 0x00000020) == 0x00000020),
                   getParentForChildren(),
@@ -21113,7 +21089,7 @@ public final class DescriptorProtos {
             }
             case 7994: {
               if (!((mutable_bitField0_ & 0x00000004) == 0x00000004)) {
-                uninterpretedOption_ = new java.util.ArrayList<com.google.protobuf.DescriptorProtos.UninterpretedOption>();
+                uninterpretedOption_ = new java.util.ArrayList<>();
                 mutable_bitField0_ |= 0x00000004;
               }
               uninterpretedOption_.add(input.readMessage(com.google.protobuf.DescriptorProtos.UninterpretedOption.parser(), extensionRegistry));
@@ -21679,7 +21655,7 @@ public final class DescriptorProtos {
         java.util.Collections.emptyList();
       private void ensureUninterpretedOptionIsMutable() {
         if (!((bitField0_ & 0x00000004) == 0x00000004)) {
-          uninterpretedOption_ = new java.util.ArrayList<com.google.protobuf.DescriptorProtos.UninterpretedOption>(uninterpretedOption_);
+          uninterpretedOption_ = new java.util.ArrayList<>(uninterpretedOption_);
           bitField0_ |= 0x00000004;
          }
       }
@@ -21976,8 +21952,7 @@ public final class DescriptorProtos {
           com.google.protobuf.DescriptorProtos.UninterpretedOption, com.google.protobuf.DescriptorProtos.UninterpretedOption.Builder, com.google.protobuf.DescriptorProtos.UninterpretedOptionOrBuilder> 
           getUninterpretedOptionFieldBuilder() {
         if (uninterpretedOptionBuilder_ == null) {
-          uninterpretedOptionBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-              com.google.protobuf.DescriptorProtos.UninterpretedOption, com.google.protobuf.DescriptorProtos.UninterpretedOption.Builder, com.google.protobuf.DescriptorProtos.UninterpretedOptionOrBuilder>(
+          uninterpretedOptionBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<>(
                   uninterpretedOption_,
                   ((bitField0_ & 0x00000004) == 0x00000004),
                   getParentForChildren(),
@@ -22157,7 +22132,7 @@ public final class DescriptorProtos {
             }
             case 7994: {
               if (!((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
-                uninterpretedOption_ = new java.util.ArrayList<com.google.protobuf.DescriptorProtos.UninterpretedOption>();
+                uninterpretedOption_ = new java.util.ArrayList<>();
                 mutable_bitField0_ |= 0x00000002;
               }
               uninterpretedOption_.add(input.readMessage(com.google.protobuf.DescriptorProtos.UninterpretedOption.parser(), extensionRegistry));
@@ -22630,7 +22605,7 @@ public final class DescriptorProtos {
         java.util.Collections.emptyList();
       private void ensureUninterpretedOptionIsMutable() {
         if (!((bitField0_ & 0x00000002) == 0x00000002)) {
-          uninterpretedOption_ = new java.util.ArrayList<com.google.protobuf.DescriptorProtos.UninterpretedOption>(uninterpretedOption_);
+          uninterpretedOption_ = new java.util.ArrayList<>(uninterpretedOption_);
           bitField0_ |= 0x00000002;
          }
       }
@@ -22927,8 +22902,7 @@ public final class DescriptorProtos {
           com.google.protobuf.DescriptorProtos.UninterpretedOption, com.google.protobuf.DescriptorProtos.UninterpretedOption.Builder, com.google.protobuf.DescriptorProtos.UninterpretedOptionOrBuilder> 
           getUninterpretedOptionFieldBuilder() {
         if (uninterpretedOptionBuilder_ == null) {
-          uninterpretedOptionBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-              com.google.protobuf.DescriptorProtos.UninterpretedOption, com.google.protobuf.DescriptorProtos.UninterpretedOption.Builder, com.google.protobuf.DescriptorProtos.UninterpretedOptionOrBuilder>(
+          uninterpretedOptionBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<>(
                   uninterpretedOption_,
                   ((bitField0_ & 0x00000002) == 0x00000002),
                   getParentForChildren(),
@@ -23108,7 +23082,7 @@ public final class DescriptorProtos {
             }
             case 7994: {
               if (!((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
-                uninterpretedOption_ = new java.util.ArrayList<com.google.protobuf.DescriptorProtos.UninterpretedOption>();
+                uninterpretedOption_ = new java.util.ArrayList<>();
                 mutable_bitField0_ |= 0x00000002;
               }
               uninterpretedOption_.add(input.readMessage(com.google.protobuf.DescriptorProtos.UninterpretedOption.parser(), extensionRegistry));
@@ -23581,7 +23555,7 @@ public final class DescriptorProtos {
         java.util.Collections.emptyList();
       private void ensureUninterpretedOptionIsMutable() {
         if (!((bitField0_ & 0x00000002) == 0x00000002)) {
-          uninterpretedOption_ = new java.util.ArrayList<com.google.protobuf.DescriptorProtos.UninterpretedOption>(uninterpretedOption_);
+          uninterpretedOption_ = new java.util.ArrayList<>(uninterpretedOption_);
           bitField0_ |= 0x00000002;
          }
       }
@@ -23878,8 +23852,7 @@ public final class DescriptorProtos {
           com.google.protobuf.DescriptorProtos.UninterpretedOption, com.google.protobuf.DescriptorProtos.UninterpretedOption.Builder, com.google.protobuf.DescriptorProtos.UninterpretedOptionOrBuilder> 
           getUninterpretedOptionFieldBuilder() {
         if (uninterpretedOptionBuilder_ == null) {
-          uninterpretedOptionBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-              com.google.protobuf.DescriptorProtos.UninterpretedOption, com.google.protobuf.DescriptorProtos.UninterpretedOption.Builder, com.google.protobuf.DescriptorProtos.UninterpretedOptionOrBuilder>(
+          uninterpretedOptionBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<>(
                   uninterpretedOption_,
                   ((bitField0_ & 0x00000002) == 0x00000002),
                   getParentForChildren(),
@@ -24059,7 +24032,7 @@ public final class DescriptorProtos {
             }
             case 7994: {
               if (!((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
-                uninterpretedOption_ = new java.util.ArrayList<com.google.protobuf.DescriptorProtos.UninterpretedOption>();
+                uninterpretedOption_ = new java.util.ArrayList<>();
                 mutable_bitField0_ |= 0x00000002;
               }
               uninterpretedOption_.add(input.readMessage(com.google.protobuf.DescriptorProtos.UninterpretedOption.parser(), extensionRegistry));
@@ -24532,7 +24505,7 @@ public final class DescriptorProtos {
         java.util.Collections.emptyList();
       private void ensureUninterpretedOptionIsMutable() {
         if (!((bitField0_ & 0x00000002) == 0x00000002)) {
-          uninterpretedOption_ = new java.util.ArrayList<com.google.protobuf.DescriptorProtos.UninterpretedOption>(uninterpretedOption_);
+          uninterpretedOption_ = new java.util.ArrayList<>(uninterpretedOption_);
           bitField0_ |= 0x00000002;
          }
       }
@@ -24829,8 +24802,7 @@ public final class DescriptorProtos {
           com.google.protobuf.DescriptorProtos.UninterpretedOption, com.google.protobuf.DescriptorProtos.UninterpretedOption.Builder, com.google.protobuf.DescriptorProtos.UninterpretedOptionOrBuilder> 
           getUninterpretedOptionFieldBuilder() {
         if (uninterpretedOptionBuilder_ == null) {
-          uninterpretedOptionBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-              com.google.protobuf.DescriptorProtos.UninterpretedOption, com.google.protobuf.DescriptorProtos.UninterpretedOption.Builder, com.google.protobuf.DescriptorProtos.UninterpretedOptionOrBuilder>(
+          uninterpretedOptionBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<>(
                   uninterpretedOption_,
                   ((bitField0_ & 0x00000002) == 0x00000002),
                   getParentForChildren(),
@@ -25053,7 +25025,7 @@ public final class DescriptorProtos {
             }
             case 18: {
               if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
-                name_ = new java.util.ArrayList<com.google.protobuf.DescriptorProtos.UninterpretedOption.NamePart>();
+                name_ = new java.util.ArrayList<>();
                 mutable_bitField0_ |= 0x00000001;
               }
               name_.add(input.readMessage(com.google.protobuf.DescriptorProtos.UninterpretedOption.NamePart.parser(), extensionRegistry));
@@ -26267,7 +26239,7 @@ public final class DescriptorProtos {
         java.util.Collections.emptyList();
       private void ensureNameIsMutable() {
         if (!((bitField0_ & 0x00000001) == 0x00000001)) {
-          name_ = new java.util.ArrayList<com.google.protobuf.DescriptorProtos.UninterpretedOption.NamePart>(name_);
+          name_ = new java.util.ArrayList<>(name_);
           bitField0_ |= 0x00000001;
          }
       }
@@ -26492,8 +26464,7 @@ public final class DescriptorProtos {
           com.google.protobuf.DescriptorProtos.UninterpretedOption.NamePart, com.google.protobuf.DescriptorProtos.UninterpretedOption.NamePart.Builder, com.google.protobuf.DescriptorProtos.UninterpretedOption.NamePartOrBuilder> 
           getNameFieldBuilder() {
         if (nameBuilder_ == null) {
-          nameBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-              com.google.protobuf.DescriptorProtos.UninterpretedOption.NamePart, com.google.protobuf.DescriptorProtos.UninterpretedOption.NamePart.Builder, com.google.protobuf.DescriptorProtos.UninterpretedOption.NamePartOrBuilder>(
+          nameBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<>(
                   name_,
                   ((bitField0_ & 0x00000001) == 0x00000001),
                   getParentForChildren(),
@@ -27160,7 +27131,7 @@ public final class DescriptorProtos {
             }
             case 10: {
               if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
-                location_ = new java.util.ArrayList<com.google.protobuf.DescriptorProtos.SourceCodeInfo.Location>();
+                location_ = new java.util.ArrayList<>();
                 mutable_bitField0_ |= 0x00000001;
               }
               location_.add(input.readMessage(com.google.protobuf.DescriptorProtos.SourceCodeInfo.Location.parser(), extensionRegistry));
@@ -27532,7 +27503,7 @@ public final class DescriptorProtos {
               }
               case 8: {
                 if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
-                  path_ = new java.util.ArrayList<java.lang.Integer>();
+                  path_ = new java.util.ArrayList<>();
                   mutable_bitField0_ |= 0x00000001;
                 }
                 path_.add(input.readInt32());
@@ -27542,7 +27513,7 @@ public final class DescriptorProtos {
                 int length = input.readRawVarint32();
                 int limit = input.pushLimit(length);
                 if (!((mutable_bitField0_ & 0x00000001) == 0x00000001) && input.getBytesUntilLimit() > 0) {
-                  path_ = new java.util.ArrayList<java.lang.Integer>();
+                  path_ = new java.util.ArrayList<>();
                   mutable_bitField0_ |= 0x00000001;
                 }
                 while (input.getBytesUntilLimit() > 0) {
@@ -27553,7 +27524,7 @@ public final class DescriptorProtos {
               }
               case 16: {
                 if (!((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
-                  span_ = new java.util.ArrayList<java.lang.Integer>();
+                  span_ = new java.util.ArrayList<>();
                   mutable_bitField0_ |= 0x00000002;
                 }
                 span_.add(input.readInt32());
@@ -27563,7 +27534,7 @@ public final class DescriptorProtos {
                 int length = input.readRawVarint32();
                 int limit = input.pushLimit(length);
                 if (!((mutable_bitField0_ & 0x00000002) == 0x00000002) && input.getBytesUntilLimit() > 0) {
-                  span_ = new java.util.ArrayList<java.lang.Integer>();
+                  span_ = new java.util.ArrayList<>();
                   mutable_bitField0_ |= 0x00000002;
                 }
                 while (input.getBytesUntilLimit() > 0) {
@@ -28342,7 +28313,7 @@ public final class DescriptorProtos {
         private java.util.List<java.lang.Integer> path_ = java.util.Collections.emptyList();
         private void ensurePathIsMutable() {
           if (!((bitField0_ & 0x00000001) == 0x00000001)) {
-            path_ = new java.util.ArrayList<java.lang.Integer>(path_);
+            path_ = new java.util.ArrayList<>(path_);
             bitField0_ |= 0x00000001;
            }
         }
@@ -28576,7 +28547,7 @@ public final class DescriptorProtos {
         private java.util.List<java.lang.Integer> span_ = java.util.Collections.emptyList();
         private void ensureSpanIsMutable() {
           if (!((bitField0_ & 0x00000002) == 0x00000002)) {
-            span_ = new java.util.ArrayList<java.lang.Integer>(span_);
+            span_ = new java.util.ArrayList<>(span_);
             bitField0_ |= 0x00000002;
            }
         }
@@ -29732,7 +29703,7 @@ public final class DescriptorProtos {
         java.util.Collections.emptyList();
       private void ensureLocationIsMutable() {
         if (!((bitField0_ & 0x00000001) == 0x00000001)) {
-          location_ = new java.util.ArrayList<com.google.protobuf.DescriptorProtos.SourceCodeInfo.Location>(location_);
+          location_ = new java.util.ArrayList<>(location_);
           bitField0_ |= 0x00000001;
          }
       }
@@ -30749,8 +30720,7 @@ public final class DescriptorProtos {
           com.google.protobuf.DescriptorProtos.SourceCodeInfo.Location, com.google.protobuf.DescriptorProtos.SourceCodeInfo.Location.Builder, com.google.protobuf.DescriptorProtos.SourceCodeInfo.LocationOrBuilder> 
           getLocationFieldBuilder() {
         if (locationBuilder_ == null) {
-          locationBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-              com.google.protobuf.DescriptorProtos.SourceCodeInfo.Location, com.google.protobuf.DescriptorProtos.SourceCodeInfo.Location.Builder, com.google.protobuf.DescriptorProtos.SourceCodeInfo.LocationOrBuilder>(
+          locationBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<>(
                   location_,
                   ((bitField0_ & 0x00000001) == 0x00000001),
                   getParentForChildren(),

--- a/bigtable-protos/src/generated/java/protos/com/google/protobuf/Enum.java
+++ b/bigtable-protos/src/generated/java/protos/com/google/protobuf/Enum.java
@@ -56,7 +56,7 @@ public  final class Enum extends
           }
           case 18: {
             if (!((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
-              enumvalue_ = new java.util.ArrayList<com.google.protobuf.EnumValue>();
+              enumvalue_ = new java.util.ArrayList<>();
               mutable_bitField0_ |= 0x00000002;
             }
             enumvalue_.add(input.readMessage(com.google.protobuf.EnumValue.parser(), extensionRegistry));
@@ -64,7 +64,7 @@ public  final class Enum extends
           }
           case 26: {
             if (!((mutable_bitField0_ & 0x00000004) == 0x00000004)) {
-              options_ = new java.util.ArrayList<com.google.protobuf.Option>();
+              options_ = new java.util.ArrayList<>();
               mutable_bitField0_ |= 0x00000004;
             }
             options_.add(input.readMessage(com.google.protobuf.Option.parser(), extensionRegistry));
@@ -725,7 +725,7 @@ public  final class Enum extends
       java.util.Collections.emptyList();
     private void ensureEnumvalueIsMutable() {
       if (!((bitField0_ & 0x00000002) == 0x00000002)) {
-        enumvalue_ = new java.util.ArrayList<com.google.protobuf.EnumValue>(enumvalue_);
+        enumvalue_ = new java.util.ArrayList<>(enumvalue_);
         bitField0_ |= 0x00000002;
        }
     }
@@ -1022,8 +1022,7 @@ public  final class Enum extends
         com.google.protobuf.EnumValue, com.google.protobuf.EnumValue.Builder, com.google.protobuf.EnumValueOrBuilder> 
         getEnumvalueFieldBuilder() {
       if (enumvalueBuilder_ == null) {
-        enumvalueBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-            com.google.protobuf.EnumValue, com.google.protobuf.EnumValue.Builder, com.google.protobuf.EnumValueOrBuilder>(
+        enumvalueBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<>(
                 enumvalue_,
                 ((bitField0_ & 0x00000002) == 0x00000002),
                 getParentForChildren(),
@@ -1037,7 +1036,7 @@ public  final class Enum extends
       java.util.Collections.emptyList();
     private void ensureOptionsIsMutable() {
       if (!((bitField0_ & 0x00000004) == 0x00000004)) {
-        options_ = new java.util.ArrayList<com.google.protobuf.Option>(options_);
+        options_ = new java.util.ArrayList<>(options_);
         bitField0_ |= 0x00000004;
        }
     }
@@ -1334,8 +1333,7 @@ public  final class Enum extends
         com.google.protobuf.Option, com.google.protobuf.Option.Builder, com.google.protobuf.OptionOrBuilder> 
         getOptionsFieldBuilder() {
       if (optionsBuilder_ == null) {
-        optionsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-            com.google.protobuf.Option, com.google.protobuf.Option.Builder, com.google.protobuf.OptionOrBuilder>(
+        optionsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<>(
                 options_,
                 ((bitField0_ & 0x00000004) == 0x00000004),
                 getParentForChildren(),
@@ -1488,8 +1486,7 @@ public  final class Enum extends
         com.google.protobuf.SourceContext, com.google.protobuf.SourceContext.Builder, com.google.protobuf.SourceContextOrBuilder> 
         getSourceContextFieldBuilder() {
       if (sourceContextBuilder_ == null) {
-        sourceContextBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-            com.google.protobuf.SourceContext, com.google.protobuf.SourceContext.Builder, com.google.protobuf.SourceContextOrBuilder>(
+        sourceContextBuilder_ = new com.google.protobuf.SingleFieldBuilder<>(
                 getSourceContext(),
                 getParentForChildren(),
                 isClean());

--- a/bigtable-protos/src/generated/java/protos/com/google/protobuf/EnumValue.java
+++ b/bigtable-protos/src/generated/java/protos/com/google/protobuf/EnumValue.java
@@ -61,7 +61,7 @@ public  final class EnumValue extends
           }
           case 26: {
             if (!((mutable_bitField0_ & 0x00000004) == 0x00000004)) {
-              options_ = new java.util.ArrayList<com.google.protobuf.Option>();
+              options_ = new java.util.ArrayList<>();
               mutable_bitField0_ |= 0x00000004;
             }
             options_.add(input.readMessage(com.google.protobuf.Option.parser(), extensionRegistry));
@@ -612,7 +612,7 @@ public  final class EnumValue extends
       java.util.Collections.emptyList();
     private void ensureOptionsIsMutable() {
       if (!((bitField0_ & 0x00000004) == 0x00000004)) {
-        options_ = new java.util.ArrayList<com.google.protobuf.Option>(options_);
+        options_ = new java.util.ArrayList<>(options_);
         bitField0_ |= 0x00000004;
        }
     }
@@ -909,8 +909,7 @@ public  final class EnumValue extends
         com.google.protobuf.Option, com.google.protobuf.Option.Builder, com.google.protobuf.OptionOrBuilder> 
         getOptionsFieldBuilder() {
       if (optionsBuilder_ == null) {
-        optionsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-            com.google.protobuf.Option, com.google.protobuf.Option.Builder, com.google.protobuf.OptionOrBuilder>(
+        optionsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<>(
                 options_,
                 ((bitField0_ & 0x00000004) == 0x00000004),
                 getParentForChildren(),

--- a/bigtable-protos/src/generated/java/protos/com/google/protobuf/Field.java
+++ b/bigtable-protos/src/generated/java/protos/com/google/protobuf/Field.java
@@ -94,7 +94,7 @@ public  final class Field extends
           }
           case 74: {
             if (!((mutable_bitField0_ & 0x00000080) == 0x00000080)) {
-              options_ = new java.util.ArrayList<com.google.protobuf.Option>();
+              options_ = new java.util.ArrayList<>();
               mutable_bitField0_ |= 0x00000080;
             }
             options_.add(input.readMessage(com.google.protobuf.Option.parser(), extensionRegistry));
@@ -1657,7 +1657,7 @@ public  final class Field extends
       java.util.Collections.emptyList();
     private void ensureOptionsIsMutable() {
       if (!((bitField0_ & 0x00000080) == 0x00000080)) {
-        options_ = new java.util.ArrayList<com.google.protobuf.Option>(options_);
+        options_ = new java.util.ArrayList<>(options_);
         bitField0_ |= 0x00000080;
        }
     }
@@ -1954,8 +1954,7 @@ public  final class Field extends
         com.google.protobuf.Option, com.google.protobuf.Option.Builder, com.google.protobuf.OptionOrBuilder> 
         getOptionsFieldBuilder() {
       if (optionsBuilder_ == null) {
-        optionsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-            com.google.protobuf.Option, com.google.protobuf.Option.Builder, com.google.protobuf.OptionOrBuilder>(
+        optionsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<>(
                 options_,
                 ((bitField0_ & 0x00000080) == 0x00000080),
                 getParentForChildren(),

--- a/bigtable-protos/src/generated/java/protos/com/google/protobuf/Method.java
+++ b/bigtable-protos/src/generated/java/protos/com/google/protobuf/Method.java
@@ -81,7 +81,7 @@ public  final class Method extends
           }
           case 50: {
             if (!((mutable_bitField0_ & 0x00000020) == 0x00000020)) {
-              options_ = new java.util.ArrayList<com.google.protobuf.Option>();
+              options_ = new java.util.ArrayList<>();
               mutable_bitField0_ |= 0x00000020;
             }
             options_.add(input.readMessage(com.google.protobuf.Option.parser(), extensionRegistry));
@@ -984,7 +984,7 @@ public  final class Method extends
       java.util.Collections.emptyList();
     private void ensureOptionsIsMutable() {
       if (!((bitField0_ & 0x00000020) == 0x00000020)) {
-        options_ = new java.util.ArrayList<com.google.protobuf.Option>(options_);
+        options_ = new java.util.ArrayList<>(options_);
         bitField0_ |= 0x00000020;
        }
     }
@@ -1281,8 +1281,7 @@ public  final class Method extends
         com.google.protobuf.Option, com.google.protobuf.Option.Builder, com.google.protobuf.OptionOrBuilder> 
         getOptionsFieldBuilder() {
       if (optionsBuilder_ == null) {
-        optionsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-            com.google.protobuf.Option, com.google.protobuf.Option.Builder, com.google.protobuf.OptionOrBuilder>(
+        optionsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<>(
                 options_,
                 ((bitField0_ & 0x00000020) == 0x00000020),
                 getParentForChildren(),

--- a/bigtable-protos/src/generated/java/protos/com/google/protobuf/Option.java
+++ b/bigtable-protos/src/generated/java/protos/com/google/protobuf/Option.java
@@ -627,8 +627,7 @@ public  final class Option extends
         com.google.protobuf.Any, com.google.protobuf.Any.Builder, com.google.protobuf.AnyOrBuilder> 
         getValueFieldBuilder() {
       if (valueBuilder_ == null) {
-        valueBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-            com.google.protobuf.Any, com.google.protobuf.Any.Builder, com.google.protobuf.AnyOrBuilder>(
+        valueBuilder_ = new com.google.protobuf.SingleFieldBuilder<>(
                 getValue(),
                 getParentForChildren(),
                 isClean());

--- a/bigtable-protos/src/generated/java/protos/com/google/protobuf/Type.java
+++ b/bigtable-protos/src/generated/java/protos/com/google/protobuf/Type.java
@@ -57,7 +57,7 @@ public  final class Type extends
           }
           case 18: {
             if (!((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
-              fields_ = new java.util.ArrayList<com.google.protobuf.Field>();
+              fields_ = new java.util.ArrayList<>();
               mutable_bitField0_ |= 0x00000002;
             }
             fields_.add(input.readMessage(com.google.protobuf.Field.parser(), extensionRegistry));
@@ -74,7 +74,7 @@ public  final class Type extends
           }
           case 34: {
             if (!((mutable_bitField0_ & 0x00000008) == 0x00000008)) {
-              options_ = new java.util.ArrayList<com.google.protobuf.Option>();
+              options_ = new java.util.ArrayList<>();
               mutable_bitField0_ |= 0x00000008;
             }
             options_.add(input.readMessage(com.google.protobuf.Option.parser(), extensionRegistry));
@@ -815,7 +815,7 @@ public  final class Type extends
       java.util.Collections.emptyList();
     private void ensureFieldsIsMutable() {
       if (!((bitField0_ & 0x00000002) == 0x00000002)) {
-        fields_ = new java.util.ArrayList<com.google.protobuf.Field>(fields_);
+        fields_ = new java.util.ArrayList<>(fields_);
         bitField0_ |= 0x00000002;
        }
     }
@@ -1112,8 +1112,7 @@ public  final class Type extends
         com.google.protobuf.Field, com.google.protobuf.Field.Builder, com.google.protobuf.FieldOrBuilder> 
         getFieldsFieldBuilder() {
       if (fieldsBuilder_ == null) {
-        fieldsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-            com.google.protobuf.Field, com.google.protobuf.Field.Builder, com.google.protobuf.FieldOrBuilder>(
+        fieldsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<>(
                 fields_,
                 ((bitField0_ & 0x00000002) == 0x00000002),
                 getParentForChildren(),
@@ -1266,7 +1265,7 @@ public  final class Type extends
       java.util.Collections.emptyList();
     private void ensureOptionsIsMutable() {
       if (!((bitField0_ & 0x00000008) == 0x00000008)) {
-        options_ = new java.util.ArrayList<com.google.protobuf.Option>(options_);
+        options_ = new java.util.ArrayList<>(options_);
         bitField0_ |= 0x00000008;
        }
     }
@@ -1563,8 +1562,7 @@ public  final class Type extends
         com.google.protobuf.Option, com.google.protobuf.Option.Builder, com.google.protobuf.OptionOrBuilder> 
         getOptionsFieldBuilder() {
       if (optionsBuilder_ == null) {
-        optionsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-            com.google.protobuf.Option, com.google.protobuf.Option.Builder, com.google.protobuf.OptionOrBuilder>(
+        optionsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<>(
                 options_,
                 ((bitField0_ & 0x00000008) == 0x00000008),
                 getParentForChildren(),
@@ -1717,8 +1715,7 @@ public  final class Type extends
         com.google.protobuf.SourceContext, com.google.protobuf.SourceContext.Builder, com.google.protobuf.SourceContextOrBuilder> 
         getSourceContextFieldBuilder() {
       if (sourceContextBuilder_ == null) {
-        sourceContextBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-            com.google.protobuf.SourceContext, com.google.protobuf.SourceContext.Builder, com.google.protobuf.SourceContextOrBuilder>(
+        sourceContextBuilder_ = new com.google.protobuf.SingleFieldBuilder<>(
                 getSourceContext(),
                 getParentForChildren(),
                 isClean());

--- a/bigtable-protos/src/generated/java/protos/com/google/rpc/BadRequest.java
+++ b/bigtable-protos/src/generated/java/protos/com/google/rpc/BadRequest.java
@@ -49,7 +49,7 @@ public  final class BadRequest extends
           }
           case 10: {
             if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
-              fieldViolations_ = new java.util.ArrayList<com.google.rpc.BadRequest.FieldViolation>();
+              fieldViolations_ = new java.util.ArrayList<>();
               mutable_bitField0_ |= 0x00000001;
             }
             fieldViolations_.add(input.readMessage(com.google.rpc.BadRequest.FieldViolation.parser(), extensionRegistry));
@@ -1070,7 +1070,7 @@ public  final class BadRequest extends
       java.util.Collections.emptyList();
     private void ensureFieldViolationsIsMutable() {
       if (!((bitField0_ & 0x00000001) == 0x00000001)) {
-        fieldViolations_ = new java.util.ArrayList<com.google.rpc.BadRequest.FieldViolation>(fieldViolations_);
+        fieldViolations_ = new java.util.ArrayList<>(fieldViolations_);
         bitField0_ |= 0x00000001;
        }
     }
@@ -1367,8 +1367,7 @@ public  final class BadRequest extends
         com.google.rpc.BadRequest.FieldViolation, com.google.rpc.BadRequest.FieldViolation.Builder, com.google.rpc.BadRequest.FieldViolationOrBuilder> 
         getFieldViolationsFieldBuilder() {
       if (fieldViolationsBuilder_ == null) {
-        fieldViolationsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-            com.google.rpc.BadRequest.FieldViolation, com.google.rpc.BadRequest.FieldViolation.Builder, com.google.rpc.BadRequest.FieldViolationOrBuilder>(
+        fieldViolationsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<>(
                 fieldViolations_,
                 ((bitField0_ & 0x00000001) == 0x00000001),
                 getParentForChildren(),

--- a/bigtable-protos/src/generated/java/protos/com/google/rpc/Help.java
+++ b/bigtable-protos/src/generated/java/protos/com/google/rpc/Help.java
@@ -51,7 +51,7 @@ public  final class Help extends
           }
           case 10: {
             if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
-              links_ = new java.util.ArrayList<com.google.rpc.Help.Link>();
+              links_ = new java.util.ArrayList<>();
               mutable_bitField0_ |= 0x00000001;
             }
             links_.add(input.readMessage(com.google.rpc.Help.Link.parser(), extensionRegistry));
@@ -1056,7 +1056,7 @@ public  final class Help extends
       java.util.Collections.emptyList();
     private void ensureLinksIsMutable() {
       if (!((bitField0_ & 0x00000001) == 0x00000001)) {
-        links_ = new java.util.ArrayList<com.google.rpc.Help.Link>(links_);
+        links_ = new java.util.ArrayList<>(links_);
         bitField0_ |= 0x00000001;
        }
     }
@@ -1353,8 +1353,7 @@ public  final class Help extends
         com.google.rpc.Help.Link, com.google.rpc.Help.Link.Builder, com.google.rpc.Help.LinkOrBuilder> 
         getLinksFieldBuilder() {
       if (linksBuilder_ == null) {
-        linksBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-            com.google.rpc.Help.Link, com.google.rpc.Help.Link.Builder, com.google.rpc.Help.LinkOrBuilder>(
+        linksBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<>(
                 links_,
                 ((bitField0_ & 0x00000001) == 0x00000001),
                 getParentForChildren(),

--- a/bigtable-protos/src/generated/java/protos/com/google/rpc/QuotaFailure.java
+++ b/bigtable-protos/src/generated/java/protos/com/google/rpc/QuotaFailure.java
@@ -56,7 +56,7 @@ public  final class QuotaFailure extends
           }
           case 10: {
             if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
-              violations_ = new java.util.ArrayList<com.google.rpc.QuotaFailure.Violation>();
+              violations_ = new java.util.ArrayList<>();
               mutable_bitField0_ |= 0x00000001;
             }
             violations_.add(input.readMessage(com.google.rpc.QuotaFailure.Violation.parser(), extensionRegistry));
@@ -1131,7 +1131,7 @@ public  final class QuotaFailure extends
       java.util.Collections.emptyList();
     private void ensureViolationsIsMutable() {
       if (!((bitField0_ & 0x00000001) == 0x00000001)) {
-        violations_ = new java.util.ArrayList<com.google.rpc.QuotaFailure.Violation>(violations_);
+        violations_ = new java.util.ArrayList<>(violations_);
         bitField0_ |= 0x00000001;
        }
     }
@@ -1428,8 +1428,7 @@ public  final class QuotaFailure extends
         com.google.rpc.QuotaFailure.Violation, com.google.rpc.QuotaFailure.Violation.Builder, com.google.rpc.QuotaFailure.ViolationOrBuilder> 
         getViolationsFieldBuilder() {
       if (violationsBuilder_ == null) {
-        violationsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-            com.google.rpc.QuotaFailure.Violation, com.google.rpc.QuotaFailure.Violation.Builder, com.google.rpc.QuotaFailure.ViolationOrBuilder>(
+        violationsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<>(
                 violations_,
                 ((bitField0_ & 0x00000001) == 0x00000001),
                 getParentForChildren(),

--- a/bigtable-protos/src/generated/java/protos/com/google/rpc/RetryInfo.java
+++ b/bigtable-protos/src/generated/java/protos/com/google/rpc/RetryInfo.java
@@ -496,8 +496,7 @@ public  final class RetryInfo extends
         com.google.protobuf.Duration, com.google.protobuf.Duration.Builder, com.google.protobuf.DurationOrBuilder> 
         getRetryDelayFieldBuilder() {
       if (retryDelayBuilder_ == null) {
-        retryDelayBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-            com.google.protobuf.Duration, com.google.protobuf.Duration.Builder, com.google.protobuf.DurationOrBuilder>(
+        retryDelayBuilder_ = new com.google.protobuf.SingleFieldBuilder<>(
                 getRetryDelay(),
                 getParentForChildren(),
                 isClean());

--- a/bigtable-protos/src/generated/java/protos/com/google/rpc/Status.java
+++ b/bigtable-protos/src/generated/java/protos/com/google/rpc/Status.java
@@ -99,7 +99,7 @@ public  final class Status extends
           }
           case 26: {
             if (!((mutable_bitField0_ & 0x00000004) == 0x00000004)) {
-              details_ = new java.util.ArrayList<com.google.protobuf.Any>();
+              details_ = new java.util.ArrayList<>();
               mutable_bitField0_ |= 0x00000004;
             }
             details_.add(input.readMessage(com.google.protobuf.Any.parser(), extensionRegistry));
@@ -707,7 +707,7 @@ public  final class Status extends
       java.util.Collections.emptyList();
     private void ensureDetailsIsMutable() {
       if (!((bitField0_ & 0x00000004) == 0x00000004)) {
-        details_ = new java.util.ArrayList<com.google.protobuf.Any>(details_);
+        details_ = new java.util.ArrayList<>(details_);
         bitField0_ |= 0x00000004;
        }
     }
@@ -1022,8 +1022,7 @@ public  final class Status extends
         com.google.protobuf.Any, com.google.protobuf.Any.Builder, com.google.protobuf.AnyOrBuilder> 
         getDetailsFieldBuilder() {
       if (detailsBuilder_ == null) {
-        detailsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-            com.google.protobuf.Any, com.google.protobuf.Any.Builder, com.google.protobuf.AnyOrBuilder>(
+        detailsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<>(
                 details_,
                 ((bitField0_ & 0x00000004) == 0x00000004),
                 getParentForChildren(),

--- a/bigtable-protos/src/generated/java/protos/com/google/type/Color.java
+++ b/bigtable-protos/src/generated/java/protos/com/google/type/Color.java
@@ -978,8 +978,7 @@ public  final class Color extends
         com.google.protobuf.FloatValue, com.google.protobuf.FloatValue.Builder, com.google.protobuf.FloatValueOrBuilder> 
         getAlphaFieldBuilder() {
       if (alphaBuilder_ == null) {
-        alphaBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-            com.google.protobuf.FloatValue, com.google.protobuf.FloatValue.Builder, com.google.protobuf.FloatValueOrBuilder>(
+        alphaBuilder_ = new com.google.protobuf.SingleFieldBuilder<>(
                 getAlpha(),
                 getParentForChildren(),
                 isClean());


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2293 - “ The diamond operator ("<>") should be used ”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2293
Please let me know if you have any questions.
Ayman Abdelghany.