### PR TITLE
equals(Object obj)" and "hashCode()" should be overridden in pairs

### DIFF
--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableOptions.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableOptions.java
@@ -385,4 +385,22 @@ public class BigtableOptions implements Serializable {
     return new Builder(this);
   }
 
+  @Override
+  public int hashCode() {
+    int result = clusterAdminHost != null ? clusterAdminHost.hashCode() : 0;
+    result = 31 * result + (tableAdminHost != null ? tableAdminHost.hashCode() : 0);
+    result = 31 * result + (dataHost != null ? dataHost.hashCode() : 0);
+    result = 31 * result + port;
+    result = 31 * result + (projectId != null ? projectId.hashCode() : 0);
+    result = 31 * result + (zoneId != null ? zoneId.hashCode() : 0);
+    result = 31 * result + (clusterId != null ? clusterId.hashCode() : 0);
+    result = 31 * result + (credentialOptions != null ? credentialOptions.hashCode() : 0);
+    result = 31 * result + (userAgent != null ? userAgent.hashCode() : 0);
+    result = 31 * result + (retryOptions != null ? retryOptions.hashCode() : 0);
+    result = 31 * result + timeoutMs;
+    result = 31 * result + dataChannelCount;
+    result = 31 * result + (clusterName != null ? clusterName.hashCode() : 0);
+    result = 31 * result + asyncMutatorCount;
+    return result;
+  }
 }

--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/CredentialOptions.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/CredentialOptions.java
@@ -147,6 +147,13 @@ public class CredentialOptions implements Serializable {
       return Objects.equal(keyFile, other.keyFile)
           && Objects.equal(serviceAccount, other.serviceAccount);
     }
+
+    @Override
+    public int hashCode() {
+      int result = serviceAccount != null ? serviceAccount.hashCode() : 0;
+      result = 31 * result + (keyFile != null ? keyFile.hashCode() : 0);
+      return result;
+    }
   }
 
   /**
@@ -171,6 +178,13 @@ public class CredentialOptions implements Serializable {
       }
       UserSuppliedCredentialOptions other = (UserSuppliedCredentialOptions) obj;
       return Objects.equal(credential, other.credential);
+    }
+
+    @Override
+    public int hashCode() {
+      int result = super.hashCode();
+      result = 31 * result + (credential != null ? credential.hashCode() : 0);
+      return result;
     }
   }
 
@@ -207,6 +221,14 @@ public class CredentialOptions implements Serializable {
       JsonCredentialsOptions other = (JsonCredentialsOptions) obj;
       return Objects.equal(cachedCredentials, other.cachedCredentials);
     }
+
+    @Override
+    public int hashCode() {
+      int result = super.hashCode();
+      result = 31 * result + (inputStream != null ? inputStream.hashCode() : 0);
+      result = 31 * result + (cachedCredentials != null ? cachedCredentials.hashCode() : 0);
+      return result;
+    }
   }
 
   private CredentialType credentialType;
@@ -229,5 +251,10 @@ public class CredentialOptions implements Serializable {
     }
     CredentialOptions other = (CredentialOptions) obj;
     return credentialType == other.credentialType;
+  }
+
+  @Override
+  public int hashCode() {
+    return credentialType != null ? credentialType.hashCode() : 0;
   }
 }

--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/RetryOptions.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/RetryOptions.java
@@ -285,4 +285,20 @@ public class RetryOptions implements Serializable {
         && streamingBatchSize == other.streamingBatchSize
         && readPartialRowTimeoutMillis == other.readPartialRowTimeoutMillis;
   }
+
+  @Override
+  public int hashCode() {
+    int result;
+    long temp;
+    result = (retriesEnabled ? 1 : 0);
+    result = 31 * result + (retryOnDeadlineExceeded ? 1 : 0);
+    result = 31 * result + initialBackoffMillis;
+    result = 31 * result + maxElaspedBackoffMillis;
+    temp = Double.doubleToLongBits(backoffMultiplier);
+    result = 31 * result + (int) (temp ^ (temp >>> 32));
+    result = 31 * result + streamingBufferSize;
+    result = 31 * result + streamingBatchSize;
+    result = 31 * result + readPartialRowTimeoutMillis;
+    return result;
+  }
 }

--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ResultQueueEntry.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ResultQueueEntry.java
@@ -89,4 +89,12 @@ class ResultQueueEntry<T> {
         && Objects.equal(response, other.response)
         && Objects.equal(isComplete, other.isComplete);
   }
+
+  @Override
+  public int hashCode() {
+    int result = throwable != null ? throwable.hashCode() : 0;
+    result = 31 * result + (response != null ? response.hashCode() : 0);
+    result = 31 * result + (isComplete ? 1 : 0);
+    return result;
+  }
 }

--- a/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/CloudBigtableConfiguration.java
+++ b/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/CloudBigtableConfiguration.java
@@ -219,4 +219,9 @@ public class CloudBigtableConfiguration implements Serializable {
     CloudBigtableConfiguration other = (CloudBigtableConfiguration) obj;
     return Objects.equals(configuration, other.configuration);
   }
+
+  @Override
+  public int hashCode() {
+    return configuration != null ? configuration.hashCode() : 0;
+  }
 }

--- a/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/CloudBigtableScanConfiguration.java
+++ b/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/CloudBigtableScanConfiguration.java
@@ -191,6 +191,11 @@ public class CloudBigtableScanConfiguration extends CloudBigtableTableConfigurat
         throw new RuntimeException("Could not check SerializableScan equality", e);
       }
     }
+
+    @Override
+    public int hashCode() {
+      return scan != null ? scan.hashCode() : 0;
+    }
   }
 
   private SerializableScan serializableScan;
@@ -240,6 +245,13 @@ public class CloudBigtableScanConfiguration extends CloudBigtableTableConfigurat
     return super.equals(obj)
         && Objects
             .equals(serializableScan, ((CloudBigtableScanConfiguration) obj).serializableScan);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = super.hashCode();
+    result = 31 * result + (serializableScan != null ? serializableScan.hashCode() : 0);
+    return result;
   }
 
   @Override

--- a/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/CloudBigtableTableConfiguration.java
+++ b/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/CloudBigtableTableConfiguration.java
@@ -163,4 +163,11 @@ public class CloudBigtableTableConfiguration extends CloudBigtableConfiguration 
     return super.equals(obj)
         && Objects.equals(tableId, ((CloudBigtableTableConfiguration) obj).tableId);
   }
+
+  @Override
+  public int hashCode() {
+    int result = super.hashCode();
+    result = 31 * result + (tableId != null ? tableId.hashCode() : 0);
+    return result;
+  }
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1206 - “ equals(Object obj) and hashCode() should be overridden in pairs ”. You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S1206
Please let me know if you have any questions.
Ayman Abdelghany.