### PR TITLE
Fixing a bigtable to hbase translation issue.

### DIFF
--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/ColumnDescriptorAdapter.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/ColumnDescriptorAdapter.java
@@ -170,7 +170,9 @@ public class ColumnDescriptorAdapter {
     if (buffer.length() != 0) {
       buffer.append(" || ");
     }
-    buffer.append(String.format("(version() > %s)", maxVersions));
+    if (maxVersions != Integer.MAX_VALUE) {
+      buffer.append(String.format("(version() > %s)", maxVersions));
+    }
 
     return buffer.toString();
   }
@@ -194,8 +196,9 @@ public class ColumnDescriptorAdapter {
   private static void convertGarbageCollectionExpression(String gcExpression,
       HColumnDescriptor columnDescriptor) {
     if (Strings.isNullOrEmpty(gcExpression)) {
-      // No GC Expression means keep all versions, MaxVersions = 0.
-      columnDescriptor.setMaxVersions(0);
+      // No GC expression in Bigtable means keeping all versions. HBase doesn't support keeping all
+      // version, so we translate it by setting the max version to Integer.MAX_VALUE.
+      columnDescriptor.setMaxVersions(Integer.MAX_VALUE);
       return;
     }
     String maxVersionExpression = null;

--- a/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/TestColumnDescriptorAdapter.java
+++ b/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/TestColumnDescriptorAdapter.java
@@ -191,10 +191,8 @@ public class TestColumnDescriptorAdapter {
 
   @Test
   public void testBlankExpression(){
-    // An empty gc expression means keep all versions, which is not supported by HBase.
-    expectedException.expectMessage("Maximum versions must be positive");
-    expectedException.expect(IllegalArgumentException.class);
-
-    adapter.adapt("family", asColumnFamily(""));
+    HColumnDescriptor descriptor = adapter.adapt("family", asColumnFamily(""));
+    Assert.assertEquals(Integer.MAX_VALUE, descriptor.getMaxVersions());
+    Assert.assertEquals("", ColumnDescriptorAdapter.buildGarbageCollectionExpression(descriptor));
   }
 }


### PR DESCRIPTION
Go Clients default to no garbage collection policy. A project breaks the hbase shell 'list' command