### PR TITLE
Update CloudBigtableIO.java

### DIFF
--- a/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/CloudBigtableIO.java
+++ b/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/CloudBigtableIO.java
@@ -80,7 +80,7 @@ import com.google.common.annotations.VisibleForTesting;
  * that's ideal for web, mobile, and Internet of Things applications requiring terabytes to
  * petabytes of data. Unlike comparable market offerings, Cloud Bigtable doesn't require you to
  * sacrifice speed, scale, or cost efficiency when your applications grow. Cloud Bigtable has been
- * battle-tested at Google for more than 10 years—it's the database driving major applications such
+ * battle-tested at Google for more than 10 years--it's the database driving major applications such
  * as Google Analytics and Gmail.
  * </p>
  * 


### PR DESCRIPTION
Character causing javadoc problems with the Doclava custom doclet: "unmappable character for encoding ASCII". Trying again with a fresh request.