### PR TITLE
Some refactoring of CloudBigtableIO objects.

### DIFF
--- a/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/HBaseResultCoder.java
+++ b/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/HBaseResultCoder.java
@@ -32,7 +32,7 @@ import java.io.Serializable;
  * A {@link Coder} that serializes and deserializes the {@link Result} objects using {@link
  * ProtobufUtil}.
  */
-public class HBaseResultCoder extends AtomicCoder<Result> implements Serializable{
+public class HBaseResultCoder extends AtomicCoder<Result> implements Serializable {
 
   private static final long serialVersionUID = -4975428837770254686L;
 
@@ -43,8 +43,8 @@ public class HBaseResultCoder extends AtomicCoder<Result> implements Serializabl
   }
 
   @Override
-  public void encode(Result value, OutputStream outputStream,
-      Coder.Context context) throws CoderException, IOException {
+  public void encode(Result value, OutputStream outputStream, Coder.Context context)
+      throws CoderException, IOException {
     ProtobufUtil.toResult(value).writeDelimitedTo(outputStream);
   }
 }

--- a/bigtable-hbase-dataflow/src/test/java/com/google/cloud/bigtable/dataflow/CloudBigtableIOTest.java
+++ b/bigtable-hbase-dataflow/src/test/java/com/google/cloud/bigtable/dataflow/CloudBigtableIOTest.java
@@ -34,6 +34,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import com.google.cloud.bigtable.dataflow.CloudBigtableIO;
+import com.google.cloud.bigtable.dataflow.CloudBigtableIO.Source;
 import com.google.cloud.dataflow.sdk.Pipeline;
 import com.google.cloud.dataflow.sdk.coders.CannotProvideCoderException;
 import com.google.cloud.dataflow.sdk.coders.Coder;
@@ -95,17 +96,16 @@ public class CloudBigtableIOTest {
 
   @Test
   public void testSourceToString() throws Exception {
-    CloudBigtableIO.Source source = new CloudBigtableIO.Source(null);
+    CloudBigtableIO.Source source = (Source) CloudBigtableIO.read(null);
     byte[] startKey = "abc d".getBytes();
     byte[] stopKey = "def g".getBytes();
-    BoundedSource<Result> sourceWithKeys = source.new SourceWithKeys(startKey, stopKey, 10);
+    BoundedSource<Result> sourceWithKeys = source.createSourceWithKeys(startKey, stopKey, 10);
     assertEquals("Split start: 'abc d', end: 'def g', size: 10", sourceWithKeys.toString());
 
     startKey = new byte[]{0, 1, 2, 3, 4, 5};
     stopKey = new byte[]{104, 101, 108, 108, 111};  // hello
-    sourceWithKeys = source.new SourceWithKeys(startKey, stopKey, 10);
+    sourceWithKeys = source.createSourceWithKeys(startKey, stopKey, 10);
     assertEquals("Split start: '\\x00\\x01\\x02\\x03\\x04\\x05', end: 'hello', size: 10",
         sourceWithKeys.toString());
   }
 }
-


### PR DESCRIPTION
Moving the Reader class out of the Source class, so there's less nesting.
Using superclasses in tests and CloudBigtableIO to reduce leaking internals.
Adding createSourceWithKeys() instead of using new.

All of these changes are steps to getting to #672