### PR TITLE
Adding more informative CDF logging

### DIFF
--- a/bigtable-hbase-dataflow/pom.xml
+++ b/bigtable-hbase-dataflow/pom.xml
@@ -56,6 +56,12 @@ limitations under the License.
             <artifactId>commons-lang</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <version>1.7.16</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <profiles>
         <profile>

--- a/bigtable-hbase-dataflow/src/test/java/com/google/cloud/bigtable/dataflow/AbstractCloudBigtableTableDoFnTest.java
+++ b/bigtable-hbase-dataflow/src/test/java/com/google/cloud/bigtable/dataflow/AbstractCloudBigtableTableDoFnTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.bigtable.dataflow;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.lang.RandomStringUtils;
+import org.apache.hadoop.hbase.client.Get;
+import org.apache.hadoop.hbase.client.RetriesExhaustedWithDetailsException;
+import org.apache.hadoop.hbase.client.Row;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.grpc.Status;
+
+@RunWith(JUnit4.class)
+public class AbstractCloudBigtableTableDoFnTest {
+
+  @Test
+  public void testLogRetriesExhaustedWithDetailsException(){
+    // Make sure that the logging doesn't have any exceptions. The details can be manually verified.
+    // TODO: add a mock logger to confirm that the logging is correct.
+    Logger log = LoggerFactory.getLogger(getClass());
+    List<Throwable> exceptions = new ArrayList<>();
+    List<Row> actions = new ArrayList<>();
+    List<String> hostnameAndPort = new ArrayList<>();
+    for (int i = 0; i < 5; i++) {
+      exceptions.add(Status.CANCELLED.asException());
+      actions.add(new Get(RandomStringUtils.randomAlphabetic(8).getBytes()));
+      hostnameAndPort.add("");
+    }
+    AbstractCloudBigtableTableDoFn.logRetriesExhaustedWithDetailsException(log, null,
+      new RetriesExhaustedWithDetailsException(exceptions, actions, hostnameAndPort));
+  }
+}

--- a/bigtable-hbase-dataflow/src/test/resources/log4j.properties
+++ b/bigtable-hbase-dataflow/src/test/resources/log4j.properties
@@ -1,0 +1,22 @@
+# Copyright 2015 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Root logger option
+log4j.rootLogger=INFO, stdout
+
+# Direct log messages to stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n


### PR DESCRIPTION
The current RetriesExhaustedWithException logging doesn't give much information about the underlying cause.  Adding the full stacktrace of the first cause.  Getting a synopsis for all causes.