### PR TITLE
Moving Channel closing responsibilities to ChannelPool

### DIFF
--- a/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestBatch.java
+++ b/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestBatch.java
@@ -380,6 +380,7 @@ public class TestBatch extends AbstractTest {
       Assert.fail("Expected an exception");
     } catch(RetriesExhaustedWithDetailsException e) {
       Assert.assertEquals(1, e.getCauses().size());
+      Assert.assertTrue(e.getCause(0).getMessage().toLowerCase().contains("closed"));
     }
   }
 }


### PR DESCRIPTION
Also making sure that ChannelPool has the responsibility of closing the underlying channels.
Making BigtableSession a Closable instead of an AutoClosable.