### PR TITLE
Allow IP address to override host name in BigtableSession.

### DIFF
--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableOptions.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableOptions.java
@@ -68,6 +68,8 @@ public class BigtableOptions implements Serializable {
     private String tableAdminHost = BIGTABLE_TABLE_ADMIN_HOST_DEFAULT;
     private String clusterAdminHost = BIGTABLE_CLUSTER_ADMIN_HOST_DEFAULT;
     private int port = BIGTABLE_PORT_DEFAULT;
+    private String dataIpOverride;
+    private String adminIpOverride;
 
     // The default credentials get credential from well known locations, such as the GCE
     // metdata service or gcloud configuration in other environments. A user can also override
@@ -94,6 +96,8 @@ public class BigtableOptions implements Serializable {
       this.tableAdminHost = original.tableAdminHost;
       this.clusterAdminHost = original.clusterAdminHost;
       this.port = original.port;
+      this.dataIpOverride = original.dataIpOverride;
+      this.adminIpOverride = original.adminIpOverride;
       this.credentialOptions = original.credentialOptions;
       this.retryOptions = original.retryOptions;
       this.timeoutMs = original.timeoutMs;
@@ -119,6 +123,16 @@ public class BigtableOptions implements Serializable {
 
     public Builder setPort(int port) {
       this.port = port;
+      return this;
+    }
+
+    public Builder setDataIpOverride(String dataIpOverride) {
+      this.dataIpOverride = dataIpOverride;
+      return this;
+    }
+
+    public Builder setAdminIpOverride(String adminIpOverride) {
+      this.adminIpOverride = adminIpOverride;
       return this;
     }
 
@@ -180,6 +194,8 @@ public class BigtableOptions implements Serializable {
           tableAdminHost,
           dataHost,
           port,
+          dataIpOverride,
+          adminIpOverride,
           projectId,
           zoneId,
           clusterId,
@@ -197,6 +213,8 @@ public class BigtableOptions implements Serializable {
   private final String tableAdminHost;
   private final String dataHost;
   private final int port;
+  private final String dataIpOverride;
+  private final String adminIpOverride;
   private final String projectId;
   private final String zoneId;
   private final String clusterId;
@@ -216,6 +234,8 @@ public class BigtableOptions implements Serializable {
       tableAdminHost = null;
       dataHost = null;
       port = 0;
+      dataIpOverride = null;
+      adminIpOverride = null;
       projectId = null;
       zoneId = null;
       clusterId = null;
@@ -234,6 +254,8 @@ public class BigtableOptions implements Serializable {
       String tableAdminHost,
       String dataHost,
       int port,
+      String dataIpOverride,
+      String adminIpOverride,
       String projectId,
       String zoneId,
       String clusterId,
@@ -252,6 +274,8 @@ public class BigtableOptions implements Serializable {
     this.clusterAdminHost = Preconditions.checkNotNull(clusterAdminHost);
     this.dataHost = Preconditions.checkNotNull(dataHost);
     this.port = port;
+    this.dataIpOverride = dataIpOverride;
+    this.adminIpOverride = adminIpOverride;
     this.projectId = projectId;
     this.zoneId = zoneId;
     this.clusterId = clusterId;
@@ -272,13 +296,15 @@ public class BigtableOptions implements Serializable {
     }
 
     LOG.debug("Connection Configuration: projectId: %s, zoneId: %s, clusterId: %s, data host %s, "
-        + "table admin host %s, cluster admin host %s.",
+        + "table admin host %s, cluster admin host %s, data ip override %s, admin ip override.",
         projectId,
         zoneId,
         clusterId,
         dataHost,
         tableAdminHost,
-        clusterAdminHost);
+        clusterAdminHost,
+        dataIpOverride,
+        adminIpOverride);
   }
 
   public String getProjectId() {
@@ -307,6 +333,14 @@ public class BigtableOptions implements Serializable {
 
   public int getPort() {
     return port;
+  }
+
+  public String getDataIpOverride() {
+    return dataIpOverride;
+  }
+
+  public String getAdminIpOverride() {
+    return adminIpOverride;
   }
 
   /**
@@ -372,6 +406,8 @@ public class BigtableOptions implements Serializable {
         && (useBulkApi == other.useBulkApi)
         && Objects.equal(clusterAdminHost, other.clusterAdminHost)
         && Objects.equal(tableAdminHost, other.tableAdminHost)
+        && Objects.equal(dataIpOverride, other.dataIpOverride)
+        && Objects.equal(adminIpOverride, other.adminIpOverride)
         && Objects.equal(dataHost, other.dataHost)
         && Objects.equal(projectId, other.projectId)
         && Objects.equal(zoneId, other.zoneId)
@@ -388,6 +424,8 @@ public class BigtableOptions implements Serializable {
         .add("dataHost", dataHost)
         .add("tableAdminHost", tableAdminHost)
         .add("clusterAdminHost", clusterAdminHost)
+        .add("dataIpOverride", dataIpOverride)
+        .add("adminIpOverride", adminIpOverride)
         .add("projectId", projectId)
         .add("zoneId", zoneId)
         .add("clusterId", clusterId)

--- a/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestBigtableSession.java
+++ b/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestBigtableSession.java
@@ -40,7 +40,7 @@ public class TestBigtableSession {
           .setZoneId(zoneId)
           .setClusterId(clusterId)
           .setUserAgent(userAgent)
-          .build(), null, null, null);
+          .build());
   }
 
   @Rule
@@ -73,5 +73,7 @@ public class TestBigtableSession {
     expectedException.expectMessage(BigtableSession.USER_AGENT_EMPTY_OR_NULL);
     createSession(PROJECT_ID, ZONE_ID, CLUSTER_ID, null);
   }
+
+
 
 }

--- a/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/CloudBigtableConfiguration.java
+++ b/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/CloudBigtableConfiguration.java
@@ -17,6 +17,7 @@ package com.google.cloud.bigtable.dataflow;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.net.InetAddress;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -111,6 +112,9 @@ public class CloudBigtableConfiguration implements Serializable {
   // Not final due to serialization of CloudBigtableScanConfiguration.
   private Map<String, String> configuration;
 
+  // Transient so we make sure to re-resolve after deserialization
+  private transient Configuration hbaseConfig;
+
   // Used for serialization of CloudBigtableScanConfiguration.
   CloudBigtableConfiguration() {
   }
@@ -176,19 +180,36 @@ public class CloudBigtableConfiguration implements Serializable {
    * Converts the {@link CloudBigtableConfiguration} to an HBase {@link Configuration}.
    * @return The {@link Configuration}.
    */
-  public Configuration toHBaseConfig() {
-    Configuration config = new Configuration(false);
+  public synchronized Configuration toHBaseConfig() throws IOException {
+    if (hbaseConfig == null) {
+      hbaseConfig = new Configuration(false);
 
-    // This setting can potentially decrease performance for large scale writes. However, this
-    // setting prevents problems that occur when streaming Sources, such as PubSub, are used.
-    // To override this behavior, call:
-    //    Builder.withConfiguration(BigtableOptionsFactory.BIGTABLE_ASYNC_MUTATOR_COUNT_KEY, 
-    //                              BigtableOptions.BIGTABLE_ASYNC_MUTATOR_COUNT_DEFAULT);
-    config.set(BigtableOptionsFactory.BIGTABLE_ASYNC_MUTATOR_COUNT_KEY, "0");
-    for (Entry<String, String> entry : configuration.entrySet()) {
-      config.set(entry.getKey(), entry.getValue());
+      // This setting can potentially decrease performance for large scale writes. However, this
+      // setting prevents problems that occur when streaming Sources, such as PubSub, are used.
+      // To override this behavior, call:
+      //    Builder.withConfiguration(BigtableOptionsFactory.BIGTABLE_ASYNC_MUTATOR_COUNT_KEY,
+      //                              BigtableOptions.BIGTABLE_ASYNC_MUTATOR_COUNT_DEFAULT);
+      hbaseConfig.set(BigtableOptionsFactory.BIGTABLE_ASYNC_MUTATOR_COUNT_KEY, "0");
+      for (Entry<String, String> entry : configuration.entrySet()) {
+        hbaseConfig.set(entry.getKey(), entry.getValue());
+      }
+
+      // TODO Stop caching IP addresses once we have fixed the issue with GRPC
+      // reconnecting to invalid IPv6 addresses after idle connection times out.
+      String dataHost = hbaseConfig.get(BigtableOptionsFactory.BIGTABLE_DATA_HOST_KEY,
+          BigtableOptions.BIGTABLE_DATA_HOST_DEFAULT);
+      InetAddress dataHostAddress = InetAddress.getByName(dataHost);
+      hbaseConfig.set(BigtableOptionsFactory.BIGTABLE_DATA_IP_OVERRIDE_KEY,
+          dataHostAddress.getHostAddress());
+
+      String adminHost = hbaseConfig.get(BigtableOptionsFactory.BIGTABLE_TABLE_ADMIN_HOST_KEY,
+          BigtableOptions.BIGTABLE_TABLE_ADMIN_HOST_DEFAULT);
+      InetAddress adminHostAddress = InetAddress.getByName(adminHost);
+      hbaseConfig.set(BigtableOptionsFactory.BIGTABLE_ADMIN_IP_OVERRIDE_KEY,
+          adminHostAddress.getHostAddress());
     }
-    return config;
+
+    return hbaseConfig;
   }
 
   /**

--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableOptionsFactory.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableOptionsFactory.java
@@ -46,7 +46,11 @@ public class BigtableOptionsFactory {
       "google.bigtable.cluster.admin.endpoint.host";
   public static final String BIGTABLE_TABLE_ADMIN_HOST_KEY =
       "google.bigtable.admin.endpoint.host";
-  public static final String BIGTABLE_HOST_KEY = "google.bigtable.endpoint.host";
+  public static final String BIGTABLE_DATA_HOST_KEY = "google.bigtable.endpoint.host";
+  public static final String BIGTABLE_DATA_IP_OVERRIDE_KEY =
+      "google.bigtable.endpoint.data.ip.override";
+  public static final String BIGTABLE_ADMIN_IP_OVERRIDE_KEY =
+      "google.bigtable.endpoint.admin.ip.override";
 
   public static final String PROJECT_ID_KEY = "google.bigtable.project.id";
   public static final String CLUSTER_KEY = "google.bigtable.cluster.name";
@@ -152,7 +156,7 @@ public class BigtableOptionsFactory {
     bigtableOptionsBuilder.setClusterId(getValue(configuration, CLUSTER_KEY, "Cluster"));
 
     bigtableOptionsBuilder.setDataHost(
-        getHost(configuration, BIGTABLE_HOST_KEY, BIGTABLE_DATA_HOST_DEFAULT, "API Data"));
+        getHost(configuration, BIGTABLE_DATA_HOST_KEY, BIGTABLE_DATA_HOST_DEFAULT, "API Data"));
 
     bigtableOptionsBuilder.setTableAdminHost(getHost(
       configuration, BIGTABLE_TABLE_ADMIN_HOST_KEY, BIGTABLE_TABLE_ADMIN_HOST_DEFAULT,
@@ -160,6 +164,9 @@ public class BigtableOptionsFactory {
 
     bigtableOptionsBuilder.setClusterAdminHost(getHost(configuration,
         BIGTABLE_CLUSTER_ADMIN_HOST_KEY, BIGTABLE_CLUSTER_ADMIN_HOST_DEFAULT, "Cluster Admin"));
+
+    bigtableOptionsBuilder.setDataIpOverride(configuration.get(BIGTABLE_DATA_IP_OVERRIDE_KEY));
+    bigtableOptionsBuilder.setAdminIpOverride(configuration.get(BIGTABLE_ADMIN_IP_OVERRIDE_KEY));
 
     int port = configuration.getInt(BIGTABLE_PORT_KEY, BIGTABLE_PORT_DEFAULT);
     bigtableOptionsBuilder.setPort(port);

--- a/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableOptionsFactory.java
+++ b/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableOptionsFactory.java
@@ -48,7 +48,7 @@ public class TestBigtableOptionsFactory {
   @Before
   public void setup() {
     configuration = new Configuration(false);
-    configuration.set(BigtableOptionsFactory.BIGTABLE_HOST_KEY, TEST_HOST);
+    configuration.set(BigtableOptionsFactory.BIGTABLE_DATA_HOST_KEY, TEST_HOST);
     configuration.set(BigtableOptionsFactory.PROJECT_ID_KEY, TEST_PROJECT_ID);
     configuration.set(BigtableOptionsFactory.CLUSTER_KEY, TEST_CLUSTER_NAME);
     configuration.set(BigtableOptionsFactory.ZONE_KEY, TEST_ZONE_NAME);
@@ -66,7 +66,7 @@ public class TestBigtableOptionsFactory {
   @Test
   public void testHostIsRequired() throws IOException {
     Configuration configuration = new Configuration(false);
-    configuration.unset(BigtableOptionsFactory.BIGTABLE_HOST_KEY);
+    configuration.unset(BigtableOptionsFactory.BIGTABLE_DATA_HOST_KEY);
 
     expectedException.expect(IllegalArgumentException.class);
     BigtableOptionsFactory.fromConfiguration(configuration);
@@ -92,7 +92,7 @@ public class TestBigtableOptionsFactory {
 
   @Test
   public void testAdminHostKeyIsUsed() throws IOException {
-    configuration.set(BigtableOptionsFactory.BIGTABLE_HOST_KEY, TEST_HOST);
+    configuration.set(BigtableOptionsFactory.BIGTABLE_DATA_HOST_KEY, TEST_HOST);
     configuration.set(BigtableOptionsFactory.BIGTABLE_TABLE_ADMIN_HOST_KEY, TEST_HOST);
     configuration.setBoolean(BigtableOptionsFactory.BIGTABE_USE_SERVICE_ACCOUNTS_KEY, false);
     configuration.setBoolean(BigtableOptionsFactory.BIGTABLE_NULL_CREDENTIAL_ENABLE_KEY, true);
@@ -102,7 +102,7 @@ public class TestBigtableOptionsFactory {
 
   @Test
   public void testOptionsAreConstructedWithValidInput() throws IOException {
-    configuration.set(BigtableOptionsFactory.BIGTABLE_HOST_KEY, TEST_HOST);
+    configuration.set(BigtableOptionsFactory.BIGTABLE_DATA_HOST_KEY, TEST_HOST);
     configuration.setBoolean(BigtableOptionsFactory.BIGTABE_USE_SERVICE_ACCOUNTS_KEY, false);
     configuration.setBoolean(BigtableOptionsFactory.BIGTABLE_NULL_CREDENTIAL_ENABLE_KEY, true);
     BigtableOptions options = BigtableOptionsFactory.fromConfiguration(configuration);
@@ -114,7 +114,7 @@ public class TestBigtableOptionsFactory {
 
   @Test
   public void testMinGoodRefreshTime() throws IOException{
-    configuration.set(BigtableOptionsFactory.BIGTABLE_HOST_KEY, TEST_HOST);
+    configuration.set(BigtableOptionsFactory.BIGTABLE_DATA_HOST_KEY, TEST_HOST);
     configuration.setBoolean(BigtableOptionsFactory.BIGTABE_USE_SERVICE_ACCOUNTS_KEY, false);
     configuration.setBoolean(BigtableOptionsFactory.BIGTABLE_NULL_CREDENTIAL_ENABLE_KEY, true);
     configuration.setLong(BigtableOptionsFactory.BIGTABLE_CHANNEL_TIMEOUT_MS_KEY, 60000);
@@ -123,7 +123,7 @@ public class TestBigtableOptionsFactory {
 
   @Test
   public void testBadRefreshTime() throws IOException{
-    configuration.set(BigtableOptionsFactory.BIGTABLE_HOST_KEY, TEST_HOST);
+    configuration.set(BigtableOptionsFactory.BIGTABLE_DATA_HOST_KEY, TEST_HOST);
     configuration.setBoolean(BigtableOptionsFactory.BIGTABE_USE_SERVICE_ACCOUNTS_KEY, false);
     configuration.setBoolean(BigtableOptionsFactory.BIGTABLE_NULL_CREDENTIAL_ENABLE_KEY, true);
     configuration.setLong(BigtableOptionsFactory.BIGTABLE_CHANNEL_TIMEOUT_MS_KEY, 59999);
@@ -133,7 +133,7 @@ public class TestBigtableOptionsFactory {
 
   @Test
   public void testZeroRefreshTime() throws IOException{
-    configuration.set(BigtableOptionsFactory.BIGTABLE_HOST_KEY, TEST_HOST);
+    configuration.set(BigtableOptionsFactory.BIGTABLE_DATA_HOST_KEY, TEST_HOST);
     configuration.setBoolean(BigtableOptionsFactory.BIGTABE_USE_SERVICE_ACCOUNTS_KEY, false);
     configuration.setBoolean(BigtableOptionsFactory.BIGTABLE_NULL_CREDENTIAL_ENABLE_KEY, true);
     configuration.setLong(BigtableOptionsFactory.BIGTABLE_CHANNEL_TIMEOUT_MS_KEY, 0);


### PR DESCRIPTION
Resolve host name to IP address for dataflow jobs to work around gRPC issue.