### PR TITLE
Caching the validity of a cloud bigtable configurtion.

### DIFF
--- a/bigtable-hbase-dataflow/src/test/java/com/google/cloud/bigtable/dataflow/CloudBigtableIOIntegrationTest.java
+++ b/bigtable-hbase-dataflow/src/test/java/com/google/cloud/bigtable/dataflow/CloudBigtableIOIntegrationTest.java
@@ -95,27 +95,6 @@ public class CloudBigtableIOIntegrationTest {
   }
 
   @Test
-  public void testWriteToTable_tableDoesNotExist() throws Exception {
-    LOG.info("Testing testWriteToTable_tableDoesNotExist()");
-    // The table doesn't exist.
-    expectedException.expect(IllegalStateException.class);
-    CloudBigtableIO.writeToTable(createTableConfig("does-not-exist-table")).validate(null);
-  }
-
-  @Test
-  public void testWriteToTable_tableExist() throws Exception {
-    try (Admin admin = connection.getAdmin()) {
-      LOG.info("Creating table in testWriteToTable_tableExist()");
-      TableName tableName = createNewTable(admin);
-      try {
-        CloudBigtableIO.writeToTable(createTableConfig(tableName.getNameAsString())).validate(null);
-      } finally {
-        admin.deleteTable(tableName);
-      }
-    }
-  }
-
-  @Test
   public void testWriteToTable_dataWrittenSerial() throws Exception {
     final int INSERT_COUNT = 50;
     try (Admin admin = connection.getAdmin()) {


### PR DESCRIPTION
Currently, the validation logic is run for every split that dataflow does in read mode.  That means that BigtableAdmin.tableExists() gets called often.  That means that in turn, list tables gets called often.  I've seen it happen up to 15x per second in some cases.  That strains the server unnecessarily.  The caching of the validation will tremendously reduce the load on listTables.