### PR TITLE
Updating RetryingRpcFunction to retry multiple times.

### DIFF
--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/BigtableRetriesExhaustedException.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/BigtableRetriesExhaustedException.java
@@ -20,10 +20,10 @@ import java.io.IOException;
 /**
  * An Exception that is thrown when an operation fails, even in the face of retries.
  */
-public class ScanRetriesExhaustedException extends IOException {
+public class BigtableRetriesExhaustedException extends IOException {
   private static final long serialVersionUID = 6905598607595217072L;
 
-  public ScanRetriesExhaustedException(String message, Throwable cause) {
+  public BigtableRetriesExhaustedException(String message, Throwable cause) {
     super(message, cause);
   }
 }

--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ResumingStreamingResultScanner.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ResumingStreamingResultScanner.java
@@ -125,16 +125,16 @@ public class ResumingStreamingResultScanner extends AbstractBigtableResultScanne
    *
    * @param cause
    * @throws IOException
-   * @throws ScanRetriesExhaustedException if retry is exhausted.
+   * @throws BigtableRetriesExhaustedException if retry is exhausted.
    */
   private void backOffAndRetry(IOException cause) throws IOException,
-      ScanRetriesExhaustedException {
+      BigtableRetriesExhaustedException {
     if (currentBackoff == null) {
       currentBackoff = retryOptions.createBackoff();
     }
     long nextBackOff = currentBackoff.nextBackOffMillis();
     if (nextBackOff == BackOff.STOP) {
-      throw new ScanRetriesExhaustedException("Exhausted streaming retries.", cause);
+      throw new BigtableRetriesExhaustedException("Exhausted streaming retries.", cause);
     }
 
     sleep(nextBackOff);

--- a/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/RetryingRpcFunctionTest.java
+++ b/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/RetryingRpcFunctionTest.java
@@ -15,10 +15,19 @@
  */
 package com.google.cloud.bigtable.grpc.async;
 
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -33,11 +42,15 @@ import org.mockito.stubbing.Answer;
 import com.google.api.client.util.NanoClock;
 import com.google.api.client.util.Sleeper;
 import com.google.bigtable.v1.ReadRowsRequest;
+import com.google.bigtable.v1.ReadRowsResponse;
 import com.google.cloud.bigtable.config.RetryOptions;
 import com.google.cloud.bigtable.config.RetryOptionsUtil;
-import com.google.cloud.bigtable.grpc.scanner.ScanRetriesExhaustedException;
+import com.google.cloud.bigtable.grpc.scanner.BigtableRetriesExhaustedException;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
 
 import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
 
 /**
  * Test for {@link RetryingRpcFunction}
@@ -49,29 +62,39 @@ public class RetryingRpcFunctionTest {
   private RetryingRpcFunction underTest;
 
   @Mock
-  private BigtableAsyncRpc readAsync;
+  private BigtableAsyncRpc<ReadRowsRequest, ReadRowsResponse> readAsync;
 
   @Rule
   public ExpectedException expectedException = ExpectedException.none();
 
   @Mock
   private NanoClock nanoClock;
+  @Mock
+  private ListenableFuture mockFuture;
+
+  private RetryOptions retryOptions;
+
+  AtomicLong totalSleep;
 
   @Before
   public void setup() {
     MockitoAnnotations.initMocks(this);
-    RetryOptions retryOptions = RetryOptionsUtil.createTestRetryOptions(nanoClock);
-    underTest =
-        RetryingRpcFunction.create(retryOptions, ReadRowsRequest.getDefaultInstance(),
-          readAsync);
-  }
+    retryOptions = RetryOptionsUtil.createTestRetryOptions(nanoClock);
 
-  @Test
-  public void testBackoff() throws Exception {
-    expectedException.expect(ScanRetriesExhaustedException.class);
+    underTest = new RetryingRpcFunction<>(retryOptions, ReadRowsRequest.getDefaultInstance(),
+        readAsync, MoreExecutors.newDirectExecutorService());
 
-    final AtomicLong totalSleep = new AtomicLong();
+    totalSleep = new AtomicLong();
+
+    underTest.sleeper = new Sleeper() {
+      @Override
+      public void sleep(long ms) throws InterruptedException {
+        totalSleep.addAndGet(ms * 1000000);
+      }
+    };
+
     final long start = System.nanoTime();
+
     // We want the nanoClock to mimic the behavior of sleeping, but without the time penalty.
     // This will allow the RetryingRpcFutureFallback's ExponentialBackOff to work properly.
     // The ExponentialBackOff sends a BackOff.STOP only when the clock time reaches
@@ -83,17 +106,60 @@ public class RetryingRpcFunctionTest {
         return start + totalSleep.get();
       }
     });
-    underTest.sleeper = new Sleeper() {
+
+    doAnswer(new Answer<Void>() {
       @Override
-      public void sleep(long ms) throws InterruptedException {
-        totalSleep.addAndGet(ms * 1000000);
+      public Void answer(InvocationOnMock invocation) throws Throwable {
+        invocation.getArgumentAt(0, Runnable.class).run();
+        return null;
       }
-    };
-    // This should throw a ScanRetriesExhaustedException after a short while.  The max of 50
-    // is a safe number of attempts before assuming that a ScanRetriesExhaustedException will
-    // not be thrown.
-    for (int i = 0; i < 50; i++) {
-      underTest.apply(Status.INTERNAL.asRuntimeException());
+    }).when(mockFuture).addListener(any(Runnable.class), any(Executor.class));
+    when(readAsync.call(any(ReadRowsRequest.class))).thenReturn(mockFuture);
+  }
+
+  @Test
+  public void testOK() throws Exception {
+    final ReadRowsResponse result = ReadRowsResponse.getDefaultInstance();
+    when(mockFuture.get()).thenReturn(result);
+    Assert.assertEquals(result, underTest.callRpcWithRetry().get(1, TimeUnit.SECONDS));
+    verify(nanoClock, times(0)).nanoTime();
+  }
+
+  @Test
+  public void testRecoveredFailure() throws Exception {
+    final ReadRowsResponse result = ReadRowsResponse.getDefaultInstance();
+    final Status errorStatus = Status.UNAVAILABLE;
+    final AtomicInteger counter = new AtomicInteger(0);
+    when(mockFuture.get()).thenAnswer(new Answer<ReadRowsResponse>() {
+      @Override
+      public ReadRowsResponse answer(InvocationOnMock invocation) throws Throwable {
+        if (counter.incrementAndGet() < 5){
+          throw errorStatus.asRuntimeException();
+        }
+        return ReadRowsResponse.getDefaultInstance();
+      }
+    });
+    Assert.assertEquals(result, underTest.callRpcWithRetry().get(1, TimeUnit.SECONDS));
+    Assert.assertEquals(5, counter.get());
+  }
+
+  @Test
+  public void testCompleteFailure() throws Exception {
+    Status expectedStatus = Status.UNAVAILABLE;
+    when(mockFuture.get()).thenThrow(expectedStatus.asRuntimeException());
+    try {
+      underTest.callRpcWithRetry().get(1, TimeUnit.SECONDS);
+      Assert.fail();
+    } catch (ExecutionException e) {
+      Assert.assertEquals(BigtableRetriesExhaustedException.class, e.getCause().getClass());
+      BigtableRetriesExhaustedException retriesExhaustedException =
+          (BigtableRetriesExhaustedException) e.getCause();
+      StatusRuntimeException sre = (StatusRuntimeException) retriesExhaustedException.getCause();
+      Assert.assertEquals(expectedStatus.getCode(), sre.getStatus().getCode());
+      long maxSleep = TimeUnit.MILLISECONDS.toNanos(retryOptions.getMaxElaspedBackoffMillis());
+      Assert.assertTrue(
+        String.format("Slept only %d seconds", TimeUnit.NANOSECONDS.toSeconds(totalSleep.get())),
+        totalSleep.get() >= maxSleep);
     }
   }
 }


### PR DESCRIPTION
RetryingRpcFunction's retries returned a future that wasn't retried.  Only the first failure caused a retry, but was not exponentially backed off.  Added a cycle of retries.