### PR TITLE
Re-adding the ChannelPool ensure capacity feature.

### DIFF
--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
@@ -240,8 +240,7 @@ public class BigtableSession implements Closeable {
       headerInterceptorBuilder.add(new UserAgentInterceptor(options.getUserAgent()));
       headerInterceptors = headerInterceptorBuilder.build();
 
-      ChannelPool dataChannel = createChannelPool(options.getDataHost(), options.getDataIpOverride(),
-          options.getChannelCount());
+      ChannelPool dataChannel = createChannelPool(options.getDataHost(), options.getDataIpOverride());
 
       BigtableSessionSharedThreadPools sharedPools = BigtableSessionSharedThreadPools.getInstance();
 
@@ -329,7 +328,7 @@ public class BigtableSession implements Closeable {
   public synchronized BigtableTableAdminClient getTableAdminClient() throws IOException {
     if (tableAdminClient == null) {
       ManagedChannel channel =
-          createChannelPool(options.getTableAdminHost(), options.getAdminIpOverride(), 1);
+          createChannelPool(options.getTableAdminHost(), options.getAdminIpOverride());
       tableAdminClient = new BigtableTableAdminGrpcClient(channel);
     }
     return tableAdminClient;
@@ -338,7 +337,7 @@ public class BigtableSession implements Closeable {
   public synchronized BigtableClusterAdminClient getClusterAdminClient() throws IOException {
     if (this.clusterAdminClient == null) {
       ManagedChannel channel =
-          createChannelPool(options.getClusterAdminHost(), null, 1);
+          createChannelPool(options.getClusterAdminHost(), null);
       this.clusterAdminClient = new BigtableClusterAdminGrpcClient(channel);
     }
 
@@ -351,14 +350,14 @@ public class BigtableSession implements Closeable {
    * </p>
    */
   protected ChannelPool createChannelPool(
-      final String hostString, @Nullable final String ipOverride, int channelCount) throws IOException {
+      final String hostString, @Nullable final String ipOverride) throws IOException {
     ChannelPool.ChannelFactory channelFactory = new ChannelPool.ChannelFactory() {
       @Override
       public ManagedChannel create() throws IOException {
         return createNettyChannel(hostString, ipOverride);
       }
     };
-    ChannelPool channelPool = new ChannelPool(headerInterceptors, channelFactory, channelCount);
+    ChannelPool channelPool = new ChannelPool(headerInterceptors, channelFactory);
     managedChannels.add(channelPool);
     return channelPool;
   }

--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/ChannelPool.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/ChannelPool.java
@@ -16,15 +16,18 @@
 package com.google.cloud.bigtable.grpc.io;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import com.google.cloud.bigtable.config.Logger;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
 import io.grpc.CallOptions;
+import io.grpc.Channel;
 import io.grpc.ClientCall;
 import io.grpc.ClientInterceptors.CheckedForwardingClientCall;
 import io.grpc.ManagedChannel;
@@ -42,42 +45,62 @@ public class ChannelPool extends ManagedChannel {
     ManagedChannel create() throws IOException;
   }
 
-  private final ImmutableList<ManagedChannel> channels;
+  private final AtomicReference<ImmutableList<ManagedChannel>> channels = new AtomicReference<>();
   private final AtomicInteger requestCount = new AtomicInteger();
   private final ImmutableList<HeaderInterceptor> headerInterceptors;
+  private final ChannelFactory factory;
   private final String authority;
 
   private boolean shutdown = false;
 
-  public ChannelPool(ChannelFactory factory, int channelCount)
+  public ChannelPool(List<HeaderInterceptor> headerInterceptors, ChannelFactory factory)
       throws IOException {
-    this(ImmutableList.<HeaderInterceptor>of(), factory, channelCount);
-  }
-
-  public ChannelPool(List<HeaderInterceptor> headerInterceptors, ChannelFactory factory, int channelCount)
-      throws IOException {
-    Preconditions.checkArgument(channelCount > 0, "Channel count has to be at least 1.");
-    Preconditions.checkNotNull(headerInterceptors, "Must pass non null headerInterceptors");
-    this.headerInterceptors = ImmutableList.copyOf(headerInterceptors);
-
-    ManagedChannel[] channelArray = new ManagedChannel[channelCount];
-    for (int i = 0; i < channelCount; i++) {
-      channelArray[i] = factory.create();
+    ManagedChannel channel = factory.create();
+    this.channels.set(ImmutableList.of(channel));
+    authority = channel.authority();
+    this.factory = factory;
+    if (headerInterceptors == null) {
+      this.headerInterceptors = ImmutableList.of();
+    } else {
+      this.headerInterceptors = ImmutableList.copyOf(headerInterceptors);
     }
-    authority = channelArray[0].authority();
-    channels = ImmutableList.copyOf(channelArray);
   }
 
   /**
-   * Performs a simple round robin on the list of {@link ManagedChannel}s.
-   * This method is thread safe.
+   * Makes sure that the number of channels is at least as big as the specified capacity.  This
+   * method is only synchornized when the pool has to be expanded.
    *
-   * @return A channel.
+   * @param capacity The minimum number of channels required for the RPCs of the ChannelPool's
+   * clients.
+   */
+  public void ensureChannelCount(int capacity) throws IOException {
+    if (this.shutdown) {
+      throw new IOException("The channel is closed.");
+    }
+    if (channels.get().size() < capacity) {
+      synchronized (this) {
+        if (channels.get().size() < capacity) {
+          List<ManagedChannel> newChannelList = new ArrayList<>(channels.get());
+          while(newChannelList.size() < capacity) {
+            newChannelList.add(factory.create());
+          }
+          setChannels(newChannelList);
+        }
+      }
+    }
+  }
+
+  /**
+   * Performs a simple round robin on the list of {@link Channel}s in the {@code channels} list.
+   * This method should not be synchronized, if possible, to reduce bottlenecks.
+   * 
+   * @return A channel that can be used for a safe 
    */
   private ManagedChannel getNextChannel() {
     int currentRequestNum = requestCount.getAndIncrement();
-    int index = Math.abs(currentRequestNum % channels.size());
-    return channels.get(index);
+    ImmutableList<ManagedChannel> channelsList = channels.get();
+    int index = Math.abs(currentRequestNum % channelsList.size());
+    return channelsList.get(index);
   }
 
   /**
@@ -109,7 +132,6 @@ public class ChannelPool extends ManagedChannel {
   private <ReqT, RespT> ClientCall<ReqT, RespT> createWrappedCall(
       MethodDescriptor<ReqT, RespT> methodDescriptor, CallOptions callOptions, ManagedChannel channel) {
     ClientCall<ReqT, RespT> delegate = channel.newCall(methodDescriptor, callOptions);
-
     return new CheckedForwardingClientCall<ReqT, RespT>(delegate) {
       @Override
       protected void checkedStart(ClientCall.Listener<RespT> responseListener, Metadata headers)
@@ -122,13 +144,23 @@ public class ChannelPool extends ManagedChannel {
     };
   }
 
+  /**
+   * Sets the values in newChannelList to the {@code channels} AtomicReference.  The values are
+   * copied into an {@link ImmutableList}.
+   *
+   * @param newChannelList A {@link List} of {@link ManagedChannel}s to set to the {@code channels}
+   */
+  private void setChannels(List<ManagedChannel> newChannelList) {
+    channels.set(ImmutableList.copyOf(newChannelList));
+  }
+
   public int size() {
-    return channels.size();
+    return channels.get().size();
   }
 
   @Override
   public synchronized ManagedChannel shutdown() {
-    for (ManagedChannel channel : channels) {
+    for (ManagedChannel channel : channels.get()) {
       channel.shutdown();
     }
     this.shutdown = true;
@@ -142,7 +174,7 @@ public class ChannelPool extends ManagedChannel {
 
   @Override
   public boolean isTerminated() {
-    for (ManagedChannel managedChannel : channels) {
+    for (ManagedChannel managedChannel: channels.get()) {
       if (!managedChannel.isTerminated()) {
         return false;
       }
@@ -152,7 +184,7 @@ public class ChannelPool extends ManagedChannel {
 
   @Override
   public ManagedChannel shutdownNow() {
-    for (ManagedChannel channel : channels) {
+    for (ManagedChannel channel : channels.get()) {
       channel.shutdownNow();
     }
     return this;
@@ -161,7 +193,7 @@ public class ChannelPool extends ManagedChannel {
   @Override
   public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
     long endTimeNanos = System.nanoTime() + unit.toNanos(timeout);
-    for (ManagedChannel channel : channels) {
+    for (ManagedChannel channel : channels.get()) {
       long awaitTimeNanos = endTimeNanos - System.nanoTime();
       if (awaitTimeNanos <= 0) {
         break;

--- a/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/io/ChannelPoolTest.java
+++ b/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/io/ChannelPoolTest.java
@@ -88,7 +88,7 @@ public class ChannelPoolTest {
     MethodDescriptor descriptor = mock(MethodDescriptor.class);
     HeaderInterceptor interceptor = mock(HeaderInterceptor.class);
     ChannelPool pool =
-        new ChannelPool(Collections.singletonList(interceptor), new MockChannelFactory(), 1);
+        new ChannelPool(Collections.singletonList(interceptor), new MockChannelFactory());
     ClientCall call = pool.newCall(descriptor, CallOptions.DEFAULT);
     Metadata headers = new Metadata();
     call.start(null, headers);
@@ -100,7 +100,8 @@ public class ChannelPoolTest {
     MockChannelFactory factory = new MockChannelFactory();
     MethodDescriptor descriptor = mock(MethodDescriptor.class);
     MockitoAnnotations.initMocks(this);
-    ChannelPool pool = new ChannelPool(factory, 2);
+    ChannelPool pool = new ChannelPool(null, factory);
+    pool.ensureChannelCount(2);
     pool.newCall(descriptor, CallOptions.DEFAULT);
     verify(factory.channels.get(0), times(1)).newCall(same(descriptor), same(CallOptions.DEFAULT));
     verify(factory.channels.get(1), times(0)).newCall(same(descriptor), same(CallOptions.DEFAULT));
@@ -110,9 +111,10 @@ public class ChannelPoolTest {
 }
 
   @Test
-  public void testCapcity() throws IOException {
+  public void testEnsureCapcity() throws IOException {
     MockChannelFactory factory = new MockChannelFactory();
-    ChannelPool pool = new ChannelPool(factory, 4);
+    ChannelPool pool = new ChannelPool(null, factory);
+    pool.ensureChannelCount(4);
     Assert.assertEquals(4, factory.channels.size());
     Assert.assertEquals(4, pool.size());
   }
@@ -120,7 +122,7 @@ public class ChannelPoolTest {
   @Test
   public void testShutdown() throws IOException {
     MockChannelFactory factory = new MockChannelFactory();
-    new ChannelPool(factory, 1).shutdown();
+    new ChannelPool(null, factory).shutdown();
     for (ManagedChannel managedChannel : factory.channels) {
       verify(managedChannel, times(1)).shutdown();
     }
@@ -129,7 +131,7 @@ public class ChannelPoolTest {
   @Test
   public void testShutdownNow() throws IOException {
     MockChannelFactory factory = new MockChannelFactory();
-    new ChannelPool(factory, 1).shutdownNow();
+    new ChannelPool(null, factory).shutdownNow();
     for (ManagedChannel managedChannel : factory.channels) {
       verify(managedChannel, times(1)).shutdownNow();
     }
@@ -138,7 +140,8 @@ public class ChannelPoolTest {
   @Test
   public void testAwaitTermination() throws IOException, InterruptedException {
     MockChannelFactory factory = new MockChannelFactory();
-    ChannelPool pool = new ChannelPool(factory, 5);
+    ChannelPool pool = new ChannelPool(null, factory);
+    pool.ensureChannelCount(5);
     for (ManagedChannel managedChannel : factory.channels) {
       when(managedChannel.isTerminated()).thenReturn(true);
     }


### PR DESCRIPTION
Removing this logic caused a 300-400 microsecond drop in Get and Put performance.  I think we should add it back in and only remove this logic once we can find the reason for the 300-400 microsecond performance issue.