### PR TITLE
Always resolve API endpoints to IP addresses for now.

### DIFF
--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableOptions.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableOptions.java
@@ -83,8 +83,6 @@ public class BigtableOptions implements Serializable {
     private String tableAdminHost = BIGTABLE_TABLE_ADMIN_HOST_DEFAULT;
     private String clusterAdminHost = BIGTABLE_CLUSTER_ADMIN_HOST_DEFAULT;
     private int port = BIGTABLE_PORT_DEFAULT;
-    private String dataIpOverride;
-    private String adminIpOverride;
 
     // The default credentials get credential from well known locations, such as the GCE
     // metdata service or gcloud configuration in other environments. A user can also override
@@ -113,8 +111,6 @@ public class BigtableOptions implements Serializable {
       this.tableAdminHost = original.tableAdminHost;
       this.clusterAdminHost = original.clusterAdminHost;
       this.port = original.port;
-      this.dataIpOverride = original.dataIpOverride;
-      this.adminIpOverride = original.adminIpOverride;
       this.credentialOptions = original.credentialOptions;
       this.retryOptions = original.retryOptions;
       this.timeoutMs = original.timeoutMs;
@@ -142,16 +138,6 @@ public class BigtableOptions implements Serializable {
 
     public Builder setPort(int port) {
       this.port = port;
-      return this;
-    }
-
-    public Builder setDataIpOverride(String dataIpOverride) {
-      this.dataIpOverride = dataIpOverride;
-      return this;
-    }
-
-    public Builder setAdminIpOverride(String adminIpOverride) {
-      this.adminIpOverride = adminIpOverride;
       return this;
     }
 
@@ -227,8 +213,6 @@ public class BigtableOptions implements Serializable {
           tableAdminHost,
           dataHost,
           port,
-          dataIpOverride,
-          adminIpOverride,
           projectId,
           zoneId,
           clusterId,
@@ -248,8 +232,6 @@ public class BigtableOptions implements Serializable {
   private final String tableAdminHost;
   private final String dataHost;
   private final int port;
-  private final String dataIpOverride;
-  private final String adminIpOverride;
   private final String projectId;
   private final String zoneId;
   private final String clusterId;
@@ -271,8 +253,6 @@ public class BigtableOptions implements Serializable {
       tableAdminHost = null;
       dataHost = null;
       port = 0;
-      dataIpOverride = null;
-      adminIpOverride = null;
       projectId = null;
       zoneId = null;
       clusterId = null;
@@ -293,8 +273,6 @@ public class BigtableOptions implements Serializable {
       String tableAdminHost,
       String dataHost,
       int port,
-      String dataIpOverride,
-      String adminIpOverride,
       String projectId,
       String zoneId,
       String clusterId,
@@ -315,8 +293,6 @@ public class BigtableOptions implements Serializable {
     this.clusterAdminHost = Preconditions.checkNotNull(clusterAdminHost);
     this.dataHost = Preconditions.checkNotNull(dataHost);
     this.port = port;
-    this.dataIpOverride = dataIpOverride;
-    this.adminIpOverride = adminIpOverride;
     this.projectId = projectId;
     this.zoneId = zoneId;
     this.clusterId = clusterId;
@@ -339,15 +315,13 @@ public class BigtableOptions implements Serializable {
     }
 
     LOG.debug("Connection Configuration: projectId: %s, zoneId: %s, clusterId: %s, data host %s, "
-        + "table admin host %s, cluster admin host %s, data ip override %s, admin ip override.",
+        + "table admin host %s, cluster admin host %s.",
         projectId,
         zoneId,
         clusterId,
         dataHost,
         tableAdminHost,
-        clusterAdminHost,
-        dataIpOverride,
-        adminIpOverride);
+        clusterAdminHost);
   }
 
   public String getProjectId() {
@@ -376,14 +350,6 @@ public class BigtableOptions implements Serializable {
 
   public int getPort() {
     return port;
-  }
-
-  public String getDataIpOverride() {
-    return dataIpOverride;
-  }
-
-  public String getAdminIpOverride() {
-    return adminIpOverride;
   }
 
   /**
@@ -461,8 +427,6 @@ public class BigtableOptions implements Serializable {
         && (bulkMaxRequestSize == other.bulkMaxRequestSize)
         && Objects.equal(clusterAdminHost, other.clusterAdminHost)
         && Objects.equal(tableAdminHost, other.tableAdminHost)
-        && Objects.equal(dataIpOverride, other.dataIpOverride)
-        && Objects.equal(adminIpOverride, other.adminIpOverride)
         && Objects.equal(dataHost, other.dataHost)
         && Objects.equal(projectId, other.projectId)
         && Objects.equal(zoneId, other.zoneId)
@@ -479,8 +443,6 @@ public class BigtableOptions implements Serializable {
         .add("dataHost", dataHost)
         .add("tableAdminHost", tableAdminHost)
         .add("clusterAdminHost", clusterAdminHost)
-        .add("dataIpOverride", dataIpOverride)
-        .add("adminIpOverride", adminIpOverride)
         .add("projectId", projectId)
         .add("zoneId", zoneId)
         .add("clusterId", clusterId)

--- a/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestBigtableSession.java
+++ b/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestBigtableSession.java
@@ -40,7 +40,7 @@ public class TestBigtableSession {
           .setZoneId(zoneId)
           .setClusterId(clusterId)
           .setUserAgent(userAgent)
-          .build());
+          .build(), null, null, null);
   }
 
   @Rule

--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableOptionsFactory.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableOptionsFactory.java
@@ -48,11 +48,7 @@ public class BigtableOptionsFactory {
       "google.bigtable.cluster.admin.endpoint.host";
   public static final String BIGTABLE_TABLE_ADMIN_HOST_KEY =
       "google.bigtable.admin.endpoint.host";
-  public static final String BIGTABLE_DATA_HOST_KEY = "google.bigtable.endpoint.host";
-  public static final String BIGTABLE_DATA_IP_OVERRIDE_KEY =
-      "google.bigtable.endpoint.data.ip.override";
-  public static final String BIGTABLE_ADMIN_IP_OVERRIDE_KEY =
-      "google.bigtable.endpoint.admin.ip.override";
+  public static final String BIGTABLE_HOST_KEY = "google.bigtable.endpoint.host";
 
   public static final String PROJECT_ID_KEY = "google.bigtable.project.id";
   public static final String CLUSTER_KEY = "google.bigtable.cluster.name";
@@ -177,7 +173,7 @@ public class BigtableOptionsFactory {
     bigtableOptionsBuilder.setClusterId(getValue(configuration, CLUSTER_KEY, "Cluster"));
 
     bigtableOptionsBuilder.setDataHost(
-        getHost(configuration, BIGTABLE_DATA_HOST_KEY, BIGTABLE_DATA_HOST_DEFAULT, "API Data"));
+        getHost(configuration, BIGTABLE_HOST_KEY, BIGTABLE_DATA_HOST_DEFAULT, "API Data"));
 
     bigtableOptionsBuilder.setTableAdminHost(getHost(
       configuration, BIGTABLE_TABLE_ADMIN_HOST_KEY, BIGTABLE_TABLE_ADMIN_HOST_DEFAULT,
@@ -185,9 +181,6 @@ public class BigtableOptionsFactory {
 
     bigtableOptionsBuilder.setClusterAdminHost(getHost(configuration,
         BIGTABLE_CLUSTER_ADMIN_HOST_KEY, BIGTABLE_CLUSTER_ADMIN_HOST_DEFAULT, "Cluster Admin"));
-
-    bigtableOptionsBuilder.setDataIpOverride(configuration.get(BIGTABLE_DATA_IP_OVERRIDE_KEY));
-    bigtableOptionsBuilder.setAdminIpOverride(configuration.get(BIGTABLE_ADMIN_IP_OVERRIDE_KEY));
 
     int port = configuration.getInt(BIGTABLE_PORT_KEY, BIGTABLE_PORT_DEFAULT);
     bigtableOptionsBuilder.setPort(port);

--- a/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableOptionsFactory.java
+++ b/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableOptionsFactory.java
@@ -48,7 +48,7 @@ public class TestBigtableOptionsFactory {
   @Before
   public void setup() {
     configuration = new Configuration(false);
-    configuration.set(BigtableOptionsFactory.BIGTABLE_DATA_HOST_KEY, TEST_HOST);
+    configuration.set(BigtableOptionsFactory.BIGTABLE_HOST_KEY, TEST_HOST);
     configuration.set(BigtableOptionsFactory.PROJECT_ID_KEY, TEST_PROJECT_ID);
     configuration.set(BigtableOptionsFactory.CLUSTER_KEY, TEST_CLUSTER_NAME);
     configuration.set(BigtableOptionsFactory.ZONE_KEY, TEST_ZONE_NAME);
@@ -66,7 +66,7 @@ public class TestBigtableOptionsFactory {
   @Test
   public void testHostIsRequired() throws IOException {
     Configuration configuration = new Configuration(false);
-    configuration.unset(BigtableOptionsFactory.BIGTABLE_DATA_HOST_KEY);
+    configuration.unset(BigtableOptionsFactory.BIGTABLE_HOST_KEY);
 
     expectedException.expect(IllegalArgumentException.class);
     BigtableOptionsFactory.fromConfiguration(configuration);
@@ -92,7 +92,7 @@ public class TestBigtableOptionsFactory {
 
   @Test
   public void testAdminHostKeyIsUsed() throws IOException {
-    configuration.set(BigtableOptionsFactory.BIGTABLE_DATA_HOST_KEY, TEST_HOST);
+    configuration.set(BigtableOptionsFactory.BIGTABLE_HOST_KEY, TEST_HOST);
     configuration.set(BigtableOptionsFactory.BIGTABLE_TABLE_ADMIN_HOST_KEY, TEST_HOST);
     configuration.setBoolean(BigtableOptionsFactory.BIGTABE_USE_SERVICE_ACCOUNTS_KEY, false);
     configuration.setBoolean(BigtableOptionsFactory.BIGTABLE_NULL_CREDENTIAL_ENABLE_KEY, true);
@@ -102,7 +102,7 @@ public class TestBigtableOptionsFactory {
 
   @Test
   public void testOptionsAreConstructedWithValidInput() throws IOException {
-    configuration.set(BigtableOptionsFactory.BIGTABLE_DATA_HOST_KEY, TEST_HOST);
+    configuration.set(BigtableOptionsFactory.BIGTABLE_HOST_KEY, TEST_HOST);
     configuration.setBoolean(BigtableOptionsFactory.BIGTABE_USE_SERVICE_ACCOUNTS_KEY, false);
     configuration.setBoolean(BigtableOptionsFactory.BIGTABLE_NULL_CREDENTIAL_ENABLE_KEY, true);
     BigtableOptions options = BigtableOptionsFactory.fromConfiguration(configuration);
@@ -114,7 +114,7 @@ public class TestBigtableOptionsFactory {
 
   @Test
   public void testMinGoodRefreshTime() throws IOException{
-    configuration.set(BigtableOptionsFactory.BIGTABLE_DATA_HOST_KEY, TEST_HOST);
+    configuration.set(BigtableOptionsFactory.BIGTABLE_HOST_KEY, TEST_HOST);
     configuration.setBoolean(BigtableOptionsFactory.BIGTABE_USE_SERVICE_ACCOUNTS_KEY, false);
     configuration.setBoolean(BigtableOptionsFactory.BIGTABLE_NULL_CREDENTIAL_ENABLE_KEY, true);
     configuration.setLong(BigtableOptionsFactory.BIGTABLE_CHANNEL_TIMEOUT_MS_KEY, 60000);
@@ -123,7 +123,7 @@ public class TestBigtableOptionsFactory {
 
   @Test
   public void testBadRefreshTime() throws IOException{
-    configuration.set(BigtableOptionsFactory.BIGTABLE_DATA_HOST_KEY, TEST_HOST);
+    configuration.set(BigtableOptionsFactory.BIGTABLE_HOST_KEY, TEST_HOST);
     configuration.setBoolean(BigtableOptionsFactory.BIGTABE_USE_SERVICE_ACCOUNTS_KEY, false);
     configuration.setBoolean(BigtableOptionsFactory.BIGTABLE_NULL_CREDENTIAL_ENABLE_KEY, true);
     configuration.setLong(BigtableOptionsFactory.BIGTABLE_CHANNEL_TIMEOUT_MS_KEY, 59999);
@@ -133,7 +133,7 @@ public class TestBigtableOptionsFactory {
 
   @Test
   public void testZeroRefreshTime() throws IOException{
-    configuration.set(BigtableOptionsFactory.BIGTABLE_DATA_HOST_KEY, TEST_HOST);
+    configuration.set(BigtableOptionsFactory.BIGTABLE_HOST_KEY, TEST_HOST);
     configuration.setBoolean(BigtableOptionsFactory.BIGTABE_USE_SERVICE_ACCOUNTS_KEY, false);
     configuration.setBoolean(BigtableOptionsFactory.BIGTABLE_NULL_CREDENTIAL_ENABLE_KEY, true);
     configuration.setLong(BigtableOptionsFactory.BIGTABLE_CHANNEL_TIMEOUT_MS_KEY, 0);


### PR DESCRIPTION
Remove after next gRPC release that has a bug fix related to
unreachable IPv6 addresses.