### PR TITLE
Defer invoking isRetryable predicate

### DIFF
--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataGrpcClient.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataGrpcClient.java
@@ -182,7 +182,7 @@ public class BigtableDataGrpcClient implements BigtableDataClient {
 
   @Override
   public ListenableFuture<Empty> addMutationRetry(ListenableFuture<Empty> future, MutateRowRequest request) {
-    return asyncUtilities.addRetry(request, mutateRowRpc, future, null, executorService);
+    return asyncUtilities.addRetry(request, mutateRowRpc, future, IS_RETRYABLE_MUTATION, null, executorService);
   }
 
   @Override
@@ -253,8 +253,8 @@ public class BigtableDataGrpcClient implements BigtableDataClient {
   private <ReqT, RespT> ListenableFuture<RespT> performRetryingAsyncRpc(ReqT request,
       BigtableAsyncRpc<ReqT, RespT> rpc, Predicate<ReqT> isRetryable,
       CancellationToken cancellationToken) {
-    if (retryOptions.enableRetries() && isRetryable.apply(request)) {
-      return asyncUtilities.performRetryingAsyncRpc(request, rpc, cancellationToken,
+    if (retryOptions.enableRetries()) {
+      return asyncUtilities.performRetryingAsyncRpc(request, rpc, isRetryable, cancellationToken,
         executorService);
     } else {
       if (retryOptions.enableRetries()) {

--- a/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/BigtableDataGrpcClientTests.java
+++ b/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/BigtableDataGrpcClientTests.java
@@ -97,7 +97,7 @@ public class BigtableDataGrpcClientTests {
     BigtableOptions options = new BigtableOptions.Builder().setRetryOptions(retryOptions).build();
     when(mockChannelPool.newCall(any(MethodDescriptor.class), any(CallOptions.class))).thenReturn(
       mockClientCall);
-    when(mockAsyncUtilities.performRetryingAsyncRpc(any(), any(BigtableAsyncRpc.class),
+    when(mockAsyncUtilities.performRetryingAsyncRpc(any(), any(BigtableAsyncRpc.class), any(Predicate.class),
       any(CancellationToken.class), any(ExecutorService.class))).thenReturn(mockFuture);
     doAnswer(new Answer<Void>() {
       @Override
@@ -121,7 +121,7 @@ public class BigtableDataGrpcClientTests {
     when(mockFuture.get()).thenReturn(Empty.getDefaultInstance());
     underTest.mutateRow(request);
     verify(mockAsyncUtilities, times(1)).performRetryingAsyncRpc(same(request),
-      any(BigtableAsyncRpc.class), any(CancellationToken.class), any(ExecutorService.class));
+      any(BigtableAsyncRpc.class), any(Predicate.class), any(CancellationToken.class), any(ExecutorService.class));
   }
 
   @Test
@@ -130,7 +130,7 @@ public class BigtableDataGrpcClientTests {
     when(mockFuture.get()).thenReturn(MutateRowsResponse.getDefaultInstance());
     underTest.mutateRowAsync(request);
     verify(mockAsyncUtilities, times(1)).performRetryingAsyncRpc(same(request),
-      any(BigtableAsyncRpc.class), any(CancellationToken.class), any(ExecutorService.class));
+      any(BigtableAsyncRpc.class), any(Predicate.class), any(CancellationToken.class), any(ExecutorService.class));
   }
 
   @Test
@@ -139,7 +139,7 @@ public class BigtableDataGrpcClientTests {
     when(mockFuture.get()).thenReturn(CheckAndMutateRowResponse.getDefaultInstance());
     underTest.checkAndMutateRow(request);
     verify(mockAsyncUtilities, times(1)).performRetryingAsyncRpc(same(request),
-      any(BigtableAsyncRpc.class), any(CancellationToken.class), any(ExecutorService.class));
+      any(BigtableAsyncRpc.class), any(Predicate.class), any(CancellationToken.class), any(ExecutorService.class));
   }
 
   @Test
@@ -147,7 +147,7 @@ public class BigtableDataGrpcClientTests {
     CheckAndMutateRowRequest request = CheckAndMutateRowRequest.getDefaultInstance();
     underTest.checkAndMutateRowAsync(request);
     verify(mockAsyncUtilities, times(1)).performRetryingAsyncRpc(same(request),
-      any(BigtableAsyncRpc.class), any(CancellationToken.class), any(ExecutorService.class));
+      any(BigtableAsyncRpc.class), any(Predicate.class), any(CancellationToken.class), any(ExecutorService.class));
   }
 
   @Test

--- a/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/RetryingRpcFunctionTest.java
+++ b/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/RetryingRpcFunctionTest.java
@@ -27,6 +27,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
+import com.google.common.base.Predicates;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -83,7 +84,7 @@ public class RetryingRpcFunctionTest {
     retryOptions = RetryOptionsUtil.createTestRetryOptions(nanoClock);
 
     underTest = new RetryingRpcFunction<>(retryOptions, ReadRowsRequest.getDefaultInstance(),
-        readAsync, MoreExecutors.newDirectExecutorService(), null);
+        readAsync, Predicates.<ReadRowsRequest>alwaysTrue(), MoreExecutors.newDirectExecutorService(), null);
 
     totalSleep = new AtomicLong();
 


### PR DESCRIPTION
Doesn't move the needle on performance tests, but is defensive against more expensive predicates that could be introduced in the future.