### PR TITLE
Removing extraneous Executor from BigtableSession.

### DIFF
--- a/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestBigtableSession.java
+++ b/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestBigtableSession.java
@@ -40,7 +40,7 @@ public class TestBigtableSession {
           .setZoneId(zoneId)
           .setClusterId(clusterId)
           .setUserAgent(userAgent)
-          .build(), null, null, null);
+          .build());
   }
 
   @Rule


### PR DESCRIPTION
Also
- making the initial shared executor creation into an async process.
- Using the non-deprecated constructor for BigtableSession in TestBigtableSession.