### PR TITLE
Refactoring ResultQueueEntry methods to be distinct classes

### DIFF
--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/StreamingBigtableResultScanner.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/StreamingBigtableResultScanner.java
@@ -48,15 +48,15 @@ public class StreamingBigtableResultScanner extends AbstractBigtableResultScanne
   }
 
   public void addResult(ReadRowsResponse response) {
-    add(ResultQueueEntry.newResult(response));
+    add(ResultQueueEntry.fromResponse(response));
   }
 
   public void setError(Throwable error) {
-    add(ResultQueueEntry.<ReadRowsResponse> newThrowable(error));
+    add(ResultQueueEntry.<ReadRowsResponse> fromThrowable(error));
   }
 
   public void complete() {
-    add(ResultQueueEntry.<ReadRowsResponse> newCompletionMarker());
+    add(ResultQueueEntry.<ReadRowsResponse> completionMarker());
   }
 
   @Override

--- a/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/scanner/ResponseQueueReaderTest.java
+++ b/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/scanner/ResponseQueueReaderTest.java
@@ -101,7 +101,7 @@ public class ResponseQueueReaderTest {
       ResponseQueueReader reader,
       ReadRowsResponse... responses) throws InterruptedException {
     for (ReadRowsResponse response : responses) {
-      reader.add(ResultQueueEntry.newResult(response));
+      reader.add(ResultQueueEntry.fromResponse(response));
     }
   }
 
@@ -109,12 +109,12 @@ public class ResponseQueueReaderTest {
       ResponseQueueReader reader,
       Iterable<ReadRowsResponse> responses) throws InterruptedException {
     for (ReadRowsResponse response : responses) {
-      reader.add(ResultQueueEntry.newResult(response));
+      reader.add(ResultQueueEntry.fromResponse(response));
     }
   }
 
   private void addCompletion(ResponseQueueReader reader) throws InterruptedException {
-    reader.add(ResultQueueEntry.<ReadRowsResponse> newCompletionMarker());
+    reader.add(ResultQueueEntry.<ReadRowsResponse> completionMarker());
   }
 
   static void assertReaderContains(ResponseQueueReader reader, Iterable<Row> rows)
@@ -163,7 +163,7 @@ public class ResponseQueueReaderTest {
     List<ReadRowsResponse> responses = generateReadRowsResponses("rowKey-%s", 2);
     final String innerExceptionMessage = "This message is the causedBy message";
     addResponsesToReader(reader, responses);
-    reader.add(ResultQueueEntry.<ReadRowsResponse> newThrowable(new IOException(
+    reader.add(ResultQueueEntry.<ReadRowsResponse> fromThrowable(new IOException(
         innerExceptionMessage)));
 
     assertReaderContains(reader, extractRowsWithKeys(responses));

--- a/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/scanner/StreamingBigtableResultScannerTest.java
+++ b/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/scanner/StreamingBigtableResultScannerTest.java
@@ -52,7 +52,7 @@ public class StreamingBigtableResultScannerTest {
   public void testAddResult() throws IOException, InterruptedException {
     ReadRowsResponse response = ReadRowsResponse.getDefaultInstance();
     scanner.addResult(response);
-    verify(reader, times(1)).add(eq(ResultQueueEntry.newResult(response)));
+    verify(reader, times(1)).add(eq(ResultQueueEntry.fromResponse(response)));
     scanner.close();
   }
 
@@ -60,14 +60,14 @@ public class StreamingBigtableResultScannerTest {
   public void testSetException() throws IOException, InterruptedException {
     IOException e = new IOException("Some exception");
     scanner.setError(e);
-    verify(reader, times(1)).add(eq(ResultQueueEntry.<ReadRowsResponse> newThrowable(e)));
+    verify(reader, times(1)).add(eq(ResultQueueEntry.<ReadRowsResponse> fromThrowable(e)));
     scanner.close();
   }
 
   @Test
   public void testComplete() throws IOException, InterruptedException {
     scanner.complete();
-    verify(reader, times(1)).add(eq(ResultQueueEntry.<ReadRowsResponse> newCompletionMarker()));
+    verify(reader, times(1)).add(eq(ResultQueueEntry.<ReadRowsResponse> completionMarker()));
     scanner.close();
   }
 


### PR DESCRIPTION
This will hopefully improve scanning performance by reducing the number of checks required to get a result for the normal case of a response based ResultQueueEntry