### PR TITLE
Passing a ScheduledExecutorService instead of ExecutorService.

### DIFF
--- a/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/BigtableDataGrpcClientTests.java
+++ b/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/BigtableDataGrpcClientTests.java
@@ -27,7 +27,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -97,8 +97,9 @@ public class BigtableDataGrpcClientTests {
     BigtableOptions options = new BigtableOptions.Builder().setRetryOptions(retryOptions).build();
     when(mockChannelPool.newCall(any(MethodDescriptor.class), any(CallOptions.class))).thenReturn(
       mockClientCall);
-    when(mockAsyncUtilities.performRetryingAsyncRpc(any(), any(BigtableAsyncRpc.class), any(Predicate.class),
-      any(CancellationToken.class), any(ExecutorService.class))).thenReturn(mockFuture);
+    when(mockAsyncUtilities.performRetryingAsyncRpc(any(), any(BigtableAsyncRpc.class),
+      any(Predicate.class), any(CancellationToken.class), any(ScheduledExecutorService.class)))
+          .thenReturn(mockFuture);
     doAnswer(new Answer<Void>() {
       @Override
       public Void answer(InvocationOnMock invocation) throws Throwable {
@@ -110,7 +111,7 @@ public class BigtableDataGrpcClientTests {
     underTest =
         new BigtableDataGrpcClient(
             mockChannelPool,
-            BigtableSessionSharedThreadPools.getInstance().getBatchThreadPool(),
+            BigtableSessionSharedThreadPools.getInstance().getRetryExecutor(),
             options,
             mockAsyncUtilities);
   }
@@ -121,7 +122,8 @@ public class BigtableDataGrpcClientTests {
     when(mockFuture.get()).thenReturn(Empty.getDefaultInstance());
     underTest.mutateRow(request);
     verify(mockAsyncUtilities, times(1)).performRetryingAsyncRpc(same(request),
-      any(BigtableAsyncRpc.class), any(Predicate.class), any(CancellationToken.class), any(ExecutorService.class));
+      any(BigtableAsyncRpc.class), any(Predicate.class), any(CancellationToken.class),
+      any(ScheduledExecutorService.class));
   }
 
   @Test
@@ -130,7 +132,8 @@ public class BigtableDataGrpcClientTests {
     when(mockFuture.get()).thenReturn(MutateRowsResponse.getDefaultInstance());
     underTest.mutateRowAsync(request);
     verify(mockAsyncUtilities, times(1)).performRetryingAsyncRpc(same(request),
-      any(BigtableAsyncRpc.class), any(Predicate.class), any(CancellationToken.class), any(ExecutorService.class));
+      any(BigtableAsyncRpc.class), any(Predicate.class), any(CancellationToken.class),
+      any(ScheduledExecutorService.class));
   }
 
   @Test
@@ -139,7 +142,8 @@ public class BigtableDataGrpcClientTests {
     when(mockFuture.get()).thenReturn(CheckAndMutateRowResponse.getDefaultInstance());
     underTest.checkAndMutateRow(request);
     verify(mockAsyncUtilities, times(1)).performRetryingAsyncRpc(same(request),
-      any(BigtableAsyncRpc.class), any(Predicate.class), any(CancellationToken.class), any(ExecutorService.class));
+      any(BigtableAsyncRpc.class), any(Predicate.class), any(CancellationToken.class),
+      any(ScheduledExecutorService.class));
   }
 
   @Test
@@ -147,7 +151,8 @@ public class BigtableDataGrpcClientTests {
     CheckAndMutateRowRequest request = CheckAndMutateRowRequest.getDefaultInstance();
     underTest.checkAndMutateRowAsync(request);
     verify(mockAsyncUtilities, times(1)).performRetryingAsyncRpc(same(request),
-      any(BigtableAsyncRpc.class), any(Predicate.class), any(CancellationToken.class), any(ExecutorService.class));
+      any(BigtableAsyncRpc.class), any(Predicate.class), any(CancellationToken.class),
+      any(ScheduledExecutorService.class));
   }
 
   @Test

--- a/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/RetryingRpcFunctionTest.java
+++ b/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/RetryingRpcFunctionTest.java
@@ -46,10 +46,10 @@ import com.google.bigtable.v1.ReadRowsRequest;
 import com.google.bigtable.v1.ReadRowsResponse;
 import com.google.cloud.bigtable.config.RetryOptions;
 import com.google.cloud.bigtable.config.RetryOptionsUtil;
+import com.google.cloud.bigtable.grpc.BigtableSessionSharedThreadPools;
 import com.google.cloud.bigtable.grpc.io.CancellationToken;
 import com.google.cloud.bigtable.grpc.scanner.BigtableRetriesExhaustedException;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.MoreExecutors;
 
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
@@ -84,7 +84,8 @@ public class RetryingRpcFunctionTest {
     retryOptions = RetryOptionsUtil.createTestRetryOptions(nanoClock);
 
     underTest = new RetryingRpcFunction<>(retryOptions, ReadRowsRequest.getDefaultInstance(),
-        readAsync, Predicates.<ReadRowsRequest>alwaysTrue(), MoreExecutors.newDirectExecutorService(), null);
+        readAsync, Predicates.<ReadRowsRequest> alwaysTrue(),
+        BigtableSessionSharedThreadPools.getInstance().getRetryExecutor(), null);
 
     totalSleep = new AtomicLong();
 


### PR DESCRIPTION
Currently, it's still used by RetryingRpcFunction as a plain ExecutorService.  It will be used to schedule changes in a future commit.