### PR TITLE
Moving persistence logic into BulkMutation.

### DIFF
--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AsyncExecutor.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AsyncExecutor.java
@@ -320,4 +320,8 @@ public class AsyncExecutor {
       MutateRowRequest request) {
     return this.client.addMutationRetry(future, request);
   }
+
+  public RpcThrottler getRpcThrottler() {
+    return rpcThrottler;
+  }
 }

--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BulkMutation.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BulkMutation.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
+import com.google.api.client.repackaged.com.google.common.annotations.VisibleForTesting;
 import com.google.bigtable.v1.MutateRowRequest;
 import com.google.bigtable.v1.MutateRowsRequest;
 import com.google.bigtable.v1.MutateRowsResponse;
@@ -44,14 +45,143 @@ public class BulkMutation {
           .withDescription("Mutation does not have a status")
           .asRuntimeException();
 
-  private final List<SettableFuture<Empty>> futures = new ArrayList<>();
-  private final MutateRowsRequest.Builder builder;
-  
-  private long approximateByteSize = 0l;
+  @VisibleForTesting
+  static class Batch {
 
-  public BulkMutation(String tableName) {
-    this.builder = MutateRowsRequest.newBuilder().setTableName(tableName);
-    this.approximateByteSize = tableName.length() + 2;
+    private final int maxRowKeyCount;
+    private final long maxRequestSize;
+    private final AsyncExecutor asyncExecutor;
+
+    private final List<SettableFuture<Empty>> futures = new ArrayList<>();
+    private final MutateRowsRequest.Builder builder;
+
+    private long approximateByteSize = 0l;
+
+    Batch(String tableName, AsyncExecutor asyncExecutor, int maxRowKeyCount, long maxRequestSize) {
+      this.builder = MutateRowsRequest.newBuilder().setTableName(tableName);
+      this.asyncExecutor = asyncExecutor;
+      this.maxRowKeyCount = maxRowKeyCount;
+      this.maxRequestSize = maxRequestSize;
+      this.approximateByteSize = tableName.length() + 2;
+    }
+
+    /**
+     * Adds a {@link MutateRowRequest} to the
+     * {@link com.google.bigtable.v1.MutateRowsRequest.Builder}. NOTE: Users have to make sure that
+     * this gets called in a thread safe way.
+     * @param request The {@link MutateRowRequest} to add
+     * @return a {@link SettableFuture} that will be populated when the {@link MutateRowsResponse}
+     *         returns from the server. See {@link #addCallback(ListenableFuture)} for
+     *         more information about how the SettableFuture is set.
+     */
+    ListenableFuture<Empty> add(MutateRowRequest request) {
+      SettableFuture<Empty> future = SettableFuture.create();
+      futures.add(future);
+      MutateRowsRequest.Entry entry = MutateRowsRequest.Entry.newBuilder()
+        .setRowKey(request.getRowKey())
+        .addAllMutations(request.getMutationsList())
+        .build();
+      builder.addEntries(entry);
+      approximateByteSize += entry.getSerializedSize();
+      ListenableFuture<Empty> retryingFuture = asyncExecutor.addMutationRetry(future, request);
+      // Make sure that flush will not finish until the retries are finished.
+      asyncExecutor.getRpcThrottler().registerRetry(retryingFuture);
+
+      return retryingFuture;
+    }
+
+    boolean isFull() {
+      return futures.size() >= maxRowKeyCount || approximateByteSize >= maxRequestSize;
+    }
+
+    /**
+     * @return a completed {@link MutateRowsRequest} with all of the entries from
+     * {@link BulkMutation#add(MutateRowRequest)}.
+     */
+    MutateRowsRequest toRequest(){
+      return builder.build();
+    }
+
+    /**
+     * Adds a {@link FutureCallback} that will update all of the SettableFutures created by
+     * {@link BulkMutation#add(MutateRowRequest)} when the provided {@link ListenableFuture} for the
+     * {@link MutateRowsResponse} is complete.
+     */
+    void addCallback(ListenableFuture<MutateRowsResponse> bulkFuture) {
+      FutureCallback<MutateRowsResponse> callback = new FutureCallback<MutateRowsResponse>() {
+        @Override
+        public void onSuccess(MutateRowsResponse result) {
+          Iterator<Status> statuses = result.getStatusesList().iterator();
+          Iterator<SettableFuture<Empty>> entries = futures.iterator();
+          while (entries.hasNext() && statuses.hasNext()) {
+            SettableFuture<Empty> future = entries.next();
+            Status status = statuses.next();
+            if (status.getCode() == io.grpc.Status.Code.OK.value()) {
+              future.set(Empty.getDefaultInstance());
+            } else {
+              future.setException(toException(status));
+            }
+          }
+          // TODO: better handling of these cases?
+          while (entries.hasNext()) {
+            entries.next().setException(MISSING_ENTRY_EXCEPTION);
+          }
+          if (statuses.hasNext()) {
+            int count = 0;
+            while (statuses.hasNext()) {
+              count++;
+              statuses.next();
+            }
+            throw new IllegalStateException(String.format("Got %d extra statusus", count));
+          }
+        }
+
+        protected StatusRuntimeException toException(Status status) {
+          io.grpc.Status grpcStatus = io.grpc.Status
+              .fromCodeValue(status.getCode())
+              .withDescription(status.getMessage());
+          for (Any detail : status.getDetailsList()) {
+            grpcStatus.augmentDescription(detail.toString());
+          }
+          return grpcStatus.asRuntimeException();
+        }
+
+        @Override
+        public void onFailure(Throwable t) {
+          for (SettableFuture<Empty> future : futures) {
+            future.setException(t);
+          }
+        }
+      };
+      Futures.addCallback(bulkFuture, callback);
+    }
+
+    void sendRows() {
+      ListenableFuture<MutateRowsResponse> future = null;
+      try {
+        future = asyncExecutor.mutateRowsAsync(toRequest());
+      } catch (InterruptedException e) {
+        future = Futures.<MutateRowsResponse> immediateFailedFuture(e);
+      } finally {
+        addCallback(future);
+      }
+    }
+  }
+
+  @VisibleForTesting
+  Batch currentBatch = null;
+
+  private final String tableName;
+  private final int maxRowKeyCount;
+  private final long maxRequestSize;
+  private final AsyncExecutor asyncExecutor;
+
+  public BulkMutation(String tableName, AsyncExecutor asyncExecutor,  int maxRowKeyCount,
+      long maxRequestSize) {
+    this.tableName = tableName;
+    this.asyncExecutor = asyncExecutor;
+    this.maxRowKeyCount = maxRowKeyCount;
+    this.maxRequestSize = maxRequestSize;
   }
 
   /**
@@ -60,87 +190,26 @@ public class BulkMutation {
    * this gets called in a thread safe way.
    * @param request The {@link MutateRowRequest} to add
    * @return a {@link SettableFuture} that will be populated when the {@link MutateRowsResponse}
-   *         returns from the server. See {@link BulkMutation#addCallback(ListenableFuture)} for
+   *         returns from the server. See {@link Batch#addCallback(ListenableFuture)} for
    *         more information about how the SettableFuture is set.
    */
-  public SettableFuture<Empty> add(MutateRowRequest request) {
-    SettableFuture<Empty> future = SettableFuture.create();
-    futures.add(future);
-    MutateRowsRequest.Entry entry = MutateRowsRequest.Entry.newBuilder()
-      .setRowKey(request.getRowKey())
-      .addAllMutations(request.getMutationsList())
-      .build();
-    builder.addEntries(entry);
-    approximateByteSize += entry.getSerializedSize();
+  public synchronized ListenableFuture<Empty> add(MutateRowRequest request) {
+    if (currentBatch == null) {
+      currentBatch = new Batch(tableName, asyncExecutor, maxRowKeyCount, maxRequestSize);
+    }
+
+    ListenableFuture<Empty> future = currentBatch.add(request);
+    if (currentBatch.isFull()) {
+      currentBatch.sendRows();
+      currentBatch = null;
+    }
     return future;
   }
 
-  public long getApproximateByteSize() {
-    return approximateByteSize;
-  }
-
-  public int getRowKeyCount() {
-    return futures.size();
-  }
-  /**
-   * @return a completed {@link MutateRowsRequest} with all of the entries from
-   * {@link BulkMutation#add(MutateRowRequest)}.
-   */
-  public MutateRowsRequest toRequest(){
-    return builder.build();
-  }
-
-  /**
-   * Adds a {@link FutureCallback} that will update all of the SettableFutures created by
-   * {@link BulkMutation#add(MutateRowRequest)} when the provided {@link ListenableFuture} for the
-   * {@link MutateRowsResponse} is complete.
-   */
-  public void addCallback(ListenableFuture<MutateRowsResponse> bulkFuture) {
-    FutureCallback<MutateRowsResponse> callback = new FutureCallback<MutateRowsResponse>() {
-      @Override
-      public void onSuccess(MutateRowsResponse result) {
-        Iterator<Status> statuses = result.getStatusesList().iterator();
-        Iterator<SettableFuture<Empty>> entries = futures.iterator();
-        while (entries.hasNext() && statuses.hasNext()) {
-          SettableFuture<Empty> future = entries.next();
-          Status status = statuses.next();
-          if (status.getCode() == io.grpc.Status.Code.OK.value()) {
-            future.set(Empty.getDefaultInstance());
-          } else {
-            future.setException(toException(status));
-          }
-        }
-        // TODO: better handling of these cases?
-        while (entries.hasNext()) {
-          entries.next().setException(MISSING_ENTRY_EXCEPTION);
-        }
-        if (statuses.hasNext()) {
-          int count = 0;
-          while (statuses.hasNext()) {
-            count++;
-            statuses.next();
-          }
-          throw new IllegalStateException(String.format("Got %d extra statusus", count));
-        }
-      }
-
-      protected StatusRuntimeException toException(Status status) {
-        io.grpc.Status grpcStatus = io.grpc.Status
-            .fromCodeValue(status.getCode())
-            .withDescription(status.getMessage());
-        for (Any detail : status.getDetailsList()) {
-          grpcStatus.augmentDescription(detail.toString());
-        }
-        return grpcStatus.asRuntimeException();
-      }
-
-      @Override
-      public void onFailure(Throwable t) {
-        for (SettableFuture<Empty> future : futures) {
-          future.setException(t);
-        }
-      }
-    };
-    Futures.addCallback(bulkFuture, callback);
+  public synchronized void flush() {
+    if (currentBatch != null) {
+      currentBatch.sendRows();
+      currentBatch = null;
+    }
   }
 }

--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BatchExecutor.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BatchExecutor.java
@@ -35,7 +35,6 @@ import org.apache.hadoop.hbase.client.coprocessor.Batch;
 
 import com.google.api.client.util.Preconditions;
 import com.google.bigtable.v1.MutateRowRequest;
-import com.google.bigtable.v1.MutateRowsResponse;
 import com.google.bigtable.v1.ReadRowsRequest;
 import com.google.cloud.bigtable.config.BigtableOptions;
 import com.google.cloud.bigtable.config.Logger;
@@ -50,7 +49,6 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.SettableFuture;
-import com.google.protobuf.Empty;
 import com.google.protobuf.GeneratedMessage;
 
 /**
@@ -133,46 +131,24 @@ public class BatchExecutor {
 
   protected static class BulkOperation {
     private final AsyncExecutor asyncExecutor;
-    private final String tableName;
     private final BigtableOptions options;
     private BulkMutation bulkMutation;
     private BulkRead bulkRead;
 
     public BulkOperation(AsyncExecutor asyncExecutor, String tableName, BigtableOptions options) {
       this.asyncExecutor = asyncExecutor;
-      this.tableName = Preconditions.checkNotNull(tableName);
       this.options = options;
       this.bulkRead = new BulkRead(asyncExecutor.getClient(), tableName);
+      this.bulkMutation = new BulkMutation(tableName, asyncExecutor,
+          options.getBulkMaxRowKeyCount(), options.getBulkMaxRequestSize());
     }
 
     public ListenableFuture<? extends GeneratedMessage> mutateRowAsync(MutateRowRequest request)
         throws InterruptedException {
       if (!options.useBulkApi()) {
         return asyncExecutor.mutateRowAsync(request);
-      }
-      if (bulkMutation == null) {
-        bulkMutation = new BulkMutation(tableName);
-      }
-      ListenableFuture<Empty> future = bulkMutation.add(request);
-      if (bulkMutation.getRowKeyCount() >= options.getBulkMaxRowKeyCount()
-          || bulkMutation.getApproximateByteSize() >= options.getBulkMaxRequestSize()) {
-        mutateRowAsync();
-        bulkMutation = null;
-      }
-      return future;
-    }
-
-    private void mutateRowAsync() {
-      ListenableFuture<MutateRowsResponse> future = null;
-      try {
-        future = asyncExecutor.mutateRowsAsync(bulkMutation.toRequest());
-      } catch (InterruptedException e) {
-        future = Futures.<MutateRowsResponse> immediateFailedFuture(e);
-      } finally {
-        if (future != null) {
-          bulkMutation.addCallback(future);
-        }
-        bulkMutation = null;
+      } else {
+        return bulkMutation.add(request);
       }
     }
 
@@ -187,9 +163,7 @@ public class BatchExecutor {
 
     public void flush() throws InterruptedException {
       // If there is a bulk mutation in progress, then send it.
-      if (bulkMutation != null) {
-        mutateRowAsync();
-      }
+      bulkMutation.flush();
       bulkRead.flush();
     }
   }


### PR DESCRIPTION
The BulkMutation processing was duplicated, yet was inconsistent, in BatchExecutor and BigtableBufferedMutator.  Encapsulating all of the persistence logic into BulkMutation for better reuse.