### PR TITLE
Fixing FuzzyRowFilterAdapter, but not hooking it up.

### DIFF
--- a/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestFuzzyRowFilterAdapter.java
+++ b/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestFuzzyRowFilterAdapter.java
@@ -43,10 +43,10 @@ public class TestFuzzyRowFilterAdapter {
   public void fuzzyKeysAreTranslatedToRegularExpressions() throws IOException {
     List<Pair<byte[], byte[]>> testPairs =
         ImmutableList.<Pair<byte[], byte[]>>builder()
-            .add(new Pair<>(new byte[]{0, 0, 0, 0}, Bytes.toBytes("abcd")))
-            .add(new Pair<>(new byte[]{0, 0, 1, 0}, Bytes.toBytes(".fgh")))
-            .add(new Pair<>(new byte[]{1, 1, 1, 1}, Bytes.toBytes("ijkl")))
-        .build();
+            .add(new Pair<>(Bytes.toBytes("abcd"), new byte[] {-1, -1, -1, -1}))
+            .add(new Pair<>(Bytes.toBytes(".fgh"), new byte[] {0, 0, 1, 0}))
+            .add(new Pair<>(Bytes.toBytes("ijkl"), new byte[] {1, 1, 1, 1}))
+            .build();
 
     FuzzyRowFilter filter = new FuzzyRowFilter(testPairs);
     RowFilter adaptedFilter = adapter.adapt(context, filter);


### PR DESCRIPTION
FuzzyRowFilterAdapter has a couple of problems:

1) It uses the hbase proto conversion to get the "fuzzyKeysDataList."  That conversion doesn't work when our shading is combined with non-shaded hbase.  Things just don't work.
2) The data and mask were switched in the adapter.  see https://github.com/apache/hbase/blob/master/hbase-client/src/main/java/org/apache/hadoop/hbase/filter/FuzzyRowFilter.java#L80 for more info.

This is the first step towards fixing #616.