### PR TITLE
Retrying bulkMutation failures in batch.

### DIFF
--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataClient.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataClient.java
@@ -119,7 +119,4 @@ public interface BigtableDataClient {
    * all reads have completed.
    */
   ListenableFuture<List<Row>> readRowsAsync(ReadRowsRequest request);
-
-  ListenableFuture<Empty> addMutationRetry(ListenableFuture<Empty> future,
-      MutateRowRequest request);
 }

--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataGrpcClient.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataGrpcClient.java
@@ -183,24 +183,6 @@ public class BigtableDataGrpcClient implements BigtableDataClient {
   }
 
   @Override
-  public ListenableFuture<Empty> addMutationRetry(ListenableFuture<Empty> future,
-      MutateRowRequest request) {
-    if (retryOptions.enableRetries()) {
-      RetryingRpcFunction<MutateRowRequest, Empty> retryingRpcFunction =
-          new RetryingRpcFunction<>(
-              retryOptions,
-              request,
-              mutateRowRpc,
-              IS_RETRYABLE_MUTATION,
-              retryExecutorService,
-              null);
-      return retryingRpcFunction.addRetry(future);
-    } else {
-      return mutateRowRpc.call(request, null);
-    }
-  }
-
-  @Override
   public ListenableFuture<Empty> mutateRowAsync(MutateRowRequest request) {
     expandPoolIfNecessary(this.bigtableOptions.getChannelCount());
     return performRetryingAsyncRpc(request, mutateRowRpc, IS_RETRYABLE_MUTATION, null);

--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AsyncExecutor.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AsyncExecutor.java
@@ -316,11 +316,6 @@ public class AsyncExecutor {
     return client;
   }
 
-  public ListenableFuture<Empty> addMutationRetry(ListenableFuture<Empty> future,
-      MutateRowRequest request) {
-    return this.client.addMutationRetry(future, request);
-  }
-
   public RpcThrottler getRpcThrottler() {
     return rpcThrottler;
   }

--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/RetryingRpcFunction.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/RetryingRpcFunction.java
@@ -111,7 +111,7 @@ public class RetryingRpcFunction<RequestT, ResponseT>
     return addRetry(rpc.call(request, cancellationToken));
   }
 
-  public ListenableFuture<ResponseT> addRetry(final ListenableFuture<ResponseT> future) {
+  private ListenableFuture<ResponseT> addRetry(final ListenableFuture<ResponseT> future) {
     return Futures.catchingAsync(future, StatusRuntimeException.class, this, retryExecutorService);
   }
 

--- a/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableConnection.java
+++ b/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableConnection.java
@@ -166,7 +166,12 @@ public abstract class AbstractBigtableConnection implements Connection, Closeabl
     RpcThrottler rpcThrottler = new RpcThrottler(resourceLimiter);
     AsyncExecutor asyncExecutor = new AsyncExecutor(client, rpcThrottler);
     HBaseRequestAdapter adapter = createAdapter(tableName);
-    BatchExecutor batchExecutor = new BatchExecutor(asyncExecutor, options, adapter);
+    BatchExecutor batchExecutor =
+        new BatchExecutor(
+            asyncExecutor,
+            options,
+            BigtableSessionSharedThreadPools.getInstance().getRetryExecutor(),
+            adapter);
     return new BigtableTable(this, tableName, options, client, adapter, batchExecutor);
   }
 
@@ -188,7 +193,8 @@ public abstract class AbstractBigtableConnection implements Connection, Closeabl
         options,
         params.getListener(),
         new RpcThrottler(resourceLimiter),
-        pool) {
+        pool,
+        BigtableSessionSharedThreadPools.getInstance().getRetryExecutor()) {
       @Override
       public void close() throws IOException {
         try {


### PR DESCRIPTION
Retries are now done as a batch in BulkMutation.
Shared code from BatchExecutor and BigtableBufferedMutator moved to BulkMutation.