### PR TITLE
Make the AbstractBigtableConnection.locatorCache non-static.

### DIFF
--- a/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableConnection.java
+++ b/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableConnection.java
@@ -83,7 +83,7 @@ public abstract class AbstractBigtableConnection implements Connection, Closeabl
 
   private final Logger LOG = new Logger(getClass());
 
-  private static final Set<RegionLocator> locatorCache = new CopyOnWriteArraySet<>();
+  private final Set<RegionLocator> locatorCache = new CopyOnWriteArraySet<>();
 
   private final Configuration conf;
   private volatile boolean closed = false;


### PR DESCRIPTION
In the event of connections to multiple clusters or multiple connections
to the same cluster, the dataclient that is contained within the
BigtableRegionLocator will not be valid for tables with the same name.

I couldn't find tests for the connection class to update / demo this problem, please point me to them if possible.
