### PR TITLE
Removing unused BIGTABLE_CHANNEL_TIMEOUT_MS_KEY option.

### DIFF
--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableOptions.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableOptions.java
@@ -16,7 +16,6 @@
 package com.google.cloud.bigtable.config;
 
 import java.io.Serializable;
-import java.util.concurrent.TimeUnit;
 
 import com.google.api.client.util.Objects;
 import com.google.cloud.bigtable.grpc.BigtableClusterName;
@@ -41,8 +40,6 @@ public class BigtableOptions implements Serializable {
   public static final int BIGTABLE_PORT_DEFAULT = 443;
 
   public static final int BIGTABLE_DATA_CHANNEL_COUNT_DEFAULT = getDefaultDataChannelCount();
-  public static final int BIGTABLE_CHANNEL_TIMEOUT_MS_DEFAULT =
-      (int) TimeUnit.MILLISECONDS.convert(30, TimeUnit.MINUTES);
   public static final int BIGTABLE_ASYNC_MUTATOR_COUNT_DEFAULT = 2;
 
   /**
@@ -91,7 +88,6 @@ public class BigtableOptions implements Serializable {
 
     // Performance tuning options.
     private RetryOptions retryOptions = new RetryOptions.Builder().build();
-    private int timeoutMs = BIGTABLE_CHANNEL_TIMEOUT_MS_DEFAULT;
     private int dataChannelCount = BIGTABLE_DATA_CHANNEL_COUNT_DEFAULT;
     private int asyncMutatorCount = BIGTABLE_ASYNC_MUTATOR_COUNT_DEFAULT;
 
@@ -114,7 +110,6 @@ public class BigtableOptions implements Serializable {
       this.port = original.port;
       this.credentialOptions = original.credentialOptions;
       this.retryOptions = original.retryOptions;
-      this.timeoutMs = original.timeoutMs;
       this.dataChannelCount = original.dataChannelCount;
       this.asyncMutatorCount = original.asyncMutatorCount;
       this.useBulkApi = original.useBulkApi;
@@ -178,11 +173,6 @@ public class BigtableOptions implements Serializable {
       return this;
     }
 
-    public Builder setTimeoutMs(int timeoutMs) {
-      this.timeoutMs = timeoutMs;
-      return this;
-    }
-
     public Builder setAsyncMutatorWorkerCount(int asyncMutatorCount) {
       Preconditions.checkArgument(
           asyncMutatorCount >= 0, "asyncMutatorCount must be greater or equal to 0.");
@@ -226,7 +216,6 @@ public class BigtableOptions implements Serializable {
           credentialOptions,
           userAgent,
           retryOptions,
-          timeoutMs,
           dataChannelCount,
           asyncMutatorCount,
           useBulkApi,
@@ -246,7 +235,6 @@ public class BigtableOptions implements Serializable {
   private final CredentialOptions credentialOptions;
   private final String userAgent;
   private final RetryOptions retryOptions;
-  private final int timeoutMs;
   private final int dataChannelCount;
   private final BigtableClusterName clusterName;
   private final int asyncMutatorCount;
@@ -268,7 +256,6 @@ public class BigtableOptions implements Serializable {
       credentialOptions = null;
       userAgent = null;
       retryOptions = null;
-      timeoutMs = 0;
       dataChannelCount = 1;
       clusterName = null;
       asyncMutatorCount = 1;
@@ -289,7 +276,6 @@ public class BigtableOptions implements Serializable {
       CredentialOptions credentialOptions,
       String userAgent,
       RetryOptions retryOptions,
-      int timeoutMs,
       int channelCount,
       int asyncMutatorCount,
       boolean useBulkApi,
@@ -297,8 +283,6 @@ public class BigtableOptions implements Serializable {
       long bulkMaxRequestSize,
       boolean usePlaintextNegotiation) {
     Preconditions.checkArgument(channelCount > 0, "Channel count has to be at least 1.");
-    Preconditions.checkArgument(timeoutMs >= -1,
-      "ChannelTimeoutMs has to be positive, or -1 for none.");
 
     this.tableAdminHost = Preconditions.checkNotNull(tableAdminHost);
     this.clusterAdminHost = Preconditions.checkNotNull(clusterAdminHost);
@@ -310,7 +294,6 @@ public class BigtableOptions implements Serializable {
     this.credentialOptions = credentialOptions;
     this.userAgent = userAgent;
     this.retryOptions = retryOptions;
-    this.timeoutMs = timeoutMs;
     this.dataChannelCount = channelCount;
     this.asyncMutatorCount = asyncMutatorCount;
     this.useBulkApi = useBulkApi;
@@ -388,13 +371,6 @@ public class BigtableOptions implements Serializable {
   }
 
   /**
-   * The timeout for a channel.
-   */
-  public long getTimeoutMs() {
-    return timeoutMs;
-  }
-
-  /**
    * The number of data channels to create.
    */
   public int getChannelCount() {
@@ -435,7 +411,6 @@ public class BigtableOptions implements Serializable {
     }
     BigtableOptions other = (BigtableOptions) obj;
     return (port == other.port)
-        && (timeoutMs == other.timeoutMs)
         && (dataChannelCount == other.dataChannelCount)
         && (asyncMutatorCount == other.asyncMutatorCount)
         && (useBulkApi == other.useBulkApi)
@@ -466,7 +441,6 @@ public class BigtableOptions implements Serializable {
         .add("userAgent", userAgent)
         .add("credentialType", credentialOptions.getCredentialType())
         .add("port", port)
-        .add("timeoutMs", timeoutMs)
         .add("dataChannelCount", dataChannelCount)
         .add("asyncMutatorCount", asyncMutatorCount)
         .add("useBulkApi", useBulkApi)

--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableOptionsFactory.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableOptionsFactory.java
@@ -142,12 +142,6 @@ public class BigtableOptionsFactory {
    */
   public static final String BIGTABLE_DATA_CHANNEL_COUNT_KEY = "google.bigtable.grpc.channel.count";
 
-  /**
-   * The maximum length of time to keep a Bigtable grpc channel open.
-   */
-  public static final String BIGTABLE_CHANNEL_TIMEOUT_MS_KEY =
-      "google.bigtable.grpc.channel.timeout.ms";
-
   public static final String BIGTABLE_USE_BULK_API =
       "google.bigtable.use.bulk.api";
 
@@ -234,15 +228,6 @@ public class BigtableOptionsFactory {
     int channelCount = configuration.getInt(
         BIGTABLE_DATA_CHANNEL_COUNT_KEY, BigtableOptions.BIGTABLE_DATA_CHANNEL_COUNT_DEFAULT);
     builder.setDataChannelCount(channelCount);
-
-    int channelTimeout = configuration.getInt(
-        BIGTABLE_CHANNEL_TIMEOUT_MS_KEY, BigtableOptions.BIGTABLE_CHANNEL_TIMEOUT_MS_DEFAULT);
-
-    // Connection refresh takes a couple of seconds. 1 minute is the bare minimum that this should
-    // be allowed to be set at.
-    Preconditions.checkArgument(channelTimeout == 0 || channelTimeout >= 60000,
-      BIGTABLE_CHANNEL_TIMEOUT_MS_KEY + " has to be 0 (no timeout) or 1 minute+ (60000)");
-    builder.setTimeoutMs(channelTimeout);
 
     builder.setUserAgent(BigtableConstants.USER_AGENT);
   }

--- a/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableOptionsFactory.java
+++ b/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableOptionsFactory.java
@@ -113,34 +113,6 @@ public class TestBigtableOptionsFactory {
   }
 
   @Test
-  public void testMinGoodRefreshTime() throws IOException{
-    configuration.set(BigtableOptionsFactory.BIGTABLE_HOST_KEY, TEST_HOST);
-    configuration.setBoolean(BigtableOptionsFactory.BIGTABE_USE_SERVICE_ACCOUNTS_KEY, false);
-    configuration.setBoolean(BigtableOptionsFactory.BIGTABLE_NULL_CREDENTIAL_ENABLE_KEY, true);
-    configuration.setLong(BigtableOptionsFactory.BIGTABLE_CHANNEL_TIMEOUT_MS_KEY, 60000);
-    BigtableOptionsFactory.fromConfiguration(configuration);
-  }
-
-  @Test
-  public void testBadRefreshTime() throws IOException{
-    configuration.set(BigtableOptionsFactory.BIGTABLE_HOST_KEY, TEST_HOST);
-    configuration.setBoolean(BigtableOptionsFactory.BIGTABE_USE_SERVICE_ACCOUNTS_KEY, false);
-    configuration.setBoolean(BigtableOptionsFactory.BIGTABLE_NULL_CREDENTIAL_ENABLE_KEY, true);
-    configuration.setLong(BigtableOptionsFactory.BIGTABLE_CHANNEL_TIMEOUT_MS_KEY, 59999);
-    expectedException.expect(IllegalArgumentException.class);
-    BigtableOptionsFactory.fromConfiguration(configuration);
-  }
-
-  @Test
-  public void testZeroRefreshTime() throws IOException{
-    configuration.set(BigtableOptionsFactory.BIGTABLE_HOST_KEY, TEST_HOST);
-    configuration.setBoolean(BigtableOptionsFactory.BIGTABE_USE_SERVICE_ACCOUNTS_KEY, false);
-    configuration.setBoolean(BigtableOptionsFactory.BIGTABLE_NULL_CREDENTIAL_ENABLE_KEY, true);
-    configuration.setLong(BigtableOptionsFactory.BIGTABLE_CHANNEL_TIMEOUT_MS_KEY, 0);
-    BigtableOptionsFactory.fromConfiguration(configuration);
-  }
-
-  @Test
   public void testDefaultRetryOptions() throws IOException {
     RetryOptions retryOptions =
         BigtableOptionsFactory.fromConfiguration(configuration).getRetryOptions();


### PR DESCRIPTION
This was an option used a while back for custom code we had to refresh channels.  The retries we introdced allowed us to remove the channel refreshing, but we did not remove the BigtableOption that controlled it.