### PR TITLE
BigtableSession should manage the creation of BulkMutation.

### DIFF
--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BulkMutation.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BulkMutation.java
@@ -23,6 +23,7 @@ import com.google.bigtable.v1.MutateRowsRequest.Entry;
 import com.google.bigtable.v1.MutateRowsResponse;
 import com.google.cloud.bigtable.config.Logger;
 import com.google.cloud.bigtable.config.RetryOptions;
+import com.google.cloud.bigtable.grpc.BigtableTableName;
 import com.google.cloud.bigtable.grpc.scanner.BigtableRetriesExhaustedException;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
@@ -353,13 +354,13 @@ public class BulkMutation {
   private final long maxRequestSize;
 
   public BulkMutation(
-      String tableName,
+      BigtableTableName tableName,
       AsyncExecutor asyncExecutor,
       RetryOptions retryOptions,
       ScheduledExecutorService retryExecutorService,
       int maxRowKeyCount,
       long maxRequestSize) {
-    this.tableName = tableName;
+    this.tableName = tableName.toString();
     this.asyncExecutor = asyncExecutor;
     this.retryOptions = retryOptions;
     this.retryExecutorService = retryExecutorService;

--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BulkRead.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BulkRead.java
@@ -27,6 +27,7 @@ import com.google.bigtable.v1.RowFilter;
 import com.google.bigtable.v1.RowSet;
 import com.google.cloud.bigtable.config.Logger;
 import com.google.cloud.bigtable.grpc.BigtableDataClient;
+import com.google.cloud.bigtable.grpc.BigtableTableName;
 import com.google.cloud.bigtable.grpc.scanner.ResultScanner;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
@@ -62,9 +63,9 @@ public class BulkRead {
    */
   private Multimap<ByteString, SettableFuture<List<Row>>> futures;
 
-  public BulkRead(BigtableDataClient client, String tableName) {
+  public BulkRead(BigtableDataClient client, BigtableTableName tableName) {
     this.client = client;
-    this.tableName = tableName;
+    this.tableName = tableName.toString();
   }
 
   /**

--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableTable.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableTable.java
@@ -106,14 +106,12 @@ public class BigtableTable implements Table {
   public BigtableTable(
       AbstractBigtableConnection bigtableConnection,
       TableName tableName,
-      BigtableOptions options,
-      BigtableDataClient client,
       HBaseRequestAdapter hbaseAdapter,
       BatchExecutor batchExecutor) {
     this.bigtableConnection = bigtableConnection;
     this.tableName = tableName;
-    this.options = options;
-    this.client = client;
+    this.options = bigtableConnection.getSession().getOptions();
+    this.client = bigtableConnection.getSession().getDataClient();
     this.batchExecutor = batchExecutor;
     this.hbaseAdapter = hbaseAdapter;
   }

--- a/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableTable.java
+++ b/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableTable.java
@@ -34,6 +34,7 @@ import com.google.bigtable.v1.RowFilter.Chain;
 import com.google.cloud.bigtable.config.BigtableOptions;
 import com.google.cloud.bigtable.config.RetryOptions;
 import com.google.cloud.bigtable.grpc.BigtableDataClient;
+import com.google.cloud.bigtable.grpc.BigtableSession;
 import com.google.cloud.bigtable.grpc.scanner.ResultScanner;
 import com.google.cloud.bigtable.hbase.adapters.HBaseRequestAdapter;
 import com.google.protobuf.ByteString;
@@ -81,10 +82,13 @@ public class TestBigtableTable {
   private AbstractBigtableConnection mockConnection;
 
   @Mock
+  private BigtableSession mockSession;
+
+  @Mock
   private BigtableDataClient mockClient;
 
   @Mock
-  private BatchExecutor batchExecutor;
+  private BatchExecutor mockBatchExecutor;
 
   @Mock
   private ResultScanner<Row> mockResultScanner;
@@ -113,9 +117,11 @@ public class TestBigtableTable {
     HBaseRequestAdapter hbaseAdapter =
         new HBaseRequestAdapter(options.getClusterName(), tableName, config);
     Mockito.when(mockConnection.getConfiguration()).thenReturn(config);
+    Mockito.when(mockConnection.getSession()).thenReturn(mockSession);
+    Mockito.when(mockSession.getOptions()).thenReturn(options);
+    Mockito.when(mockSession.getDataClient()).thenReturn(mockClient);
     table =
-        new BigtableTable(mockConnection, tableName, options, mockClient, hbaseAdapter,
-            batchExecutor);
+        new BigtableTable(mockConnection, tableName, hbaseAdapter, mockBatchExecutor);
   }
 
   @Test


### PR DESCRIPTION
Users who use the proto version of the API need to create BulkMutations.  This PR adds in a simple way of creating a BulkMutation.  It also moves existing ways of creating the BulkMutation and AsyncExecutor to use BigtableSession instead of creating it themselves.  This simplifies the amount of knowledge other classes need in constructing these objects.