### PR TITLE
Allowing a user to retry even if the client does not set the timestamp.

### DIFF
--- a/bigtable-client-core/src/test/java/com/google/cloud/bigtable/config/RetryOptionsUtil.java
+++ b/bigtable-client-core/src/test/java/com/google/cloud/bigtable/config/RetryOptionsUtil.java
@@ -32,11 +32,16 @@ import com.google.api.client.util.NanoClock;
  */
 public class RetryOptionsUtil {
   public static RetryOptions createTestRetryOptions(final NanoClock nanoClock) {
-    return new RetryOptions(true, DEFAULT_INITIAL_BACKOFF_MILLIS, DEFAULT_BACKOFF_MULTIPLIER,
-        DEFAULT_MAX_ELAPSED_BACKOFF_MILLIS, DEFAULT_STREAMING_BUFFER_SIZE,
-        DEFAULT_STREAMING_BATCH_SIZE, DEFAULT_READ_PARTIAL_ROW_TIMEOUT_MS,
-        DEFAULT_MAX_SCAN_TIMEOUT_RETRIES, DEFAULT_ENABLE_GRPC_RETRIES_SET) {
-          private static final long serialVersionUID = 1L;
+    return createTestRetryOptions(nanoClock, false);
+  }
+
+  public static RetryOptions createTestRetryOptions(final NanoClock nanoClock, boolean allowRetriesWithoutTimestamp) {
+    return new RetryOptions(true, allowRetriesWithoutTimestamp, DEFAULT_INITIAL_BACKOFF_MILLIS,
+        DEFAULT_BACKOFF_MULTIPLIER, DEFAULT_MAX_ELAPSED_BACKOFF_MILLIS,
+        DEFAULT_STREAMING_BUFFER_SIZE, DEFAULT_STREAMING_BATCH_SIZE,
+        DEFAULT_READ_PARTIAL_ROW_TIMEOUT_MS, DEFAULT_MAX_SCAN_TIMEOUT_RETRIES,
+        DEFAULT_ENABLE_GRPC_RETRIES_SET) {
+      private static final long serialVersionUID = 1L;
 
       @Override
       protected ExponentialBackOff.Builder createBackoffBuilder() {

--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableOptionsFactory.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableOptionsFactory.java
@@ -98,6 +98,16 @@ public class BigtableOptionsFactory {
   public static final String ENABLE_GRPC_RETRIES_KEY = "google.bigtable.grpc.retry.enable";
 
   /**
+   * By default, the hbase client will set the timestamp on the client side before sending a Put if
+   * it's not set already. That's done to ensure that only a single cell is written for the put if
+   * retries occur. Retries aren't common, and writing multiple cells isn't a problem in many cases.
+   * Sometimes, setting the server timestamp is beneficial. If you want the server-side time stamp,
+   * set this to true.
+   */
+  public static final String ALLOW_NO_TIMESTAMP_RETRIES_KEY =
+      "google.bigtable.alllow.no.timestamp.retries";
+
+  /**
    * Key to set to a comma separated list of grpc codes to retry. See {@link Status.Code} for more
    * information.
    */
@@ -299,6 +309,11 @@ public class BigtableOptionsFactory {
         ENABLE_GRPC_RETRIES_KEY, RetryOptions.DEFAULT_ENABLE_GRPC_RETRIES);
     LOG.debug("gRPC retries enabled: %s", enableRetries);
     retryOptionsBuilder.setEnableRetries(enableRetries);
+
+    boolean allowRetriesWithoutTimestamp = configuration.getBoolean(
+        ALLOW_NO_TIMESTAMP_RETRIES_KEY, false);
+    LOG.debug("allow retries without timestamp: %s", enableRetries);
+    retryOptionsBuilder.setAllowRetriesWithoutTimestamp(allowRetriesWithoutTimestamp);
 
     String retryCodes = configuration.get(ADDITIONAL_RETRY_CODES, "");
     String codes[] = retryCodes.split(",");

--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/Adapters.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/Adapters.java
@@ -19,6 +19,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.client.Append;
 import org.apache.hadoop.hbase.client.Increment;
 
+import com.google.cloud.bigtable.config.BigtableOptions;
 import com.google.cloud.bigtable.hbase.adapters.filters.FilterAdapter;
 
 /**
@@ -46,8 +47,9 @@ public final class Adapters {
       new UnsupportedOperationAdapter<Append>("append"));
   }
 
-  public static PutAdapter createPutAdapter(Configuration config) {
-    return new PutAdapter(config.getInt("hbase.client.keyvalue.maxsize", -1));
+  public static PutAdapter createPutAdapter(Configuration config, BigtableOptions options) {
+    boolean setClientTimestamp = !options.getRetryOptions().allowRetriesWithoutTimestamp();
+    return new PutAdapter(config.getInt("hbase.client.keyvalue.maxsize", -1), setClientTimestamp);
   }
 
   private Adapters() {

--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/HBaseRequestAdapter.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/HBaseRequestAdapter.java
@@ -28,7 +28,7 @@ import org.apache.hadoop.hbase.client.Scan;
 import com.google.bigtable.v1.MutateRowRequest;
 import com.google.bigtable.v1.ReadModifyWriteRowRequest;
 import com.google.bigtable.v1.ReadRowsRequest;
-import com.google.cloud.bigtable.grpc.BigtableClusterName;
+import com.google.cloud.bigtable.config.BigtableOptions;
 import com.google.cloud.bigtable.grpc.BigtableTableName;
 
  /**
@@ -43,11 +43,10 @@ public class HBaseRequestAdapter {
   protected final MutationAdapter mutationAdapter;
   protected final RowMutationsAdapter rowMutationsAdapter;
 
-  public HBaseRequestAdapter(BigtableClusterName clusterName, TableName tableName,
-      Configuration config) {
+  public HBaseRequestAdapter(BigtableOptions options, TableName tableName, Configuration config) {
     this.tableName = tableName;
-    this.bigtableTableName = clusterName.toTableName(tableName.getQualifierAsString());
-    this.putAdapter = Adapters.createPutAdapter(config);
+    this.bigtableTableName = options.getClusterName().toTableName(tableName.getQualifierAsString());
+    this.putAdapter = Adapters.createPutAdapter(config, options);
     this.mutationAdapter = Adapters.createMutationsAdapter(putAdapter);
     this.rowMutationsAdapter = new RowMutationsAdapter(mutationAdapter);
   }

--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/PutAdapter.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/PutAdapter.java
@@ -33,9 +33,16 @@ import java.util.Map.Entry;
  */
 public class PutAdapter implements OperationAdapter<Put, MutateRowRequest.Builder> {
   private final int maxKeyValueSize;
+  private final boolean setClientTimestamp;
 
   public PutAdapter(int maxKeyValueSize) {
     this.maxKeyValueSize = maxKeyValueSize;
+    this.setClientTimestamp = true;
+  }
+
+  public PutAdapter(int maxKeyValueSize, boolean setClientTimestamp) {
+    this.maxKeyValueSize = maxKeyValueSize;
+    this.setClientTimestamp = setClientTimestamp;
   }
 
   @Override
@@ -49,7 +56,7 @@ public class PutAdapter implements OperationAdapter<Put, MutateRowRequest.Builde
 
     // Bigtable uses a 1ms granularity. Use this timestamp if the Put does not have one specified to
     // make mutations idempotent.
-    long currentTimestampMicros = System.currentTimeMillis() * 1000;
+    long currentTimestampMicros = setClientTimestamp ? System.currentTimeMillis() * 1000 : -1;
 
     for (Entry<byte[], List<Cell>> entry : operation.getFamilyCellMap().entrySet()) {
       ByteString familyString = ByteString.copyFrom(entry.getKey());

--- a/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableConnection.java
+++ b/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableConnection.java
@@ -197,7 +197,7 @@ public abstract class AbstractBigtableConnection implements Connection, Closeabl
   }
 
   private HBaseRequestAdapter createAdapter(TableName tableName) {
-    return new HBaseRequestAdapter(options.getClusterName(), tableName, conf);
+    return new HBaseRequestAdapter(options, tableName, conf);
   }
 
   @Override

--- a/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/PutAdapterPerf.java
+++ b/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/PutAdapterPerf.java
@@ -17,7 +17,7 @@ package com.google.cloud.bigtable.hbase;
 
 import com.google.bigtable.v1.BigtableServiceGrpc;
 import com.google.bigtable.v1.MutateRowRequest;
-import com.google.cloud.bigtable.grpc.BigtableClusterName;
+import com.google.cloud.bigtable.config.BigtableOptions;
 import com.google.cloud.bigtable.hbase.adapters.HBaseRequestAdapter;
 import com.google.cloud.bigtable.hbase.adapters.PutAdapter;
 
@@ -38,7 +38,7 @@ public class PutAdapterPerf {
     put.addColumn(Bytes.toBytes("Family1"), Bytes.toBytes("Qaulifier"), value);
 
     HBaseRequestAdapter adapter =
-        new HBaseRequestAdapter(new BigtableClusterName("project", "zoneId", "clusterId"),
+        new HBaseRequestAdapter(new BigtableOptions.Builder().build(),
             TableName.valueOf("tableName"), new Configuration());
     for (int i = 0; i < 10; i++) {
       putAdapterPerf(adapter, put);

--- a/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBatchExecutor.java
+++ b/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBatchExecutor.java
@@ -33,7 +33,6 @@ import com.google.bigtable.v1.ReadRowsRequest;
 import com.google.bigtable.v1.Row;
 import com.google.cloud.bigtable.config.BigtableOptions;
 import com.google.cloud.bigtable.config.BulkOptions;
-import com.google.cloud.bigtable.grpc.BigtableClusterName;
 import com.google.cloud.bigtable.grpc.BigtableDataClient;
 import com.google.cloud.bigtable.grpc.BigtableSessionSharedThreadPools;
 import com.google.cloud.bigtable.grpc.async.AsyncExecutor;
@@ -124,12 +123,17 @@ public class TestBatchExecutor {
   @Mock
   private ListenableFuture mockFuture;
 
-  private HBaseRequestAdapter requestAdapter =
-      new HBaseRequestAdapter(new BigtableClusterName("project", "zone", "cluster"),
-          TableName.valueOf("table"), new Configuration(false));
-
+  private HBaseRequestAdapter requestAdapter;
   @Before
   public void setup() throws InterruptedException {
+    BigtableOptions options = new BigtableOptions.Builder()
+        .setProjectId("projectId")
+        .setZoneId("zone")
+        .setClusterId("clusterId")
+        .build();
+    requestAdapter =
+        new HBaseRequestAdapter(options, TableName.valueOf("table"), new Configuration(false));
+
     MockitoAnnotations.initMocks(this);
     when(mockAsyncExecutor.readRowsAsync(any(ReadRowsRequest.class))).thenReturn(mockFuture);
     when(mockAsyncExecutor.mutateRowAsync(any(MutateRowRequest.class))).thenReturn(mockFuture);

--- a/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableBufferedMutator.java
+++ b/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableBufferedMutator.java
@@ -123,8 +123,8 @@ public class TestBigtableBufferedMutator {
     }
 
     BigtableOptions options = BigtableOptionsFactory.fromConfiguration(configuration);
-    HBaseRequestAdapter adapter = new HBaseRequestAdapter(
-        options.getClusterName(), TableName.valueOf("TABLE"), configuration);
+    HBaseRequestAdapter adapter =
+        new HBaseRequestAdapter(options, TableName.valueOf("TABLE"), configuration);
 
     executorService = Executors.newCachedThreadPool();
     return new BigtableBufferedMutator(

--- a/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableTable.java
+++ b/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableTable.java
@@ -111,7 +111,7 @@ public class TestBigtableTable {
     Configuration config = new Configuration(false);
     TableName tableName = TableName.valueOf(TEST_TABLE);
     HBaseRequestAdapter hbaseAdapter =
-        new HBaseRequestAdapter(options.getClusterName(), tableName, config);
+        new HBaseRequestAdapter(options, tableName, config);
     Mockito.when(mockConnection.getConfiguration()).thenReturn(config);
     table =
         new BigtableTable(mockConnection, tableName, options, mockClient, hbaseAdapter,

--- a/bigtable-hbase/src/test/java/org/apache/hadoop/hbase/client/PutMicroBenchmark.java
+++ b/bigtable-hbase/src/test/java/org/apache/hadoop/hbase/client/PutMicroBenchmark.java
@@ -10,7 +10,6 @@ package org.apache.hadoop.hbase.client;
 
 import com.google.bigtable.v1.MutateRowRequest;
 import com.google.cloud.bigtable.config.BigtableOptions;
-import com.google.cloud.bigtable.grpc.BigtableClusterName;
 import com.google.cloud.bigtable.grpc.BigtableDataClient;
 import com.google.cloud.bigtable.grpc.BigtableDataGrpcClient;
 import com.google.cloud.bigtable.grpc.BigtableSession;
@@ -105,9 +104,9 @@ public class PutMicroBenchmark {
 
   protected static MutateRowRequest createRequest(String projectId, String zoneId, String clusterId,
       String tableId) {
-    HBaseRequestAdapter hbaseAdapter =
-        new HBaseRequestAdapter(new BigtableClusterName(projectId, zoneId, clusterId),
-            TableName.valueOf(tableId), new Configuration(false));
+    HBaseRequestAdapter hbaseAdapter = new HBaseRequestAdapter(
+        new BigtableOptions.Builder().build(), TableName.valueOf(tableId),
+        new Configuration(false));
     DataGenerationHelper dataHelper = new DataGenerationHelper();
     byte[] rowKey = dataHelper.randomData("testrow-");
     byte[][] quals = dataHelper.randomData("testQualifier-", NUM_CELLS);


### PR DESCRIPTION
The concern about setting the client timestamp in hbase is safe from the standpoint of most situations.  A Column Family with a single version and gets/scans where version=1 will not have a problem with retries that put in two cells into a qualifier.  Allow a user to set an option that will ensure that a server-side timestamp is set.

This PR is in response to a user request.