### PR TITLE
Changed method name to match proto method name to reduce confusion.

### DIFF
--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableTableAdminClient.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableTableAdminClient.java
@@ -66,7 +66,7 @@ public interface BigtableTableAdminClient {
   /**
    * Permanently deletes all rows in a range.
    */
-  void deleteRowRange(BulkDeleteRowsRequest request);
+  void bulkDeleteRows(BulkDeleteRowsRequest request);
 
   /**
    * Changes the name of a specified table.

--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableTableAdminGrpcClient.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableTableAdminGrpcClient.java
@@ -66,7 +66,7 @@ public class BigtableTableAdminGrpcClient implements BigtableTableAdminClient {
   }
 
   @Override
-  public void deleteRowRange(BulkDeleteRowsRequest request) {
+  public void bulkDeleteRows(BulkDeleteRowsRequest request) {
     blockingStub.bulkDeleteRows(request);
   }
 

--- a/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableAdmin.java
+++ b/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableAdmin.java
@@ -631,7 +631,7 @@ public abstract class AbstractBigtableAdmin implements Admin {
   private void issueBulkDelete(TableName tableName, BulkDeleteRowsRequest.Builder deleteRequest)
       throws IOException {
     try {
-      bigtableTableAdminClient.deleteRowRange(
+      bigtableTableAdminClient.bulkDeleteRows(
           deleteRequest
               .setTableName(options.getClusterName().toTableNameStr(tableName.getNameAsString()))
               .build());


### PR DESCRIPTION
I think we should either change the underlying method, or change the method name here to match.