### PR TITLE
Removing RenameTable from BigtableTableAdminClient.

### DIFF
--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableTableAdminClient.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableTableAdminClient.java
@@ -24,7 +24,6 @@ import com.google.bigtable.admin.table.v1.DeleteTableRequest;
 import com.google.bigtable.admin.table.v1.GetTableRequest;
 import com.google.bigtable.admin.table.v1.ListTablesRequest;
 import com.google.bigtable.admin.table.v1.ListTablesResponse;
-import com.google.bigtable.admin.table.v1.RenameTableRequest;
 import com.google.bigtable.admin.table.v1.Table;
 
 /**
@@ -73,10 +72,4 @@ public interface BigtableTableAdminClient {
    * Permanently deletes all rows in a range.
    */
   void bulkDeleteRows(BulkDeleteRowsRequest request);
-
-  /**
-   * Changes the name of a specified table.
-   * Cannot be used to move tables between clusters, zones, or projects.
-   */
-  void renameTable(RenameTableRequest request);
 }

--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableTableAdminGrpcClient.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableTableAdminGrpcClient.java
@@ -27,7 +27,6 @@ import com.google.bigtable.admin.table.v1.DeleteTableRequest;
 import com.google.bigtable.admin.table.v1.GetTableRequest;
 import com.google.bigtable.admin.table.v1.ListTablesRequest;
 import com.google.bigtable.admin.table.v1.ListTablesResponse;
-import com.google.bigtable.admin.table.v1.RenameTableRequest;
 import com.google.bigtable.admin.table.v1.Table;
 
 /**
@@ -79,10 +78,5 @@ public class BigtableTableAdminGrpcClient implements BigtableTableAdminClient {
   @Override
   public void deleteColumnFamily(DeleteColumnFamilyRequest request) {
     blockingStub.deleteColumnFamily(request);
-  }
-
-  @Override
-  public void renameTable(RenameTableRequest request) {
-    blockingStub.renameTable(request);
   }
 }


### PR DESCRIPTION
RenameTable was never implemented on the server.  It shouldn't be there
in the client either.