### PR TITLE
Adding generics to BigtableResultScannerFactory.

### DIFF
--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataGrpcClient.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataGrpcClient.java
@@ -139,8 +139,8 @@ public class BigtableDataGrpcClient implements BigtableDataClient {
   private final ScheduledExecutorService retryExecutorService;
   private final RetryOptions retryOptions;
   private final BigtableOptions bigtableOptions;
-  private final BigtableResultScannerFactory streamingScannerFactory =
-      new BigtableResultScannerFactory() {
+  private final BigtableResultScannerFactory<ReadRowsRequest, Row> streamingScannerFactory =
+      new BigtableResultScannerFactory<ReadRowsRequest, Row>() {
         @Override
         public ResultScanner<Row> createScanner(ReadRowsRequest request) {
           return streamRows(request);

--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/BigtableResultScannerFactory.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/BigtableResultScannerFactory.java
@@ -15,17 +15,14 @@
  */
 package com.google.cloud.bigtable.grpc.scanner;
 
-import com.google.bigtable.v1.ReadRowsRequest;
-import com.google.bigtable.v1.Row;
-
 /**
  * A factory for creating ResultScanners that can be used to scan over Rows for a
  * given ReadRowsRequest.
  */
-public interface BigtableResultScannerFactory {
+public interface BigtableResultScannerFactory<RequestT, ResponseT> {
 
   /**
    * Create a scanner for the given request.
    */
-  ResultScanner<Row> createScanner(ReadRowsRequest request);
+  ResultScanner<ResponseT> createScanner(RequestT request);
 }

--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ResumingStreamingResultScanner.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ResumingStreamingResultScanner.java
@@ -100,7 +100,7 @@ public class ResumingStreamingResultScanner extends AbstractBigtableResultScanne
     return previous.concat(NEXT_ROW_SUFFIX);
   }
 
-  private final BigtableResultScannerFactory scannerFactory;
+  private final BigtableResultScannerFactory<ReadRowsRequest, Row> scannerFactory;
   private final ReadRowsRequest originalRequest;
   private final RetryOptions retryOptions;
   private final RequestRestarter restarter;
@@ -118,7 +118,7 @@ public class ResumingStreamingResultScanner extends AbstractBigtableResultScanne
   public ResumingStreamingResultScanner(
     RetryOptions retryOptions,
     ReadRowsRequest originalRequest,
-    BigtableResultScannerFactory scannerFactory) {
+    BigtableResultScannerFactory<ReadRowsRequest, Row> scannerFactory) {
     this(retryOptions, originalRequest, scannerFactory, LOG);
   }
 
@@ -126,7 +126,7 @@ public class ResumingStreamingResultScanner extends AbstractBigtableResultScanne
   ResumingStreamingResultScanner(
       RetryOptions retryOptions,
       ReadRowsRequest originalRequest,
-      BigtableResultScannerFactory scannerFactory,
+      BigtableResultScannerFactory<ReadRowsRequest, Row> scannerFactory,
       Logger logger) {
     this.originalRequest = originalRequest;
     this.scannerFactory = scannerFactory;

--- a/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/scanner/ResumingStreamingResultScannerTest.java
+++ b/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/scanner/ResumingStreamingResultScannerTest.java
@@ -63,7 +63,7 @@ public class ResumingStreamingResultScannerTest {
   @Mock
   ResultScanner<Row> mockScannerPostResume;
   @Mock
-  BigtableResultScannerFactory mockScannerFactory;
+  BigtableResultScannerFactory<ReadRowsRequest, Row> mockScannerFactory;
   @Mock
   Logger logger;
 


### PR DESCRIPTION
Removing V1 specific artifacts makes this class more useful in V2.