### PR TITLE
Updating grpc versions.  That required changing dataflow coders.

### DIFF
--- a/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/CloudBigtableScanConfiguration.java
+++ b/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/CloudBigtableScanConfiguration.java
@@ -15,20 +15,18 @@
  */
 package com.google.cloud.bigtable.dataflow;
 
-import com.google.protobuf.InvalidProtocolBufferException;
-
-import org.apache.hadoop.hbase.client.Scan;
-import org.apache.hadoop.hbase.protobuf.ProtobufUtil;
-import org.apache.hadoop.hbase.protobuf.generated.ClientProtos;
-import org.apache.hadoop.hbase.util.Base64;
-
-import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
-import java.io.Serializable;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
+
+import org.apache.hadoop.hbase.client.Scan;
+
+import com.google.bigtable.v1.ReadRowsRequest;
+import com.google.cloud.bigtable.grpc.BigtableClusterName;
+import com.google.cloud.bigtable.hbase.adapters.Adapters;
+import com.google.cloud.bigtable.hbase.adapters.read.DefaultReadHooks;
+import com.google.cloud.bigtable.hbase.adapters.read.ReadHooks;
+import com.google.common.base.Preconditions;
 
 /**
  * This class defines configuration that a Cloud Bigtable client needs to connect to a user's Cloud
@@ -58,19 +56,21 @@ public class CloudBigtableScanConfiguration extends CloudBigtableTableConfigurat
    */
   public static CloudBigtableScanConfiguration fromCBTOptions(CloudBigtableOptions options,
       Scan scan) {
-    return new CloudBigtableScanConfiguration(
-        options.getBigtableProjectId(),
-        options.getBigtableZoneId(),
-        options.getBigtableClusterId(),
-        options.getBigtableTableId(),
-        scan);
+    return new Builder()
+        .withProjectId(options.getBigtableProjectId())
+        .withZoneId(options.getBigtableZoneId())
+        .withClusterId(options.getBigtableClusterId())
+        .withTableId(options.getBigtableTableId())
+        .withScan(scan)
+        .build();
   }
 
   /**
    * Builds a {@link CloudBigtableScanConfiguration}.
    */
   public static class Builder extends CloudBigtableTableConfiguration.Builder {
-    protected Scan scan = new Scan();
+    private ReadRowsRequest readRowsRequest;
+    private Scan scan = new Scan();
 
     public Builder() {
     }
@@ -91,6 +91,12 @@ public class CloudBigtableScanConfiguration extends CloudBigtableTableConfigurat
      */
     public Builder withScan(Scan scan) {
       this.scan = scan;
+      return this;
+    }
+
+
+    public Builder witReadRowsRequest(ReadRowsRequest readRowsRequest) {
+      this.readRowsRequest = readRowsRequest;
       return this;
     }
 
@@ -148,57 +154,18 @@ public class CloudBigtableScanConfiguration extends CloudBigtableTableConfigurat
      */
     @Override
     public CloudBigtableScanConfiguration build() {
-      return new CloudBigtableScanConfiguration(projectId, zoneId, clusterId, tableId, scan, additionalConfiguration);
+      if (readRowsRequest == null) {
+        ReadHooks readHooks = new DefaultReadHooks();
+        ReadRowsRequest.Builder builder = Adapters.SCAN_ADAPTER.adapt(scan, readHooks);
+        builder.setTableName(new BigtableClusterName(projectId, zoneId, clusterId).toTableNameStr(tableId));
+        this.readRowsRequest = readHooks.applyPreSendHook(builder.build());
+      }
+      return new CloudBigtableScanConfiguration(projectId, zoneId, clusterId, tableId,
+          readRowsRequest, additionalConfiguration);
     }
   }
 
-  /**
-   * HBase's {@link Scan} does not implement {@link Serializable}.  This class provides a wrapper
-   * around {@link Scan} to properly serialize it.
-   */
-  private static class SerializableScan implements Serializable {
-    private static final long serialVersionUID = 1998373680347356757L;
-    private transient Scan scan;
-
-    public SerializableScan(Scan scan) {
-      this.scan = scan;
-    }
-
-    private void writeObject(ObjectOutputStream out) throws IOException {
-      out.writeObject(toEncodedString());
-    }
-
-    private String toEncodedString() throws IOException {
-      return Base64.encodeBytes(ProtobufUtil.toScan(scan).toByteArray());
-    }
-
-    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
-      this.scan = toScan((String) in.readObject());
-    }
-
-    private static Scan toScan(String scanStr) throws IOException {
-      try {
-        return ProtobufUtil.toScan(ClientProtos.Scan.parseFrom(Base64.decode(scanStr)));
-      } catch (InvalidProtocolBufferException ipbe) {
-        throw new IOException("Could not deserialize the Scan.", ipbe);
-      }
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-      if (!(obj instanceof SerializableScan)) {
-        return false;
-      }
-      SerializableScan other = (SerializableScan) obj;
-      try {
-        return toEncodedString().equals(other.toEncodedString());
-      } catch (IOException e) {
-        throw new RuntimeException("Could not check SerializableScan equality", e);
-      }
-    }
-  }
-
-  private SerializableScan serializableScan;
+  private ReadRowsRequest readRowsRequest;
 
   /**
    * Creates a {@link CloudBigtableScanConfiguration} using the specified project ID, zone, cluster
@@ -208,11 +175,11 @@ public class CloudBigtableScanConfiguration extends CloudBigtableTableConfigurat
    * @param zoneId The zone where the cluster is located.
    * @param clusterId The cluster ID for the cluster.
    * @param tableId The table to connect to in the cluster.
-   * @param scan The {@link Scan} that will be used to filter the table.
+   * @param readRowsRequest The {@link ReadRowsRequest} that will be used to filter the table.
    */
   public CloudBigtableScanConfiguration(String projectId, String zoneId, String clusterId,
-      String tableId, Scan scan) {
-    this(projectId, zoneId, clusterId, tableId, scan, Collections.<String, String> emptyMap());
+      String tableId, ReadRowsRequest readRowsRequest) {
+    this(projectId, zoneId, clusterId, tableId, readRowsRequest, Collections.<String, String> emptyMap());
   }
 
   /**
@@ -227,30 +194,25 @@ public class CloudBigtableScanConfiguration extends CloudBigtableTableConfigurat
    * @param additionalConfiguration A {@link Map} with additional connection configuration.
    */
   public CloudBigtableScanConfiguration(String projectId, String zoneId, String clusterId,
-      String tableId, Scan scan, Map<String, String> additionalConfiguration) {
+      String tableId, ReadRowsRequest readRowsRequest, Map<String, String> additionalConfiguration) {
     super(projectId, zoneId, clusterId, tableId, additionalConfiguration);
-    this.serializableScan = new SerializableScan(scan);
+    this.readRowsRequest = Preconditions.checkNotNull(readRowsRequest);
   }
 
-  /**
-   * Gets the {@link Scan} used to filter the table.
-   * @return The {@link Scan}.
-   */
-  public Scan getScan() {
-    return serializableScan.scan;
+  public ReadRowsRequest getReadRowsRequest() {
+    return readRowsRequest;
   }
 
   @Override
   public boolean equals(Object obj) {
     return super.equals(obj)
-        && Objects
-            .equals(serializableScan, ((CloudBigtableScanConfiguration) obj).serializableScan);
+        && Objects.equals(readRowsRequest, ((CloudBigtableScanConfiguration) obj).readRowsRequest);
   }
 
   @Override
   public Builder toBuilder() {
     return new Builder(getConfiguration())
         .withTableId(tableId)
-        .withScan(serializableScan.scan);
+        .witReadRowsRequest(readRowsRequest);
   }
 }

--- a/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/HBaseResultArrayCoder.java
+++ b/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/HBaseResultArrayCoder.java
@@ -15,21 +15,22 @@
  */
 package com.google.cloud.bigtable.dataflow;
 
+import com.google.bigtable.v1.Row;
+import com.google.cloud.bigtable.hbase.adapters.Adapters;
 import com.google.cloud.dataflow.sdk.coders.AtomicCoder;
 import com.google.cloud.dataflow.sdk.coders.Coder;
 import com.google.cloud.dataflow.sdk.coders.CoderException;
 
 import org.apache.hadoop.hbase.client.Result;
-import org.apache.hadoop.hbase.protobuf.ProtobufUtil;
-import org.apache.hadoop.hbase.protobuf.generated.ClientProtos.ScanResponse;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.io.OutputStream;
 
 /**
- * A {@link Coder} that serializes and deserializes the {@link Result} array using
- * {@link ProtobufUtil}.
+ * A {@link Coder} that serializes and deserializes the {@link Result} array.
  */
 public class HBaseResultArrayCoder extends AtomicCoder<Result[]>{
 
@@ -44,10 +45,10 @@ public class HBaseResultArrayCoder extends AtomicCoder<Result[]>{
   @Override
   public Result[] decode(InputStream inputStream, Coder.Context context)
       throws CoderException, IOException {
-    ScanResponse response = ScanResponse.parseDelimitedFrom(inputStream);
-    Result[] results = new Result[response.getResultsCount()];
-    for (int i = 0; i < results.length; i++) {
-      results[i] = ProtobufUtil.toResult(response.getResults(i));
+    int resultCount = new ObjectInputStream(inputStream).readInt();
+    Result[] results = new Result[resultCount];
+    for (int i = 0; i < resultCount; i++) {
+      results[i] = Adapters.ROW_ADAPTER.adaptResponse(Row.parseDelimitedFrom(inputStream));
     }
     return results;
   }
@@ -55,11 +56,11 @@ public class HBaseResultArrayCoder extends AtomicCoder<Result[]>{
   @Override
   public void encode(Result[] results, OutputStream outputStream, Coder.Context context)
       throws CoderException, IOException {
-    ScanResponse.Builder scanResponseBuilder = ScanResponse.newBuilder();
+    ObjectOutputStream oos = new ObjectOutputStream(outputStream);
+    oos.writeInt(results.length);
+    oos.flush();
     for (Result result : results) {
-      scanResponseBuilder.addResults(ProtobufUtil.toResult(result));
+      Adapters.ROW_ADAPTER.adaptRow(result).writeDelimitedTo(outputStream);
     }
-    scanResponseBuilder.build().writeDelimitedTo(outputStream);
   }
-
 }

--- a/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/HBaseResultCoder.java
+++ b/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/HBaseResultCoder.java
@@ -15,13 +15,13 @@
  */
 package com.google.cloud.bigtable.dataflow;
 
+import com.google.bigtable.v1.Row;
+import com.google.cloud.bigtable.hbase.adapters.Adapters;
 import com.google.cloud.dataflow.sdk.coders.AtomicCoder;
 import com.google.cloud.dataflow.sdk.coders.Coder;
 import com.google.cloud.dataflow.sdk.coders.CoderException;
 
 import org.apache.hadoop.hbase.client.Result;
-import org.apache.hadoop.hbase.protobuf.ProtobufUtil;
-import org.apache.hadoop.hbase.protobuf.generated.ClientProtos;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -29,8 +29,7 @@ import java.io.OutputStream;
 import java.io.Serializable;
 
 /**
- * A {@link Coder} that serializes and deserializes the {@link Result} objects using {@link
- * ProtobufUtil}.
+ * A {@link Coder} that serializes and deserializes the {@link Result}.
  */
 public class HBaseResultCoder extends AtomicCoder<Result> implements Serializable {
 
@@ -45,12 +44,12 @@ public class HBaseResultCoder extends AtomicCoder<Result> implements Serializabl
   @Override
   public Result decode(InputStream inputStream, Coder.Context context)
       throws CoderException, IOException {
-    return ProtobufUtil.toResult(ClientProtos.Result.parseDelimitedFrom(inputStream));
+    return Adapters.ROW_ADAPTER.adaptResponse(Row.parseDelimitedFrom(inputStream));
   }
 
   @Override
   public void encode(Result value, OutputStream outputStream, Coder.Context context)
       throws CoderException, IOException {
-    ProtobufUtil.toResult(value).writeDelimitedTo(outputStream);
+    Adapters.ROW_ADAPTER.adaptRow(value).writeDelimitedTo(outputStream);
   }
 }

--- a/bigtable-hbase-dataflow/src/test/java/com/google/cloud/bigtable/dataflow/CloudBigtableIOIntegrationTest.java
+++ b/bigtable-hbase-dataflow/src/test/java/com/google/cloud/bigtable/dataflow/CloudBigtableIOIntegrationTest.java
@@ -179,8 +179,7 @@ public class CloudBigtableIOIntegrationTest {
   }
 
   private void checkTableRowCountViaDataflowResultReader(TableName tableName, int rowCount) throws Exception {
-    CloudBigtableScanConfiguration configuration = new CloudBigtableScanConfiguration(projectId,
-        zoneId, clusterId, tableName.getNameAsString(), new Scan());
+    CloudBigtableScanConfiguration configuration = createConfig(tableName);
     BoundedSource<Result> source = CloudBigtableIO.read(configuration);
     List<? extends BoundedSource<Result>> splits = source.splitIntoBundles(1 << 20, null);
     int count = 0;
@@ -193,6 +192,11 @@ public class CloudBigtableIOIntegrationTest {
       }
     }
     Assert.assertEquals(rowCount, count);
+  }
+
+  protected CloudBigtableScanConfiguration createConfig(TableName tableName) {
+    return new CloudBigtableScanConfiguration.Builder().withProjectId(projectId).withZoneId(zoneId)
+        .withClusterId(clusterId).withTableId(tableName.getNameAsString()).build();
   }
 
   @Test
@@ -210,8 +214,7 @@ public class CloudBigtableIOIntegrationTest {
   }
 
   private void checkTableRowCountViaDataflowResultArrayReader(TableName tableName, int rowCount) throws Exception {
-    CloudBigtableScanConfiguration configuration = new CloudBigtableScanConfiguration(projectId,
-        zoneId, clusterId, tableName.getNameAsString(), new Scan());
+    CloudBigtableScanConfiguration configuration = createConfig(tableName);
     int batchCount = 10;
     BoundedSource<Result[]> source = CloudBigtableIO.readBulk(configuration, batchCount);
      List<? extends BoundedSource<Result[]>> splits = source.splitIntoBundles(1 << 20, null);
@@ -245,9 +248,7 @@ public class CloudBigtableIOIntegrationTest {
       LOG.info("getSampleKeys() in testEstimatedAndSplitForSmallTable()");
 
       try {
-        CloudBigtableScanConfiguration config =
-            new CloudBigtableScanConfiguration(projectId, zoneId, clusterId,
-                tableName.getQualifierAsString(), new Scan());
+        CloudBigtableScanConfiguration config = createConfig(tableName);
         CloudBigtableIO.Source<Result> source = (Source<Result>) CloudBigtableIO.read(config);
         List<SampleRowKeysResponse> sampleRowKeys = source.getSampleRowKeys();
         LOG.info("Creating BoundedSource in testEstimatedAndSplitForSmallTable()");
@@ -289,9 +290,7 @@ public class CloudBigtableIOIntegrationTest {
 
       try {
         LOG.info("Getting Source in testEstimatedAndSplitForLargeTable()");
-        CloudBigtableScanConfiguration config =
-            new CloudBigtableScanConfiguration(projectId, zoneId, clusterId,
-                tableName.getQualifierAsString(), new Scan());
+        CloudBigtableScanConfiguration config = createConfig(tableName);
         CloudBigtableIO.Source<Result> source = (Source<Result>) CloudBigtableIO.read(config);
         List<SampleRowKeysResponse> sampleRowKeys = source.getSampleRowKeys();
         LOG.info("Getting estimated size in testEstimatedAndSplitForLargeTable()");

--- a/bigtable-hbase-dataflow/src/test/java/com/google/cloud/bigtable/dataflow/HBaseResultArrayCoderTest.java
+++ b/bigtable-hbase-dataflow/src/test/java/com/google/cloud/bigtable/dataflow/HBaseResultArrayCoderTest.java
@@ -32,18 +32,16 @@ public class HBaseResultArrayCoderTest {
 
   @Test
   public void testRoundTrip() throws Exception {
-    Result[] copy = CoderTestUtil.encodeAndDecode(underTest, original);
     // This method throws an exception if the values are not equal.
-    Result.compareResults(original[0], copy[0]);
+    Result.compareResults(original[0], CoderTestUtil.encodeAndDecode(underTest, original)[0]);
   }
 
   private Result createResult() {
-    KeyValue kv =
-        new KeyValue("key".getBytes(), "family".getBytes(), "qualifier".getBytes(),
-            System.currentTimeMillis(), "value".getBytes());
-    return Result.create(new Cell[] { kv });
+    return Result.create(new Cell[] { new KeyValue("key".getBytes(), "family".getBytes(),
+        "qualifier".getBytes(), System.currentTimeMillis(), "value".getBytes()) });
   }
 
+  @Test
   public void ensureDeterministic() throws Exception {
     Assert.assertArrayEquals(CoderTestUtil.encode(underTest, original),
       CoderTestUtil.encode(underTest, original));

--- a/bigtable-hbase-dataflow/src/test/java/com/google/cloud/bigtable/dataflow/HBaseResultCoderTest.java
+++ b/bigtable-hbase-dataflow/src/test/java/com/google/cloud/bigtable/dataflow/HBaseResultCoderTest.java
@@ -38,12 +38,11 @@ public class HBaseResultCoderTest {
   }
 
   private Result createResult() {
-    KeyValue kv =
-        new KeyValue("key".getBytes(), "family".getBytes(), "qualifier".getBytes(),
-            System.currentTimeMillis(), "value".getBytes());
-    return Result.create(new Cell[] { kv });
+    return Result.create(new Cell[] { new KeyValue("key".getBytes(), "family".getBytes(),
+        "qualifier".getBytes(), System.currentTimeMillis(), "value".getBytes()) });
   }
 
+  @Test
   public void ensureDeterministic() throws Exception {
     Assert.assertArrayEquals(CoderTestUtil.encode(underTest, original),
       CoderTestUtil.encode(underTest, original));

--- a/bigtable-hbase-integration-tests/pom.xml
+++ b/bigtable-hbase-integration-tests/pom.xml
@@ -89,6 +89,7 @@ limitations under the License.
                                     <systemPropertyVariables>
                                         <bigtable.test.extra.resources>bigtable-test.xml</bigtable.test.extra.resources>
                                     </systemPropertyVariables>
+                                    <forkedProcessTimeoutInSeconds>600</forkedProcessTimeoutInSeconds>
                                 </configuration>
                             </execution>
                         </executions>
@@ -107,8 +108,7 @@ limitations under the License.
                 <dependency>
                     <groupId>io.netty</groupId>
                     <artifactId>netty-tcnative-boringssl-static</artifactId>
-                    <version>1.1.33.Fork13</version>
-                    <classifier>${os.detected.classifier}</classifier>
+                    <version>1.1.33.Fork16</version>
                 </dependency>
             </dependencies>
             <build>
@@ -139,6 +139,7 @@ limitations under the License.
                                     <systemPropertyVariables>
                                         <bigtable.test.extra.resources>bigtable-test.xml</bigtable.test.extra.resources>
                                     </systemPropertyVariables>
+                                    <forkedProcessTimeoutInSeconds>600</forkedProcessTimeoutInSeconds>
                                 </configuration>
                             </execution>
                         </executions>
@@ -194,6 +195,7 @@ limitations under the License.
                                     <systemPropertyVariables>
                                         <bigtable.test.extra.resources>bigtable-test.xml</bigtable.test.extra.resources>
                                     </systemPropertyVariables>
+                                    <forkedProcessTimeoutInSeconds>600</forkedProcessTimeoutInSeconds>
                                 </configuration>
                             </execution>
                         </executions>
@@ -363,14 +365,6 @@ limitations under the License.
         </dependency>
     </dependencies>
     <build>
-        <extensions>
-            <!-- Use os-maven-plugin to initialize the "os.detected" properties -->
-            <extension>
-                <groupId>kr.motd.maven</groupId>
-                <artifactId>os-maven-plugin</artifactId>
-                <version>1.4.1.Final</version>
-            </extension>
-        </extensions>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/bigtable-hbase/pom.xml
+++ b/bigtable-hbase/pom.xml
@@ -73,14 +73,4 @@ limitations under the License.
             <artifactId>commons-lang</artifactId>
         </dependency>
     </dependencies>
-    <build>
-        <extensions>
-            <!-- Use os-maven-plugin to initialize the "os.detected" properties -->
-            <extension>
-                <groupId>kr.motd.maven</groupId>
-                <artifactId>os-maven-plugin</artifactId>
-                <version>1.4.1.Final</version>
-            </extension>
-        </extensions>
-    </build>
 </project>

--- a/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/PutAdapter.java
+++ b/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/PutAdapter.java
@@ -17,14 +17,19 @@ package com.google.cloud.bigtable.hbase.adapters;
 
 import com.google.bigtable.v1.MutateRowRequest;
 import com.google.bigtable.v1.Mutation;
+import com.google.bigtable.v1.Mutation.MutationCase;
+import com.google.bigtable.v1.Mutation.SetCell;
 import com.google.bigtable.v1.Mutation.SetCell.Builder;
 import com.google.cloud.bigtable.hbase.BigtableConstants;
+import com.google.cloud.bigtable.hbase.adapters.read.RowCell;
+import com.google.protobuf.BigtableZeroCopyByteStringUtil;
 import com.google.protobuf.ByteString;
 
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.client.Put;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Map.Entry;
 
@@ -47,12 +52,13 @@ public class PutAdapter implements OperationAdapter<Put, MutateRowRequest.Builde
 
   @Override
   public MutateRowRequest.Builder adapt(Put operation) {
-    MutateRowRequest.Builder result = MutateRowRequest.newBuilder();
-    result.setRowKey(ByteString.copyFrom(operation.getRow()));
 
     if (operation.isEmpty()) {
       throw new IllegalArgumentException("No columns to insert");
     }
+
+    MutateRowRequest.Builder result = MutateRowRequest.newBuilder();
+    result.setRowKey(ByteString.copyFrom(operation.getRow()));
 
     // Bigtable uses a 1ms granularity. Use this timestamp if the Put does not have one specified to
     // make mutations idempotent.
@@ -101,5 +107,35 @@ public class PutAdapter implements OperationAdapter<Put, MutateRowRequest.Builde
     }
 
     return result;
+  }
+
+  public Put adapt(MutateRowRequest request) throws IOException {
+    if (request.getMutationsCount() == 0) {
+      throw new IllegalArgumentException("No columns to insert");
+    }
+
+    byte[] rowkeyArray = request.getRowKey().toByteArray();
+    Put put = new Put(rowkeyArray);
+    for (Mutation mutation : request.getMutationsList()) {
+      if (mutation.getMutationCase() != MutationCase.SET_CELL) {
+        throw new IllegalArgumentException(
+            "Cannot process mutation of type: " + mutation.getMutationCase());
+      }
+      SetCell setCell = mutation.getSetCell();
+      long timestampHbase;
+      if (setCell.getTimestampMicros() == -1) {
+        timestampHbase = HConstants.LATEST_TIMESTAMP;
+      } else {
+        timestampHbase = BigtableConstants.HBASE_TIMEUNIT.convert(setCell.getTimestampMicros(),
+          BigtableConstants.BIGTABLE_TIMEUNIT);
+      }
+      put.add(new RowCell(rowkeyArray, getBytes(setCell.getFamilyNameBytes()),
+          getBytes(setCell.getColumnQualifier()), timestampHbase, getBytes(setCell.getValue())));
+    }
+    return put;
+  }
+
+  private static byte[] getBytes(ByteString bs) {
+    return BigtableZeroCopyByteStringUtil.zeroCopyGetBytes(bs);
   }
 }

--- a/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/TestDeleteAdapter.java
+++ b/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/TestDeleteAdapter.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.bigtable.hbase.adapters;
 
+import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.hbase.client.Delete;
@@ -43,7 +44,7 @@ public class TestDeleteAdapter {
   protected DataGenerationHelper randomHelper = new DataGenerationHelper();
 
   @Test
-  public void testFullRowDelete() {
+  public void testFullRowDelete() throws IOException {
     byte[] rowKey = randomHelper.randomData("rk1-");
     Delete delete = new Delete(rowKey);
     MutateRowRequest.Builder rowMutation = deleteAdapter.adapt(delete);
@@ -54,6 +55,8 @@ public class TestDeleteAdapter {
     Mutation.MutationCase mutationCase = rowMutation.getMutations(0).getMutationCase();
 
     Assert.assertEquals(MutationCase.DELETE_FROM_ROW, mutationCase);
+
+    testTwoWayAdapt(delete, deleteAdapter);
   }
 
   @Test
@@ -68,7 +71,7 @@ public class TestDeleteAdapter {
   }
 
   @Test
-  public void testColumnFamilyDelete() {
+  public void testColumnFamilyDelete() throws IOException {
     byte[] rowKey = randomHelper.randomData("rk1-");
     byte[] family = randomHelper.randomData("family1-");
     Delete delete = new Delete(rowKey);
@@ -85,6 +88,8 @@ public class TestDeleteAdapter {
     Mutation.DeleteFromFamily deleteFromFamily =
         rowMutation.getMutations(0).getDeleteFromFamily();
     Assert.assertArrayEquals(family, deleteFromFamily.getFamilyNameBytes().toByteArray());
+
+    testTwoWayAdapt(delete, deleteAdapter);
   }
 
   @Test
@@ -100,7 +105,7 @@ public class TestDeleteAdapter {
   }
 
   @Test
-  public void testDeleteColumnAtTimestamp() {
+  public void testDeleteColumnAtTimestamp() throws IOException {
     byte[] rowKey = randomHelper.randomData("rk1-");
     byte[] family = randomHelper.randomData("family1-");
     byte[] qualifier = randomHelper.randomData("qualifier");
@@ -128,6 +133,8 @@ public class TestDeleteAdapter {
     TimestampRange timeStampRange = deleteFromColumn.getTimeRange();
     Assert.assertEquals(bigtableStartTimestamp, timeStampRange.getStartTimestampMicros());
     Assert.assertEquals(bigtableEndTimestamp, timeStampRange.getEndTimestampMicros());
+
+    testTwoWayAdapt(delete, deleteAdapter);
   }
 
   @Test
@@ -146,7 +153,7 @@ public class TestDeleteAdapter {
   }
 
   @Test
-  public void testDeleteColumnBeforeTimestamp() {
+  public void testDeleteColumnBeforeTimestamp() throws IOException {
     byte[] rowKey = randomHelper.randomData("rk1-");
     byte[] family = randomHelper.randomData("family1-");
     byte[] qualifier = randomHelper.randomData("qualifier");
@@ -170,6 +177,8 @@ public class TestDeleteAdapter {
     TimestampRange timeRange = deleteFromColumn.getTimeRange();
     Assert.assertEquals(0L, timeRange.getStartTimestampMicros());
     Assert.assertEquals(bigtableTimestamp, timeRange.getEndTimestampMicros());
+
+    testTwoWayAdapt(delete, deleteAdapter);
   }
 
   @Test
@@ -186,5 +195,18 @@ public class TestDeleteAdapter {
     expectedException.expectMessage("Cannot perform column family deletion at timestamp");
 
     deleteAdapter.adapt(delete);
+  }
+
+  /**
+   * Convert the delete to a mutation, back to a delete, back to mutation. Compare the two mutations
+   * for equality.
+   */
+  private void testTwoWayAdapt(Delete delete, DeleteAdapter adapter) throws IOException {
+    // delete -> mutation
+    MutateRowRequest firstAdapt = adapter.adapt(delete).build();
+    // mutation -> delete -> mutation;
+    MutateRowRequest secondAdapt = adapter.adapt(adapter.adapt(firstAdapt)).build();
+    // The round trips
+    Assert.assertEquals(firstAdapt, secondAdapt);
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -61,12 +61,12 @@ limitations under the License.
         <junit.version>4.12</junit.version>
         <mockito.version>1.10.19</mockito.version>
         <protobuff-java.version>3.0.0-beta-1</protobuff-java.version>
-        <grpc.version>0.13.1</grpc.version>
+        <grpc.version>0.14.0</grpc.version>
         <google.api.client.version>1.21.0</google.api.client.version>
         <!-- For Netty HTTP2/TLS negotiation -->
         <alpn.jdk7.version>7.1.3.v20150130</alpn.jdk7.version>
         <alpn.jdk8.version>8.1.3.v20150130</alpn.jdk8.version>
-        <netty.version>4.1.0.CR1</netty.version>
+        <netty.version>4.1.0.CR7</netty.version>
         <guava.version>19.0</guava.version>
         <google.auth.library.version>0.4.0</google.auth.library.version>
         <google.http.client.version>1.21.0</google.http.client.version>


### PR DESCRIPTION
HBase provided a simple serialization mechansi that the Cloud Bigtable
Dataflow took advantage of.  It's incompatible with newer versions
protobuf.  Added new converters between Cloud Bigtable protos to hbase
objects rather than relying on HBase protobuf objects.