### PR TITLE
Integration tests have been taking longer.  

### DIFF
--- a/bigtable-hbase-integration-tests/pom.xml
+++ b/bigtable-hbase-integration-tests/pom.xml
@@ -89,6 +89,7 @@ limitations under the License.
                                     <systemPropertyVariables>
                                         <bigtable.test.extra.resources>bigtable-test.xml</bigtable.test.extra.resources>
                                     </systemPropertyVariables>
+                                    <forkedProcessTimeoutInSeconds>600</forkedProcessTimeoutInSeconds>
                                 </configuration>
                             </execution>
                         </executions>
@@ -139,6 +140,7 @@ limitations under the License.
                                     <systemPropertyVariables>
                                         <bigtable.test.extra.resources>bigtable-test.xml</bigtable.test.extra.resources>
                                     </systemPropertyVariables>
+                                    <forkedProcessTimeoutInSeconds>600</forkedProcessTimeoutInSeconds>
                                 </configuration>
                             </execution>
                         </executions>
@@ -194,6 +196,7 @@ limitations under the License.
                                     <systemPropertyVariables>
                                         <bigtable.test.extra.resources>bigtable-test.xml</bigtable.test.extra.resources>
                                     </systemPropertyVariables>
+                                    <forkedProcessTimeoutInSeconds>600</forkedProcessTimeoutInSeconds>
                                 </configuration>
                             </execution>
                         </executions>
@@ -234,6 +237,7 @@ limitations under the License.
                                         <include>**/IntegrationTests.java</include>
                                     </includes>
                                     <reportNameSuffix>local-mini-cluster</reportNameSuffix>
+                                    <forkedProcessTimeoutInSeconds>600</forkedProcessTimeoutInSeconds>
                                 </configuration>
                             </execution>
                         </executions>
@@ -287,6 +291,7 @@ limitations under the License.
                                     <systemPropertyVariables>
                                         <bigtable.test.extra.resources>bigtable-test.xml</bigtable.test.extra.resources>
                                     </systemPropertyVariables>
+                                    <forkedProcessTimeoutInSeconds>600</forkedProcessTimeoutInSeconds>
                                 </configuration>
                             </execution>
                         </executions>


### PR DESCRIPTION
Fail after 10 minutes, not 5 minutes like we do now.

Hopefully both the bigtable and hbase cluster tests will fail less frequently, especially on developer machines.