### PR TITLE
Refactoring Dataflow configuration.

### DIFF
--- a/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/CloudBigtableConfiguration.java
+++ b/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/CloudBigtableConfiguration.java
@@ -106,7 +106,7 @@ public class CloudBigtableConfiguration implements Serializable {
     public CloudBigtableConfiguration build() {
       return new CloudBigtableConfiguration(projectId, zoneId, clusterId, additionalConfiguration);
     }
-}
+  }
 
   // Not final due to serialization of CloudBigtableScanConfiguration.
   private Map<String, String> configuration;

--- a/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/CloudBigtableIO.java
+++ b/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/CloudBigtableIO.java
@@ -55,7 +55,6 @@ import com.google.cloud.bigtable.config.BulkOptions;
 import com.google.cloud.bigtable.grpc.BigtableDataClient;
 import com.google.cloud.bigtable.grpc.BigtableSession;
 import com.google.cloud.bigtable.grpc.BigtableTableName;
-import com.google.cloud.bigtable.grpc.async.AsyncExecutor;
 import com.google.cloud.bigtable.hbase.BigtableOptionsFactory;
 import com.google.cloud.bigtable.hbase1_0.BigtableConnection;
 import com.google.cloud.dataflow.sdk.Pipeline;
@@ -270,10 +269,9 @@ public class CloudBigtableIO {
     protected List<SourceWithKeys<ResultOutputType>> getSplits(long desiredBundleSizeBytes) throws Exception {
       desiredBundleSizeBytes = Math.max(getEstimatedSizeBytes(null) / SIZED_BASED_MAX_SPLIT_COUNT,
         desiredBundleSizeBytes);
-      Scan scan = configuration.getScan();
-      byte[] scanStartKey = scan.getStartRow();
+      byte[] scanStartKey = configuration.getStartRow();
 
-      byte[] scanEndKey = scan.getStopRow();
+      byte[] scanEndKey = configuration.getStopRow();
       List<SourceWithKeys<ResultOutputType>> splits = new ArrayList<>();
       byte[] startKey = HConstants.EMPTY_START_ROW;
       long lastOffset = 0;
@@ -402,9 +400,8 @@ public class CloudBigtableIO {
     public long getEstimatedSizeBytes(PipelineOptions options) throws Exception {
       long totalEstimatedSizeBytes = 0;
 
-      Scan scan = configuration.getScan();
-      byte[] scanStartKey = scan.getStartRow();
-      byte[] scanEndKey = scan.getStopRow();
+      byte[] scanStartKey = configuration.getStartRow();
+      byte[] scanEndKey = configuration.getStopRow();
 
       byte[] startKey = HConstants.EMPTY_START_ROW;
       long lastOffset = 0;
@@ -550,9 +547,8 @@ public class CloudBigtableIO {
     public long getEstimatedSizeBytes(PipelineOptions options) throws Exception {
       long totalEstimatedSizeBytes = 0;
 
-      Scan scan = configuration.getScan();
-      byte[] scanStartKey = scan.getStartRow();
-      byte[] scanEndKey = scan.getStopRow();
+      byte[] scanStartKey = configuration.getStartRow();
+      byte[] scanEndKey = configuration.getStopRow();
 
       byte[] startKey = HConstants.EMPTY_START_ROW;
       long lastOffset = 0;
@@ -605,10 +601,9 @@ public class CloudBigtableIO {
         ScanIterator<ResultOutputType> scanIterator,
         long estimatedSize) {
       super(configuration, coderType, scanIterator);
-      Scan scan = configuration.getScan();
 
-      byte[] startRow = scan.getStartRow();
-      byte[] stopRow = scan.getStopRow();
+      byte[] startRow = configuration.getStartRow();
+      byte[] stopRow = configuration.getStopRow();
       if (stopRow.length > 0) {
         if (Bytes.compareTo(startRow, stopRow) >= 0) {
           throw new IllegalArgumentException(String.format(
@@ -657,28 +652,26 @@ public class CloudBigtableIO {
     @Override
     public List<? extends BoundedSource<ResultOutputType>> splitIntoBundles(long desiredBundleSizeBytes,
         PipelineOptions options) throws Exception {
-      Scan scan = configuration.getScan();
-      List<? extends BoundedSource<ResultOutputType>> newSplits =
-          split(estimatedSize, desiredBundleSizeBytes, scan.getStartRow(), scan.getStopRow());
+      List<? extends BoundedSource<ResultOutputType>> newSplits = split(estimatedSize,
+        desiredBundleSizeBytes, configuration.getStartRow(), configuration.getStopRow());
       SOURCE_LOG.trace("Splitting split {} into {}", this, newSplits);
       return newSplits;
     }
 
     public byte[] getStartRow() {
-      return configuration.getScan().getStartRow();
+      return configuration.getStartRow();
     }
 
     public byte[] getStopRow() {
-      return configuration.getScan().getStopRow();
+      return configuration.getStopRow();
     }
 
     @Override
     public String toString() {
-      Scan scan = configuration.getScan();
       return String.format(
           "Split start: '%s', end: '%s', size: %d",
-          Bytes.toStringBinary(scan.getStartRow()),
-          Bytes.toStringBinary(scan.getStopRow()),
+          Bytes.toStringBinary(configuration.getStartRow()),
+          Bytes.toStringBinary(configuration.getStopRow()),
           estimatedSize);
     }
   }
@@ -768,12 +761,10 @@ public class CloudBigtableIO {
 
     @Override
     public String toString() {
-      byte[] startRow = config.getScan().getStartRow();
-      byte[] stopRow = config.getScan().getStopRow();
       return String.format(
           "Reader for: ['%s' - '%s']",
-          Bytes.toStringBinary(startRow),
-          Bytes.toStringBinary(stopRow));
+          Bytes.toStringBinary(config.getStartRow()),
+          Bytes.toStringBinary(config.getStopRow()));
     }
   }
 

--- a/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/CloudBigtableScanConfiguration.java
+++ b/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/CloudBigtableScanConfiguration.java
@@ -240,6 +240,20 @@ public class CloudBigtableScanConfiguration extends CloudBigtableTableConfigurat
     return serializableScan.scan;
   }
 
+  /**
+   * @return The start row for this configuration.
+   */
+  public byte[] getStartRow() {
+    return getScan().getStartRow();
+  }
+
+  /**
+   * @return The stop row for this configuration.
+   */
+  public byte[] getStopRow() {
+    return getScan().getStopRow();
+  }
+
   @Override
   public boolean equals(Object obj) {
     return super.equals(obj)

--- a/bigtable-hbase-dataflow/src/test/java/com/google/cloud/bigtable/dataflow/CloudBigtableConfigurationTest.java
+++ b/bigtable-hbase-dataflow/src/test/java/com/google/cloud/bigtable/dataflow/CloudBigtableConfigurationTest.java
@@ -19,7 +19,6 @@ package com.google.cloud.bigtable.dataflow;
 import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
-import java.util.Collections;
 
 import org.junit.Assert;
 
@@ -41,11 +40,17 @@ public class CloudBigtableConfigurationTest {
   private static final String CLUSTER = "cluster";
   private static final String ZONE = "some-zone-1a";
 
+  private static CloudBigtableConfiguration createConfiguration() {
+    return new CloudBigtableConfiguration.Builder()
+        .withProjectId(PROJECT)
+        .withClusterId(CLUSTER)
+        .withZoneId(ZONE)
+        .build();
+  }
+
   @Test
   public void testHBaseConfig() throws IOException {
-    CloudBigtableConfiguration underTest =
-        new CloudBigtableConfiguration(PROJECT, ZONE, CLUSTER,
-            Collections.<String, String> emptyMap());
+    CloudBigtableConfiguration underTest = createConfiguration();
 
     Configuration config = underTest.toHBaseConfig();
 
@@ -56,21 +61,14 @@ public class CloudBigtableConfigurationTest {
 
   @Test
   public void testEquals() {
-    CloudBigtableConfiguration underTest1 =
-        new CloudBigtableConfiguration(PROJECT, ZONE, CLUSTER,
-            Collections.<String, String> emptyMap());
-    CloudBigtableConfiguration underTest2 =
-        new CloudBigtableConfiguration(PROJECT, ZONE, CLUSTER,
-            Collections.<String, String> emptyMap());
+    CloudBigtableConfiguration underTest1 = createConfiguration();
+    CloudBigtableConfiguration underTest2 = createConfiguration();
     CloudBigtableConfiguration underTest3 =
-        new CloudBigtableConfiguration(PROJECT, ZONE, CLUSTER,
-            Collections.singletonMap("somekey", "somevalue"));
+        createConfiguration().toBuilder().withConfiguration("somekey", "somevalue").build();
     CloudBigtableConfiguration underTest4 =
-        new CloudBigtableConfiguration("other_project", ZONE, CLUSTER,
-            Collections.<String, String> emptyMap());
+        createConfiguration().toBuilder().withProjectId("other_project").build();
     CloudBigtableConfiguration underTest5 =
-      new CloudBigtableConfiguration(PROJECT, ZONE, CLUSTER,
-        Collections.singletonMap("somekey", "somevalue"));
+        createConfiguration().toBuilder().withConfiguration("somekey", "somevalue").build();
 
     // Test CloudBigtableConfiguration that should be equal.
     Assert.assertEquals(underTest1, underTest2);
@@ -88,8 +86,7 @@ public class CloudBigtableConfigurationTest {
   @Test
   public void testToBuilder() {
     CloudBigtableConfiguration underTest =
-        new CloudBigtableConfiguration(PROJECT, ZONE, CLUSTER, Collections.singletonMap("somekey",
-          "somevalue"));
+        createConfiguration().toBuilder().withConfiguration("somekey", "somevalue").build();
     CloudBigtableConfiguration copy = underTest.toBuilder().build();
     Assert.assertNotSame(underTest, copy);
     Assert.assertEquals(underTest, copy);

--- a/bigtable-hbase-dataflow/src/test/java/com/google/cloud/bigtable/dataflow/CloudBigtableIOIntegrationTest.java
+++ b/bigtable-hbase-dataflow/src/test/java/com/google/cloud/bigtable/dataflow/CloudBigtableIOIntegrationTest.java
@@ -3,7 +3,6 @@ package com.google.cloud.bigtable.dataflow;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
@@ -90,8 +89,12 @@ public class CloudBigtableIOIntegrationTest {
   }
 
   private static CloudBigtableTableConfiguration createTableConfig(String tableId) {
-    return new CloudBigtableTableConfiguration(projectId,
-        zoneId, clusterId, tableId, Collections.<String, String>emptyMap());
+    return new CloudBigtableTableConfiguration.Builder()
+        .withProjectId(projectId)
+        .withZoneId(zoneId)
+        .withClusterId(clusterId)
+        .withTableId(tableId)
+        .build();
   }
 
   @Test

--- a/bigtable-hbase-dataflow/src/test/java/com/google/cloud/bigtable/dataflow/CloudBigtableScanConfigurationTest.java
+++ b/bigtable-hbase-dataflow/src/test/java/com/google/cloud/bigtable/dataflow/CloudBigtableScanConfigurationTest.java
@@ -22,8 +22,6 @@ import org.junit.Test;
 import com.google.cloud.bigtable.dataflow.CloudBigtableScanConfiguration;
 import com.google.cloud.dataflow.sdk.util.SerializableUtils;
 
-import java.util.Collections;
-
 /**
  * Tests for {@link CloudBigtableScanConfiguration}.
  */
@@ -37,15 +35,20 @@ public class CloudBigtableScanConfigurationTest {
   public static final byte[] START_ROW = "aa".getBytes();
   public static final byte[] STOP_ROW = "zz".getBytes();
 
+
+  private static CloudBigtableScanConfiguration createConfiguration(Scan scan) {
+    return new CloudBigtableScanConfiguration.Builder()
+        .withProjectId(PROJECT)
+        .withZoneId(ZONE)
+        .withClusterId(CLUSTER)
+        .withTableId(TABLE)
+        .withScan(scan)
+        .build();
+  }
+
   @Test
   public void testSerialization() {
-    CloudBigtableScanConfiguration config = new CloudBigtableScanConfiguration.Builder()
-      .withProjectId(PROJECT)
-      .withZoneId(ZONE)
-      .withClusterId(CLUSTER)
-      .withTableId(TABLE)
-      .withScan(new Scan(START_ROW, STOP_ROW))
-      .build();
+    CloudBigtableScanConfiguration config = createConfiguration(new Scan(START_ROW, STOP_ROW));
 
     CloudBigtableScanConfiguration serialized = SerializableUtils.ensureSerializable(config);
 
@@ -62,15 +65,9 @@ public class CloudBigtableScanConfigurationTest {
   public void testEquals() {
     Scan scan1 = new Scan();
     Scan scan2 = new Scan(START_ROW, STOP_ROW);
-    CloudBigtableScanConfiguration underTest1 =
-        new CloudBigtableScanConfiguration(PROJECT, ZONE, CLUSTER, TABLE, scan1,
-            Collections.<String, String> emptyMap());
-    CloudBigtableScanConfiguration underTest2 =
-        new CloudBigtableScanConfiguration(PROJECT, ZONE, CLUSTER, TABLE, scan1,
-            Collections.<String, String> emptyMap());
-    CloudBigtableScanConfiguration underTest3 =
-        new CloudBigtableScanConfiguration(PROJECT, ZONE, CLUSTER, TABLE, scan2,
-            Collections.<String, String> emptyMap());
+    CloudBigtableScanConfiguration underTest1 = createConfiguration(scan1);
+    CloudBigtableScanConfiguration underTest2 = createConfiguration(scan1);
+    CloudBigtableScanConfiguration underTest3 = createConfiguration(scan2);
 
     // Test CloudBigtableScanConfigurations that should be equal.
     Assert.assertEquals(underTest1, underTest2);
@@ -81,12 +78,9 @@ public class CloudBigtableScanConfigurationTest {
 
   @Test
   public void testToBuilder() {
-    CloudBigtableScanConfiguration underTest =
-        new CloudBigtableScanConfiguration(PROJECT, ZONE, CLUSTER, TABLE, new Scan(START_ROW,
-            STOP_ROW), Collections.<String, String> emptyMap());
+    CloudBigtableScanConfiguration underTest = createConfiguration(new Scan(START_ROW, STOP_ROW));
     CloudBigtableScanConfiguration copy = underTest.toBuilder().build();
     Assert.assertNotSame(underTest, copy);
     Assert.assertEquals(underTest, copy);
   }
 }
-

--- a/bigtable-hbase-dataflow/src/test/java/com/google/cloud/bigtable/dataflow/CloudBigtableTableConfigurationTest.java
+++ b/bigtable-hbase-dataflow/src/test/java/com/google/cloud/bigtable/dataflow/CloudBigtableTableConfigurationTest.java
@@ -19,7 +19,6 @@ package com.google.cloud.bigtable.dataflow;
 import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
-import java.util.Collections;
 
 import org.junit.Assert;
 
@@ -42,11 +41,19 @@ public class CloudBigtableTableConfigurationTest {
   private static final String ZONE = "some-zone-1a";
   private static final String TABLE = "some-zone-1a";
 
+  protected static CloudBigtableTableConfiguration buildConfiguration() {
+    return configure(new CloudBigtableTableConfiguration.Builder().withTableId(TABLE)).build();
+  }
+
+  protected static <ConfigurationBuilder extends CloudBigtableConfiguration.Builder>
+      ConfigurationBuilder configure(ConfigurationBuilder builder) {
+    builder.withProjectId(PROJECT).withZoneId(ZONE).withClusterId(CLUSTER);
+    return builder;
+  }
+
   @Test
   public void testHBaseConfig() throws IOException {
-    CloudBigtableTableConfiguration underTest =
-        new CloudBigtableTableConfiguration(PROJECT, ZONE, CLUSTER, TABLE,
-            Collections.<String, String> emptyMap());
+    CloudBigtableTableConfiguration underTest = buildConfiguration();
 
     Configuration config = underTest.toHBaseConfig();
 
@@ -58,21 +65,14 @@ public class CloudBigtableTableConfigurationTest {
 
   @Test
   public void testEquals() {
-    CloudBigtableTableConfiguration underTest1 =
-        new CloudBigtableTableConfiguration(PROJECT, ZONE, CLUSTER, TABLE,
-            Collections.<String, String> emptyMap());
-    CloudBigtableTableConfiguration underTest2 =
-        new CloudBigtableTableConfiguration(PROJECT, ZONE, CLUSTER, TABLE,
-            Collections.<String, String> emptyMap());
+    CloudBigtableTableConfiguration underTest1 = buildConfiguration();
+    CloudBigtableTableConfiguration underTest2 = buildConfiguration();
     CloudBigtableTableConfiguration underTest3 =
-        new CloudBigtableTableConfiguration(PROJECT, ZONE, CLUSTER, TABLE,
-            Collections.singletonMap("somekey", "somevalue"));
+        underTest1.toBuilder().withConfiguration("somekey", "somevalue").build();
     CloudBigtableTableConfiguration underTest4 =
-        new CloudBigtableTableConfiguration("other_project", ZONE, CLUSTER, TABLE,
-            Collections.<String, String> emptyMap());
+        underTest1.toBuilder().withProjectId("other_project").build();
     CloudBigtableConfiguration underTest5 =
-        new CloudBigtableConfiguration(PROJECT, ZONE, CLUSTER,
-            Collections.<String, String> emptyMap());
+        configure(new CloudBigtableConfiguration.Builder()).build();
 
     // Test CloudBigtableTableConfiguration that should be equal.
     Assert.assertEquals(underTest1, underTest2);
@@ -94,8 +94,7 @@ public class CloudBigtableTableConfigurationTest {
   @Test
   public void testToBuilder(){
     CloudBigtableTableConfiguration underTest =
-        new CloudBigtableTableConfiguration(PROJECT, ZONE, CLUSTER, TABLE,
-            Collections.singletonMap("somekey", "somevalue"));
+        buildConfiguration().toBuilder().withConfiguration("somekey", "somevalue").build();
     CloudBigtableTableConfiguration copy = underTest.toBuilder().build();
     Assert.assertNotSame(underTest, copy);
     Assert.assertEquals(underTest, copy);


### PR DESCRIPTION
- Replacing usages of CloudBigtableScanConfiguration scan start and stop keys to use new methods in CloudBigtableScanConfiguration.
- Replacing usages of CloudBigtable*Configuration constructors to use Builders instead.