### PR TITLE
Updating grpc, netty and protobuf versions.

### DIFF
--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/util/ByteStringer.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/util/ByteStringer.java
@@ -17,7 +17,7 @@ public class ByteStringer {
    */
   private static boolean USE_ZEROCOPYBYTESTRING = true;
 
-  // Can I classload HBaseZeroCopyByteString without IllegalAccessError?
+  // Can I classload BigtableZeroCopyByteStringUtil without IllegalAccessError?
   // If we can, use it passing ByteStrings to pb else use native ByteString though more costly
   // because it makes a copy of the passed in array.
   static {

--- a/bigtable-dataflow-import/src/test/java/org/apache/hadoop/hbase/util/ByteStringer.java
+++ b/bigtable-dataflow-import/src/test/java/org/apache/hadoop/hbase/util/ByteStringer.java
@@ -1,0 +1,71 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.util;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.hbase.classification.InterfaceAudience;
+
+import com.google.cloud.bigtable.dataflowimport.testing.SequenceFileIoUtils;
+import com.google.protobuf.BigtableZeroCopyByteStringUtil;
+import com.google.protobuf.ByteString;
+
+/**
+ * Hack to make {@link SequenceFileIoUtils#createFileWithData(java.io.File, java.util.Collection)}
+ * work with the newer version of protobuf required by bigtable.
+ */
+@InterfaceAudience.Private
+public class ByteStringer {
+  private static final Log LOG = LogFactory.getLog(ByteStringer.class);
+
+  /**
+   * Flag set at class loading time.
+   */
+  private static boolean USE_ZEROCOPYBYTESTRING = true;
+
+  // Can I classload BigtableZeroCopyByteStringUtil without IllegalAccessError?
+  // If we can, use it passing ByteStrings to pb else use native ByteString though more costly
+  // because it makes a copy of the passed in array.
+  static {
+    try {
+      BigtableZeroCopyByteStringUtil.wrap(new byte [0]);
+    } catch (IllegalAccessError iae) {
+      USE_ZEROCOPYBYTESTRING = false;
+      LOG.debug("Failed to classload BigtableZeroCopyByteString: " + iae.toString());
+    }
+  }
+
+  private ByteStringer() {
+    super();
+  }
+
+  /**
+   * Wraps a byte array in a {@link ByteString} without copying it.
+   */
+  public static ByteString wrap(final byte[] array) {
+    return USE_ZEROCOPYBYTESTRING? BigtableZeroCopyByteStringUtil.wrap(array): ByteString.copyFrom(array);
+  }
+
+  /**
+   * Wraps a subset of a byte array in a {@link ByteString} without copying it.
+   */
+  public static ByteString wrap(final byte[] array, int offset, int length) {
+    return USE_ZEROCOPYBYTESTRING? BigtableZeroCopyByteStringUtil.wrap(array, offset, length):
+      ByteString.copyFrom(array, offset, length);
+  }
+}

--- a/bigtable-hbase-integration-tests/pom.xml
+++ b/bigtable-hbase-integration-tests/pom.xml
@@ -108,8 +108,7 @@ limitations under the License.
                 <dependency>
                     <groupId>io.netty</groupId>
                     <artifactId>netty-tcnative-boringssl-static</artifactId>
-                    <version>1.1.33.Fork13</version>
-                    <classifier>${os.detected.classifier}</classifier>
+                    <version>1.1.33.Fork16</version>
                 </dependency>
             </dependencies>
             <build>
@@ -255,9 +254,8 @@ limitations under the License.
                 </dependency>
                 <dependency>
                     <groupId>io.netty</groupId>
-                    <artifactId>netty-tcnative</artifactId>
-                    <version>1.1.33.Fork9</version>
-                    <classifier>${os.detected.classifier}</classifier>
+                    <artifactId>netty-tcnative-boringssl-static</artifactId>
+                    <version>1.1.33.Fork16</version>
                 </dependency>
             </dependencies>
             <build>
@@ -368,14 +366,6 @@ limitations under the License.
         </dependency>
     </dependencies>
     <build>
-        <extensions>
-            <!-- Use os-maven-plugin to initialize the "os.detected" properties -->
-            <extension>
-                <groupId>kr.motd.maven</groupId>
-                <artifactId>os-maven-plugin</artifactId>
-                <version>1.4.1.Final</version>
-            </extension>
-        </extensions>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/bigtable-hbase/pom.xml
+++ b/bigtable-hbase/pom.xml
@@ -73,14 +73,4 @@ limitations under the License.
             <artifactId>commons-lang</artifactId>
         </dependency>
     </dependencies>
-    <build>
-        <extensions>
-            <!-- Use os-maven-plugin to initialize the "os.detected" properties -->
-            <extension>
-                <groupId>kr.motd.maven</groupId>
-                <artifactId>os-maven-plugin</artifactId>
-                <version>1.4.1.Final</version>
-            </extension>
-        </extensions>
-    </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -60,13 +60,13 @@ limitations under the License.
         <compat.module>hbase-hadoop2-compat</compat.module>
         <junit.version>4.12</junit.version>
         <mockito.version>1.10.19</mockito.version>
-        <protobuff-java.version>3.0.0-beta-1</protobuff-java.version>
-        <grpc.version>0.13.1</grpc.version>
+        <protobuff-java.version>3.0.0-beta-2</protobuff-java.version>
+        <grpc.version>0.14.0</grpc.version>
         <google.api.client.version>1.21.0</google.api.client.version>
         <!-- For Netty HTTP2/TLS negotiation -->
         <alpn.jdk7.version>7.1.3.v20150130</alpn.jdk7.version>
         <alpn.jdk8.version>8.1.3.v20150130</alpn.jdk8.version>
-        <netty.version>4.1.0.CR1</netty.version>
+        <netty.version>4.1.0.CR7</netty.version>
         <guava.version>19.0</guava.version>
         <google.auth.library.version>0.4.0</google.auth.library.version>
         <google.http.client.version>1.21.0</google.http.client.version>


### PR DESCRIPTION
We needed to do a bit of a hack with org.apache.hadoop.hbase.util.ByteStringer to get the bigtable-dataflow-import utilities create test files.