### PR TITLE
Adding v2 BulkMutation

### DIFF
--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BulkMutation.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BulkMutation.java
@@ -38,7 +38,7 @@ import io.grpc.StatusRuntimeException;
 
 import java.io.IOException;
 import java.util.ArrayList;
- import java.util.Iterator;
+import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -163,11 +163,10 @@ public class BulkMutation {
 
             @Override
             public void onFailure(Throwable t) {
-              perfromFullRetry(new AtomicReference<Long>(), t);
+              performFullRetry(new AtomicReference<Long>(), t);
             }
           });
     }
-
 
     synchronized void handleResult(MutateRowsResponse result) {
       AtomicReference<Long> backoffTime = new AtomicReference<>();
@@ -179,7 +178,7 @@ public class BulkMutation {
       if (result == null
           || result.getStatusesList() == null
           || result.getStatusesList().isEmpty()) {
-        perfromFullRetry(backoffTime, new IllegalStateException("empty result or statuses"));
+        performFullRetry(backoffTime, new IllegalStateException("empty result or statuses"));
         return;
       }
 
@@ -198,11 +197,11 @@ public class BulkMutation {
         LOG.error(
           "Unexpected Exception occurred. Treating this issue as a temporary issue and retrying.",
           e);
-        perfromFullRetry(backoffTime, e);
+        performFullRetry(backoffTime, e);
       }
     }
 
-    private void perfromFullRetry(AtomicReference<Long> backOffTime, Throwable t) {
+    private void performFullRetry(AtomicReference<Long> backOffTime, Throwable t) {
       getCurrentBackoff(backOffTime);
       if (backOffTime.get() == BackOff.STOP) {
         setFailure(new BigtableRetriesExhaustedException("Exhausted retries.", t));

--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/v2/AsyncExecutor.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/v2/AsyncExecutor.java
@@ -1,0 +1,318 @@
+/*
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.grpc.async.v2;
+
+import java.io.IOException;
+import java.util.List;
+
+import com.google.bigtable.v2.CheckAndMutateRowRequest;
+import com.google.bigtable.v2.CheckAndMutateRowResponse;
+import com.google.bigtable.v2.MutateRowRequest;
+import com.google.bigtable.v2.MutateRowResponse;
+import com.google.bigtable.v2.MutateRowsRequest;
+import com.google.bigtable.v2.MutateRowsResponse;
+import com.google.bigtable.v2.ReadModifyWriteRowRequest;
+import com.google.bigtable.v2.ReadModifyWriteRowResponse;
+import com.google.bigtable.v2.ReadRowsRequest;
+import com.google.bigtable.v2.Row;
+import com.google.cloud.bigtable.config.Logger;
+import com.google.cloud.bigtable.grpc.async.RpcThrottler;
+import com.google.cloud.bigtable.grpc.v2.BigtableDataClient;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.protobuf.GeneratedMessage;
+
+/**
+ * This class provides management of asynchronous Bigtable RPCs. It ensures that there aren't too
+ * many concurrent, in flight asynchronous RPCs and also makes sure that the memory used by the
+ * requests doesn't exceed a threshold.
+ */
+public class AsyncExecutor {
+
+  protected static final Logger LOG = new Logger(AsyncExecutor.class);
+
+  protected interface AsyncCall<RequestT, ResponseT> {
+    ListenableFuture<ResponseT> call(BigtableDataClient client, RequestT request);
+  }
+
+  /**
+   * Calls {@link BigtableDataClient#mutateRowAsync(MutateRowRequest)}.
+   */
+  protected static AsyncCall<MutateRowRequest, MutateRowResponse> MUTATE_ROW_ASYNC =
+      new AsyncCall<MutateRowRequest, MutateRowResponse>() {
+        @Override
+        public ListenableFuture<MutateRowResponse> call(BigtableDataClient client, MutateRowRequest request) {
+          return client.mutateRowAsync(request);
+        }
+      };
+
+  /**
+   * Calls {@link BigtableDataClient#mutateRowsAsync(MutateRowsRequest)}.
+   */
+  protected static AsyncCall<MutateRowsRequest, List<MutateRowsResponse>> MUTATE_ROWS_ASYNC =
+      new AsyncCall<MutateRowsRequest, List<MutateRowsResponse>>() {
+        @Override
+        public ListenableFuture<List<MutateRowsResponse>> call(BigtableDataClient client,
+            MutateRowsRequest request) {
+          return client.mutateRowsAsync(request);
+        }
+      };
+
+  /**
+   * Calls {@link BigtableDataClient#readModifyWriteRowAsync(ReadModifyWriteRowRequest)}.
+   */
+  protected static AsyncCall<ReadModifyWriteRowRequest, ReadModifyWriteRowResponse> READ_MODIFY_WRITE_ASYNC =
+      new AsyncCall<ReadModifyWriteRowRequest, ReadModifyWriteRowResponse>() {
+        @Override
+        public ListenableFuture<ReadModifyWriteRowResponse> call(BigtableDataClient client,
+            ReadModifyWriteRowRequest request) {
+          return client.readModifyWriteRowAsync(request);
+        }
+      };
+
+  /**
+   * Calls {@link BigtableDataClient#checkAndMutateRowAsync(CheckAndMutateRowRequest)}.
+   */
+  protected static AsyncCall<CheckAndMutateRowRequest, CheckAndMutateRowResponse> CHECK_AND_MUTATE_ASYNC =
+      new AsyncCall<CheckAndMutateRowRequest, CheckAndMutateRowResponse>() {
+        @Override
+        public ListenableFuture<CheckAndMutateRowResponse> call(BigtableDataClient client,
+            CheckAndMutateRowRequest request) {
+          return client.checkAndMutateRowAsync(request);
+        }
+      };
+
+  /**
+   * Calls {@link BigtableDataClient#readRowsAsync(ReadRowsRequest)}.
+   */
+  protected static AsyncCall<ReadRowsRequest, List<Row>> READ_ROWS_ASYNC =
+      new AsyncCall<ReadRowsRequest, List<Row>>() {
+        @Override
+        public ListenableFuture<List<Row>> call(BigtableDataClient client, ReadRowsRequest request) {
+          return client.readRowsAsync(request);
+        }
+      };
+
+  private final BigtableDataClient client;
+  private final RpcThrottler rpcThrottler;
+
+  public AsyncExecutor(BigtableDataClient client, RpcThrottler rpcThrottler) {
+    this.client = client;
+    this.rpcThrottler = rpcThrottler;
+  }
+
+  /**
+   * Performs a {@link BigtableDataClient#mutateRowAsync(MutateRowRequest)} on the
+   * {@link MutateRowRequest} given an operationId generated from
+   * {@link RpcThrottler#registerOperationWithHeapSize(long)}.
+   *
+   * @param request The {@link MutateRowRequest} to send.
+   * @param operationId The Id generated from
+   *          {@link RpcThrottler#registerOperationWithHeapSize(long)} that will be released when
+   *          the mutate operation is completed.
+   *
+   * @return a {@link ListenableFuture} which can be listened to for completion events.
+   */
+  public ListenableFuture<MutateRowResponse> mutateRowAsync(MutateRowRequest request,
+      long operationId) {
+    return call(MUTATE_ROW_ASYNC, request, operationId);
+  }
+
+  /**
+   * Performs a {@link BigtableDataClient#mutateRowsAsync(MutateRowsRequest)} on the
+   * {@link MutateRowsRequest} given an operationId generated from
+   * {@link RpcThrottler#registerOperationWithHeapSize(long)}.
+   *
+   * @param request The {@link MutateRowsRequest} to send.
+   * @param operationId The Id generated from
+   *          {@link RpcThrottler#registerOperationWithHeapSize(long)} that will be released when
+   *          the mutate operation is completed.
+   *
+   * @return a {@link ListenableFuture} which can be listened to for completion events.
+   */
+  public ListenableFuture<List<MutateRowsResponse>> mutateRowAsync(MutateRowsRequest request,
+      long operationId) {
+    return call(MUTATE_ROWS_ASYNC, request, operationId);
+  }
+
+  /**
+   * Performs a {@link BigtableDataClient#checkAndMutateRowAsync(CheckAndMutateRowRequest)} on the
+   * {@link CheckAndMutateRowRequest} given an operationId generated from
+   * {@link RpcThrottler#registerOperationWithHeapSize(long)}.
+   *
+   * @param request The {@link CheckAndMutateRowRequest} to send.
+   * @param operationId The Id generated from
+   *          {@link RpcThrottler#registerOperationWithHeapSize(long)} that will be released when
+   *          the checkAndMutateRow operation is completed.
+   *
+   * @return a {@link ListenableFuture} which can be listened to for completion events.
+   */
+  public ListenableFuture<CheckAndMutateRowResponse> checkAndMutateRowAsync(
+      CheckAndMutateRowRequest request, long operationId) {
+    return call(CHECK_AND_MUTATE_ASYNC, request, operationId);
+  }
+
+  /**
+   * Performs a {@link BigtableDataClient#readModifyWriteRowAsync(ReadModifyWriteRowRequest)} on the
+   * {@link ReadModifyWriteRowRequest} given an operationId generated from
+   * {@link RpcThrottler#registerOperationWithHeapSize(long)}.
+   *
+   * @param request The {@link ReadModifyWriteRowRequest} to send.
+   * @param operationId The Id generated from
+   *          {@link RpcThrottler#registerOperationWithHeapSize(long)} that will be released when
+   *          the readModifyWriteRowAsync operation is completed.
+   *
+   * @return a {@link ListenableFuture} which can be listened to for completion events.
+   */
+  public ListenableFuture<ReadModifyWriteRowResponse>
+      readModifyWriteRowAsync(ReadModifyWriteRowRequest request, long operationId) {
+    return call(READ_MODIFY_WRITE_ASYNC, request, operationId);
+  }
+
+  /**
+   * Performs a {@link BigtableDataClient#readRowsAsync(ReadRowsRequest)} on the
+   * {@link ReadRowsRequest} given an operationId generated from
+   * {@link RpcThrottler#registerOperationWithHeapSize(long)}.
+   *
+   * @param request The {@link ReadRowsRequest} to send.
+   *
+   * @return a {@link ListenableFuture} which can be listened to for completion events.
+   */
+  public ListenableFuture<List<Row>> readRowsAsync(ReadRowsRequest request, long operationId) {
+    return call(READ_ROWS_ASYNC, request, operationId);
+  }
+
+  /**
+   * Performs a {@link BigtableDataClient#mutateRowAsync(MutateRowRequest)} on the
+   * {@link MutateRowRequest}. This method may block if
+   * {@link RpcThrottler#registerOperationWithHeapSize(long)} blocks.
+   *
+   * @param request The {@link MutateRowRequest} to send.
+   *
+   * @return a {@link ListenableFuture} which can be listened to for completion events.
+   */
+  public ListenableFuture<MutateRowResponse> mutateRowAsync(MutateRowRequest request)
+      throws InterruptedException {
+    return call(MUTATE_ROW_ASYNC, request);
+  }
+
+  /**
+   * Performs a {@link BigtableDataClient#mutateRowsAsync(MutateRowsRequest)} on the
+   * {@link MutateRowsRequest}. This method may block if
+   * {@link RpcThrottler#registerOperationWithHeapSize(long)} blocks.
+   * @param request The {@link MutateRowRequest} to send.
+   * @return a {@link ListenableFuture} which can be listened to for completion events.
+   */
+  public ListenableFuture<List<MutateRowsResponse>> mutateRowsAsync(MutateRowsRequest request)
+      throws InterruptedException {
+    return call(MUTATE_ROWS_ASYNC, request);
+  }
+
+  /**
+   * Performs a {@link BigtableDataClient#checkAndMutateRowAsync(CheckAndMutateRowRequest)} on the
+   * {@link CheckAndMutateRowRequest}. This method may block if
+   * {@link RpcThrottler#registerOperationWithHeapSize(long)} blocks.
+   *
+   * @param request The {@link CheckAndMutateRowRequest} to send.
+   *
+   * @return a {@link ListenableFuture} which can be listened to for completion events.
+   */
+  public ListenableFuture<CheckAndMutateRowResponse> checkAndMutateRowAsync(
+      CheckAndMutateRowRequest request) throws InterruptedException {
+    return call(CHECK_AND_MUTATE_ASYNC, request);
+  }
+
+  /**
+   * Performs a {@link BigtableDataClient#readModifyWriteRow(ReadModifyWriteRowRequest)} on the
+   * {@link ReadModifyWriteRowRequest}. This method may block if
+   * {@link RpcThrottler#registerOperationWithHeapSize(long)} blocks.
+   *
+   * @param request The {@link ReadModifyWriteRowRequest} to send.
+   *
+   * @return a {@link ListenableFuture} which can be listened to for completion events.
+   */
+  public ListenableFuture<ReadModifyWriteRowResponse>
+      readModifyWriteRowAsync(ReadModifyWriteRowRequest request) throws InterruptedException {
+    return call(READ_MODIFY_WRITE_ASYNC, request);
+  }
+
+  /**
+   * Performs a {@link BigtableDataClient#readRowsAsync(ReadRowsRequest)} on the
+   * {@link ReadRowsRequest}. This method may block if
+   * {@link RpcThrottler#registerOperationWithHeapSize(long)} blocks.
+   *
+   * @param request The {@link ReadRowsRequest} to send.
+   *
+   * @return a {@link ListenableFuture} which can be listened to for completion events.
+   */
+  public ListenableFuture<List<Row>> readRowsAsync(ReadRowsRequest request)
+      throws InterruptedException {
+    return call(READ_ROWS_ASYNC, request);
+  }
+
+  private <RequestT extends GeneratedMessage, ResponseT> ListenableFuture<ResponseT> call(
+      AsyncCall<RequestT, ResponseT> rpc, RequestT request) throws InterruptedException {
+    // Wait until both the memory and rpc count maximum requirements are achieved before getting a
+    // unique id used to track this request.
+    long id = rpcThrottler.registerOperationWithHeapSize(request.getSerializedSize());
+    return call(rpc, request, id);
+  }
+
+  private <ResponseT, RequestT extends GeneratedMessage> ListenableFuture<ResponseT>
+      call(AsyncCall<RequestT, ResponseT> rpc, RequestT request, long id) {
+    ListenableFuture<ResponseT> future;
+    try {
+      future = rpc.call(client, request);
+    } catch (Exception e) {
+      future = Futures.immediateFailedFuture(e);
+    }
+    rpcThrottler.addCallback(future, id);
+    return future;
+  }
+
+  /**
+   * Waits until all operations managed by the {@link RpcThrottler} complete. See
+   * {@link RpcThrottler#awaitCompletion()} for more information.
+   *
+   * @throws IOException if something goes wrong.
+   */
+  public void flush() throws IOException {
+    LOG.trace("Flushing");
+    try {
+      rpcThrottler.awaitCompletion();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IOException("Batch operations were interrupted.");
+    }
+    LOG.trace("Done flushing");
+  }
+
+  public boolean hasInflightRequests() {
+    return rpcThrottler.hasInflightRequests();
+  }
+
+  public long getMaxHeapSize() {
+    return rpcThrottler.getMaxHeapSize();
+  }
+
+  public BigtableDataClient getClient() {
+    return client;
+  }
+
+  public RpcThrottler getRpcThrottler() {
+    return rpcThrottler;
+  }
+}

--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/v2/BulkMutation.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/v2/BulkMutation.java
@@ -1,0 +1,418 @@
+/*
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.grpc.async.v2;
+
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.api.client.util.BackOff;
+import com.google.bigtable.v2.MutateRowRequest;
+import com.google.bigtable.v2.MutateRowResponse;
+import com.google.bigtable.v2.MutateRowsRequest;
+import com.google.bigtable.v2.MutateRowsResponse;
+import com.google.bigtable.v2.MutateRowsResponse.Entry;
+import com.google.cloud.bigtable.config.Logger;
+import com.google.cloud.bigtable.config.RetryOptions;
+import com.google.cloud.bigtable.grpc.BigtableTableName;
+import com.google.cloud.bigtable.grpc.scanner.BigtableRetriesExhaustedException;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
+import com.google.protobuf.Any;
+import com.google.rpc.Status;
+
+import io.grpc.Status.Code;
+import io.grpc.StatusRuntimeException;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * This class combines a collection of {@link MutateRowRequest}s into a single
+ * {@link MutateRowsRequest}. This class is not thread safe, and requires calling classes to make it
+ * thread safe.
+ */
+public class BulkMutation {
+
+  private final static StatusRuntimeException MISSING_ENTRY_EXCEPTION =
+      io.grpc.Status.UNKNOWN
+          .withDescription("Mutation does not have a status")
+          .asRuntimeException();
+  protected final static Logger LOG = new Logger(BulkMutation.class);
+
+  private static StatusRuntimeException toException(Status status) {
+    io.grpc.Status grpcStatus = io.grpc.Status
+        .fromCodeValue(status.getCode())
+        .withDescription(status.getMessage());
+    for (Any detail : status.getDetailsList()) {
+      grpcStatus.augmentDescription(detail.toString());
+    }
+    return grpcStatus.asRuntimeException();
+  }
+
+  @VisibleForTesting
+  static MutateRowsRequest.Entry convert(MutateRowRequest request) {
+    return MutateRowsRequest.Entry.newBuilder()
+            .setRowKey(request.getRowKey())
+            .addAllMutations(request.getMutationsList())
+            .build();
+  }
+
+  @VisibleForTesting
+  static class RequestManager {
+    private final List<SettableFuture<MutateRowResponse>> futures = new ArrayList<>();
+    private final MutateRowsRequest.Builder builder;
+    private MutateRowsRequest request;
+    private long approximateByteSize = 0l;
+
+    RequestManager(String tableName) {
+      this.builder = MutateRowsRequest.newBuilder().setTableName(tableName);
+      this.approximateByteSize = tableName.length() + 2;
+    }
+
+    void add(SettableFuture<MutateRowResponse> future, MutateRowsRequest.Entry entry) {
+      futures.add(future);
+      builder.addEntries(entry);
+      approximateByteSize += entry.getSerializedSize();
+    }
+
+    MutateRowsRequest build() {
+      request = builder.build();
+      return request;
+    }
+  }
+
+  @VisibleForTesting
+  static class Batch implements Runnable {
+    private final AsyncExecutor asyncExecutor;
+    private final RetryOptions retryOptions;
+    private final ScheduledExecutorService retryExecutorService;
+    private final int maxRowKeyCount;
+    private final long maxRequestSize;
+
+    private RequestManager currentRequestManager;
+    private Long retryId;
+    private BackOff currentBackoff;
+    private int failedCount;
+
+    Batch(
+        String tableName,
+        AsyncExecutor asyncExecutor,
+        RetryOptions retryOptions,
+        ScheduledExecutorService retryExecutorService,
+        int maxRowKeyCount,
+        long maxRequestSize) {
+      this.currentRequestManager = new RequestManager(tableName);
+      this.asyncExecutor = asyncExecutor;
+      this.retryOptions = retryOptions;
+      this.retryExecutorService = retryExecutorService;
+      this.maxRowKeyCount = maxRowKeyCount;
+      this.maxRequestSize = maxRequestSize;
+    }
+
+    /**
+     * Adds a {@link MutateRowRequest} to the
+     * {@link com.google.bigtable.v1.MutateRowsRequest.Builder}. NOTE: Users have to make sure that
+     * this gets called in a thread safe way.
+     * @param request The {@link MutateRowRequest} to add
+     * @return a {@link SettableFuture} that will be populated when the {@link MutateRowsResponse}
+     *         returns from the server. See {@link #addCallback(ListenableFuture)} for
+     *         more information about how the SettableFuture is set.
+     */
+    ListenableFuture<MutateRowResponse> add(MutateRowRequest request) {
+      SettableFuture<MutateRowResponse> future = SettableFuture.create();
+      currentRequestManager.add(future, convert(request));
+      return future;
+    }
+
+    boolean isFull() {
+      return getRequestCount() >= maxRowKeyCount
+          || currentRequestManager.approximateByteSize >= maxRequestSize;
+    }
+
+    /**
+     * Adds a {@link FutureCallback} that will update all of the SettableFutures created by
+     * {@link BulkMutation#add(MutateRowRequest)} when the provided {@link ListenableFuture} for the
+     * {@link MutateRowsResponse} is complete.
+     */
+    void addCallback(ListenableFuture<List<MutateRowsResponse>> bulkFuture) {
+      Futures.addCallback(
+          bulkFuture,
+          new FutureCallback<List<MutateRowsResponse>>() {
+            @Override
+            public void onSuccess(List<MutateRowsResponse> result) {
+              handleResult(result);
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+              perfromFullRetry(new AtomicReference<Long>(), t);
+            }
+          });
+    }
+
+    synchronized void handleResult(List<MutateRowsResponse> result) {
+      AtomicReference<Long> backoffTime = new AtomicReference<>();
+      if (this.currentRequestManager == null) {
+        LOG.warn("Got duplicate responses for bulk mutation.");
+        return;
+      }
+
+      if (result == null || result.isEmpty()) {
+        perfromFullRetry(backoffTime, new IllegalStateException("MutateRowResponse result or statuses"));
+        return;
+      }
+
+      List<MutateRowsResponse.Entry> entries = new ArrayList<>();
+      for (MutateRowsResponse response : result) {
+        entries.addAll(response.getEntriesList());
+      }
+
+      if (entries.isEmpty()) {
+        perfromFullRetry(backoffTime, new IllegalStateException("MutateRowResponse result or statuses"));
+        return;
+      }
+
+      try {
+        String tableName = currentRequestManager.request.getTableName();
+        RequestManager retryRequestManager = new RequestManager(tableName);
+
+        int processedCount = handleResponses(backoffTime, entries, retryRequestManager);
+        handleExtraFutures(backoffTime, processedCount, retryRequestManager, entries);
+        completeOrRetry(backoffTime, retryRequestManager);
+      } catch (RuntimeException e) {
+        LOG.error(
+          "Unexpected Exception occurred. Treating this issue as a temporary issue and retrying.",
+          e);
+        perfromFullRetry(backoffTime, e);
+      }
+    }
+
+    private void perfromFullRetry(AtomicReference<Long> backOffTime, Throwable t) {
+      getCurrentBackoff(backOffTime);
+      if (backOffTime.get() == BackOff.STOP) {
+        setFailure(new BigtableRetriesExhaustedException("Exhausted retries.", t));
+      } else {
+        LOG.info("Retrying failed call. Failure #%d, got: %s", t, failedCount++,
+          io.grpc.Status.fromThrowable(t));
+        retryExecutorService.schedule(this, backOffTime.get(), TimeUnit.MILLISECONDS);
+      }
+    }
+
+    private Long getCurrentBackoff(AtomicReference<Long> backOffTime) {
+      if (backOffTime.get() == null) {
+        try {
+          if(this.currentBackoff == null) {
+            this.currentBackoff = retryOptions.createBackoff();
+          }
+          backOffTime.set(this.currentBackoff.nextBackOffMillis());
+        } catch (IOException e) {
+          // Something unusually bad happened in getting the nextBackOff. The Exponential backoff
+          // doesn't throw an exception. A different backoff was used that does I/O. Just stop in this
+          // case.
+          LOG.warn("Could not get the next backoff.", e);
+          backOffTime.set(BackOff.STOP);
+        }
+      }
+      return backOffTime.get();
+    }
+
+    private int handleResponses(AtomicReference<Long> backoffTime,
+        Iterable<MutateRowsResponse.Entry> entries, RequestManager retryRequestManager) {
+      int count = 0;
+      for (MutateRowsResponse.Entry entry : entries) {
+        Status status = entry.getStatus();
+        int index = (int) entry.getIndex();
+        if (index >= currentRequestManager.futures.size()) {
+          LOG.error("Got %extra status: %s", entry);
+          break;
+        }
+        SettableFuture<MutateRowResponse> future = currentRequestManager.futures.get(index);
+
+        if (status.getCode() == io.grpc.Status.Code.OK.value()) {
+          future.set(MutateRowResponse.getDefaultInstance());
+        } else if (!isRetryable(status) || getCurrentBackoff(backoffTime) == BackOff.STOP) {
+          future.setException(toException(status));
+        } else {
+          retryRequestManager.add(future, this.currentRequestManager.request.getEntries(count));
+        }
+        count++;
+      }
+      return count;
+    }
+
+    private void handleExtraFutures(AtomicReference<Long> backoffTime, int processedCount,
+        RequestManager retryRequestManager, List<Entry> entries) {
+      Set<Integer> indexes = new HashSet<>();
+      indexes.addAll(getIndexes(entries));
+      long missingEntriesCount = 0;
+      getCurrentBackoff(backoffTime);
+      for (int i = 0; i < currentRequestManager.futures.size(); i++) {
+        // If the indexes do not contain this future, then there's a problem.
+        if (!indexes.remove(i)) {
+          missingEntriesCount++;
+          if (backoffTime.get() == BackOff.STOP) {
+            currentRequestManager.futures.get(i).setException(MISSING_ENTRY_EXCEPTION);
+          } else {
+            retryRequestManager.add(currentRequestManager.futures.get(i),
+              this.currentRequestManager.request.getEntries(processedCount));
+          }
+        }
+      }
+      String handling =
+          backoffTime.get() == BackOff.STOP ? "Setting exceptions on the futures" : "Retrying";
+      LOG.error("Missing %d responses for bulkWrite. %s.", missingEntriesCount, handling);
+    }
+
+    private List<Integer> getIndexes(List<Entry> entries) {
+      List<Integer> indexes = new ArrayList<>(entries.size());
+      for (Entry entry : entries) {
+        indexes.add((int) entry.getIndex());
+      }
+      return indexes;
+    }
+
+    private void completeOrRetry(AtomicReference<Long> backoffTime, RequestManager retryRequestManager) {
+      if (retryRequestManager == null || retryRequestManager.futures.isEmpty()) {
+        this.currentRequestManager = null;
+        setRetryComplete();
+      } else {
+        this.currentRequestManager = retryRequestManager;
+        LOG.info(
+          "Retrying failed call. Failure #%d, got #%d failures",
+          failedCount++,
+          currentRequestManager.futures.size());
+        retryExecutorService.schedule(this, getCurrentBackoff(backoffTime), TimeUnit.MILLISECONDS);
+      }
+    }
+
+    private boolean isRetryable(Status status) {
+      int codeId = status.getCode();
+      Code code = io.grpc.Status.fromCodeValue(codeId).getCode();
+      return retryOptions.isRetryable(code);
+    }
+
+    @Override
+    public synchronized void run() {
+      ListenableFuture<List<MutateRowsResponse>> future = null;
+      try {
+        if (retryId == null) {
+          retryId = Long.valueOf(this.asyncExecutor.getRpcThrottler().registerRetry());
+        }
+        future = asyncExecutor.mutateRowsAsync(currentRequestManager.build());
+      } catch (InterruptedException e) {
+        future = Futures.<List<MutateRowsResponse>> immediateFailedFuture(e);
+      } finally {
+        addCallback(future);
+      }
+    }
+
+    /**
+     *       // This would have happened after all retries are exhausted on the MutateRowsRequest.
+      // Don't retry individual mutations.
+     * @param t
+     */
+    private void setFailure(Throwable t) {
+      try {
+        for (SettableFuture<MutateRowResponse> future : currentRequestManager.futures) {
+          future.setException(t);
+        }
+      } finally {
+        setRetryComplete();
+      }
+    }
+
+    private void setRetryComplete() {
+      this.asyncExecutor.getRpcThrottler().onRetryCompletion(retryId);
+    }
+
+    @VisibleForTesting
+   int getRequestCount() {
+      return currentRequestManager == null ? 0 : currentRequestManager.futures.size();
+    }
+  }
+
+  @VisibleForTesting
+  Batch currentBatch = null;
+
+  private final String tableName;
+  private final AsyncExecutor asyncExecutor;
+  private final RetryOptions retryOptions;
+  private final ScheduledExecutorService retryExecutorService;
+  private final int maxRowKeyCount;
+  private final long maxRequestSize;
+
+  public BulkMutation(
+      BigtableTableName tableName,
+      AsyncExecutor asyncExecutor,
+      RetryOptions retryOptions,
+      ScheduledExecutorService retryExecutorService,
+      int maxRowKeyCount,
+      long maxRequestSize) {
+    this.tableName = tableName.toString();
+    this.asyncExecutor = asyncExecutor;
+    this.retryOptions = retryOptions;
+    this.retryExecutorService = retryExecutorService;
+    this.maxRowKeyCount = maxRowKeyCount;
+    this.maxRequestSize = maxRequestSize;
+  }
+
+  /**
+   * Adds a {@link MutateRowRequest} to the
+   * {@link com.google.bigtable.v1.MutateRowsRequest.Builder}. NOTE: Users have to make sure that
+   * this gets called in a thread safe way.
+   * @param request The {@link MutateRowRequest} to add
+   * @return a {@link SettableFuture} that will be populated when the {@link MutateRowsResponse}
+   *         returns from the server. See {@link Batch#addCallback(ListenableFuture)} for
+   *         more information about how the SettableFuture is set.
+   */
+  public synchronized ListenableFuture<MutateRowResponse> add(MutateRowRequest request) {
+    if (currentBatch == null) {
+      currentBatch =
+          new Batch(
+              tableName,
+              asyncExecutor,
+              retryOptions,
+              retryExecutorService,
+              maxRowKeyCount,
+              maxRequestSize);
+    }
+
+    ListenableFuture<MutateRowResponse> future = currentBatch.add(request);
+    if (currentBatch.isFull()) {
+      currentBatch.run();
+      currentBatch = null;
+    }
+    return future;
+  }
+
+  public synchronized void flush() {
+    if (currentBatch != null) {
+      currentBatch.run();
+      currentBatch = null;
+    }
+  }
+
+  public synchronized boolean isFlushed() {
+    return currentBatch == null;
+  }
+}

--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/v2/BulkMutation.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/v2/BulkMutation.java
@@ -165,7 +165,7 @@ public class BulkMutation {
 
             @Override
             public void onFailure(Throwable t) {
-              perfromFullRetry(new AtomicReference<Long>(), t);
+              performFullRetry(new AtomicReference<Long>(), t);
             }
           });
     }
@@ -178,7 +178,8 @@ public class BulkMutation {
       }
 
       if (result == null || result.isEmpty()) {
-        perfromFullRetry(backoffTime, new IllegalStateException("MutateRowResponse result or statuses"));
+        performFullRetry(
+            backoffTime, new IllegalStateException("No MutateRowResponses were found."));
         return;
       }
 
@@ -188,7 +189,8 @@ public class BulkMutation {
       }
 
       if (entries.isEmpty()) {
-        perfromFullRetry(backoffTime, new IllegalStateException("MutateRowResponse result or statuses"));
+        performFullRetry(
+            backoffTime, new IllegalStateException("No MutateRowsResponses entries were found."));
         return;
       }
 
@@ -203,11 +205,11 @@ public class BulkMutation {
         LOG.error(
           "Unexpected Exception occurred. Treating this issue as a temporary issue and retrying.",
           e);
-        perfromFullRetry(backoffTime, e);
+        performFullRetry(backoffTime, e);
       }
     }
 
-    private void perfromFullRetry(AtomicReference<Long> backOffTime, Throwable t) {
+    private void performFullRetry(AtomicReference<Long> backOffTime, Throwable t) {
       getCurrentBackoff(backOffTime);
       if (backOffTime.get() == BackOff.STOP) {
         setFailure(new BigtableRetriesExhaustedException("Exhausted retries.", t));

--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/v2/BigtableDataClient.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/v2/BigtableDataClient.java
@@ -53,21 +53,17 @@ public interface BigtableDataClient {
   ListenableFuture<MutateRowResponse> mutateRowAsync(MutateRowRequest request);
 
   /**
-   * Mutates multiple rows in a batch. Each individual row is mutated
-   * atomically as in MutateRow, but the entire batch is not executed
-   * atomically. 
+   * Mutates multiple rows in a batch. Each individual row is mutated atomically as in MutateRow,
+   * but the entire batch is not executed atomically.
    */
-  MutateRowsResponse mutateRows(MutateRowsRequest request) throws ServiceException;
+  List<MutateRowsResponse> mutateRows(MutateRowsRequest request) throws ServiceException;
 
   /**
-   * Mutates multiple rows in a batch. Each individual row is mutated
-   * atomically as in MutateRow, but the entire batch is not executed
-   * atomically.
-   * 
-   * @return a {@link ListenableFuture} that will finish when
-   * the mutations have all been completed.
+   * Mutates multiple rows in a batch. Each individual row is mutated atomically as in MutateRow,
+   * but the entire batch is not executed atomically.
+   * @return a {@link ListenableFuture} that will finish when the mutations have all been completed.
    */
-  ListenableFuture<MutateRowsResponse> mutateRowsAsync(MutateRowsRequest request);
+  ListenableFuture<List<MutateRowsResponse>> mutateRowsAsync(MutateRowsRequest request);
 
   /**
    * Mutate a row atomically dependent on a precondition.

--- a/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/v2/BigtableDataGrpcClient.java
+++ b/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/v2/BigtableDataGrpcClient.java
@@ -219,13 +219,13 @@ public class BigtableDataGrpcClient implements BigtableDataClient {
   }
 
   @Override
-  public MutateRowsResponse mutateRows(MutateRowsRequest request) throws ServiceException {
-    return getBlockingUnaryResult(request, mutateRowsRpc);
+  public List<MutateRowsResponse> mutateRows(MutateRowsRequest request) throws ServiceException {
+    return getBlockingStreamingResult(request, mutateRowsRpc);
   }
 
   @Override
-  public ListenableFuture<MutateRowsResponse> mutateRowsAsync(MutateRowsRequest request) {
-    return getUnaryFuture(request, mutateRowsRpc);
+  public ListenableFuture<List<MutateRowsResponse>> mutateRowsAsync(MutateRowsRequest request) {
+    return getStreamingFuture(request, mutateRowsRpc);
   }
 
   @Override

--- a/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestAsyncExecutor.java
+++ b/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestAsyncExecutor.java
@@ -146,20 +146,20 @@ public class TestAsyncExecutor {
       for (int i = 0; i < 10; i++) {
         underTest.mutateRowAsync(MutateRowRequest.getDefaultInstance());
       }
-      final AtomicBoolean eleventRpcInvoked = new AtomicBoolean(false);
+      final AtomicBoolean eleventhRpcInvoked = new AtomicBoolean(false);
       testExecutor.submit(new Callable<Void>() {
         @Override
         public Void call() throws Exception {
           underTest.mutateRowAsync(MutateRowRequest.getDefaultInstance());
-          eleventRpcInvoked.set(true);
+          eleventhRpcInvoked.set(true);
           return null;
         }
       });
       Thread.sleep(50);
-      Assert.assertFalse(eleventRpcInvoked.get());
+      Assert.assertFalse(eleventhRpcInvoked.get());
       completeCall();
       Thread.sleep(50);
-      Assert.assertTrue(eleventRpcInvoked.get());
+      Assert.assertTrue(eleventhRpcInvoked.get());
     } finally {
       testExecutor.shutdownNow();
     }
@@ -177,13 +177,11 @@ public class TestAsyncExecutor {
       // Send a huge request to block further RPCs.
       underTest.mutateRowAsync(MutateRowRequest.newBuilder()
           .setRowKey(ByteString.copyFrom(new byte[1000])).build());
-      final AtomicBoolean newRpcInvoked = new AtomicBoolean(false);
-      Future<Void> future = testExecutor.submit(new Callable<Void>() {
+      Future<Boolean> future = testExecutor.submit(new Callable<Boolean>() {
         @Override
-        public Void call() throws Exception {
+        public Boolean call() throws Exception {
           underTest.mutateRowAsync(MutateRowRequest.getDefaultInstance());
-          newRpcInvoked.set(true);
-          return null;
+          return true;
         }
       });
       try {
@@ -193,8 +191,7 @@ public class TestAsyncExecutor {
         // Expected Exception.
       }
       completeCall();
-      future.get(50, TimeUnit.MILLISECONDS);
-      Assert.assertTrue(newRpcInvoked.get());
+      Assert.assertTrue(future.get(50, TimeUnit.MILLISECONDS));
     } finally {
       testExecutor.shutdownNow();
     }

--- a/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/v2/TestAsyncExecutor.java
+++ b/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/v2/TestAsyncExecutor.java
@@ -148,20 +148,20 @@ public class TestAsyncExecutor {
       for (int i = 0; i < 10; i++) {
         underTest.mutateRowAsync(MutateRowRequest.getDefaultInstance());
       }
-      final AtomicBoolean eleventRpcInvoked = new AtomicBoolean(false);
+      final AtomicBoolean eleventhRpcInvoked = new AtomicBoolean(false);
       testExecutor.submit(new Callable<Void>() {
         @Override
         public Void call() throws Exception {
           underTest.mutateRowAsync(MutateRowRequest.getDefaultInstance());
-          eleventRpcInvoked.set(true);
+          eleventhRpcInvoked.set(true);
           return null;
         }
       });
       Thread.sleep(50);
-      Assert.assertFalse(eleventRpcInvoked.get());
+      Assert.assertFalse(eleventhRpcInvoked.get());
       completeCall();
       Thread.sleep(50);
-      Assert.assertTrue(eleventRpcInvoked.get());
+      Assert.assertTrue(eleventhRpcInvoked.get());
     } finally {
       testExecutor.shutdownNow();
     }

--- a/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/v2/TestAsyncExecutor.java
+++ b/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/v2/TestAsyncExecutor.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.grpc.async.v2;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import com.google.bigtable.v2.CheckAndMutateRowRequest;
+import com.google.bigtable.v2.MutateRowRequest;
+import com.google.bigtable.v2.ReadModifyWriteRowRequest;
+import com.google.bigtable.v2.ReadRowsRequest;
+import com.google.cloud.bigtable.grpc.v2.BigtableDataClient;
+import com.google.cloud.bigtable.grpc.async.ResourceLimiter;
+import com.google.cloud.bigtable.grpc.async.RpcThrottler;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.protobuf.ByteString;
+
+/**
+ * Tests for {@link AsyncExecutor}
+ */
+@SuppressWarnings("unchecked")
+@RunWith(JUnit4.class)
+public class TestAsyncExecutor {
+
+  @Mock
+  private BigtableDataClient client;
+
+  @SuppressWarnings("rawtypes")
+  @Mock
+  private ListenableFuture future;
+
+  private AsyncExecutor underTest;
+  private RpcThrottler rpcThrottler;
+  private List<FutureCallback<?>> callbacks;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+    callbacks = new ArrayList<>();
+    rpcThrottler = new RpcThrottler(new ResourceLimiter(1000, 10)) {
+      @Override
+      public <T> FutureCallback<T> addCallback(ListenableFuture<T> future, long id) {
+        FutureCallback<T> callback = super.addCallback(future, id);
+        synchronized (callbacks) {
+          callbacks.add(callback);
+        }
+        return callback;
+      }
+    };
+
+    underTest = new AsyncExecutor(client, rpcThrottler);
+  }
+
+  @Test
+  public void testNoMutation() {
+    Assert.assertFalse(underTest.hasInflightRequests());
+  }
+
+  @Test
+  public void testMutation() throws InterruptedException {
+    when(client.mutateRowAsync(any(MutateRowRequest.class))).thenReturn(future);
+    underTest.mutateRowAsync(MutateRowRequest.getDefaultInstance());
+    Assert.assertTrue(underTest.hasInflightRequests());
+    completeCall();
+    Assert.assertFalse(underTest.hasInflightRequests());
+  }
+
+  @Test
+  public void testCheckAndMutate() throws InterruptedException {
+    when(client.checkAndMutateRowAsync(any(CheckAndMutateRowRequest.class))).thenReturn(future);
+    underTest.checkAndMutateRowAsync(CheckAndMutateRowRequest.getDefaultInstance());
+    Assert.assertTrue(underTest.hasInflightRequests());
+    completeCall();
+    Assert.assertFalse(underTest.hasInflightRequests());
+  }
+
+  @Test
+  public void testReadWriteModify() throws InterruptedException {
+    when(client.readModifyWriteRowAsync(any(ReadModifyWriteRowRequest.class))).thenReturn(future);
+    underTest.readModifyWriteRowAsync(ReadModifyWriteRowRequest.getDefaultInstance());
+    Assert.assertTrue(underTest.hasInflightRequests());
+    completeCall();
+    Assert.assertFalse(underTest.hasInflightRequests());
+  }
+
+  @Test
+  public void testReadRowsAsync() throws InterruptedException {
+    when(client.readRowsAsync(any(ReadRowsRequest.class))).thenReturn(future);
+    underTest.readRowsAsync(ReadRowsRequest.getDefaultInstance());
+    Assert.assertTrue(underTest.hasInflightRequests());
+    completeCall();
+    Assert.assertFalse(underTest.hasInflightRequests());
+  }
+
+  @Test
+  public void testInvalidMutation() throws Exception {
+    try {
+      when(client.mutateRowAsync(any(MutateRowRequest.class))).thenThrow(new RuntimeException());
+      underTest.mutateRowAsync(MutateRowRequest.getDefaultInstance());
+    } catch(Exception ignored) {
+    }
+    completeCall();
+    Assert.assertFalse(underTest.hasInflightRequests());
+  }
+
+  @Test
+  /**
+   * Tests to make sure that mutateRowAsync will perform a wait() if there is a bigger count of RPCs
+   * than the maximum of the RpcThrottler.
+   */
+  public void testRegisterWaitsAfterCountLimit() throws Exception {
+    ExecutorService testExecutor = Executors.newCachedThreadPool();
+    try {
+      when(client.mutateRowAsync(any(MutateRowRequest.class))).thenReturn(future);
+      // Fill up the Queue
+      for (int i = 0; i < 10; i++) {
+        underTest.mutateRowAsync(MutateRowRequest.getDefaultInstance());
+      }
+      final AtomicBoolean eleventRpcInvoked = new AtomicBoolean(false);
+      testExecutor.submit(new Callable<Void>() {
+        @Override
+        public Void call() throws Exception {
+          underTest.mutateRowAsync(MutateRowRequest.getDefaultInstance());
+          eleventRpcInvoked.set(true);
+          return null;
+        }
+      });
+      Thread.sleep(50);
+      Assert.assertFalse(eleventRpcInvoked.get());
+      completeCall();
+      Thread.sleep(50);
+      Assert.assertTrue(eleventRpcInvoked.get());
+    } finally {
+      testExecutor.shutdownNow();
+    }
+  }
+
+  @Test
+  /**
+   * Tests to make sure that mutateRowAsync will perform a wait() if there is a bigger accumulated
+   * serialized size of RPCs than the maximum of the RpcThrottler.
+   */
+  public void testRegisterWaitsAfterSizeLimit() throws Exception {
+    ExecutorService testExecutor = Executors.newCachedThreadPool();
+    try {
+      when(client.mutateRowAsync(any(MutateRowRequest.class))).thenReturn(future);
+      // Send a huge request to block further RPCs.
+      underTest.mutateRowAsync(MutateRowRequest.newBuilder()
+          .setRowKey(ByteString.copyFrom(new byte[1000])).build());
+      final AtomicBoolean newRpcInvoked = new AtomicBoolean(false);
+      Future<Void> future = testExecutor.submit(new Callable<Void>() {
+        @Override
+        public Void call() throws Exception {
+          underTest.mutateRowAsync(MutateRowRequest.getDefaultInstance());
+          newRpcInvoked.set(true);
+          return null;
+        }
+      });
+      try {
+        future.get(50, TimeUnit.MILLISECONDS);
+        Assert.fail("The future.get() call should timeout.");
+      } catch(TimeoutException expected) {
+        // Expected Exception.
+      }
+      completeCall();
+      future.get(50, TimeUnit.MILLISECONDS);
+      Assert.assertTrue(newRpcInvoked.get());
+    } finally {
+      testExecutor.shutdownNow();
+    }
+  }
+
+  private void completeCall() {
+    synchronized (callbacks) {
+      for (FutureCallback<?> fc : callbacks) {
+        fc.onSuccess(null);
+      }
+      callbacks.clear();
+    }
+  }
+}

--- a/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/v2/TestBulkMutation.java
+++ b/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/v2/TestBulkMutation.java
@@ -1,0 +1,268 @@
+/*
+ * Copyright 2015 Google Inc. All Rights Reserved. Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable
+ * law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
+ * for the specific language governing permissions and limitations under the License.
+ */
+package com.google.cloud.bigtable.grpc.async.v2;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import com.google.api.client.util.NanoClock;
+import com.google.bigtable.v2.MutateRowRequest;
+import com.google.bigtable.v2.MutateRowResponse;
+import com.google.bigtable.v2.MutateRowsRequest;
+import com.google.bigtable.v2.MutateRowsRequest.Entry;
+import com.google.bigtable.v2.MutateRowsResponse;
+import com.google.bigtable.v2.Mutation;
+import com.google.bigtable.v2.Mutation.SetCell;
+import com.google.cloud.bigtable.config.RetryOptions;
+import com.google.cloud.bigtable.config.RetryOptionsUtil;
+import com.google.cloud.bigtable.grpc.async.RpcThrottler;
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
+import com.google.protobuf.ByteString;
+
+import io.grpc.StatusRuntimeException;
+
+/**
+ * Tests for {@link BulkMutation}
+ */
+@SuppressWarnings({"rawtypes", "unchecked"})
+@RunWith(JUnit4.class)
+public class TestBulkMutation {
+  private final static String TABLE_NAME = "table";
+  private final static ByteString QUALIFIER = ByteString.copyFrom("qual".getBytes());
+
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+
+  @Mock
+  AsyncExecutor asyncExecutor;
+
+  @Mock
+  ScheduledExecutorService retryExecutorService;
+
+  @Mock
+  RpcThrottler rpcThrottler;
+
+  @Mock
+  ListenableFuture mockFuture;
+
+  @Mock NanoClock nanoClock;
+
+  RetryOptions retryOptions;
+
+  private AtomicLong retryIdGenerator = new AtomicLong();
+  private BulkMutation.Batch underTest;
+
+  @Before
+  public void setup() throws InterruptedException {
+    MockitoAnnotations.initMocks(this);
+    retryOptions = RetryOptionsUtil.createTestRetryOptions(nanoClock);
+
+    when(asyncExecutor.mutateRowsAsync(any(MutateRowsRequest.class))).thenReturn(mockFuture);
+    when(asyncExecutor.getRpcThrottler()).thenReturn(rpcThrottler);
+
+    doAnswer(new Answer<Void>() {
+      @Override
+      public Void answer(InvocationOnMock invocation) throws Throwable {
+        invocation.getArgumentAt(0, Runnable.class).run();
+        return null;
+      }
+    }).when(mockFuture).addListener(any(Runnable.class), any(Executor.class));
+
+    when(rpcThrottler.registerRetry()).then(new Answer<Long>() {
+      @Override
+      public Long answer(InvocationOnMock invocation) throws Throwable {
+        return retryIdGenerator.incrementAndGet();
+      }
+    });
+
+    underTest = new BulkMutation.Batch(TABLE_NAME, asyncExecutor, retryOptions, retryExecutorService,
+      1000, 1000000L);
+  }
+
+  @Test
+  public void testAdd() {
+    MutateRowRequest mutateRowRequest = createRequest();
+    BulkMutation.RequestManager requestManager = new BulkMutation.RequestManager(TABLE_NAME);
+    requestManager.add(null, BulkMutation.convert(mutateRowRequest));
+    MutateRowsRequest expected = MutateRowsRequest.newBuilder()
+        .setTableName(TABLE_NAME)
+        .addEntries(Entry.newBuilder().addMutations(mutateRowRequest.getMutations(0)).build())
+        .build();
+    Assert.assertEquals(expected, requestManager.build());
+  }
+
+  protected static MutateRowRequest createRequest() {
+    return MutateRowRequest.newBuilder().addMutations(
+      Mutation.newBuilder()
+        .setSetCell(
+            SetCell.newBuilder()
+              .setFamilyName("cf1")
+              .setColumnQualifier(QUALIFIER))
+            .build())
+        .build();
+  }
+
+  @Test
+  public void testCallableSuccess()
+      throws InterruptedException, ExecutionException, TimeoutException {
+    ListenableFuture<MutateRowResponse> rowFuture = underTest.add(createRequest());
+    setResponse(io.grpc.Status.OK);
+    MutateRowResponse result = rowFuture.get(10, TimeUnit.MILLISECONDS);
+    Assert.assertTrue(rowFuture.isDone());
+    Assert.assertEquals(MutateRowResponse.getDefaultInstance(), result);
+    verify(rpcThrottler, times(1)).onRetryCompletion(eq(retryIdGenerator.get()));
+  }
+
+  @Test
+  public void testCallableNotRetriedStatus()
+      throws InterruptedException, ExecutionException, TimeoutException {
+    ListenableFuture<MutateRowResponse> rowFuture = underTest.add(createRequest());
+    ListenableFuture<List<MutateRowsResponse>> rowsFuture = SettableFuture.<List<MutateRowsResponse>>create();
+    when(nanoClock.nanoTime()).thenReturn(1l);
+    underTest.addCallback(rowsFuture);
+    Assert.assertFalse(rowFuture.isDone());
+    setResponse(io.grpc.Status.NOT_FOUND);
+
+    try {
+      rowFuture.get(100, TimeUnit.MILLISECONDS);
+    } catch (ExecutionException e) {
+      Assert.assertEquals(StatusRuntimeException.class, e.getCause().getClass());
+      verify(rpcThrottler, times(1)).onRetryCompletion(eq(retryIdGenerator.get()));
+    }
+  }
+
+  @Test
+  public void testRetriedStatus() throws InterruptedException, ExecutionException {
+    ListenableFuture<MutateRowResponse> rowFuture = underTest.add(createRequest());
+    Assert.assertFalse(rowFuture.isDone());
+
+    // Send Deadline exceeded,
+    setResponse(io.grpc.Status.DEADLINE_EXCEEDED);
+    when(nanoClock.nanoTime()).thenReturn(1l);
+
+    // Make sure that the request is scheduled
+    Assert.assertFalse(rowFuture.isDone());
+    verify(retryExecutorService, times(1)).schedule(any(Runnable.class), anyLong(),
+      same(TimeUnit.MILLISECONDS));
+    verify(rpcThrottler, times(0)).onRetryCompletion(eq(retryIdGenerator.get()));
+
+    // Make sure that a second try works.
+    setResponse(io.grpc.Status.OK);
+    Assert.assertTrue(rowFuture.isDone());
+    verify(rpcThrottler, times(1)).onRetryCompletion(eq(retryIdGenerator.get()));
+  }
+
+  @Test
+  public void testCallableTooFewStatuses() throws InterruptedException, ExecutionException {
+    ListenableFuture<MutateRowResponse> rowFuture1 = underTest.add(createRequest());
+    ListenableFuture<MutateRowResponse> rowFuture2 = underTest.add(createRequest());
+    SettableFuture<List<MutateRowsResponse>> rowsFuture = SettableFuture.<List<MutateRowsResponse>> create();
+    underTest.addCallback(rowsFuture);
+    Assert.assertFalse(rowFuture1.isDone());
+    Assert.assertFalse(rowFuture2.isDone());
+
+    Assert.assertEquals(2, underTest.getRequestCount());
+    // Send only one response - this is poor server behavior.
+    setResponse(io.grpc.Status.OK);
+    when(nanoClock.nanoTime()).thenReturn(0l);
+    Assert.assertEquals(1, underTest.getRequestCount());
+
+    // Make sure that the first request completes, but the second does not.
+    Assert.assertTrue(rowFuture1.isDone());
+    Assert.assertFalse(rowFuture2.isDone());
+    Assert.assertEquals(MutateRowResponse.getDefaultInstance(), rowFuture1.get());
+    verify(retryExecutorService, times(1)).schedule(any(Runnable.class), anyLong(),
+      same(TimeUnit.MILLISECONDS));
+    verify(rpcThrottler, times(0)).onRetryCompletion(eq(retryIdGenerator.get()));
+
+    // Make sure that only the second request was sent.
+    setResponse(io.grpc.Status.OK);
+    Assert.assertEquals(0, underTest.getRequestCount());
+    Assert.assertTrue(rowFuture2.isDone());
+    verify(rpcThrottler, times(1)).onRetryCompletion(eq(retryIdGenerator.get()));
+  }
+
+  @Test
+  public void testRunOutOfTime() throws InterruptedException, ExecutionException, TimeoutException {
+    ListenableFuture<MutateRowResponse> rowFuture = underTest.add(createRequest());
+
+    AtomicLong waitedNanos = new AtomicLong();
+    setupScheduler(waitedNanos);
+    setResponse(io.grpc.Status.DEADLINE_EXCEEDED);
+    try {
+      rowFuture.get(1, TimeUnit.MINUTES);
+      Assert.fail("Expected exception");
+    } catch (ExecutionException e) {
+      Assert.assertEquals(io.grpc.Status.DEADLINE_EXCEEDED.getCode(), io.grpc.Status.fromThrowable(e).getCode());
+    }
+    Assert.assertTrue(
+        waitedNanos.get()
+            > TimeUnit.MILLISECONDS.toNanos(retryOptions.getMaxElaspedBackoffMillis()));
+  }
+
+  private void setupScheduler(final AtomicLong waitedNanos) {
+    final long start = System.nanoTime();
+    doAnswer(new Answer<Long>() {
+      @Override
+      public Long answer(InvocationOnMock invocation) throws Throwable {
+        return start + waitedNanos.get();
+      }
+    }).when(nanoClock).nanoTime();
+
+    doAnswer(new Answer<ScheduledFuture<?>>() {
+      @Override
+      public ScheduledFuture<?> answer(InvocationOnMock invocation) throws Throwable {
+        waitedNanos
+            .addAndGet(TimeUnit.MILLISECONDS.toNanos(invocation.getArgumentAt(1, Long.class)));
+        invocation.getArgumentAt(0, Runnable.class).run();
+        return null;
+      }
+    }).when(retryExecutorService).schedule(any(Runnable.class), anyLong(),
+      same(TimeUnit.MILLISECONDS));
+  }
+
+  private void setResponse(final io.grpc.Status code)
+      throws InterruptedException, ExecutionException {
+    MutateRowsResponse.Builder responseBuilder = MutateRowsResponse.newBuilder();
+    responseBuilder.addEntriesBuilder()
+        .setIndex(0)
+        .getStatusBuilder().setCode(code.getCode().value());
+    when(mockFuture.get()).thenReturn(ImmutableList.of(responseBuilder.build()));
+    underTest.run();
+  }
+}


### PR DESCRIPTION
- Updated BigtableDataClient to reflect the fact that MutateRowsResponse is a streaming response rather than unary.
- Copied AsyncExecutor to v2. Updated to v2 return types (for example MutateRowResponse in v2 vs. Empty in v1), and List<MutateRowsResponse> instead of a single response
- Copied BulkMutation to v2. The handleResult() method looks significantly differently with the streaming response.
- Copied the tests for AsyncExecutor and BulkMutation with minor changes.