### PR TITLE
Upgrading dataflow.

### DIFF
--- a/bigtable-dataflow-import/src/main/java/com/google/cloud/bigtable/dataflowimport/HBaseImportIO.java
+++ b/bigtable-dataflow-import/src/main/java/com/google/cloud/bigtable/dataflowimport/HBaseImportIO.java
@@ -15,7 +15,8 @@
  */
 package com.google.cloud.bigtable.dataflowimport;
 
-import com.google.cloud.bigtable.dataflow.HBaseResultCoder;
+import com.google.bigtable.repackaged.com.google.cloud.dataflow.tools.HBaseResultConverter;
+import com.google.cloud.bigtable.dataflow.BigtableConverterCoder;
 import com.google.cloud.dataflow.sdk.coders.KvCoder;
 import com.google.cloud.dataflow.sdk.io.BoundedSource;
 import com.google.cloud.dataflow.sdk.runners.DirectPipelineRunner;
@@ -109,7 +110,8 @@ public class HBaseImportIO {
         SequenceFileInputFormat.class,
         ImmutableBytesWritable.class,
         Result.class,
-        KvCoder.of(new WritableCoder<>(ImmutableBytesWritable.class), new HBaseResultCoder()),
+      KvCoder.of(new WritableCoder<>(ImmutableBytesWritable.class),
+        new BigtableConverterCoder<>(new HBaseResultConverter())),
         createSerializationProperties(options));
   }
 

--- a/bigtable-dataflow-import/src/test/java/com/google/cloud/bigtable/dataflowimport/HBaseImportIOTest.java
+++ b/bigtable-dataflow-import/src/test/java/com/google/cloud/bigtable/dataflowimport/HBaseImportIOTest.java
@@ -20,7 +20,8 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
-import com.google.cloud.bigtable.dataflow.HBaseResultCoder;
+import com.google.bigtable.repackaged.com.google.cloud.dataflow.tools.HBaseResultConverter;
+import com.google.cloud.bigtable.dataflow.BigtableConverterCoder;
 import com.google.cloud.bigtable.dataflowimport.HadoopFileSource.HadoopFileReader;
 import com.google.cloud.bigtable.dataflowimport.testing.SequenceFileIoUtils;
 import com.google.cloud.dataflow.sdk.coders.KvCoder;
@@ -134,7 +135,10 @@ public class HBaseImportIOTest {
     KvCoder<ImmutableBytesWritable, Result> defaultOutputCoder =
         (KvCoder<ImmutableBytesWritable, Result>) source.getDefaultOutputCoder();
     assertTrue(defaultOutputCoder.getKeyCoder() instanceof WritableCoder);
-    assertTrue(defaultOutputCoder.getValueCoder() instanceof HBaseResultCoder);
+    assertTrue(defaultOutputCoder.getValueCoder() instanceof BigtableConverterCoder);
+    @SuppressWarnings("rawtypes")
+    BigtableConverterCoder coder = (BigtableConverterCoder) defaultOutputCoder.getValueCoder();
+    assertTrue(coder.getConverter() instanceof HBaseResultConverter);
 
     // Verify the constant serializer properties
     Configuration deserializerConfigs = getDeserializerConfigurationFromSource(source);

--- a/bigtable-hbase-dataflow-tools/pom.xml
+++ b/bigtable-hbase-dataflow-tools/pom.xml
@@ -20,22 +20,17 @@ limitations under the License.
     </parent>
 
     <groupId>com.google.cloud.bigtable</groupId>
-    <artifactId>bigtable-hbase-dataflow</artifactId>
+    <artifactId>bigtable-hbase-dataflow-tools</artifactId>
     <packaging>jar</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>
-       This project contains artifacts that provide Cloud Bigtable client readers and writers in Google Cloud Dataflow.
+       This project contains artifacts that provide utility functions for Cloud Bigtable client readers and writers in Google Cloud Dataflow. Dataflow includes a different version of the cloud bigtable client, resulting in a need to have a separation of concerns and an abstraction. More importantly, there is a need for shading and renaming of packages so that Dataflow nad bigtable-hbase-dataflow's two sets of shading (needed for a variety of reasons) don't clash with each other.  This submodule does package renaming which is needed for bigtable-hbase-dataflow and alleviates some issues related to developing that module.
     </description>
 
     <dependencies>
         <dependency>
-            <groupId>com.google.cloud.dataflow</groupId>
-            <artifactId>google-cloud-dataflow-java-sdk-all</artifactId>
-            <version>1.5.1</version>
-        </dependency>
-        <dependency>
             <groupId>com.google.cloud.bigtable</groupId>
-            <artifactId>bigtable-hbase-dataflow-tools</artifactId>
+            <artifactId>bigtable-hbase-1.0</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
@@ -64,56 +59,6 @@ limitations under the License.
         </dependency>
     </dependencies>
     <profiles>
-        <profile>
-            <id>bigtableDataflowIntegrationTest</id>
-            <dependencies>
-                <dependency>
-                    <groupId>org.mortbay.jetty.alpn</groupId>
-                    <artifactId>alpn-boot</artifactId>
-                </dependency>
-            </dependencies>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>api-integration-test</id>
-                                <goals>
-                                    <goal>test</goal>
-                                </goals>
-                                <phase>none</phase>
-                            </execution>
-                            <execution>
-                                <id>api-gap-test</id>
-                                <goals>
-                                    <goal>test</goal>
-                                </goals>
-                                <phase>integration-test</phase>
-                                <configuration>
-                                    <!-- ALPN is needed for SSL engine rewrites -->
-                                    <!-- to enable netty logging, include:
-                                    -Djava.util.logging.config.file=src/test/resources/logging.properties
-                                    -->
-                                    <argLine>
-                                        -Xbootclasspath/p:${settings.localRepository}/org/mortbay/jetty/alpn/alpn-boot/${alpn.version}/alpn-boot-${alpn.version}.jar
-                                    </argLine>
-                                    <forkCount>1</forkCount>
-                                    <includes>
-                                        <include>**/CloudBigtableIOIntegrationTest.java</include>
-                                    </includes>
-                                    <reportNameSuffix>bigtable-server</reportNameSuffix>
-                                    <systemPropertyVariables>
-                                        <bigtable.test.extra.resources>bigtable-test.xml</bigtable.test.extra.resources>
-                                    </systemPropertyVariables>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
         <profile>
             <id>release</id>
             <build>
@@ -165,11 +110,47 @@ limitations under the License.
                         <configuration>
                             <shadedArtifactAttached>false</shadedArtifactAttached>
                             <createDependencyReducedPom>true</createDependencyReducedPom>
+                            <shadeTestJar>true</shadeTestJar>
                             <artifactSet>
                                 <includes>
-                                    <include>${project.groupId}:bigtable-hbase-dataflow-tools</include>
+                                    <include>${project.groupId}:bigtable-hbase-1.0</include>
                                 </includes>
                             </artifactSet>
+                            <relocations>
+                                <relocation>
+                                    <pattern>com.google.cloud.bigtable</pattern>
+                                    <shadedPattern>com.google.bigtable.repackaged.com.google.cloud</shadedPattern>
+                                    <excludes>
+                                        <exclude>com.google.cloud.bigtable.hbase1_0.BigtableConnection*</exclude>
+                                        <exclude>com.google.cloud.bigtable.dataflow.*</exclude>
+                                        <exclude>com.google.cloud.bigtable.hbase.*</exclude>
+                                    </excludes>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.google.bigtable.v1</pattern>
+                                    <shadedPattern>com.google.bigtable.repackaged.com.google.com.google.bigtable.v1</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.google.bigtable.v2</pattern>
+                                    <shadedPattern>com.google.bigtable.repackaged.com.google.com.google.bigtable.v2</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.google.bigtable.admin</pattern>
+                                    <shadedPattern>com.google.bigtable.repackaged.com.google.com.google.bigtable.admin</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.google.type</pattern>
+                                    <shadedPattern>com.google.bigtable.repackaged.com.google.com.google.type</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.google.longrunning</pattern>
+                                    <shadedPattern>com.google.bigtable.repackaged.com.google.com.google.longrunning</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.google.rpc</pattern>
+                                    <shadedPattern>com.google.bigtable.repackaged.com.google.com.google.rpc</shadedPattern>
+                                </relocation>
+                            </relocations>
                         </configuration>
                     </execution>
                 </executions>

--- a/bigtable-hbase-dataflow-tools/resources/log4j.properties
+++ b/bigtable-hbase-dataflow-tools/resources/log4j.properties
@@ -1,0 +1,22 @@
+# Copyright 2015 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Root logger option
+log4j.rootLogger=INFO, stdout
+
+# Direct log messages to stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n

--- a/bigtable-hbase-dataflow-tools/src/main/java/com/google/cloud/bigtable/dataflow/tools/BigtableConverter.java
+++ b/bigtable-hbase-dataflow-tools/src/main/java/com/google/cloud/bigtable/dataflow/tools/BigtableConverter.java
@@ -1,0 +1,27 @@
+/** Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.dataflow.tools;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.Serializable;
+
+/** Encodes and decodes some inputs */
+public interface BigtableConverter<T> extends Serializable {
+  void encode(T input, OutputStream outStream) throws IOException;
+
+  T decode(InputStream inStream) throws IOException;
+}

--- a/bigtable-hbase-dataflow-tools/src/main/java/com/google/cloud/bigtable/dataflow/tools/HBaseResultArrayConverter.java
+++ b/bigtable-hbase-dataflow-tools/src/main/java/com/google/cloud/bigtable/dataflow/tools/HBaseResultArrayConverter.java
@@ -13,13 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.cloud.bigtable.dataflow;
+package com.google.cloud.bigtable.dataflow.tools;
 
 import com.google.bigtable.v1.Row;
 import com.google.cloud.bigtable.hbase.adapters.Adapters;
-import com.google.cloud.dataflow.sdk.coders.AtomicCoder;
-import com.google.cloud.dataflow.sdk.coders.Coder;
-import com.google.cloud.dataflow.sdk.coders.CoderException;
 
 import org.apache.hadoop.hbase.client.Result;
 
@@ -30,21 +27,21 @@ import java.io.ObjectOutputStream;
 import java.io.OutputStream;
 
 /**
- * A {@link Coder} that serializes and deserializes the {@link Result} array.
+ * A {@link BigtableConverter} that serializes and deserializes the {@link Result} array.
  */
-public class HBaseResultArrayCoder extends AtomicCoder<Result[]>{
+public class HBaseResultArrayConverter implements BigtableConverter<Result[]>{
 
-  private static final HBaseResultArrayCoder INSTANCE = new HBaseResultArrayCoder();
+  private static final HBaseResultArrayConverter INSTANCE = new HBaseResultArrayConverter();
 
-  public static HBaseResultArrayCoder getInstance() {
+  public static HBaseResultArrayConverter getInstance() {
     return INSTANCE;
   }
 
   private static final long serialVersionUID = -4975428837770254686L;
 
   @Override
-  public Result[] decode(InputStream inputStream, Coder.Context context)
-      throws CoderException, IOException {
+  public Result[] decode(InputStream inputStream)
+      throws IOException {
     ObjectInputStream ois = new ObjectInputStream(inputStream);
     int resultCount = ois.readInt();
     Result[] results = new Result[resultCount];
@@ -55,8 +52,8 @@ public class HBaseResultArrayCoder extends AtomicCoder<Result[]>{
   }
 
   @Override
-  public void encode(Result[] results, OutputStream outputStream, Coder.Context context)
-      throws CoderException, IOException {
+  public void encode(Result[] results, OutputStream outputStream)
+      throws IOException {
     ObjectOutputStream oos = new ObjectOutputStream(outputStream);
     oos.writeInt(results.length);
     oos.flush();

--- a/bigtable-hbase-dataflow-tools/src/main/java/com/google/cloud/bigtable/dataflow/tools/HBaseResultConverter.java
+++ b/bigtable-hbase-dataflow-tools/src/main/java/com/google/cloud/bigtable/dataflow/tools/HBaseResultConverter.java
@@ -13,43 +13,39 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.cloud.bigtable.dataflow;
-
-import com.google.bigtable.v1.Row;
-import com.google.cloud.bigtable.hbase.adapters.Adapters;
-import com.google.cloud.dataflow.sdk.coders.AtomicCoder;
-import com.google.cloud.dataflow.sdk.coders.Coder;
-import com.google.cloud.dataflow.sdk.coders.CoderException;
-
-import org.apache.hadoop.hbase.client.Result;
+package com.google.cloud.bigtable.dataflow.tools;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.Serializable;
+
+import org.apache.hadoop.hbase.client.Result;
+
+import com.google.bigtable.v1.Row;
+import com.google.cloud.bigtable.hbase.adapters.Adapters;
 
 /**
- * A {@link Coder} that serializes and deserializes the {@link Result}.
+ * A {@link BigtableConverter} that serializes and deserializes the {@link Result}.
  */
-public class HBaseResultCoder extends AtomicCoder<Result> implements Serializable {
+public class HBaseResultConverter implements BigtableConverter<Result> {
 
   private static final long serialVersionUID = -4975428837770254686L;
 
-  private static final HBaseResultCoder INSTANCE = new HBaseResultCoder();
+  private static final HBaseResultConverter INSTANCE = new HBaseResultConverter();
 
-  public static HBaseResultCoder getInstance() {
+  public static HBaseResultConverter getInstance() {
     return INSTANCE;
   }
 
   @Override
-  public Result decode(InputStream inputStream, Coder.Context context)
-      throws CoderException, IOException {
+  public Result decode(InputStream inputStream)
+      throws IOException {
     return Adapters.ROW_ADAPTER.adaptResponse(Row.parseDelimitedFrom(inputStream));
   }
 
   @Override
-  public void encode(Result value, OutputStream outputStream, Coder.Context context)
-      throws CoderException, IOException {
+  public void encode(Result value, OutputStream outputStream)
+      throws IOException {
     Adapters.ROW_ADAPTER.adaptToRow(value).writeDelimitedTo(outputStream);
   }
 }

--- a/bigtable-hbase-dataflow-tools/src/test/java/com/google/cloud/bigtable/dataflow/tools/CoderTestUtil.java
+++ b/bigtable-hbase-dataflow-tools/src/test/java/com/google/cloud/bigtable/dataflow/tools/CoderTestUtil.java
@@ -13,30 +13,26 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package com.google.cloud.bigtable.dataflow;
+package com.google.cloud.bigtable.dataflow.tools;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
-import com.google.cloud.dataflow.sdk.coders.Coder;
-import com.google.cloud.dataflow.sdk.coders.CoderException;
-
 /**
- * Simple tool to help with testing coders
+ * Simple tool to help with testing {@link BigtableConverter}s.
  */
 public class CoderTestUtil {
 
-  public static <T> T encodeAndDecode(Coder<T> coder, T original) throws CoderException,
-      IOException {
-    ByteArrayInputStream bais = new ByteArrayInputStream(encode(coder, original));
-    return coder.decode(bais, null);
+  public static <T> T encodeAndDecode(BigtableConverter<T> converter, T original)
+      throws IOException {
+    ByteArrayInputStream bais = new ByteArrayInputStream(encode(converter, original));
+    return converter.decode(bais);
   }
 
-  public static <T> byte[] encode(Coder<T> coder, T original) throws CoderException, IOException {
+  public static <T> byte[] encode(BigtableConverter<T> coder, T original) throws IOException {
     ByteArrayOutputStream bos = new ByteArrayOutputStream();
-    coder.encode(original, bos, null);
+    coder.encode(original, bos);
     return bos.toByteArray();
   }
-
 }

--- a/bigtable-hbase-dataflow-tools/src/test/java/com/google/cloud/bigtable/dataflow/tools/HBaseMutationCoderTest.java
+++ b/bigtable-hbase-dataflow-tools/src/test/java/com/google/cloud/bigtable/dataflow/tools/HBaseMutationCoderTest.java
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package com.google.cloud.bigtable.dataflow;
+package com.google.cloud.bigtable.dataflow.tools;
 
 import static org.apache.hadoop.hbase.util.Bytes.toBytes;
 
@@ -24,25 +24,22 @@ import org.apache.hadoop.hbase.client.Put;
 import org.junit.Assert;
 import org.junit.Test;
 
-import com.google.cloud.dataflow.sdk.coders.CoderException;
-
 /**
  * Tests for {@link HBaseMutationCoder}.
  */
 public class HBaseMutationCoderTest {
 
-  private HBaseMutationCoder underTest = new HBaseMutationCoder();
+  private HBaseMutationConverter underTest = new HBaseMutationConverter();
 
   @Test
-  public void testPut() throws CoderException, IOException {
+  public void testPut() throws IOException {
     Put original = new Put(toBytes("key")).addColumn(toBytes("family"), toBytes("column"), toBytes("value"));
     Assert.assertEquals(0, original.compareTo(CoderTestUtil.encodeAndDecode(underTest, original)));
   }
 
   @Test
-  public void testDelete() throws CoderException, IOException {
+  public void testDelete() throws IOException {
     Delete original = new Delete(toBytes("key"));
     Assert.assertEquals(0, original.compareTo(CoderTestUtil.encodeAndDecode(underTest, original)));
   }
 }
-

--- a/bigtable-hbase-dataflow-tools/src/test/java/com/google/cloud/bigtable/dataflow/tools/HBaseResultArrayCoderTest.java
+++ b/bigtable-hbase-dataflow-tools/src/test/java/com/google/cloud/bigtable/dataflow/tools/HBaseResultArrayCoderTest.java
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package com.google.cloud.bigtable.dataflow;
+package com.google.cloud.bigtable.dataflow.tools;
 
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.KeyValue;
@@ -22,19 +22,19 @@ import org.junit.Assert;
 import org.junit.Test;
 
 /**
- * Tests for {@link HBaseResultCoder}
+ * Tests for {@link HBaseResultArrayCoder}
  */
-public class HBaseResultCoderTest {
+public class HBaseResultArrayCoderTest {
 
-  private HBaseResultCoder underTest = new HBaseResultCoder();
+  private HBaseResultArrayConverter underTest = new HBaseResultArrayConverter();
 
-  private Result original = createResult();
+  private Result[] original = new Result[]{createResult()};
 
   @Test
   public void testRoundTrip() throws Exception {
-    Result copy = CoderTestUtil.encodeAndDecode(underTest, original);
+    Result[] copy = CoderTestUtil.encodeAndDecode(underTest, original);
     // This method throws an exception if the values are not equal.
-    Result.compareResults(original, copy);
+    Result.compareResults(original[0], copy[0]);
   }
 
   private Result createResult() {

--- a/bigtable-hbase-dataflow-tools/src/test/java/com/google/cloud/bigtable/dataflow/tools/HBaseResultConverterTest.java
+++ b/bigtable-hbase-dataflow-tools/src/test/java/com/google/cloud/bigtable/dataflow/tools/HBaseResultConverterTest.java
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package com.google.cloud.bigtable.dataflow;
+package com.google.cloud.bigtable.dataflow.tools;
 
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.KeyValue;
@@ -22,19 +22,19 @@ import org.junit.Assert;
 import org.junit.Test;
 
 /**
- * Tests for {@link HBaseResultArrayCoder}
+ * Tests for {@link HBaseResultCoder}
  */
-public class HBaseResultArrayCoderTest {
+public class HBaseResultConverterTest {
 
-  private HBaseResultArrayCoder underTest = new HBaseResultArrayCoder();
+  private HBaseResultConverter underTest = new HBaseResultConverter();
 
-  private Result[] original = new Result[]{createResult()};
+  private Result original = createResult();
 
   @Test
   public void testRoundTrip() throws Exception {
-    Result[] copy = CoderTestUtil.encodeAndDecode(underTest, original);
+    Result copy = CoderTestUtil.encodeAndDecode(underTest, original);
     // This method throws an exception if the values are not equal.
-    Result.compareResults(original[0], copy[0]);
+    Result.compareResults(original, copy);
   }
 
   private Result createResult() {

--- a/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/BigtableConverterCoder.java
+++ b/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/BigtableConverterCoder.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.dataflow;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import com.google.bigtable.repackaged.com.google.cloud.dataflow.tools.BigtableConverter;
+import com.google.cloud.dataflow.sdk.coders.AtomicCoder;
+import com.google.cloud.dataflow.sdk.coders.Coder;
+import com.google.cloud.dataflow.sdk.coders.CoderException;
+
+public class BigtableConverterCoder<T> extends AtomicCoder<T> {
+
+  private static final long serialVersionUID = 864682049542548090L;
+
+  private BigtableConverter<T> converter;
+
+  public BigtableConverterCoder(BigtableConverter<T> converter) {
+    this.converter = converter;
+  }
+
+  @Override
+  public void encode(T value, OutputStream outStream,
+      Coder.Context context)
+          throws CoderException, IOException {
+    converter.encode(value, outStream);
+  }
+
+  @Override
+  public T decode(InputStream inStream, Coder.Context context)
+      throws CoderException, IOException {
+    return converter.decode(inStream);
+  }
+
+  public BigtableConverter<T> getConverter() {
+    return converter;
+  }
+}

--- a/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/CloudBigtableConfiguration.java
+++ b/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/CloudBigtableConfiguration.java
@@ -24,10 +24,10 @@ import java.util.Map.Entry;
 
 import org.apache.hadoop.conf.Configuration;
 
+import com.google.bigtable.repackaged.com.google.cloud.config.BigtableOptions;
+import com.google.cloud.bigtable.hbase.BigtableOptionsFactory;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
-import com.google.cloud.bigtable.config.BigtableOptions;
-import com.google.cloud.bigtable.hbase.BigtableOptionsFactory;
 
 /**
  * This class defines configuration that a Cloud Bigtable client needs to connect to a Cloud

--- a/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/CloudBigtableScanConfiguration.java
+++ b/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/CloudBigtableScanConfiguration.java
@@ -15,13 +15,14 @@
  */
 package com.google.cloud.bigtable.dataflow;
 
-import com.google.bigtable.v1.ReadRowsRequest;
-import com.google.cloud.bigtable.grpc.BigtableClusterName;
-import com.google.cloud.bigtable.hbase.adapters.Adapters;
-import com.google.cloud.bigtable.hbase.adapters.read.DefaultReadHooks;
-import com.google.cloud.bigtable.hbase.adapters.read.ReadHooks;
 
 import org.apache.hadoop.hbase.client.Scan;
+
+import com.google.bigtable.repackaged.com.google.cloud.grpc.BigtableClusterName;
+import com.google.bigtable.repackaged.com.google.cloud.hbase.adapters.Adapters;
+import com.google.bigtable.repackaged.com.google.cloud.hbase.adapters.read.DefaultReadHooks;
+import com.google.bigtable.repackaged.com.google.cloud.hbase.adapters.read.ReadHooks;
+import com.google.bigtable.repackaged.com.google.com.google.bigtable.v1.ReadRowsRequest;
 
 import java.util.Map;
 import java.util.Objects;

--- a/bigtable-hbase-dataflow/src/test/java/com/google/cloud/bigtable/dataflow/CloudBigtableIOIntegrationTest.java
+++ b/bigtable-hbase-dataflow/src/test/java/com/google/cloud/bigtable/dataflow/CloudBigtableIOIntegrationTest.java
@@ -30,8 +30,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import com.google.bigtable.v1.SampleRowKeysResponse;
-import com.google.cloud.bigtable.config.Logger;
+import com.google.bigtable.repackaged.com.google.cloud.config.Logger;
+import com.google.bigtable.repackaged.com.google.com.google.bigtable.v1.SampleRowKeysResponse;
 import com.google.cloud.bigtable.dataflow.CloudBigtableIO.Source;
 import com.google.cloud.bigtable.hbase1_0.BigtableConnection;
 import com.google.cloud.dataflow.sdk.io.BoundedSource;

--- a/bigtable-hbase-dataflow/src/test/java/com/google/cloud/bigtable/dataflow/CloudBigtableIOTest.java
+++ b/bigtable-hbase-dataflow/src/test/java/com/google/cloud/bigtable/dataflow/CloudBigtableIOTest.java
@@ -17,6 +17,7 @@ package com.google.cloud.bigtable.dataflow;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
 
@@ -39,8 +40,9 @@ import org.junit.rules.ExpectedException;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import com.google.bigtable.repackaged.com.google.cloud.dataflow.tools.HBaseMutationConverter;
+import com.google.bigtable.repackaged.com.google.com.google.bigtable.v1.SampleRowKeysResponse;
 import com.google.bigtable.repackaged.com.google.protobuf.ByteString;
-import com.google.bigtable.v1.SampleRowKeysResponse;
 import com.google.cloud.bigtable.dataflow.CloudBigtableIO.AbstractSource;
 import com.google.cloud.bigtable.dataflow.CloudBigtableIO.Source;
 import com.google.cloud.bigtable.dataflow.CloudBigtableIO.SourceWithKeys;
@@ -85,11 +87,13 @@ public class CloudBigtableIOTest {
 
   }
 
+  @SuppressWarnings("rawtypes")
   private void checkRegistry(Class<? extends Mutation> mutationClass)
       throws CannotProvideCoderException {
     Coder<? extends Mutation> coder = registry.getCoder(TypeDescriptor.of(mutationClass));
     assertNotNull(coder);
-    assertEquals(HBaseMutationCoder.class, coder.getClass());
+    assertEquals(BigtableConverterCoder.class, coder.getClass());
+    assertTrue(((BigtableConverterCoder) coder).getConverter() instanceof HBaseMutationConverter);
   }
 
   @Test

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@ limitations under the License.
         <module>bigtable-hbase-1.1</module>
         <module>bigtable-hbase-1.2</module>
         <module>bigtable-hbase-mapreduce</module>
+        <module>bigtable-hbase-dataflow-tools</module>
         <module>bigtable-hbase-dataflow</module>
         <module>bigtable-dataflow-import</module>
     </modules>


### PR DESCRIPTION
This required a a maven submodule refactoring.  There's some funky shading that happens in bigtable-hbase-dataflow/pom.xml which was done to fix a problem relating to bigtable-client-core's inclusion in the dataflow sdk.  The dataflow sdk had to do some funky shading because various projects they use have conflicting dependencies.  They added cloud-bigtable-core 0.2.3 in dataflow sdk 1.5.0+ and did shading causing conflicts with classes in the cloud-bigtable-hbase-* projects.  cloud-bigtable-hbase-dataflow's shading when combined with dataflow sdk shading causes some funkiness when running maven and using an IDE.  An intermediate submodule alleviates those issues.