### PR TITLE
Adding some infrastructure for liquid sharding.

### DIFF
--- a/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/CloudBigtableIO.java
+++ b/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/CloudBigtableIO.java
@@ -828,11 +828,20 @@ public class CloudBigtableIO {
     }
 
     @Override
+    /**
+     * What percentage of the range is complete? This is the best guess based on the lexicographical
+     * ordering of the Reader's key range.
+     */
     public final Double getFractionConsumed() {
       return rangeTracker.getFractionConsumed();
     }
 
     @Override
+    /**
+     * Attempt to split the work by some percent of the ByteKeyRange based on a lexicographical
+     * split (and not statistics about the underlying table, which would be better, but that
+     * information does not exist).
+     */
     public final synchronized BoundedSource<Results> splitAtFraction(double fraction) {
       ByteKeyRange originalRange = source.getRange();
       ByteKey splitKey;

--- a/bigtable-hbase-dataflow/src/test/java/com/google/cloud/bigtable/dataflow/CloudBigtableIOTest.java
+++ b/bigtable-hbase-dataflow/src/test/java/com/google/cloud/bigtable/dataflow/CloudBigtableIOTest.java
@@ -121,13 +121,18 @@ public class CloudBigtableIOTest {
     byte[] startKey = "abc d".getBytes();
     byte[] stopKey = "def g".getBytes();
     BoundedSource<Result> sourceWithKeys = source.createSourceWithKeys(startKey, stopKey, 10);
-    assertEquals("Split start: 'abc d', end: 'def g', size: 10", sourceWithKeys.toString());
+    assertEquals(
+      "Split start: 'abc d', end: 'def g', size: 10,"
+          + " range: ByteKeyRange{startKey=[6162632064], endKey=[6465662067]}",
+      sourceWithKeys.toString());
 
     startKey = new byte[]{0, 1, 2, 3, 4, 5};
     stopKey = new byte[]{104, 101, 108, 108, 111};  // hello
     sourceWithKeys = source.createSourceWithKeys(startKey, stopKey, 10);
-    assertEquals("Split start: '\\x00\\x01\\x02\\x03\\x04\\x05', end: 'hello', size: 10",
-        sourceWithKeys.toString());
+    assertEquals(
+      "Split start: '\\x00\\x01\\x02\\x03\\x04\\x05', end: 'hello', size: 10,"
+          + " range: ByteKeyRange{startKey=[000102030405], endKey=[68656c6c6f]}",
+      sourceWithKeys.toString());
   }
 
   @SuppressWarnings({ "rawtypes", "unchecked" })


### PR DESCRIPTION
Liquid sharding allows Dataflow to split off some work if a Reader is going too slow, and another worker has some capacity.  There are some open questions that need to be worked out with the Dataflow team, so the actual implementation doesn't exist yet.

see https://github.com/apache/incubator-beam/blob/master/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIO.java for more details on how Apache Beam does it.