### PR TITLE
Updating grpc, io.netty, protobuf and tcnative versions.

### DIFF
--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/api/CustomHttpPattern.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/api/CustomHttpPattern.java
@@ -48,13 +48,13 @@ public  final class CustomHttpPattern extends
             break;
           }
           case 10: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             kind_ = s;
             break;
           }
           case 18: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             path_ = s;
             break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/api/HttpRule.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/api/HttpRule.java
@@ -196,37 +196,37 @@ public  final class HttpRule extends
             break;
           }
           case 18: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
             patternCase_ = 2;
             pattern_ = s;
             break;
           }
           case 26: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
             patternCase_ = 3;
             pattern_ = s;
             break;
           }
           case 34: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
             patternCase_ = 4;
             pattern_ = s;
             break;
           }
           case 42: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
             patternCase_ = 5;
             pattern_ = s;
             break;
           }
           case 50: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
             patternCase_ = 6;
             pattern_ = s;
             break;
           }
           case 58: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             body_ = s;
             break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/cluster/v1/Cluster.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/cluster/v1/Cluster.java
@@ -50,7 +50,7 @@ public  final class Cluster extends
             break;
           }
           case 10: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             name_ = s;
             break;
@@ -69,7 +69,7 @@ public  final class Cluster extends
             break;
           }
           case 34: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             displayName_ = s;
             break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/cluster/v1/CreateClusterRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/cluster/v1/CreateClusterRequest.java
@@ -48,13 +48,13 @@ public  final class CreateClusterRequest extends
             break;
           }
           case 10: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             name_ = s;
             break;
           }
           case 18: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             clusterId_ = s;
             break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/cluster/v1/DeleteClusterRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/cluster/v1/DeleteClusterRequest.java
@@ -47,7 +47,7 @@ public  final class DeleteClusterRequest extends
             break;
           }
           case 10: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             name_ = s;
             break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/cluster/v1/GetClusterRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/cluster/v1/GetClusterRequest.java
@@ -47,7 +47,7 @@ public  final class GetClusterRequest extends
             break;
           }
           case 10: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             name_ = s;
             break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/cluster/v1/ListClustersRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/cluster/v1/ListClustersRequest.java
@@ -47,7 +47,7 @@ public  final class ListClustersRequest extends
             break;
           }
           case 10: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             name_ = s;
             break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/cluster/v1/ListZonesRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/cluster/v1/ListZonesRequest.java
@@ -47,7 +47,7 @@ public  final class ListZonesRequest extends
             break;
           }
           case 10: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             name_ = s;
             break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/cluster/v1/UndeleteClusterRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/cluster/v1/UndeleteClusterRequest.java
@@ -47,7 +47,7 @@ public  final class UndeleteClusterRequest extends
             break;
           }
           case 10: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             name_ = s;
             break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/cluster/v1/Zone.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/cluster/v1/Zone.java
@@ -50,13 +50,13 @@ public  final class Zone extends
             break;
           }
           case 10: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             name_ = s;
             break;
           }
           case 18: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             displayName_ = s;
             break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/table/v1/BulkDeleteRowsRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/table/v1/BulkDeleteRowsRequest.java
@@ -43,7 +43,7 @@ public  final class BulkDeleteRowsRequest extends
             break;
           }
           case 10: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             tableName_ = s;
             break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/table/v1/ColumnFamily.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/table/v1/ColumnFamily.java
@@ -48,13 +48,13 @@ public  final class ColumnFamily extends
             break;
           }
           case 10: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             name_ = s;
             break;
           }
           case 18: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             gcExpression_ = s;
             break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/table/v1/CreateColumnFamilyRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/table/v1/CreateColumnFamilyRequest.java
@@ -44,13 +44,13 @@ public  final class CreateColumnFamilyRequest extends
             break;
           }
           case 10: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             name_ = s;
             break;
           }
           case 18: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             columnFamilyId_ = s;
             break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/table/v1/CreateTableRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/table/v1/CreateTableRequest.java
@@ -45,13 +45,13 @@ public  final class CreateTableRequest extends
             break;
           }
           case 10: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             name_ = s;
             break;
           }
           case 18: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             tableId_ = s;
             break;
@@ -70,7 +70,7 @@ public  final class CreateTableRequest extends
             break;
           }
           case 34: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
             if (!((mutable_bitField0_ & 0x00000008) == 0x00000008)) {
               initialSplitKeys_ = new com.google.protobuf.LazyStringArrayList();
               mutable_bitField0_ |= 0x00000008;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/table/v1/DeleteColumnFamilyRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/table/v1/DeleteColumnFamilyRequest.java
@@ -43,7 +43,7 @@ public  final class DeleteColumnFamilyRequest extends
             break;
           }
           case 10: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             name_ = s;
             break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/table/v1/DeleteTableRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/table/v1/DeleteTableRequest.java
@@ -43,7 +43,7 @@ public  final class DeleteTableRequest extends
             break;
           }
           case 10: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             name_ = s;
             break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/table/v1/GetTableRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/table/v1/GetTableRequest.java
@@ -43,7 +43,7 @@ public  final class GetTableRequest extends
             break;
           }
           case 10: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             name_ = s;
             break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/table/v1/ListTablesRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/table/v1/ListTablesRequest.java
@@ -43,7 +43,7 @@ public  final class ListTablesRequest extends
             break;
           }
           case 10: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             name_ = s;
             break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/table/v1/RenameTableRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/table/v1/RenameTableRequest.java
@@ -44,13 +44,13 @@ public  final class RenameTableRequest extends
             break;
           }
           case 10: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             name_ = s;
             break;
           }
           case 18: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             newId_ = s;
             break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/table/v1/Table.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/table/v1/Table.java
@@ -49,7 +49,7 @@ public  final class Table extends
             break;
           }
           case 10: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             name_ = s;
             break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/Cluster.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/Cluster.java
@@ -53,13 +53,13 @@ public  final class Cluster extends
             break;
           }
           case 10: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             name_ = s;
             break;
           }
           case 18: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             location_ = s;
             break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/CreateClusterRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/CreateClusterRequest.java
@@ -48,13 +48,13 @@ public  final class CreateClusterRequest extends
             break;
           }
           case 10: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             parent_ = s;
             break;
           }
           case 18: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             clusterId_ = s;
             break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/CreateInstanceRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/CreateInstanceRequest.java
@@ -48,13 +48,13 @@ public  final class CreateInstanceRequest extends
             break;
           }
           case 10: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             parent_ = s;
             break;
           }
           case 18: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             instanceId_ = s;
             break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/CreateTableRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/CreateTableRequest.java
@@ -49,13 +49,13 @@ public  final class CreateTableRequest extends
             break;
           }
           case 10: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             parent_ = s;
             break;
           }
           case 18: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             tableId_ = s;
             break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/DeleteClusterRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/DeleteClusterRequest.java
@@ -47,7 +47,7 @@ public  final class DeleteClusterRequest extends
             break;
           }
           case 10: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             name_ = s;
             break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/DeleteInstanceRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/DeleteInstanceRequest.java
@@ -47,7 +47,7 @@ public  final class DeleteInstanceRequest extends
             break;
           }
           case 10: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             name_ = s;
             break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/DeleteTableRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/DeleteTableRequest.java
@@ -47,7 +47,7 @@ public  final class DeleteTableRequest extends
             break;
           }
           case 10: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             name_ = s;
             break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/DropRowRangeRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/DropRowRangeRequest.java
@@ -47,7 +47,7 @@ public  final class DropRowRangeRequest extends
             break;
           }
           case 10: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             name_ = s;
             break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/GetClusterRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/GetClusterRequest.java
@@ -47,7 +47,7 @@ public  final class GetClusterRequest extends
             break;
           }
           case 10: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             name_ = s;
             break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/GetInstanceRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/GetInstanceRequest.java
@@ -47,7 +47,7 @@ public  final class GetInstanceRequest extends
             break;
           }
           case 10: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             name_ = s;
             break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/GetTableRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/GetTableRequest.java
@@ -48,7 +48,7 @@ public  final class GetTableRequest extends
             break;
           }
           case 10: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             name_ = s;
             break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/Instance.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/Instance.java
@@ -52,13 +52,13 @@ public  final class Instance extends
             break;
           }
           case 10: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             name_ = s;
             break;
           }
           case 18: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             displayName_ = s;
             break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/ListClustersRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/ListClustersRequest.java
@@ -48,13 +48,13 @@ public  final class ListClustersRequest extends
             break;
           }
           case 10: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             parent_ = s;
             break;
           }
           case 18: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             pageToken_ = s;
             break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/ListClustersResponse.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/ListClustersResponse.java
@@ -57,7 +57,7 @@ public  final class ListClustersResponse extends
             break;
           }
           case 18: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
             if (!((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
               failedLocations_ = new com.google.protobuf.LazyStringArrayList();
               mutable_bitField0_ |= 0x00000002;
@@ -66,7 +66,7 @@ public  final class ListClustersResponse extends
             break;
           }
           case 26: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             nextPageToken_ = s;
             break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/ListInstancesRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/ListInstancesRequest.java
@@ -48,13 +48,13 @@ public  final class ListInstancesRequest extends
             break;
           }
           case 10: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             parent_ = s;
             break;
           }
           case 18: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             pageToken_ = s;
             break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/ListInstancesResponse.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/ListInstancesResponse.java
@@ -57,7 +57,7 @@ public  final class ListInstancesResponse extends
             break;
           }
           case 18: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
             if (!((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
               failedLocations_ = new com.google.protobuf.LazyStringArrayList();
               mutable_bitField0_ |= 0x00000002;
@@ -66,7 +66,7 @@ public  final class ListInstancesResponse extends
             break;
           }
           case 26: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             nextPageToken_ = s;
             break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/ListTablesRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/ListTablesRequest.java
@@ -49,7 +49,7 @@ public  final class ListTablesRequest extends
             break;
           }
           case 10: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             parent_ = s;
             break;
@@ -61,7 +61,7 @@ public  final class ListTablesRequest extends
             break;
           }
           case 26: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             pageToken_ = s;
             break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/ListTablesResponse.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/ListTablesResponse.java
@@ -56,7 +56,7 @@ public  final class ListTablesResponse extends
             break;
           }
           case 18: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             nextPageToken_ = s;
             break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/ModifyColumnFamiliesRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/ModifyColumnFamiliesRequest.java
@@ -48,7 +48,7 @@ public  final class ModifyColumnFamiliesRequest extends
             break;
           }
           case 10: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             name_ = s;
             break;
@@ -204,7 +204,7 @@ public  final class ModifyColumnFamiliesRequest extends
               break;
             }
             case 10: {
-              String s = input.readStringRequireUtf8();
+              java.lang.String s = input.readStringRequireUtf8();
 
               id_ = s;
               break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/Table.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/Table.java
@@ -49,7 +49,7 @@ public  final class Table extends
             break;
           }
           case 10: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             name_ = s;
             break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v1/Cell.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v1/Cell.java
@@ -59,7 +59,7 @@ public  final class Cell extends
             break;
           }
           case 26: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
             if (!((mutable_bitField0_ & 0x00000004) == 0x00000004)) {
               labels_ = new com.google.protobuf.LazyStringArrayList();
               mutable_bitField0_ |= 0x00000004;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v1/CheckAndMutateRowRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v1/CheckAndMutateRowRequest.java
@@ -50,7 +50,7 @@ public  final class CheckAndMutateRowRequest extends
             break;
           }
           case 10: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             tableName_ = s;
             break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v1/ColumnRange.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v1/ColumnRange.java
@@ -50,7 +50,7 @@ public  final class ColumnRange extends
             break;
           }
           case 10: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             familyName_ = s;
             break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v1/Family.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v1/Family.java
@@ -48,7 +48,7 @@ public  final class Family extends
             break;
           }
           case 10: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             name_ = s;
             break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v1/MutateRowRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v1/MutateRowRequest.java
@@ -49,7 +49,7 @@ public  final class MutateRowRequest extends
             break;
           }
           case 10: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             tableName_ = s;
             break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v1/MutateRowsRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v1/MutateRowsRequest.java
@@ -48,7 +48,7 @@ public  final class MutateRowsRequest extends
             break;
           }
           case 10: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             tableName_ = s;
             break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v1/Mutation.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v1/Mutation.java
@@ -228,7 +228,7 @@ public  final class Mutation extends
               break;
             }
             case 10: {
-              String s = input.readStringRequireUtf8();
+              java.lang.String s = input.readStringRequireUtf8();
 
               familyName_ = s;
               break;
@@ -1000,7 +1000,7 @@ public  final class Mutation extends
               break;
             }
             case 10: {
-              String s = input.readStringRequireUtf8();
+              java.lang.String s = input.readStringRequireUtf8();
 
               familyName_ = s;
               break;
@@ -1799,7 +1799,7 @@ public  final class Mutation extends
               break;
             }
             case 10: {
-              String s = input.readStringRequireUtf8();
+              java.lang.String s = input.readStringRequireUtf8();
 
               familyName_ = s;
               break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v1/ReadModifyWriteRowRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v1/ReadModifyWriteRowRequest.java
@@ -49,7 +49,7 @@ public  final class ReadModifyWriteRowRequest extends
             break;
           }
           case 10: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             tableName_ = s;
             break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v1/ReadModifyWriteRule.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v1/ReadModifyWriteRule.java
@@ -49,7 +49,7 @@ public  final class ReadModifyWriteRule extends
             break;
           }
           case 10: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             familyName_ = s;
             break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v1/ReadRowsRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v1/ReadRowsRequest.java
@@ -49,7 +49,7 @@ public  final class ReadRowsRequest extends
             break;
           }
           case 10: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             tableName_ = s;
             break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v1/RowFilter.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v1/RowFilter.java
@@ -120,7 +120,7 @@ public  final class RowFilter extends
             break;
           }
           case 42: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
             filterCase_ = 5;
             filter_ = s;
             break;
@@ -218,7 +218,7 @@ public  final class RowFilter extends
             break;
           }
           case 154: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
             filterCase_ = 19;
             filter_ = s;
             break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v1/SampleRowKeysRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v1/SampleRowKeysRequest.java
@@ -47,7 +47,7 @@ public  final class SampleRowKeysRequest extends
             break;
           }
           case 10: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             tableName_ = s;
             break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/Cell.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/Cell.java
@@ -59,7 +59,7 @@ public  final class Cell extends
             break;
           }
           case 26: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
             if (!((mutable_bitField0_ & 0x00000004) == 0x00000004)) {
               labels_ = new com.google.protobuf.LazyStringArrayList();
               mutable_bitField0_ |= 0x00000004;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/CheckAndMutateRowRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/CheckAndMutateRowRequest.java
@@ -50,7 +50,7 @@ public  final class CheckAndMutateRowRequest extends
             break;
           }
           case 10: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             tableName_ = s;
             break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/ColumnRange.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/ColumnRange.java
@@ -50,7 +50,7 @@ public  final class ColumnRange extends
             break;
           }
           case 10: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             familyName_ = s;
             break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/Family.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/Family.java
@@ -49,7 +49,7 @@ public  final class Family extends
             break;
           }
           case 10: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             name_ = s;
             break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/MutateRowRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/MutateRowRequest.java
@@ -49,7 +49,7 @@ public  final class MutateRowRequest extends
             break;
           }
           case 10: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             tableName_ = s;
             break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/MutateRowsRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/MutateRowsRequest.java
@@ -48,7 +48,7 @@ public  final class MutateRowsRequest extends
             break;
           }
           case 10: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             tableName_ = s;
             break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/Mutation.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/Mutation.java
@@ -228,7 +228,7 @@ public  final class Mutation extends
               break;
             }
             case 10: {
-              String s = input.readStringRequireUtf8();
+              java.lang.String s = input.readStringRequireUtf8();
 
               familyName_ = s;
               break;
@@ -1000,7 +1000,7 @@ public  final class Mutation extends
               break;
             }
             case 10: {
-              String s = input.readStringRequireUtf8();
+              java.lang.String s = input.readStringRequireUtf8();
 
               familyName_ = s;
               break;
@@ -1799,7 +1799,7 @@ public  final class Mutation extends
               break;
             }
             case 10: {
-              String s = input.readStringRequireUtf8();
+              java.lang.String s = input.readStringRequireUtf8();
 
               familyName_ = s;
               break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/ReadModifyWriteRowRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/ReadModifyWriteRowRequest.java
@@ -49,7 +49,7 @@ public  final class ReadModifyWriteRowRequest extends
             break;
           }
           case 10: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             tableName_ = s;
             break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/ReadModifyWriteRule.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/ReadModifyWriteRule.java
@@ -49,7 +49,7 @@ public  final class ReadModifyWriteRule extends
             break;
           }
           case 10: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             familyName_ = s;
             break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/ReadRowsRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/ReadRowsRequest.java
@@ -48,7 +48,7 @@ public  final class ReadRowsRequest extends
             break;
           }
           case 10: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             tableName_ = s;
             break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/ReadRowsResponse.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/ReadRowsResponse.java
@@ -371,7 +371,7 @@ public  final class ReadRowsResponse extends
               break;
             }
             case 42: {
-              String s = input.readStringRequireUtf8();
+              java.lang.String s = input.readStringRequireUtf8();
               if (!((mutable_bitField0_ & 0x00000010) == 0x00000010)) {
                 labels_ = new com.google.protobuf.LazyStringArrayList();
                 mutable_bitField0_ |= 0x00000010;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/RowFilter.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/RowFilter.java
@@ -120,7 +120,7 @@ public  final class RowFilter extends
             break;
           }
           case 42: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
             filterCase_ = 5;
             filter_ = s;
             break;
@@ -218,7 +218,7 @@ public  final class RowFilter extends
             break;
           }
           case 154: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
             filterCase_ = 19;
             filter_ = s;
             break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/SampleRowKeysRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/SampleRowKeysRequest.java
@@ -47,7 +47,7 @@ public  final class SampleRowKeysRequest extends
             break;
           }
           case 10: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             tableName_ = s;
             break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/longrunning/CancelOperationRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/longrunning/CancelOperationRequest.java
@@ -47,7 +47,7 @@ public  final class CancelOperationRequest extends
             break;
           }
           case 10: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             name_ = s;
             break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/longrunning/DeleteOperationRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/longrunning/DeleteOperationRequest.java
@@ -47,7 +47,7 @@ public  final class DeleteOperationRequest extends
             break;
           }
           case 10: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             name_ = s;
             break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/longrunning/GetOperationRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/longrunning/GetOperationRequest.java
@@ -47,7 +47,7 @@ public  final class GetOperationRequest extends
             break;
           }
           case 10: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             name_ = s;
             break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/longrunning/ListOperationsRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/longrunning/ListOperationsRequest.java
@@ -50,7 +50,7 @@ public  final class ListOperationsRequest extends
             break;
           }
           case 10: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             filter_ = s;
             break;
@@ -61,13 +61,13 @@ public  final class ListOperationsRequest extends
             break;
           }
           case 26: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             pageToken_ = s;
             break;
           }
           case 34: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             name_ = s;
             break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/longrunning/ListOperationsResponse.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/longrunning/ListOperationsResponse.java
@@ -56,7 +56,7 @@ public  final class ListOperationsResponse extends
             break;
           }
           case 18: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             nextPageToken_ = s;
             break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/longrunning/Operation.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/longrunning/Operation.java
@@ -49,7 +49,7 @@ public  final class Operation extends
             break;
           }
           case 10: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             name_ = s;
             break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/rpc/BadRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/rpc/BadRequest.java
@@ -171,13 +171,13 @@ public  final class BadRequest extends
               break;
             }
             case 10: {
-              String s = input.readStringRequireUtf8();
+              java.lang.String s = input.readStringRequireUtf8();
 
               field_ = s;
               break;
             }
             case 18: {
-              String s = input.readStringRequireUtf8();
+              java.lang.String s = input.readStringRequireUtf8();
 
               description_ = s;
               break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/rpc/DebugInfo.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/rpc/DebugInfo.java
@@ -48,7 +48,7 @@ public  final class DebugInfo extends
             break;
           }
           case 10: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
             if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
               stackEntries_ = new com.google.protobuf.LazyStringArrayList();
               mutable_bitField0_ |= 0x00000001;
@@ -57,7 +57,7 @@ public  final class DebugInfo extends
             break;
           }
           case 18: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             detail_ = s;
             break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/rpc/Help.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/rpc/Help.java
@@ -169,13 +169,13 @@ public  final class Help extends
               break;
             }
             case 10: {
-              String s = input.readStringRequireUtf8();
+              java.lang.String s = input.readStringRequireUtf8();
 
               description_ = s;
               break;
             }
             case 18: {
-              String s = input.readStringRequireUtf8();
+              java.lang.String s = input.readStringRequireUtf8();
 
               url_ = s;
               break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/rpc/QuotaFailure.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/rpc/QuotaFailure.java
@@ -189,13 +189,13 @@ public  final class QuotaFailure extends
               break;
             }
             case 10: {
-              String s = input.readStringRequireUtf8();
+              java.lang.String s = input.readStringRequireUtf8();
 
               subject_ = s;
               break;
             }
             case 18: {
-              String s = input.readStringRequireUtf8();
+              java.lang.String s = input.readStringRequireUtf8();
 
               description_ = s;
               break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/rpc/RequestInfo.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/rpc/RequestInfo.java
@@ -49,13 +49,13 @@ public  final class RequestInfo extends
             break;
           }
           case 10: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             requestId_ = s;
             break;
           }
           case 18: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             servingData_ = s;
             break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/rpc/ResourceInfo.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/rpc/ResourceInfo.java
@@ -50,25 +50,25 @@ public  final class ResourceInfo extends
             break;
           }
           case 10: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             resourceType_ = s;
             break;
           }
           case 18: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             resourceName_ = s;
             break;
           }
           case 26: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             owner_ = s;
             break;
           }
           case 34: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             description_ = s;
             break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/rpc/Status.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/rpc/Status.java
@@ -92,7 +92,7 @@ public  final class Status extends
             break;
           }
           case 18: {
-            String s = input.readStringRequireUtf8();
+            java.lang.String s = input.readStringRequireUtf8();
 
             message_ = s;
             break;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/services/com/google/bigtable/admin/cluster/v1/BigtableClusterServiceGrpc.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/services/com/google/bigtable/admin/cluster/v1/BigtableClusterServiceGrpc.java
@@ -12,8 +12,17 @@ import static io.grpc.stub.ServerCalls.asyncUnaryCall;
 import static io.grpc.stub.ServerCalls.asyncServerStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncClientStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncBidiStreamingCall;
+import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
+import static io.grpc.stub.ServerCalls.asyncUnimplementedStreamingCall;
 
-@javax.annotation.Generated("by gRPC proto compiler")
+/**
+ * <pre>
+ * Service for managing zonal Cloud Bigtable resources.
+ * </pre>
+ */
+@javax.annotation.Generated(
+    value = "by gRPC proto compiler (version 0.14.1)",
+    comments = "Source: google/bigtable/admin/cluster/v1/bigtable_cluster_service.proto")
 public class BigtableClusterServiceGrpc {
 
   private BigtableClusterServiceGrpc() {}
@@ -85,81 +94,449 @@ public class BigtableClusterServiceGrpc {
           io.grpc.protobuf.ProtoUtils.marshaller(com.google.bigtable.admin.cluster.v1.UndeleteClusterRequest.getDefaultInstance()),
           io.grpc.protobuf.ProtoUtils.marshaller(com.google.longrunning.Operation.getDefaultInstance()));
 
+  /**
+   * Creates a new async stub that supports all call types for the service
+   */
   public static BigtableClusterServiceStub newStub(io.grpc.Channel channel) {
     return new BigtableClusterServiceStub(channel);
   }
 
+  /**
+   * Creates a new blocking-style stub that supports unary and streaming output calls on the service
+   */
   public static BigtableClusterServiceBlockingStub newBlockingStub(
       io.grpc.Channel channel) {
     return new BigtableClusterServiceBlockingStub(channel);
   }
 
+  /**
+   * Creates a new ListenableFuture-style stub that supports unary and streaming output calls on the service
+   */
   public static BigtableClusterServiceFutureStub newFutureStub(
       io.grpc.Channel channel) {
     return new BigtableClusterServiceFutureStub(channel);
   }
 
+  /**
+   * <pre>
+   * Service for managing zonal Cloud Bigtable resources.
+   * </pre>
+   */
   public static interface BigtableClusterService {
 
+    /**
+     * <pre>
+     * Lists the supported zones for the given project.
+     * </pre>
+     */
     public void listZones(com.google.bigtable.admin.cluster.v1.ListZonesRequest request,
         io.grpc.stub.StreamObserver<com.google.bigtable.admin.cluster.v1.ListZonesResponse> responseObserver);
 
+    /**
+     * <pre>
+     * Gets information about a particular cluster.
+     * </pre>
+     */
     public void getCluster(com.google.bigtable.admin.cluster.v1.GetClusterRequest request,
         io.grpc.stub.StreamObserver<com.google.bigtable.admin.cluster.v1.Cluster> responseObserver);
 
+    /**
+     * <pre>
+     * Lists all clusters in the given project, along with any zones for which
+     * cluster information could not be retrieved.
+     * </pre>
+     */
     public void listClusters(com.google.bigtable.admin.cluster.v1.ListClustersRequest request,
         io.grpc.stub.StreamObserver<com.google.bigtable.admin.cluster.v1.ListClustersResponse> responseObserver);
 
+    /**
+     * <pre>
+     * Creates a cluster and begins preparing it to begin serving. The returned
+     * cluster embeds as its "current_operation" a long-running operation which
+     * can be used to track the progress of turning up the new cluster.
+     * Immediately upon completion of this request:
+     *  * The cluster will be readable via the API, with all requested attributes
+     *    but no allocated resources.
+     * Until completion of the embedded operation:
+     *  * Cancelling the operation will render the cluster immediately unreadable
+     *    via the API.
+     *  * All other attempts to modify or delete the cluster will be rejected.
+     * Upon completion of the embedded operation:
+     *  * Billing for all successfully-allocated resources will begin (some types
+     *    may have lower than the requested levels).
+     *  * New tables can be created in the cluster.
+     *  * The cluster's allocated resource levels will be readable via the API.
+     * The embedded operation's "metadata" field type is
+     * [CreateClusterMetadata][google.bigtable.admin.cluster.v1.CreateClusterMetadata] The embedded operation's "response" field type is
+     * [Cluster][google.bigtable.admin.cluster.v1.Cluster], if successful.
+     * </pre>
+     */
     public void createCluster(com.google.bigtable.admin.cluster.v1.CreateClusterRequest request,
         io.grpc.stub.StreamObserver<com.google.bigtable.admin.cluster.v1.Cluster> responseObserver);
 
+    /**
+     * <pre>
+     * Updates a cluster, and begins allocating or releasing resources as
+     * requested. The returned cluster embeds as its "current_operation" a
+     * long-running operation which can be used to track the progress of updating
+     * the cluster.
+     * Immediately upon completion of this request:
+     *  * For resource types where a decrease in the cluster's allocation has been
+     *    requested, billing will be based on the newly-requested level.
+     * Until completion of the embedded operation:
+     *  * Cancelling the operation will set its metadata's "cancelled_at_time",
+     *    and begin restoring resources to their pre-request values. The operation
+     *    is guaranteed to succeed at undoing all resource changes, after which
+     *    point it will terminate with a CANCELLED status.
+     *  * All other attempts to modify or delete the cluster will be rejected.
+     *  * Reading the cluster via the API will continue to give the pre-request
+     *    resource levels.
+     * Upon completion of the embedded operation:
+     *  * Billing will begin for all successfully-allocated resources (some types
+     *    may have lower than the requested levels).
+     *  * All newly-reserved resources will be available for serving the cluster's
+     *    tables.
+     *  * The cluster's new resource levels will be readable via the API.
+     * [UpdateClusterMetadata][google.bigtable.admin.cluster.v1.UpdateClusterMetadata] The embedded operation's "response" field type is
+     * [Cluster][google.bigtable.admin.cluster.v1.Cluster], if successful.
+     * </pre>
+     */
     public void updateCluster(com.google.bigtable.admin.cluster.v1.Cluster request,
         io.grpc.stub.StreamObserver<com.google.bigtable.admin.cluster.v1.Cluster> responseObserver);
 
+    /**
+     * <pre>
+     * Marks a cluster and all of its tables for permanent deletion in 7 days.
+     * Immediately upon completion of the request:
+     *  * Billing will cease for all of the cluster's reserved resources.
+     *  * The cluster's "delete_time" field will be set 7 days in the future.
+     * Soon afterward:
+     *  * All tables within the cluster will become unavailable.
+     * Prior to the cluster's "delete_time":
+     *  * The cluster can be recovered with a call to UndeleteCluster.
+     *  * All other attempts to modify or delete the cluster will be rejected.
+     * At the cluster's "delete_time":
+     *  * The cluster and *all of its tables* will immediately and irrevocably
+     *    disappear from the API, and their data will be permanently deleted.
+     * </pre>
+     */
     public void deleteCluster(com.google.bigtable.admin.cluster.v1.DeleteClusterRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver);
 
+    /**
+     * <pre>
+     * Cancels the scheduled deletion of an cluster and begins preparing it to
+     * resume serving. The returned operation will also be embedded as the
+     * cluster's "current_operation".
+     * Immediately upon completion of this request:
+     *  * The cluster's "delete_time" field will be unset, protecting it from
+     *    automatic deletion.
+     * Until completion of the returned operation:
+     *  * The operation cannot be cancelled.
+     * Upon completion of the returned operation:
+     *  * Billing for the cluster's resources will resume.
+     *  * All tables within the cluster will be available.
+     * [UndeleteClusterMetadata][google.bigtable.admin.cluster.v1.UndeleteClusterMetadata] The embedded operation's "response" field type is
+     * [Cluster][google.bigtable.admin.cluster.v1.Cluster], if successful.
+     * </pre>
+     */
     public void undeleteCluster(com.google.bigtable.admin.cluster.v1.UndeleteClusterRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver);
   }
 
+  @io.grpc.ExperimentalApi
+  public static abstract class AbstractBigtableClusterService implements BigtableClusterService, io.grpc.BindableService {
+
+    @java.lang.Override
+    public void listZones(com.google.bigtable.admin.cluster.v1.ListZonesRequest request,
+        io.grpc.stub.StreamObserver<com.google.bigtable.admin.cluster.v1.ListZonesResponse> responseObserver) {
+      asyncUnimplementedUnaryCall(METHOD_LIST_ZONES, responseObserver);
+    }
+
+    @java.lang.Override
+    public void getCluster(com.google.bigtable.admin.cluster.v1.GetClusterRequest request,
+        io.grpc.stub.StreamObserver<com.google.bigtable.admin.cluster.v1.Cluster> responseObserver) {
+      asyncUnimplementedUnaryCall(METHOD_GET_CLUSTER, responseObserver);
+    }
+
+    @java.lang.Override
+    public void listClusters(com.google.bigtable.admin.cluster.v1.ListClustersRequest request,
+        io.grpc.stub.StreamObserver<com.google.bigtable.admin.cluster.v1.ListClustersResponse> responseObserver) {
+      asyncUnimplementedUnaryCall(METHOD_LIST_CLUSTERS, responseObserver);
+    }
+
+    @java.lang.Override
+    public void createCluster(com.google.bigtable.admin.cluster.v1.CreateClusterRequest request,
+        io.grpc.stub.StreamObserver<com.google.bigtable.admin.cluster.v1.Cluster> responseObserver) {
+      asyncUnimplementedUnaryCall(METHOD_CREATE_CLUSTER, responseObserver);
+    }
+
+    @java.lang.Override
+    public void updateCluster(com.google.bigtable.admin.cluster.v1.Cluster request,
+        io.grpc.stub.StreamObserver<com.google.bigtable.admin.cluster.v1.Cluster> responseObserver) {
+      asyncUnimplementedUnaryCall(METHOD_UPDATE_CLUSTER, responseObserver);
+    }
+
+    @java.lang.Override
+    public void deleteCluster(com.google.bigtable.admin.cluster.v1.DeleteClusterRequest request,
+        io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
+      asyncUnimplementedUnaryCall(METHOD_DELETE_CLUSTER, responseObserver);
+    }
+
+    @java.lang.Override
+    public void undeleteCluster(com.google.bigtable.admin.cluster.v1.UndeleteClusterRequest request,
+        io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
+      asyncUnimplementedUnaryCall(METHOD_UNDELETE_CLUSTER, responseObserver);
+    }
+
+    @java.lang.Override public io.grpc.ServerServiceDefinition bindService() {
+      return BigtableClusterServiceGrpc.bindService(this);
+    }
+  }
+
+  /**
+   * <pre>
+   * Service for managing zonal Cloud Bigtable resources.
+   * </pre>
+   */
   public static interface BigtableClusterServiceBlockingClient {
 
+    /**
+     * <pre>
+     * Lists the supported zones for the given project.
+     * </pre>
+     */
     public com.google.bigtable.admin.cluster.v1.ListZonesResponse listZones(com.google.bigtable.admin.cluster.v1.ListZonesRequest request);
 
+    /**
+     * <pre>
+     * Gets information about a particular cluster.
+     * </pre>
+     */
     public com.google.bigtable.admin.cluster.v1.Cluster getCluster(com.google.bigtable.admin.cluster.v1.GetClusterRequest request);
 
+    /**
+     * <pre>
+     * Lists all clusters in the given project, along with any zones for which
+     * cluster information could not be retrieved.
+     * </pre>
+     */
     public com.google.bigtable.admin.cluster.v1.ListClustersResponse listClusters(com.google.bigtable.admin.cluster.v1.ListClustersRequest request);
 
+    /**
+     * <pre>
+     * Creates a cluster and begins preparing it to begin serving. The returned
+     * cluster embeds as its "current_operation" a long-running operation which
+     * can be used to track the progress of turning up the new cluster.
+     * Immediately upon completion of this request:
+     *  * The cluster will be readable via the API, with all requested attributes
+     *    but no allocated resources.
+     * Until completion of the embedded operation:
+     *  * Cancelling the operation will render the cluster immediately unreadable
+     *    via the API.
+     *  * All other attempts to modify or delete the cluster will be rejected.
+     * Upon completion of the embedded operation:
+     *  * Billing for all successfully-allocated resources will begin (some types
+     *    may have lower than the requested levels).
+     *  * New tables can be created in the cluster.
+     *  * The cluster's allocated resource levels will be readable via the API.
+     * The embedded operation's "metadata" field type is
+     * [CreateClusterMetadata][google.bigtable.admin.cluster.v1.CreateClusterMetadata] The embedded operation's "response" field type is
+     * [Cluster][google.bigtable.admin.cluster.v1.Cluster], if successful.
+     * </pre>
+     */
     public com.google.bigtable.admin.cluster.v1.Cluster createCluster(com.google.bigtable.admin.cluster.v1.CreateClusterRequest request);
 
+    /**
+     * <pre>
+     * Updates a cluster, and begins allocating or releasing resources as
+     * requested. The returned cluster embeds as its "current_operation" a
+     * long-running operation which can be used to track the progress of updating
+     * the cluster.
+     * Immediately upon completion of this request:
+     *  * For resource types where a decrease in the cluster's allocation has been
+     *    requested, billing will be based on the newly-requested level.
+     * Until completion of the embedded operation:
+     *  * Cancelling the operation will set its metadata's "cancelled_at_time",
+     *    and begin restoring resources to their pre-request values. The operation
+     *    is guaranteed to succeed at undoing all resource changes, after which
+     *    point it will terminate with a CANCELLED status.
+     *  * All other attempts to modify or delete the cluster will be rejected.
+     *  * Reading the cluster via the API will continue to give the pre-request
+     *    resource levels.
+     * Upon completion of the embedded operation:
+     *  * Billing will begin for all successfully-allocated resources (some types
+     *    may have lower than the requested levels).
+     *  * All newly-reserved resources will be available for serving the cluster's
+     *    tables.
+     *  * The cluster's new resource levels will be readable via the API.
+     * [UpdateClusterMetadata][google.bigtable.admin.cluster.v1.UpdateClusterMetadata] The embedded operation's "response" field type is
+     * [Cluster][google.bigtable.admin.cluster.v1.Cluster], if successful.
+     * </pre>
+     */
     public com.google.bigtable.admin.cluster.v1.Cluster updateCluster(com.google.bigtable.admin.cluster.v1.Cluster request);
 
+    /**
+     * <pre>
+     * Marks a cluster and all of its tables for permanent deletion in 7 days.
+     * Immediately upon completion of the request:
+     *  * Billing will cease for all of the cluster's reserved resources.
+     *  * The cluster's "delete_time" field will be set 7 days in the future.
+     * Soon afterward:
+     *  * All tables within the cluster will become unavailable.
+     * Prior to the cluster's "delete_time":
+     *  * The cluster can be recovered with a call to UndeleteCluster.
+     *  * All other attempts to modify or delete the cluster will be rejected.
+     * At the cluster's "delete_time":
+     *  * The cluster and *all of its tables* will immediately and irrevocably
+     *    disappear from the API, and their data will be permanently deleted.
+     * </pre>
+     */
     public com.google.protobuf.Empty deleteCluster(com.google.bigtable.admin.cluster.v1.DeleteClusterRequest request);
 
+    /**
+     * <pre>
+     * Cancels the scheduled deletion of an cluster and begins preparing it to
+     * resume serving. The returned operation will also be embedded as the
+     * cluster's "current_operation".
+     * Immediately upon completion of this request:
+     *  * The cluster's "delete_time" field will be unset, protecting it from
+     *    automatic deletion.
+     * Until completion of the returned operation:
+     *  * The operation cannot be cancelled.
+     * Upon completion of the returned operation:
+     *  * Billing for the cluster's resources will resume.
+     *  * All tables within the cluster will be available.
+     * [UndeleteClusterMetadata][google.bigtable.admin.cluster.v1.UndeleteClusterMetadata] The embedded operation's "response" field type is
+     * [Cluster][google.bigtable.admin.cluster.v1.Cluster], if successful.
+     * </pre>
+     */
     public com.google.longrunning.Operation undeleteCluster(com.google.bigtable.admin.cluster.v1.UndeleteClusterRequest request);
   }
 
+  /**
+   * <pre>
+   * Service for managing zonal Cloud Bigtable resources.
+   * </pre>
+   */
   public static interface BigtableClusterServiceFutureClient {
 
+    /**
+     * <pre>
+     * Lists the supported zones for the given project.
+     * </pre>
+     */
     public com.google.common.util.concurrent.ListenableFuture<com.google.bigtable.admin.cluster.v1.ListZonesResponse> listZones(
         com.google.bigtable.admin.cluster.v1.ListZonesRequest request);
 
+    /**
+     * <pre>
+     * Gets information about a particular cluster.
+     * </pre>
+     */
     public com.google.common.util.concurrent.ListenableFuture<com.google.bigtable.admin.cluster.v1.Cluster> getCluster(
         com.google.bigtable.admin.cluster.v1.GetClusterRequest request);
 
+    /**
+     * <pre>
+     * Lists all clusters in the given project, along with any zones for which
+     * cluster information could not be retrieved.
+     * </pre>
+     */
     public com.google.common.util.concurrent.ListenableFuture<com.google.bigtable.admin.cluster.v1.ListClustersResponse> listClusters(
         com.google.bigtable.admin.cluster.v1.ListClustersRequest request);
 
+    /**
+     * <pre>
+     * Creates a cluster and begins preparing it to begin serving. The returned
+     * cluster embeds as its "current_operation" a long-running operation which
+     * can be used to track the progress of turning up the new cluster.
+     * Immediately upon completion of this request:
+     *  * The cluster will be readable via the API, with all requested attributes
+     *    but no allocated resources.
+     * Until completion of the embedded operation:
+     *  * Cancelling the operation will render the cluster immediately unreadable
+     *    via the API.
+     *  * All other attempts to modify or delete the cluster will be rejected.
+     * Upon completion of the embedded operation:
+     *  * Billing for all successfully-allocated resources will begin (some types
+     *    may have lower than the requested levels).
+     *  * New tables can be created in the cluster.
+     *  * The cluster's allocated resource levels will be readable via the API.
+     * The embedded operation's "metadata" field type is
+     * [CreateClusterMetadata][google.bigtable.admin.cluster.v1.CreateClusterMetadata] The embedded operation's "response" field type is
+     * [Cluster][google.bigtable.admin.cluster.v1.Cluster], if successful.
+     * </pre>
+     */
     public com.google.common.util.concurrent.ListenableFuture<com.google.bigtable.admin.cluster.v1.Cluster> createCluster(
         com.google.bigtable.admin.cluster.v1.CreateClusterRequest request);
 
+    /**
+     * <pre>
+     * Updates a cluster, and begins allocating or releasing resources as
+     * requested. The returned cluster embeds as its "current_operation" a
+     * long-running operation which can be used to track the progress of updating
+     * the cluster.
+     * Immediately upon completion of this request:
+     *  * For resource types where a decrease in the cluster's allocation has been
+     *    requested, billing will be based on the newly-requested level.
+     * Until completion of the embedded operation:
+     *  * Cancelling the operation will set its metadata's "cancelled_at_time",
+     *    and begin restoring resources to their pre-request values. The operation
+     *    is guaranteed to succeed at undoing all resource changes, after which
+     *    point it will terminate with a CANCELLED status.
+     *  * All other attempts to modify or delete the cluster will be rejected.
+     *  * Reading the cluster via the API will continue to give the pre-request
+     *    resource levels.
+     * Upon completion of the embedded operation:
+     *  * Billing will begin for all successfully-allocated resources (some types
+     *    may have lower than the requested levels).
+     *  * All newly-reserved resources will be available for serving the cluster's
+     *    tables.
+     *  * The cluster's new resource levels will be readable via the API.
+     * [UpdateClusterMetadata][google.bigtable.admin.cluster.v1.UpdateClusterMetadata] The embedded operation's "response" field type is
+     * [Cluster][google.bigtable.admin.cluster.v1.Cluster], if successful.
+     * </pre>
+     */
     public com.google.common.util.concurrent.ListenableFuture<com.google.bigtable.admin.cluster.v1.Cluster> updateCluster(
         com.google.bigtable.admin.cluster.v1.Cluster request);
 
+    /**
+     * <pre>
+     * Marks a cluster and all of its tables for permanent deletion in 7 days.
+     * Immediately upon completion of the request:
+     *  * Billing will cease for all of the cluster's reserved resources.
+     *  * The cluster's "delete_time" field will be set 7 days in the future.
+     * Soon afterward:
+     *  * All tables within the cluster will become unavailable.
+     * Prior to the cluster's "delete_time":
+     *  * The cluster can be recovered with a call to UndeleteCluster.
+     *  * All other attempts to modify or delete the cluster will be rejected.
+     * At the cluster's "delete_time":
+     *  * The cluster and *all of its tables* will immediately and irrevocably
+     *    disappear from the API, and their data will be permanently deleted.
+     * </pre>
+     */
     public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.Empty> deleteCluster(
         com.google.bigtable.admin.cluster.v1.DeleteClusterRequest request);
 
+    /**
+     * <pre>
+     * Cancels the scheduled deletion of an cluster and begins preparing it to
+     * resume serving. The returned operation will also be embedded as the
+     * cluster's "current_operation".
+     * Immediately upon completion of this request:
+     *  * The cluster's "delete_time" field will be unset, protecting it from
+     *    automatic deletion.
+     * Until completion of the returned operation:
+     *  * The operation cannot be cancelled.
+     * Upon completion of the returned operation:
+     *  * Billing for the cluster's resources will resume.
+     *  * All tables within the cluster will be available.
+     * [UndeleteClusterMetadata][google.bigtable.admin.cluster.v1.UndeleteClusterMetadata] The embedded operation's "response" field type is
+     * [Cluster][google.bigtable.admin.cluster.v1.Cluster], if successful.
+     * </pre>
+     */
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation> undeleteCluster(
         com.google.bigtable.admin.cluster.v1.UndeleteClusterRequest request);
   }
@@ -379,6 +756,7 @@ public class BigtableClusterServiceGrpc {
       this.methodId = methodId;
     }
 
+    @java.lang.Override
     @java.lang.SuppressWarnings("unchecked")
     public void invoke(Req request, io.grpc.stub.StreamObserver<Resp> responseObserver) {
       switch (methodId) {
@@ -415,6 +793,7 @@ public class BigtableClusterServiceGrpc {
       }
     }
 
+    @java.lang.Override
     @java.lang.SuppressWarnings("unchecked")
     public io.grpc.stub.StreamObserver<Req> invoke(
         io.grpc.stub.StreamObserver<Resp> responseObserver) {

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/services/com/google/bigtable/admin/table/v1/BigtableTableServiceGrpc.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/services/com/google/bigtable/admin/table/v1/BigtableTableServiceGrpc.java
@@ -12,8 +12,18 @@ import static io.grpc.stub.ServerCalls.asyncUnaryCall;
 import static io.grpc.stub.ServerCalls.asyncServerStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncClientStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncBidiStreamingCall;
+import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
+import static io.grpc.stub.ServerCalls.asyncUnimplementedStreamingCall;
 
-@javax.annotation.Generated("by gRPC proto compiler")
+/**
+ * <pre>
+ * Service for creating, configuring, and deleting Cloud Bigtable tables.
+ * Provides access to the table schemas only, not the data stored within the tables.
+ * </pre>
+ */
+@javax.annotation.Generated(
+    value = "by gRPC proto compiler (version 0.14.1)",
+    comments = "Source: google/bigtable/admin/table/v1/bigtable_table_service.proto")
 public class BigtableTableServiceGrpc {
 
   private BigtableTableServiceGrpc() {}
@@ -103,97 +113,330 @@ public class BigtableTableServiceGrpc {
           io.grpc.protobuf.ProtoUtils.marshaller(com.google.bigtable.admin.table.v1.BulkDeleteRowsRequest.getDefaultInstance()),
           io.grpc.protobuf.ProtoUtils.marshaller(com.google.protobuf.Empty.getDefaultInstance()));
 
+  /**
+   * Creates a new async stub that supports all call types for the service
+   */
   public static BigtableTableServiceStub newStub(io.grpc.Channel channel) {
     return new BigtableTableServiceStub(channel);
   }
 
+  /**
+   * Creates a new blocking-style stub that supports unary and streaming output calls on the service
+   */
   public static BigtableTableServiceBlockingStub newBlockingStub(
       io.grpc.Channel channel) {
     return new BigtableTableServiceBlockingStub(channel);
   }
 
+  /**
+   * Creates a new ListenableFuture-style stub that supports unary and streaming output calls on the service
+   */
   public static BigtableTableServiceFutureStub newFutureStub(
       io.grpc.Channel channel) {
     return new BigtableTableServiceFutureStub(channel);
   }
 
+  /**
+   * <pre>
+   * Service for creating, configuring, and deleting Cloud Bigtable tables.
+   * Provides access to the table schemas only, not the data stored within the tables.
+   * </pre>
+   */
   public static interface BigtableTableService {
 
+    /**
+     * <pre>
+     * Creates a new table, to be served from a specified cluster.
+     * The table can be created with a full set of initial column families,
+     * specified in the request.
+     * </pre>
+     */
     public void createTable(com.google.bigtable.admin.table.v1.CreateTableRequest request,
         io.grpc.stub.StreamObserver<com.google.bigtable.admin.table.v1.Table> responseObserver);
 
+    /**
+     * <pre>
+     * Lists the names of all tables served from a specified cluster.
+     * </pre>
+     */
     public void listTables(com.google.bigtable.admin.table.v1.ListTablesRequest request,
         io.grpc.stub.StreamObserver<com.google.bigtable.admin.table.v1.ListTablesResponse> responseObserver);
 
+    /**
+     * <pre>
+     * Gets the schema of the specified table, including its column families.
+     * </pre>
+     */
     public void getTable(com.google.bigtable.admin.table.v1.GetTableRequest request,
         io.grpc.stub.StreamObserver<com.google.bigtable.admin.table.v1.Table> responseObserver);
 
+    /**
+     * <pre>
+     * Permanently deletes a specified table and all of its data.
+     * </pre>
+     */
     public void deleteTable(com.google.bigtable.admin.table.v1.DeleteTableRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver);
 
+    /**
+     * <pre>
+     * Changes the name of a specified table.
+     * Cannot be used to move tables between clusters, zones, or projects.
+     * </pre>
+     */
     public void renameTable(com.google.bigtable.admin.table.v1.RenameTableRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver);
 
+    /**
+     * <pre>
+     * Creates a new column family within a specified table.
+     * </pre>
+     */
     public void createColumnFamily(com.google.bigtable.admin.table.v1.CreateColumnFamilyRequest request,
         io.grpc.stub.StreamObserver<com.google.bigtable.admin.table.v1.ColumnFamily> responseObserver);
 
+    /**
+     * <pre>
+     * Changes the configuration of a specified column family.
+     * </pre>
+     */
     public void updateColumnFamily(com.google.bigtable.admin.table.v1.ColumnFamily request,
         io.grpc.stub.StreamObserver<com.google.bigtable.admin.table.v1.ColumnFamily> responseObserver);
 
+    /**
+     * <pre>
+     * Permanently deletes a specified column family and all of its data.
+     * </pre>
+     */
     public void deleteColumnFamily(com.google.bigtable.admin.table.v1.DeleteColumnFamilyRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver);
 
+    /**
+     * <pre>
+     * Delete all rows in a table corresponding to a particular prefix
+     * </pre>
+     */
     public void bulkDeleteRows(com.google.bigtable.admin.table.v1.BulkDeleteRowsRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver);
   }
 
+  @io.grpc.ExperimentalApi
+  public static abstract class AbstractBigtableTableService implements BigtableTableService, io.grpc.BindableService {
+
+    @java.lang.Override
+    public void createTable(com.google.bigtable.admin.table.v1.CreateTableRequest request,
+        io.grpc.stub.StreamObserver<com.google.bigtable.admin.table.v1.Table> responseObserver) {
+      asyncUnimplementedUnaryCall(METHOD_CREATE_TABLE, responseObserver);
+    }
+
+    @java.lang.Override
+    public void listTables(com.google.bigtable.admin.table.v1.ListTablesRequest request,
+        io.grpc.stub.StreamObserver<com.google.bigtable.admin.table.v1.ListTablesResponse> responseObserver) {
+      asyncUnimplementedUnaryCall(METHOD_LIST_TABLES, responseObserver);
+    }
+
+    @java.lang.Override
+    public void getTable(com.google.bigtable.admin.table.v1.GetTableRequest request,
+        io.grpc.stub.StreamObserver<com.google.bigtable.admin.table.v1.Table> responseObserver) {
+      asyncUnimplementedUnaryCall(METHOD_GET_TABLE, responseObserver);
+    }
+
+    @java.lang.Override
+    public void deleteTable(com.google.bigtable.admin.table.v1.DeleteTableRequest request,
+        io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
+      asyncUnimplementedUnaryCall(METHOD_DELETE_TABLE, responseObserver);
+    }
+
+    @java.lang.Override
+    public void renameTable(com.google.bigtable.admin.table.v1.RenameTableRequest request,
+        io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
+      asyncUnimplementedUnaryCall(METHOD_RENAME_TABLE, responseObserver);
+    }
+
+    @java.lang.Override
+    public void createColumnFamily(com.google.bigtable.admin.table.v1.CreateColumnFamilyRequest request,
+        io.grpc.stub.StreamObserver<com.google.bigtable.admin.table.v1.ColumnFamily> responseObserver) {
+      asyncUnimplementedUnaryCall(METHOD_CREATE_COLUMN_FAMILY, responseObserver);
+    }
+
+    @java.lang.Override
+    public void updateColumnFamily(com.google.bigtable.admin.table.v1.ColumnFamily request,
+        io.grpc.stub.StreamObserver<com.google.bigtable.admin.table.v1.ColumnFamily> responseObserver) {
+      asyncUnimplementedUnaryCall(METHOD_UPDATE_COLUMN_FAMILY, responseObserver);
+    }
+
+    @java.lang.Override
+    public void deleteColumnFamily(com.google.bigtable.admin.table.v1.DeleteColumnFamilyRequest request,
+        io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
+      asyncUnimplementedUnaryCall(METHOD_DELETE_COLUMN_FAMILY, responseObserver);
+    }
+
+    @java.lang.Override
+    public void bulkDeleteRows(com.google.bigtable.admin.table.v1.BulkDeleteRowsRequest request,
+        io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
+      asyncUnimplementedUnaryCall(METHOD_BULK_DELETE_ROWS, responseObserver);
+    }
+
+    @java.lang.Override public io.grpc.ServerServiceDefinition bindService() {
+      return BigtableTableServiceGrpc.bindService(this);
+    }
+  }
+
+  /**
+   * <pre>
+   * Service for creating, configuring, and deleting Cloud Bigtable tables.
+   * Provides access to the table schemas only, not the data stored within the tables.
+   * </pre>
+   */
   public static interface BigtableTableServiceBlockingClient {
 
+    /**
+     * <pre>
+     * Creates a new table, to be served from a specified cluster.
+     * The table can be created with a full set of initial column families,
+     * specified in the request.
+     * </pre>
+     */
     public com.google.bigtable.admin.table.v1.Table createTable(com.google.bigtable.admin.table.v1.CreateTableRequest request);
 
+    /**
+     * <pre>
+     * Lists the names of all tables served from a specified cluster.
+     * </pre>
+     */
     public com.google.bigtable.admin.table.v1.ListTablesResponse listTables(com.google.bigtable.admin.table.v1.ListTablesRequest request);
 
+    /**
+     * <pre>
+     * Gets the schema of the specified table, including its column families.
+     * </pre>
+     */
     public com.google.bigtable.admin.table.v1.Table getTable(com.google.bigtable.admin.table.v1.GetTableRequest request);
 
+    /**
+     * <pre>
+     * Permanently deletes a specified table and all of its data.
+     * </pre>
+     */
     public com.google.protobuf.Empty deleteTable(com.google.bigtable.admin.table.v1.DeleteTableRequest request);
 
+    /**
+     * <pre>
+     * Changes the name of a specified table.
+     * Cannot be used to move tables between clusters, zones, or projects.
+     * </pre>
+     */
     public com.google.protobuf.Empty renameTable(com.google.bigtable.admin.table.v1.RenameTableRequest request);
 
+    /**
+     * <pre>
+     * Creates a new column family within a specified table.
+     * </pre>
+     */
     public com.google.bigtable.admin.table.v1.ColumnFamily createColumnFamily(com.google.bigtable.admin.table.v1.CreateColumnFamilyRequest request);
 
+    /**
+     * <pre>
+     * Changes the configuration of a specified column family.
+     * </pre>
+     */
     public com.google.bigtable.admin.table.v1.ColumnFamily updateColumnFamily(com.google.bigtable.admin.table.v1.ColumnFamily request);
 
+    /**
+     * <pre>
+     * Permanently deletes a specified column family and all of its data.
+     * </pre>
+     */
     public com.google.protobuf.Empty deleteColumnFamily(com.google.bigtable.admin.table.v1.DeleteColumnFamilyRequest request);
 
+    /**
+     * <pre>
+     * Delete all rows in a table corresponding to a particular prefix
+     * </pre>
+     */
     public com.google.protobuf.Empty bulkDeleteRows(com.google.bigtable.admin.table.v1.BulkDeleteRowsRequest request);
   }
 
+  /**
+   * <pre>
+   * Service for creating, configuring, and deleting Cloud Bigtable tables.
+   * Provides access to the table schemas only, not the data stored within the tables.
+   * </pre>
+   */
   public static interface BigtableTableServiceFutureClient {
 
+    /**
+     * <pre>
+     * Creates a new table, to be served from a specified cluster.
+     * The table can be created with a full set of initial column families,
+     * specified in the request.
+     * </pre>
+     */
     public com.google.common.util.concurrent.ListenableFuture<com.google.bigtable.admin.table.v1.Table> createTable(
         com.google.bigtable.admin.table.v1.CreateTableRequest request);
 
+    /**
+     * <pre>
+     * Lists the names of all tables served from a specified cluster.
+     * </pre>
+     */
     public com.google.common.util.concurrent.ListenableFuture<com.google.bigtable.admin.table.v1.ListTablesResponse> listTables(
         com.google.bigtable.admin.table.v1.ListTablesRequest request);
 
+    /**
+     * <pre>
+     * Gets the schema of the specified table, including its column families.
+     * </pre>
+     */
     public com.google.common.util.concurrent.ListenableFuture<com.google.bigtable.admin.table.v1.Table> getTable(
         com.google.bigtable.admin.table.v1.GetTableRequest request);
 
+    /**
+     * <pre>
+     * Permanently deletes a specified table and all of its data.
+     * </pre>
+     */
     public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.Empty> deleteTable(
         com.google.bigtable.admin.table.v1.DeleteTableRequest request);
 
+    /**
+     * <pre>
+     * Changes the name of a specified table.
+     * Cannot be used to move tables between clusters, zones, or projects.
+     * </pre>
+     */
     public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.Empty> renameTable(
         com.google.bigtable.admin.table.v1.RenameTableRequest request);
 
+    /**
+     * <pre>
+     * Creates a new column family within a specified table.
+     * </pre>
+     */
     public com.google.common.util.concurrent.ListenableFuture<com.google.bigtable.admin.table.v1.ColumnFamily> createColumnFamily(
         com.google.bigtable.admin.table.v1.CreateColumnFamilyRequest request);
 
+    /**
+     * <pre>
+     * Changes the configuration of a specified column family.
+     * </pre>
+     */
     public com.google.common.util.concurrent.ListenableFuture<com.google.bigtable.admin.table.v1.ColumnFamily> updateColumnFamily(
         com.google.bigtable.admin.table.v1.ColumnFamily request);
 
+    /**
+     * <pre>
+     * Permanently deletes a specified column family and all of its data.
+     * </pre>
+     */
     public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.Empty> deleteColumnFamily(
         com.google.bigtable.admin.table.v1.DeleteColumnFamilyRequest request);
 
+    /**
+     * <pre>
+     * Delete all rows in a table corresponding to a particular prefix
+     * </pre>
+     */
     public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.Empty> bulkDeleteRows(
         com.google.bigtable.admin.table.v1.BulkDeleteRowsRequest request);
   }
@@ -455,6 +698,7 @@ public class BigtableTableServiceGrpc {
       this.methodId = methodId;
     }
 
+    @java.lang.Override
     @java.lang.SuppressWarnings("unchecked")
     public void invoke(Req request, io.grpc.stub.StreamObserver<Resp> responseObserver) {
       switch (methodId) {
@@ -499,6 +743,7 @@ public class BigtableTableServiceGrpc {
       }
     }
 
+    @java.lang.Override
     @java.lang.SuppressWarnings("unchecked")
     public io.grpc.stub.StreamObserver<Req> invoke(
         io.grpc.stub.StreamObserver<Resp> responseObserver) {

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/services/com/google/bigtable/admin/v2/BigtableInstanceAdminGrpc.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/services/com/google/bigtable/admin/v2/BigtableInstanceAdminGrpc.java
@@ -12,8 +12,19 @@ import static io.grpc.stub.ServerCalls.asyncUnaryCall;
 import static io.grpc.stub.ServerCalls.asyncServerStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncClientStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncBidiStreamingCall;
+import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
+import static io.grpc.stub.ServerCalls.asyncUnimplementedStreamingCall;
 
-@javax.annotation.Generated("by gRPC proto compiler")
+/**
+ * <pre>
+ * Service for creating, configuring, and deleting Cloud Bigtable Instances and
+ * Clusters. Provides access to the Instance and Cluster schemas only, not the
+ * tables metadata or data stored in those tables.
+ * </pre>
+ */
+@javax.annotation.Generated(
+    value = "by gRPC proto compiler (version 0.14.1)",
+    comments = "Source: google/bigtable/admin/v2/bigtable_instance_admin.proto")
 public class BigtableInstanceAdminGrpc {
 
   private BigtableInstanceAdminGrpc() {}
@@ -112,105 +123,353 @@ public class BigtableInstanceAdminGrpc {
           io.grpc.protobuf.ProtoUtils.marshaller(com.google.bigtable.admin.v2.DeleteClusterRequest.getDefaultInstance()),
           io.grpc.protobuf.ProtoUtils.marshaller(com.google.protobuf.Empty.getDefaultInstance()));
 
+  /**
+   * Creates a new async stub that supports all call types for the service
+   */
   public static BigtableInstanceAdminStub newStub(io.grpc.Channel channel) {
     return new BigtableInstanceAdminStub(channel);
   }
 
+  /**
+   * Creates a new blocking-style stub that supports unary and streaming output calls on the service
+   */
   public static BigtableInstanceAdminBlockingStub newBlockingStub(
       io.grpc.Channel channel) {
     return new BigtableInstanceAdminBlockingStub(channel);
   }
 
+  /**
+   * Creates a new ListenableFuture-style stub that supports unary and streaming output calls on the service
+   */
   public static BigtableInstanceAdminFutureStub newFutureStub(
       io.grpc.Channel channel) {
     return new BigtableInstanceAdminFutureStub(channel);
   }
 
+  /**
+   * <pre>
+   * Service for creating, configuring, and deleting Cloud Bigtable Instances and
+   * Clusters. Provides access to the Instance and Cluster schemas only, not the
+   * tables metadata or data stored in those tables.
+   * </pre>
+   */
   public static interface BigtableInstanceAdmin {
 
+    /**
+     * <pre>
+     * Create an instance within a project.
+     * </pre>
+     */
     public void createInstance(com.google.bigtable.admin.v2.CreateInstanceRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver);
 
+    /**
+     * <pre>
+     * Gets information about an instance.
+     * </pre>
+     */
     public void getInstance(com.google.bigtable.admin.v2.GetInstanceRequest request,
         io.grpc.stub.StreamObserver<com.google.bigtable.admin.v2.Instance> responseObserver);
 
+    /**
+     * <pre>
+     * Lists information about instances in a project.
+     * </pre>
+     */
     public void listInstances(com.google.bigtable.admin.v2.ListInstancesRequest request,
         io.grpc.stub.StreamObserver<com.google.bigtable.admin.v2.ListInstancesResponse> responseObserver);
 
+    /**
+     * <pre>
+     * Updates an instance within a project.
+     * </pre>
+     */
     public void updateInstance(com.google.bigtable.admin.v2.Instance request,
         io.grpc.stub.StreamObserver<com.google.bigtable.admin.v2.Instance> responseObserver);
 
+    /**
+     * <pre>
+     * Delete an instance from a project.
+     * </pre>
+     */
     public void deleteInstance(com.google.bigtable.admin.v2.DeleteInstanceRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver);
 
+    /**
+     * <pre>
+     * Creates a cluster within an instance.
+     * </pre>
+     */
     public void createCluster(com.google.bigtable.admin.v2.CreateClusterRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver);
 
+    /**
+     * <pre>
+     * Gets information about a cluster.
+     * </pre>
+     */
     public void getCluster(com.google.bigtable.admin.v2.GetClusterRequest request,
         io.grpc.stub.StreamObserver<com.google.bigtable.admin.v2.Cluster> responseObserver);
 
+    /**
+     * <pre>
+     * Lists information about clusters in an instance.
+     * </pre>
+     */
     public void listClusters(com.google.bigtable.admin.v2.ListClustersRequest request,
         io.grpc.stub.StreamObserver<com.google.bigtable.admin.v2.ListClustersResponse> responseObserver);
 
+    /**
+     * <pre>
+     * Updates a cluster within an instance.
+     * </pre>
+     */
     public void updateCluster(com.google.bigtable.admin.v2.Cluster request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver);
 
+    /**
+     * <pre>
+     * Deletes a cluster from an instance.
+     * </pre>
+     */
     public void deleteCluster(com.google.bigtable.admin.v2.DeleteClusterRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver);
   }
 
+  @io.grpc.ExperimentalApi
+  public static abstract class AbstractBigtableInstanceAdmin implements BigtableInstanceAdmin, io.grpc.BindableService {
+
+    @java.lang.Override
+    public void createInstance(com.google.bigtable.admin.v2.CreateInstanceRequest request,
+        io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
+      asyncUnimplementedUnaryCall(METHOD_CREATE_INSTANCE, responseObserver);
+    }
+
+    @java.lang.Override
+    public void getInstance(com.google.bigtable.admin.v2.GetInstanceRequest request,
+        io.grpc.stub.StreamObserver<com.google.bigtable.admin.v2.Instance> responseObserver) {
+      asyncUnimplementedUnaryCall(METHOD_GET_INSTANCE, responseObserver);
+    }
+
+    @java.lang.Override
+    public void listInstances(com.google.bigtable.admin.v2.ListInstancesRequest request,
+        io.grpc.stub.StreamObserver<com.google.bigtable.admin.v2.ListInstancesResponse> responseObserver) {
+      asyncUnimplementedUnaryCall(METHOD_LIST_INSTANCES, responseObserver);
+    }
+
+    @java.lang.Override
+    public void updateInstance(com.google.bigtable.admin.v2.Instance request,
+        io.grpc.stub.StreamObserver<com.google.bigtable.admin.v2.Instance> responseObserver) {
+      asyncUnimplementedUnaryCall(METHOD_UPDATE_INSTANCE, responseObserver);
+    }
+
+    @java.lang.Override
+    public void deleteInstance(com.google.bigtable.admin.v2.DeleteInstanceRequest request,
+        io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
+      asyncUnimplementedUnaryCall(METHOD_DELETE_INSTANCE, responseObserver);
+    }
+
+    @java.lang.Override
+    public void createCluster(com.google.bigtable.admin.v2.CreateClusterRequest request,
+        io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
+      asyncUnimplementedUnaryCall(METHOD_CREATE_CLUSTER, responseObserver);
+    }
+
+    @java.lang.Override
+    public void getCluster(com.google.bigtable.admin.v2.GetClusterRequest request,
+        io.grpc.stub.StreamObserver<com.google.bigtable.admin.v2.Cluster> responseObserver) {
+      asyncUnimplementedUnaryCall(METHOD_GET_CLUSTER, responseObserver);
+    }
+
+    @java.lang.Override
+    public void listClusters(com.google.bigtable.admin.v2.ListClustersRequest request,
+        io.grpc.stub.StreamObserver<com.google.bigtable.admin.v2.ListClustersResponse> responseObserver) {
+      asyncUnimplementedUnaryCall(METHOD_LIST_CLUSTERS, responseObserver);
+    }
+
+    @java.lang.Override
+    public void updateCluster(com.google.bigtable.admin.v2.Cluster request,
+        io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
+      asyncUnimplementedUnaryCall(METHOD_UPDATE_CLUSTER, responseObserver);
+    }
+
+    @java.lang.Override
+    public void deleteCluster(com.google.bigtable.admin.v2.DeleteClusterRequest request,
+        io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
+      asyncUnimplementedUnaryCall(METHOD_DELETE_CLUSTER, responseObserver);
+    }
+
+    @java.lang.Override public io.grpc.ServerServiceDefinition bindService() {
+      return BigtableInstanceAdminGrpc.bindService(this);
+    }
+  }
+
+  /**
+   * <pre>
+   * Service for creating, configuring, and deleting Cloud Bigtable Instances and
+   * Clusters. Provides access to the Instance and Cluster schemas only, not the
+   * tables metadata or data stored in those tables.
+   * </pre>
+   */
   public static interface BigtableInstanceAdminBlockingClient {
 
+    /**
+     * <pre>
+     * Create an instance within a project.
+     * </pre>
+     */
     public com.google.longrunning.Operation createInstance(com.google.bigtable.admin.v2.CreateInstanceRequest request);
 
+    /**
+     * <pre>
+     * Gets information about an instance.
+     * </pre>
+     */
     public com.google.bigtable.admin.v2.Instance getInstance(com.google.bigtable.admin.v2.GetInstanceRequest request);
 
+    /**
+     * <pre>
+     * Lists information about instances in a project.
+     * </pre>
+     */
     public com.google.bigtable.admin.v2.ListInstancesResponse listInstances(com.google.bigtable.admin.v2.ListInstancesRequest request);
 
+    /**
+     * <pre>
+     * Updates an instance within a project.
+     * </pre>
+     */
     public com.google.bigtable.admin.v2.Instance updateInstance(com.google.bigtable.admin.v2.Instance request);
 
+    /**
+     * <pre>
+     * Delete an instance from a project.
+     * </pre>
+     */
     public com.google.protobuf.Empty deleteInstance(com.google.bigtable.admin.v2.DeleteInstanceRequest request);
 
+    /**
+     * <pre>
+     * Creates a cluster within an instance.
+     * </pre>
+     */
     public com.google.longrunning.Operation createCluster(com.google.bigtable.admin.v2.CreateClusterRequest request);
 
+    /**
+     * <pre>
+     * Gets information about a cluster.
+     * </pre>
+     */
     public com.google.bigtable.admin.v2.Cluster getCluster(com.google.bigtable.admin.v2.GetClusterRequest request);
 
+    /**
+     * <pre>
+     * Lists information about clusters in an instance.
+     * </pre>
+     */
     public com.google.bigtable.admin.v2.ListClustersResponse listClusters(com.google.bigtable.admin.v2.ListClustersRequest request);
 
+    /**
+     * <pre>
+     * Updates a cluster within an instance.
+     * </pre>
+     */
     public com.google.longrunning.Operation updateCluster(com.google.bigtable.admin.v2.Cluster request);
 
+    /**
+     * <pre>
+     * Deletes a cluster from an instance.
+     * </pre>
+     */
     public com.google.protobuf.Empty deleteCluster(com.google.bigtable.admin.v2.DeleteClusterRequest request);
   }
 
+  /**
+   * <pre>
+   * Service for creating, configuring, and deleting Cloud Bigtable Instances and
+   * Clusters. Provides access to the Instance and Cluster schemas only, not the
+   * tables metadata or data stored in those tables.
+   * </pre>
+   */
   public static interface BigtableInstanceAdminFutureClient {
 
+    /**
+     * <pre>
+     * Create an instance within a project.
+     * </pre>
+     */
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation> createInstance(
         com.google.bigtable.admin.v2.CreateInstanceRequest request);
 
+    /**
+     * <pre>
+     * Gets information about an instance.
+     * </pre>
+     */
     public com.google.common.util.concurrent.ListenableFuture<com.google.bigtable.admin.v2.Instance> getInstance(
         com.google.bigtable.admin.v2.GetInstanceRequest request);
 
+    /**
+     * <pre>
+     * Lists information about instances in a project.
+     * </pre>
+     */
     public com.google.common.util.concurrent.ListenableFuture<com.google.bigtable.admin.v2.ListInstancesResponse> listInstances(
         com.google.bigtable.admin.v2.ListInstancesRequest request);
 
+    /**
+     * <pre>
+     * Updates an instance within a project.
+     * </pre>
+     */
     public com.google.common.util.concurrent.ListenableFuture<com.google.bigtable.admin.v2.Instance> updateInstance(
         com.google.bigtable.admin.v2.Instance request);
 
+    /**
+     * <pre>
+     * Delete an instance from a project.
+     * </pre>
+     */
     public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.Empty> deleteInstance(
         com.google.bigtable.admin.v2.DeleteInstanceRequest request);
 
+    /**
+     * <pre>
+     * Creates a cluster within an instance.
+     * </pre>
+     */
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation> createCluster(
         com.google.bigtable.admin.v2.CreateClusterRequest request);
 
+    /**
+     * <pre>
+     * Gets information about a cluster.
+     * </pre>
+     */
     public com.google.common.util.concurrent.ListenableFuture<com.google.bigtable.admin.v2.Cluster> getCluster(
         com.google.bigtable.admin.v2.GetClusterRequest request);
 
+    /**
+     * <pre>
+     * Lists information about clusters in an instance.
+     * </pre>
+     */
     public com.google.common.util.concurrent.ListenableFuture<com.google.bigtable.admin.v2.ListClustersResponse> listClusters(
         com.google.bigtable.admin.v2.ListClustersRequest request);
 
+    /**
+     * <pre>
+     * Updates a cluster within an instance.
+     * </pre>
+     */
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation> updateCluster(
         com.google.bigtable.admin.v2.Cluster request);
 
+    /**
+     * <pre>
+     * Deletes a cluster from an instance.
+     * </pre>
+     */
     public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.Empty> deleteCluster(
         com.google.bigtable.admin.v2.DeleteClusterRequest request);
   }
@@ -493,6 +752,7 @@ public class BigtableInstanceAdminGrpc {
       this.methodId = methodId;
     }
 
+    @java.lang.Override
     @java.lang.SuppressWarnings("unchecked")
     public void invoke(Req request, io.grpc.stub.StreamObserver<Resp> responseObserver) {
       switch (methodId) {
@@ -541,6 +801,7 @@ public class BigtableInstanceAdminGrpc {
       }
     }
 
+    @java.lang.Override
     @java.lang.SuppressWarnings("unchecked")
     public io.grpc.stub.StreamObserver<Req> invoke(
         io.grpc.stub.StreamObserver<Resp> responseObserver) {

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/services/com/google/bigtable/admin/v2/BigtableTableAdminGrpc.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/services/com/google/bigtable/admin/v2/BigtableTableAdminGrpc.java
@@ -12,8 +12,19 @@ import static io.grpc.stub.ServerCalls.asyncUnaryCall;
 import static io.grpc.stub.ServerCalls.asyncServerStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncClientStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncBidiStreamingCall;
+import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
+import static io.grpc.stub.ServerCalls.asyncUnimplementedStreamingCall;
 
-@javax.annotation.Generated("by gRPC proto compiler")
+/**
+ * <pre>
+ * Service for creating, configuring, and deleting Cloud Bigtable tables.
+ * Provides access to the table schemas only, not the data stored within
+ * the tables.
+ * </pre>
+ */
+@javax.annotation.Generated(
+    value = "by gRPC proto compiler (version 0.14.1)",
+    comments = "Source: google/bigtable/admin/v2/bigtable_table_admin.proto")
 public class BigtableTableAdminGrpc {
 
   private BigtableTableAdminGrpc() {}
@@ -76,73 +87,252 @@ public class BigtableTableAdminGrpc {
           io.grpc.protobuf.ProtoUtils.marshaller(com.google.bigtable.admin.v2.DropRowRangeRequest.getDefaultInstance()),
           io.grpc.protobuf.ProtoUtils.marshaller(com.google.protobuf.Empty.getDefaultInstance()));
 
+  /**
+   * Creates a new async stub that supports all call types for the service
+   */
   public static BigtableTableAdminStub newStub(io.grpc.Channel channel) {
     return new BigtableTableAdminStub(channel);
   }
 
+  /**
+   * Creates a new blocking-style stub that supports unary and streaming output calls on the service
+   */
   public static BigtableTableAdminBlockingStub newBlockingStub(
       io.grpc.Channel channel) {
     return new BigtableTableAdminBlockingStub(channel);
   }
 
+  /**
+   * Creates a new ListenableFuture-style stub that supports unary and streaming output calls on the service
+   */
   public static BigtableTableAdminFutureStub newFutureStub(
       io.grpc.Channel channel) {
     return new BigtableTableAdminFutureStub(channel);
   }
 
+  /**
+   * <pre>
+   * Service for creating, configuring, and deleting Cloud Bigtable tables.
+   * Provides access to the table schemas only, not the data stored within
+   * the tables.
+   * </pre>
+   */
   public static interface BigtableTableAdmin {
 
+    /**
+     * <pre>
+     * Creates a new table in the specified instance.
+     * The table can be created with a full set of initial column families,
+     * specified in the request.
+     * </pre>
+     */
     public void createTable(com.google.bigtable.admin.v2.CreateTableRequest request,
         io.grpc.stub.StreamObserver<com.google.bigtable.admin.v2.Table> responseObserver);
 
+    /**
+     * <pre>
+     * Lists all tables served from a specified instance.
+     * </pre>
+     */
     public void listTables(com.google.bigtable.admin.v2.ListTablesRequest request,
         io.grpc.stub.StreamObserver<com.google.bigtable.admin.v2.ListTablesResponse> responseObserver);
 
+    /**
+     * <pre>
+     * Gets metadata information about the specified table.
+     * </pre>
+     */
     public void getTable(com.google.bigtable.admin.v2.GetTableRequest request,
         io.grpc.stub.StreamObserver<com.google.bigtable.admin.v2.Table> responseObserver);
 
+    /**
+     * <pre>
+     * Permanently deletes a specified table and all of its data.
+     * </pre>
+     */
     public void deleteTable(com.google.bigtable.admin.v2.DeleteTableRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver);
 
+    /**
+     * <pre>
+     * Atomically performs a series of column family modifications
+     * on the specified table.
+     * </pre>
+     */
     public void modifyColumnFamilies(com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest request,
         io.grpc.stub.StreamObserver<com.google.bigtable.admin.v2.Table> responseObserver);
 
+    /**
+     * <pre>
+     * Permanently drop/delete a row range from a specified table. The request can
+     * specify whether to delete all rows in a table, or only those that match a
+     * particular prefix.
+     * </pre>
+     */
     public void dropRowRange(com.google.bigtable.admin.v2.DropRowRangeRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver);
   }
 
+  @io.grpc.ExperimentalApi
+  public static abstract class AbstractBigtableTableAdmin implements BigtableTableAdmin, io.grpc.BindableService {
+
+    @java.lang.Override
+    public void createTable(com.google.bigtable.admin.v2.CreateTableRequest request,
+        io.grpc.stub.StreamObserver<com.google.bigtable.admin.v2.Table> responseObserver) {
+      asyncUnimplementedUnaryCall(METHOD_CREATE_TABLE, responseObserver);
+    }
+
+    @java.lang.Override
+    public void listTables(com.google.bigtable.admin.v2.ListTablesRequest request,
+        io.grpc.stub.StreamObserver<com.google.bigtable.admin.v2.ListTablesResponse> responseObserver) {
+      asyncUnimplementedUnaryCall(METHOD_LIST_TABLES, responseObserver);
+    }
+
+    @java.lang.Override
+    public void getTable(com.google.bigtable.admin.v2.GetTableRequest request,
+        io.grpc.stub.StreamObserver<com.google.bigtable.admin.v2.Table> responseObserver) {
+      asyncUnimplementedUnaryCall(METHOD_GET_TABLE, responseObserver);
+    }
+
+    @java.lang.Override
+    public void deleteTable(com.google.bigtable.admin.v2.DeleteTableRequest request,
+        io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
+      asyncUnimplementedUnaryCall(METHOD_DELETE_TABLE, responseObserver);
+    }
+
+    @java.lang.Override
+    public void modifyColumnFamilies(com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest request,
+        io.grpc.stub.StreamObserver<com.google.bigtable.admin.v2.Table> responseObserver) {
+      asyncUnimplementedUnaryCall(METHOD_MODIFY_COLUMN_FAMILIES, responseObserver);
+    }
+
+    @java.lang.Override
+    public void dropRowRange(com.google.bigtable.admin.v2.DropRowRangeRequest request,
+        io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
+      asyncUnimplementedUnaryCall(METHOD_DROP_ROW_RANGE, responseObserver);
+    }
+
+    @java.lang.Override public io.grpc.ServerServiceDefinition bindService() {
+      return BigtableTableAdminGrpc.bindService(this);
+    }
+  }
+
+  /**
+   * <pre>
+   * Service for creating, configuring, and deleting Cloud Bigtable tables.
+   * Provides access to the table schemas only, not the data stored within
+   * the tables.
+   * </pre>
+   */
   public static interface BigtableTableAdminBlockingClient {
 
+    /**
+     * <pre>
+     * Creates a new table in the specified instance.
+     * The table can be created with a full set of initial column families,
+     * specified in the request.
+     * </pre>
+     */
     public com.google.bigtable.admin.v2.Table createTable(com.google.bigtable.admin.v2.CreateTableRequest request);
 
+    /**
+     * <pre>
+     * Lists all tables served from a specified instance.
+     * </pre>
+     */
     public com.google.bigtable.admin.v2.ListTablesResponse listTables(com.google.bigtable.admin.v2.ListTablesRequest request);
 
+    /**
+     * <pre>
+     * Gets metadata information about the specified table.
+     * </pre>
+     */
     public com.google.bigtable.admin.v2.Table getTable(com.google.bigtable.admin.v2.GetTableRequest request);
 
+    /**
+     * <pre>
+     * Permanently deletes a specified table and all of its data.
+     * </pre>
+     */
     public com.google.protobuf.Empty deleteTable(com.google.bigtable.admin.v2.DeleteTableRequest request);
 
+    /**
+     * <pre>
+     * Atomically performs a series of column family modifications
+     * on the specified table.
+     * </pre>
+     */
     public com.google.bigtable.admin.v2.Table modifyColumnFamilies(com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest request);
 
+    /**
+     * <pre>
+     * Permanently drop/delete a row range from a specified table. The request can
+     * specify whether to delete all rows in a table, or only those that match a
+     * particular prefix.
+     * </pre>
+     */
     public com.google.protobuf.Empty dropRowRange(com.google.bigtable.admin.v2.DropRowRangeRequest request);
   }
 
+  /**
+   * <pre>
+   * Service for creating, configuring, and deleting Cloud Bigtable tables.
+   * Provides access to the table schemas only, not the data stored within
+   * the tables.
+   * </pre>
+   */
   public static interface BigtableTableAdminFutureClient {
 
+    /**
+     * <pre>
+     * Creates a new table in the specified instance.
+     * The table can be created with a full set of initial column families,
+     * specified in the request.
+     * </pre>
+     */
     public com.google.common.util.concurrent.ListenableFuture<com.google.bigtable.admin.v2.Table> createTable(
         com.google.bigtable.admin.v2.CreateTableRequest request);
 
+    /**
+     * <pre>
+     * Lists all tables served from a specified instance.
+     * </pre>
+     */
     public com.google.common.util.concurrent.ListenableFuture<com.google.bigtable.admin.v2.ListTablesResponse> listTables(
         com.google.bigtable.admin.v2.ListTablesRequest request);
 
+    /**
+     * <pre>
+     * Gets metadata information about the specified table.
+     * </pre>
+     */
     public com.google.common.util.concurrent.ListenableFuture<com.google.bigtable.admin.v2.Table> getTable(
         com.google.bigtable.admin.v2.GetTableRequest request);
 
+    /**
+     * <pre>
+     * Permanently deletes a specified table and all of its data.
+     * </pre>
+     */
     public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.Empty> deleteTable(
         com.google.bigtable.admin.v2.DeleteTableRequest request);
 
+    /**
+     * <pre>
+     * Atomically performs a series of column family modifications
+     * on the specified table.
+     * </pre>
+     */
     public com.google.common.util.concurrent.ListenableFuture<com.google.bigtable.admin.v2.Table> modifyColumnFamilies(
         com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest request);
 
+    /**
+     * <pre>
+     * Permanently drop/delete a row range from a specified table. The request can
+     * specify whether to delete all rows in a table, or only those that match a
+     * particular prefix.
+     * </pre>
+     */
     public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.Empty> dropRowRange(
         com.google.bigtable.admin.v2.DropRowRangeRequest request);
   }
@@ -341,6 +531,7 @@ public class BigtableTableAdminGrpc {
       this.methodId = methodId;
     }
 
+    @java.lang.Override
     @java.lang.SuppressWarnings("unchecked")
     public void invoke(Req request, io.grpc.stub.StreamObserver<Resp> responseObserver) {
       switch (methodId) {
@@ -373,6 +564,7 @@ public class BigtableTableAdminGrpc {
       }
     }
 
+    @java.lang.Override
     @java.lang.SuppressWarnings("unchecked")
     public io.grpc.stub.StreamObserver<Req> invoke(
         io.grpc.stub.StreamObserver<Resp> responseObserver) {

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/services/com/google/bigtable/v1/BigtableServiceGrpc.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/services/com/google/bigtable/v1/BigtableServiceGrpc.java
@@ -12,8 +12,17 @@ import static io.grpc.stub.ServerCalls.asyncUnaryCall;
 import static io.grpc.stub.ServerCalls.asyncServerStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncClientStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncBidiStreamingCall;
+import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
+import static io.grpc.stub.ServerCalls.asyncUnimplementedStreamingCall;
 
-@javax.annotation.Generated("by gRPC proto compiler")
+/**
+ * <pre>
+ * Service for reading from and writing to existing Bigtables.
+ * </pre>
+ */
+@javax.annotation.Generated(
+    value = "by gRPC proto compiler (version 0.14.1)",
+    comments = "Source: google/bigtable/v1/bigtable_service.proto")
 public class BigtableServiceGrpc {
 
   private BigtableServiceGrpc() {}
@@ -76,69 +85,247 @@ public class BigtableServiceGrpc {
           io.grpc.protobuf.ProtoUtils.marshaller(com.google.bigtable.v1.ReadModifyWriteRowRequest.getDefaultInstance()),
           io.grpc.protobuf.ProtoUtils.marshaller(com.google.bigtable.v1.Row.getDefaultInstance()));
 
+  /**
+   * Creates a new async stub that supports all call types for the service
+   */
   public static BigtableServiceStub newStub(io.grpc.Channel channel) {
     return new BigtableServiceStub(channel);
   }
 
+  /**
+   * Creates a new blocking-style stub that supports unary and streaming output calls on the service
+   */
   public static BigtableServiceBlockingStub newBlockingStub(
       io.grpc.Channel channel) {
     return new BigtableServiceBlockingStub(channel);
   }
 
+  /**
+   * Creates a new ListenableFuture-style stub that supports unary and streaming output calls on the service
+   */
   public static BigtableServiceFutureStub newFutureStub(
       io.grpc.Channel channel) {
     return new BigtableServiceFutureStub(channel);
   }
 
+  /**
+   * <pre>
+   * Service for reading from and writing to existing Bigtables.
+   * </pre>
+   */
   public static interface BigtableService {
 
+    /**
+     * <pre>
+     * Streams back the contents of all requested rows, optionally applying
+     * the same Reader filter to each. Depending on their size, rows may be
+     * broken up across multiple responses, but atomicity of each row will still
+     * be preserved.
+     * </pre>
+     */
     public void readRows(com.google.bigtable.v1.ReadRowsRequest request,
         io.grpc.stub.StreamObserver<com.google.bigtable.v1.ReadRowsResponse> responseObserver);
 
+    /**
+     * <pre>
+     * Returns a sample of row keys in the table. The returned row keys will
+     * delimit contiguous sections of the table of approximately equal size,
+     * which can be used to break up the data for distributed tasks like
+     * mapreduces.
+     * </pre>
+     */
     public void sampleRowKeys(com.google.bigtable.v1.SampleRowKeysRequest request,
         io.grpc.stub.StreamObserver<com.google.bigtable.v1.SampleRowKeysResponse> responseObserver);
 
+    /**
+     * <pre>
+     * Mutates a row atomically. Cells already present in the row are left
+     * unchanged unless explicitly changed by 'mutation'.
+     * </pre>
+     */
     public void mutateRow(com.google.bigtable.v1.MutateRowRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver);
 
+    /**
+     * <pre>
+     * Mutates multiple rows in a batch. Each individual row is mutated
+     * atomically as in MutateRow, but the entire batch is not executed
+     * atomically.
+     * </pre>
+     */
     public void mutateRows(com.google.bigtable.v1.MutateRowsRequest request,
         io.grpc.stub.StreamObserver<com.google.bigtable.v1.MutateRowsResponse> responseObserver);
 
+    /**
+     * <pre>
+     * Mutates a row atomically based on the output of a predicate Reader filter.
+     * </pre>
+     */
     public void checkAndMutateRow(com.google.bigtable.v1.CheckAndMutateRowRequest request,
         io.grpc.stub.StreamObserver<com.google.bigtable.v1.CheckAndMutateRowResponse> responseObserver);
 
+    /**
+     * <pre>
+     * Modifies a row atomically, reading the latest existing timestamp/value from
+     * the specified columns and writing a new value at
+     * max(existing timestamp, current server time) based on pre-defined
+     * read/modify/write rules. Returns the new contents of all modified cells.
+     * </pre>
+     */
     public void readModifyWriteRow(com.google.bigtable.v1.ReadModifyWriteRowRequest request,
         io.grpc.stub.StreamObserver<com.google.bigtable.v1.Row> responseObserver);
   }
 
+  @io.grpc.ExperimentalApi
+  public static abstract class AbstractBigtableService implements BigtableService, io.grpc.BindableService {
+
+    @java.lang.Override
+    public void readRows(com.google.bigtable.v1.ReadRowsRequest request,
+        io.grpc.stub.StreamObserver<com.google.bigtable.v1.ReadRowsResponse> responseObserver) {
+      asyncUnimplementedUnaryCall(METHOD_READ_ROWS, responseObserver);
+    }
+
+    @java.lang.Override
+    public void sampleRowKeys(com.google.bigtable.v1.SampleRowKeysRequest request,
+        io.grpc.stub.StreamObserver<com.google.bigtable.v1.SampleRowKeysResponse> responseObserver) {
+      asyncUnimplementedUnaryCall(METHOD_SAMPLE_ROW_KEYS, responseObserver);
+    }
+
+    @java.lang.Override
+    public void mutateRow(com.google.bigtable.v1.MutateRowRequest request,
+        io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
+      asyncUnimplementedUnaryCall(METHOD_MUTATE_ROW, responseObserver);
+    }
+
+    @java.lang.Override
+    public void mutateRows(com.google.bigtable.v1.MutateRowsRequest request,
+        io.grpc.stub.StreamObserver<com.google.bigtable.v1.MutateRowsResponse> responseObserver) {
+      asyncUnimplementedUnaryCall(METHOD_MUTATE_ROWS, responseObserver);
+    }
+
+    @java.lang.Override
+    public void checkAndMutateRow(com.google.bigtable.v1.CheckAndMutateRowRequest request,
+        io.grpc.stub.StreamObserver<com.google.bigtable.v1.CheckAndMutateRowResponse> responseObserver) {
+      asyncUnimplementedUnaryCall(METHOD_CHECK_AND_MUTATE_ROW, responseObserver);
+    }
+
+    @java.lang.Override
+    public void readModifyWriteRow(com.google.bigtable.v1.ReadModifyWriteRowRequest request,
+        io.grpc.stub.StreamObserver<com.google.bigtable.v1.Row> responseObserver) {
+      asyncUnimplementedUnaryCall(METHOD_READ_MODIFY_WRITE_ROW, responseObserver);
+    }
+
+    @java.lang.Override public io.grpc.ServerServiceDefinition bindService() {
+      return BigtableServiceGrpc.bindService(this);
+    }
+  }
+
+  /**
+   * <pre>
+   * Service for reading from and writing to existing Bigtables.
+   * </pre>
+   */
   public static interface BigtableServiceBlockingClient {
 
+    /**
+     * <pre>
+     * Streams back the contents of all requested rows, optionally applying
+     * the same Reader filter to each. Depending on their size, rows may be
+     * broken up across multiple responses, but atomicity of each row will still
+     * be preserved.
+     * </pre>
+     */
     public java.util.Iterator<com.google.bigtable.v1.ReadRowsResponse> readRows(
         com.google.bigtable.v1.ReadRowsRequest request);
 
+    /**
+     * <pre>
+     * Returns a sample of row keys in the table. The returned row keys will
+     * delimit contiguous sections of the table of approximately equal size,
+     * which can be used to break up the data for distributed tasks like
+     * mapreduces.
+     * </pre>
+     */
     public java.util.Iterator<com.google.bigtable.v1.SampleRowKeysResponse> sampleRowKeys(
         com.google.bigtable.v1.SampleRowKeysRequest request);
 
+    /**
+     * <pre>
+     * Mutates a row atomically. Cells already present in the row are left
+     * unchanged unless explicitly changed by 'mutation'.
+     * </pre>
+     */
     public com.google.protobuf.Empty mutateRow(com.google.bigtable.v1.MutateRowRequest request);
 
+    /**
+     * <pre>
+     * Mutates multiple rows in a batch. Each individual row is mutated
+     * atomically as in MutateRow, but the entire batch is not executed
+     * atomically.
+     * </pre>
+     */
     public com.google.bigtable.v1.MutateRowsResponse mutateRows(com.google.bigtable.v1.MutateRowsRequest request);
 
+    /**
+     * <pre>
+     * Mutates a row atomically based on the output of a predicate Reader filter.
+     * </pre>
+     */
     public com.google.bigtable.v1.CheckAndMutateRowResponse checkAndMutateRow(com.google.bigtable.v1.CheckAndMutateRowRequest request);
 
+    /**
+     * <pre>
+     * Modifies a row atomically, reading the latest existing timestamp/value from
+     * the specified columns and writing a new value at
+     * max(existing timestamp, current server time) based on pre-defined
+     * read/modify/write rules. Returns the new contents of all modified cells.
+     * </pre>
+     */
     public com.google.bigtable.v1.Row readModifyWriteRow(com.google.bigtable.v1.ReadModifyWriteRowRequest request);
   }
 
+  /**
+   * <pre>
+   * Service for reading from and writing to existing Bigtables.
+   * </pre>
+   */
   public static interface BigtableServiceFutureClient {
 
+    /**
+     * <pre>
+     * Mutates a row atomically. Cells already present in the row are left
+     * unchanged unless explicitly changed by 'mutation'.
+     * </pre>
+     */
     public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.Empty> mutateRow(
         com.google.bigtable.v1.MutateRowRequest request);
 
+    /**
+     * <pre>
+     * Mutates multiple rows in a batch. Each individual row is mutated
+     * atomically as in MutateRow, but the entire batch is not executed
+     * atomically.
+     * </pre>
+     */
     public com.google.common.util.concurrent.ListenableFuture<com.google.bigtable.v1.MutateRowsResponse> mutateRows(
         com.google.bigtable.v1.MutateRowsRequest request);
 
+    /**
+     * <pre>
+     * Mutates a row atomically based on the output of a predicate Reader filter.
+     * </pre>
+     */
     public com.google.common.util.concurrent.ListenableFuture<com.google.bigtable.v1.CheckAndMutateRowResponse> checkAndMutateRow(
         com.google.bigtable.v1.CheckAndMutateRowRequest request);
 
+    /**
+     * <pre>
+     * Modifies a row atomically, reading the latest existing timestamp/value from
+     * the specified columns and writing a new value at
+     * max(existing timestamp, current server time) based on pre-defined
+     * read/modify/write rules. Returns the new contents of all modified cells.
+     * </pre>
+     */
     public com.google.common.util.concurrent.ListenableFuture<com.google.bigtable.v1.Row> readModifyWriteRow(
         com.google.bigtable.v1.ReadModifyWriteRowRequest request);
   }
@@ -325,6 +512,7 @@ public class BigtableServiceGrpc {
       this.methodId = methodId;
     }
 
+    @java.lang.Override
     @java.lang.SuppressWarnings("unchecked")
     public void invoke(Req request, io.grpc.stub.StreamObserver<Resp> responseObserver) {
       switch (methodId) {
@@ -357,6 +545,7 @@ public class BigtableServiceGrpc {
       }
     }
 
+    @java.lang.Override
     @java.lang.SuppressWarnings("unchecked")
     public io.grpc.stub.StreamObserver<Req> invoke(
         io.grpc.stub.StreamObserver<Resp> responseObserver) {

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/services/com/google/bigtable/v2/BigtableGrpc.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/services/com/google/bigtable/v2/BigtableGrpc.java
@@ -12,8 +12,17 @@ import static io.grpc.stub.ServerCalls.asyncUnaryCall;
 import static io.grpc.stub.ServerCalls.asyncServerStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncClientStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncBidiStreamingCall;
+import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
+import static io.grpc.stub.ServerCalls.asyncUnimplementedStreamingCall;
 
-@javax.annotation.Generated("by gRPC proto compiler")
+/**
+ * <pre>
+ * Service for reading from and writing to existing Bigtable tables.
+ * </pre>
+ */
+@javax.annotation.Generated(
+    value = "by gRPC proto compiler (version 0.14.1)",
+    comments = "Source: google/bigtable/v2/bigtable.proto")
 public class BigtableGrpc {
 
   private BigtableGrpc() {}
@@ -76,67 +85,243 @@ public class BigtableGrpc {
           io.grpc.protobuf.ProtoUtils.marshaller(com.google.bigtable.v2.ReadModifyWriteRowRequest.getDefaultInstance()),
           io.grpc.protobuf.ProtoUtils.marshaller(com.google.bigtable.v2.ReadModifyWriteRowResponse.getDefaultInstance()));
 
+  /**
+   * Creates a new async stub that supports all call types for the service
+   */
   public static BigtableStub newStub(io.grpc.Channel channel) {
     return new BigtableStub(channel);
   }
 
+  /**
+   * Creates a new blocking-style stub that supports unary and streaming output calls on the service
+   */
   public static BigtableBlockingStub newBlockingStub(
       io.grpc.Channel channel) {
     return new BigtableBlockingStub(channel);
   }
 
+  /**
+   * Creates a new ListenableFuture-style stub that supports unary and streaming output calls on the service
+   */
   public static BigtableFutureStub newFutureStub(
       io.grpc.Channel channel) {
     return new BigtableFutureStub(channel);
   }
 
+  /**
+   * <pre>
+   * Service for reading from and writing to existing Bigtable tables.
+   * </pre>
+   */
   public static interface Bigtable {
 
+    /**
+     * <pre>
+     * Streams back the contents of all requested rows, optionally
+     * applying the same Reader filter to each. Depending on their size,
+     * rows and cells may be broken up across multiple responses, but
+     * atomicity of each row will still be preserved. See the
+     * ReadRowsResponse documentation for details.
+     * </pre>
+     */
     public void readRows(com.google.bigtable.v2.ReadRowsRequest request,
         io.grpc.stub.StreamObserver<com.google.bigtable.v2.ReadRowsResponse> responseObserver);
 
+    /**
+     * <pre>
+     * Returns a sample of row keys in the table. The returned row keys will
+     * delimit contiguous sections of the table of approximately equal size,
+     * which can be used to break up the data for distributed tasks like
+     * mapreduces.
+     * </pre>
+     */
     public void sampleRowKeys(com.google.bigtable.v2.SampleRowKeysRequest request,
         io.grpc.stub.StreamObserver<com.google.bigtable.v2.SampleRowKeysResponse> responseObserver);
 
+    /**
+     * <pre>
+     * Mutates a row atomically. Cells already present in the row are left
+     * unchanged unless explicitly changed by `mutation`.
+     * </pre>
+     */
     public void mutateRow(com.google.bigtable.v2.MutateRowRequest request,
         io.grpc.stub.StreamObserver<com.google.bigtable.v2.MutateRowResponse> responseObserver);
 
+    /**
+     * <pre>
+     * Mutates multiple rows in a batch. Each individual row is mutated
+     * atomically as in MutateRow, but the entire batch is not executed
+     * atomically.
+     * </pre>
+     */
     public void mutateRows(com.google.bigtable.v2.MutateRowsRequest request,
         io.grpc.stub.StreamObserver<com.google.bigtable.v2.MutateRowsResponse> responseObserver);
 
+    /**
+     * <pre>
+     * Mutates a row atomically based on the output of a predicate Reader filter.
+     * </pre>
+     */
     public void checkAndMutateRow(com.google.bigtable.v2.CheckAndMutateRowRequest request,
         io.grpc.stub.StreamObserver<com.google.bigtable.v2.CheckAndMutateRowResponse> responseObserver);
 
+    /**
+     * <pre>
+     * Modifies a row atomically. The method reads the latest existing timestamp
+     * and value from the specified columns and writes a new entry based on
+     * pre-defined read/modify/write rules. The new value for the timestamp is the
+     * greater of the existing timestamp or the current server time. The method
+     * returns the new contents of all modified cells.
+     * </pre>
+     */
     public void readModifyWriteRow(com.google.bigtable.v2.ReadModifyWriteRowRequest request,
         io.grpc.stub.StreamObserver<com.google.bigtable.v2.ReadModifyWriteRowResponse> responseObserver);
   }
 
+  @io.grpc.ExperimentalApi
+  public static abstract class AbstractBigtable implements Bigtable, io.grpc.BindableService {
+
+    @java.lang.Override
+    public void readRows(com.google.bigtable.v2.ReadRowsRequest request,
+        io.grpc.stub.StreamObserver<com.google.bigtable.v2.ReadRowsResponse> responseObserver) {
+      asyncUnimplementedUnaryCall(METHOD_READ_ROWS, responseObserver);
+    }
+
+    @java.lang.Override
+    public void sampleRowKeys(com.google.bigtable.v2.SampleRowKeysRequest request,
+        io.grpc.stub.StreamObserver<com.google.bigtable.v2.SampleRowKeysResponse> responseObserver) {
+      asyncUnimplementedUnaryCall(METHOD_SAMPLE_ROW_KEYS, responseObserver);
+    }
+
+    @java.lang.Override
+    public void mutateRow(com.google.bigtable.v2.MutateRowRequest request,
+        io.grpc.stub.StreamObserver<com.google.bigtable.v2.MutateRowResponse> responseObserver) {
+      asyncUnimplementedUnaryCall(METHOD_MUTATE_ROW, responseObserver);
+    }
+
+    @java.lang.Override
+    public void mutateRows(com.google.bigtable.v2.MutateRowsRequest request,
+        io.grpc.stub.StreamObserver<com.google.bigtable.v2.MutateRowsResponse> responseObserver) {
+      asyncUnimplementedUnaryCall(METHOD_MUTATE_ROWS, responseObserver);
+    }
+
+    @java.lang.Override
+    public void checkAndMutateRow(com.google.bigtable.v2.CheckAndMutateRowRequest request,
+        io.grpc.stub.StreamObserver<com.google.bigtable.v2.CheckAndMutateRowResponse> responseObserver) {
+      asyncUnimplementedUnaryCall(METHOD_CHECK_AND_MUTATE_ROW, responseObserver);
+    }
+
+    @java.lang.Override
+    public void readModifyWriteRow(com.google.bigtable.v2.ReadModifyWriteRowRequest request,
+        io.grpc.stub.StreamObserver<com.google.bigtable.v2.ReadModifyWriteRowResponse> responseObserver) {
+      asyncUnimplementedUnaryCall(METHOD_READ_MODIFY_WRITE_ROW, responseObserver);
+    }
+
+    @java.lang.Override public io.grpc.ServerServiceDefinition bindService() {
+      return BigtableGrpc.bindService(this);
+    }
+  }
+
+  /**
+   * <pre>
+   * Service for reading from and writing to existing Bigtable tables.
+   * </pre>
+   */
   public static interface BigtableBlockingClient {
 
+    /**
+     * <pre>
+     * Streams back the contents of all requested rows, optionally
+     * applying the same Reader filter to each. Depending on their size,
+     * rows and cells may be broken up across multiple responses, but
+     * atomicity of each row will still be preserved. See the
+     * ReadRowsResponse documentation for details.
+     * </pre>
+     */
     public java.util.Iterator<com.google.bigtable.v2.ReadRowsResponse> readRows(
         com.google.bigtable.v2.ReadRowsRequest request);
 
+    /**
+     * <pre>
+     * Returns a sample of row keys in the table. The returned row keys will
+     * delimit contiguous sections of the table of approximately equal size,
+     * which can be used to break up the data for distributed tasks like
+     * mapreduces.
+     * </pre>
+     */
     public java.util.Iterator<com.google.bigtable.v2.SampleRowKeysResponse> sampleRowKeys(
         com.google.bigtable.v2.SampleRowKeysRequest request);
 
+    /**
+     * <pre>
+     * Mutates a row atomically. Cells already present in the row are left
+     * unchanged unless explicitly changed by `mutation`.
+     * </pre>
+     */
     public com.google.bigtable.v2.MutateRowResponse mutateRow(com.google.bigtable.v2.MutateRowRequest request);
 
+    /**
+     * <pre>
+     * Mutates multiple rows in a batch. Each individual row is mutated
+     * atomically as in MutateRow, but the entire batch is not executed
+     * atomically.
+     * </pre>
+     */
     public java.util.Iterator<com.google.bigtable.v2.MutateRowsResponse> mutateRows(
         com.google.bigtable.v2.MutateRowsRequest request);
 
+    /**
+     * <pre>
+     * Mutates a row atomically based on the output of a predicate Reader filter.
+     * </pre>
+     */
     public com.google.bigtable.v2.CheckAndMutateRowResponse checkAndMutateRow(com.google.bigtable.v2.CheckAndMutateRowRequest request);
 
+    /**
+     * <pre>
+     * Modifies a row atomically. The method reads the latest existing timestamp
+     * and value from the specified columns and writes a new entry based on
+     * pre-defined read/modify/write rules. The new value for the timestamp is the
+     * greater of the existing timestamp or the current server time. The method
+     * returns the new contents of all modified cells.
+     * </pre>
+     */
     public com.google.bigtable.v2.ReadModifyWriteRowResponse readModifyWriteRow(com.google.bigtable.v2.ReadModifyWriteRowRequest request);
   }
 
+  /**
+   * <pre>
+   * Service for reading from and writing to existing Bigtable tables.
+   * </pre>
+   */
   public static interface BigtableFutureClient {
 
+    /**
+     * <pre>
+     * Mutates a row atomically. Cells already present in the row are left
+     * unchanged unless explicitly changed by `mutation`.
+     * </pre>
+     */
     public com.google.common.util.concurrent.ListenableFuture<com.google.bigtable.v2.MutateRowResponse> mutateRow(
         com.google.bigtable.v2.MutateRowRequest request);
 
+    /**
+     * <pre>
+     * Mutates a row atomically based on the output of a predicate Reader filter.
+     * </pre>
+     */
     public com.google.common.util.concurrent.ListenableFuture<com.google.bigtable.v2.CheckAndMutateRowResponse> checkAndMutateRow(
         com.google.bigtable.v2.CheckAndMutateRowRequest request);
 
+    /**
+     * <pre>
+     * Modifies a row atomically. The method reads the latest existing timestamp
+     * and value from the specified columns and writes a new entry based on
+     * pre-defined read/modify/write rules. The new value for the timestamp is the
+     * greater of the existing timestamp or the current server time. The method
+     * returns the new contents of all modified cells.
+     * </pre>
+     */
     public com.google.common.util.concurrent.ListenableFuture<com.google.bigtable.v2.ReadModifyWriteRowResponse> readModifyWriteRow(
         com.google.bigtable.v2.ReadModifyWriteRowRequest request);
   }
@@ -317,6 +502,7 @@ public class BigtableGrpc {
       this.methodId = methodId;
     }
 
+    @java.lang.Override
     @java.lang.SuppressWarnings("unchecked")
     public void invoke(Req request, io.grpc.stub.StreamObserver<Resp> responseObserver) {
       switch (methodId) {
@@ -349,6 +535,7 @@ public class BigtableGrpc {
       }
     }
 
+    @java.lang.Override
     @java.lang.SuppressWarnings("unchecked")
     public io.grpc.stub.StreamObserver<Req> invoke(
         io.grpc.stub.StreamObserver<Resp> responseObserver) {

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/services/com/google/longrunning/OperationsGrpc.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/services/com/google/longrunning/OperationsGrpc.java
@@ -12,8 +12,25 @@ import static io.grpc.stub.ServerCalls.asyncUnaryCall;
 import static io.grpc.stub.ServerCalls.asyncServerStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncClientStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncBidiStreamingCall;
+import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
+import static io.grpc.stub.ServerCalls.asyncUnimplementedStreamingCall;
 
-@javax.annotation.Generated("by gRPC proto compiler")
+/**
+ * <pre>
+ * Manages long-running operations with an API service.
+ * When an API method normally takes long time to complete, it can be designed
+ * to return [Operation][google.longrunning.Operation] to the client, and the client can use this
+ * interface to receive the real response asynchronously by polling the
+ * operation resource, or using `google.watcher.v1.Watcher` interface to watch
+ * the response, or pass the operation resource to another API (such as Google
+ * Cloud Pub/Sub API) to receive the response.  Any API service that returns
+ * long-running operations should implement the `Operations` interface so
+ * developers can have a consistent client experience.
+ * </pre>
+ */
+@javax.annotation.Generated(
+    value = "by gRPC proto compiler (version 0.14.1)",
+    comments = "Source: google/longrunning/operations.proto")
 public class OperationsGrpc {
 
   private OperationsGrpc() {}
@@ -58,57 +75,227 @@ public class OperationsGrpc {
           io.grpc.protobuf.ProtoUtils.marshaller(com.google.longrunning.DeleteOperationRequest.getDefaultInstance()),
           io.grpc.protobuf.ProtoUtils.marshaller(com.google.protobuf.Empty.getDefaultInstance()));
 
+  /**
+   * Creates a new async stub that supports all call types for the service
+   */
   public static OperationsStub newStub(io.grpc.Channel channel) {
     return new OperationsStub(channel);
   }
 
+  /**
+   * Creates a new blocking-style stub that supports unary and streaming output calls on the service
+   */
   public static OperationsBlockingStub newBlockingStub(
       io.grpc.Channel channel) {
     return new OperationsBlockingStub(channel);
   }
 
+  /**
+   * Creates a new ListenableFuture-style stub that supports unary and streaming output calls on the service
+   */
   public static OperationsFutureStub newFutureStub(
       io.grpc.Channel channel) {
     return new OperationsFutureStub(channel);
   }
 
+  /**
+   * <pre>
+   * Manages long-running operations with an API service.
+   * When an API method normally takes long time to complete, it can be designed
+   * to return [Operation][google.longrunning.Operation] to the client, and the client can use this
+   * interface to receive the real response asynchronously by polling the
+   * operation resource, or using `google.watcher.v1.Watcher` interface to watch
+   * the response, or pass the operation resource to another API (such as Google
+   * Cloud Pub/Sub API) to receive the response.  Any API service that returns
+   * long-running operations should implement the `Operations` interface so
+   * developers can have a consistent client experience.
+   * </pre>
+   */
   public static interface Operations {
 
+    /**
+     * <pre>
+     * Gets the latest state of a long-running operation.  Clients may use this
+     * method to poll the operation result at intervals as recommended by the API
+     * service.
+     * </pre>
+     */
     public void getOperation(com.google.longrunning.GetOperationRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver);
 
+    /**
+     * <pre>
+     * Lists operations that match the specified filter in the request. If the
+     * server doesn't support this method, it returns
+     * `google.rpc.Code.UNIMPLEMENTED`.
+     * </pre>
+     */
     public void listOperations(com.google.longrunning.ListOperationsRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.ListOperationsResponse> responseObserver);
 
+    /**
+     * <pre>
+     * Starts asynchronous cancellation on a long-running operation.  The server
+     * makes a best effort to cancel the operation, but success is not
+     * guaranteed.  If the server doesn't support this method, it returns
+     * `google.rpc.Code.UNIMPLEMENTED`.  Clients may use
+     * [Operations.GetOperation] or other methods to check whether the
+     * cancellation succeeded or the operation completed despite cancellation.
+     * </pre>
+     */
     public void cancelOperation(com.google.longrunning.CancelOperationRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver);
 
+    /**
+     * <pre>
+     * Deletes a long-running operation.  It indicates the client is no longer
+     * interested in the operation result. It does not cancel the operation.
+     * </pre>
+     */
     public void deleteOperation(com.google.longrunning.DeleteOperationRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver);
   }
 
+  @io.grpc.ExperimentalApi
+  public static abstract class AbstractOperations implements Operations, io.grpc.BindableService {
+
+    @java.lang.Override
+    public void getOperation(com.google.longrunning.GetOperationRequest request,
+        io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
+      asyncUnimplementedUnaryCall(METHOD_GET_OPERATION, responseObserver);
+    }
+
+    @java.lang.Override
+    public void listOperations(com.google.longrunning.ListOperationsRequest request,
+        io.grpc.stub.StreamObserver<com.google.longrunning.ListOperationsResponse> responseObserver) {
+      asyncUnimplementedUnaryCall(METHOD_LIST_OPERATIONS, responseObserver);
+    }
+
+    @java.lang.Override
+    public void cancelOperation(com.google.longrunning.CancelOperationRequest request,
+        io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
+      asyncUnimplementedUnaryCall(METHOD_CANCEL_OPERATION, responseObserver);
+    }
+
+    @java.lang.Override
+    public void deleteOperation(com.google.longrunning.DeleteOperationRequest request,
+        io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
+      asyncUnimplementedUnaryCall(METHOD_DELETE_OPERATION, responseObserver);
+    }
+
+    @java.lang.Override public io.grpc.ServerServiceDefinition bindService() {
+      return OperationsGrpc.bindService(this);
+    }
+  }
+
+  /**
+   * <pre>
+   * Manages long-running operations with an API service.
+   * When an API method normally takes long time to complete, it can be designed
+   * to return [Operation][google.longrunning.Operation] to the client, and the client can use this
+   * interface to receive the real response asynchronously by polling the
+   * operation resource, or using `google.watcher.v1.Watcher` interface to watch
+   * the response, or pass the operation resource to another API (such as Google
+   * Cloud Pub/Sub API) to receive the response.  Any API service that returns
+   * long-running operations should implement the `Operations` interface so
+   * developers can have a consistent client experience.
+   * </pre>
+   */
   public static interface OperationsBlockingClient {
 
+    /**
+     * <pre>
+     * Gets the latest state of a long-running operation.  Clients may use this
+     * method to poll the operation result at intervals as recommended by the API
+     * service.
+     * </pre>
+     */
     public com.google.longrunning.Operation getOperation(com.google.longrunning.GetOperationRequest request);
 
+    /**
+     * <pre>
+     * Lists operations that match the specified filter in the request. If the
+     * server doesn't support this method, it returns
+     * `google.rpc.Code.UNIMPLEMENTED`.
+     * </pre>
+     */
     public com.google.longrunning.ListOperationsResponse listOperations(com.google.longrunning.ListOperationsRequest request);
 
+    /**
+     * <pre>
+     * Starts asynchronous cancellation on a long-running operation.  The server
+     * makes a best effort to cancel the operation, but success is not
+     * guaranteed.  If the server doesn't support this method, it returns
+     * `google.rpc.Code.UNIMPLEMENTED`.  Clients may use
+     * [Operations.GetOperation] or other methods to check whether the
+     * cancellation succeeded or the operation completed despite cancellation.
+     * </pre>
+     */
     public com.google.protobuf.Empty cancelOperation(com.google.longrunning.CancelOperationRequest request);
 
+    /**
+     * <pre>
+     * Deletes a long-running operation.  It indicates the client is no longer
+     * interested in the operation result. It does not cancel the operation.
+     * </pre>
+     */
     public com.google.protobuf.Empty deleteOperation(com.google.longrunning.DeleteOperationRequest request);
   }
 
+  /**
+   * <pre>
+   * Manages long-running operations with an API service.
+   * When an API method normally takes long time to complete, it can be designed
+   * to return [Operation][google.longrunning.Operation] to the client, and the client can use this
+   * interface to receive the real response asynchronously by polling the
+   * operation resource, or using `google.watcher.v1.Watcher` interface to watch
+   * the response, or pass the operation resource to another API (such as Google
+   * Cloud Pub/Sub API) to receive the response.  Any API service that returns
+   * long-running operations should implement the `Operations` interface so
+   * developers can have a consistent client experience.
+   * </pre>
+   */
   public static interface OperationsFutureClient {
 
+    /**
+     * <pre>
+     * Gets the latest state of a long-running operation.  Clients may use this
+     * method to poll the operation result at intervals as recommended by the API
+     * service.
+     * </pre>
+     */
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation> getOperation(
         com.google.longrunning.GetOperationRequest request);
 
+    /**
+     * <pre>
+     * Lists operations that match the specified filter in the request. If the
+     * server doesn't support this method, it returns
+     * `google.rpc.Code.UNIMPLEMENTED`.
+     * </pre>
+     */
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.ListOperationsResponse> listOperations(
         com.google.longrunning.ListOperationsRequest request);
 
+    /**
+     * <pre>
+     * Starts asynchronous cancellation on a long-running operation.  The server
+     * makes a best effort to cancel the operation, but success is not
+     * guaranteed.  If the server doesn't support this method, it returns
+     * `google.rpc.Code.UNIMPLEMENTED`.  Clients may use
+     * [Operations.GetOperation] or other methods to check whether the
+     * cancellation succeeded or the operation completed despite cancellation.
+     * </pre>
+     */
     public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.Empty> cancelOperation(
         com.google.longrunning.CancelOperationRequest request);
 
+    /**
+     * <pre>
+     * Deletes a long-running operation.  It indicates the client is no longer
+     * interested in the operation result. It does not cancel the operation.
+     * </pre>
+     */
     public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.Empty> deleteOperation(
         com.google.longrunning.DeleteOperationRequest request);
   }
@@ -265,6 +452,7 @@ public class OperationsGrpc {
       this.methodId = methodId;
     }
 
+    @java.lang.Override
     @java.lang.SuppressWarnings("unchecked")
     public void invoke(Req request, io.grpc.stub.StreamObserver<Resp> responseObserver) {
       switch (methodId) {
@@ -289,6 +477,7 @@ public class OperationsGrpc {
       }
     }
 
+    @java.lang.Override
     @java.lang.SuppressWarnings("unchecked")
     public io.grpc.stub.StreamObserver<Req> invoke(
         io.grpc.stub.StreamObserver<Resp> responseObserver) {

--- a/pom.xml
+++ b/pom.xml
@@ -53,11 +53,11 @@ limitations under the License.
         <compat.module>hbase-hadoop2-compat</compat.module>
         <junit.version>4.12</junit.version>
         <mockito.version>1.10.19</mockito.version>
-        <protobuff-java.version>3.0.0-beta-1</protobuff-java.version>
-        <grpc.version>0.13.1</grpc.version>
+        <protobuff-java.version>3.0.0-beta-2</protobuff-java.version>
+        <grpc.version>0.14.1</grpc.version>
         <google.api.client.version>1.22.0</google.api.client.version>
         <google.http.client.version>1.22.0</google.http.client.version>
-        <netty.version>4.1.0.CR1</netty.version>
+        <netty.version>4.1.1.Final</netty.version>
         <guava.version>19.0</guava.version>
         <google.auth.library.version>0.4.0</google.auth.library.version>
 
@@ -533,7 +533,7 @@ limitations under the License.
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-tcnative-boringssl-static</artifactId>
-                <version>1.1.33.Fork13</version>
+                <version>1.1.33.Fork18</version>
                 <classifier>${os.detected.classifier}</classifier>
                 <scope>test</scope>
             </dependency>


### PR DESCRIPTION
This version of grpc works a lot better for us in terms of scan performance.

Since protobuf was updated, I regenerated all of the java classes.  It turns out that we didn't regenerate the services before we released 0.9.0, so the comments from the service protos got updated in the generated java files.