### PR TITLE
Fix documentation of data proto

### DIFF
--- a/bigtable-client-core-parent/bigtable-protos/src/main/proto/google/bigtable/v2/data.proto
+++ b/bigtable-client-core-parent/bigtable-protos/src/main/proto/google/bigtable/v2/data.proto
@@ -97,10 +97,10 @@ message RowRange {
   // The row key at which to end the range.
   // If neither field is set, interpreted as the infinite row key, exclusive.
   oneof end_key {
-    // Used when giving an inclusive upper bound for the range.
+    // Used when giving an exclusive upper bound for the range.
     bytes end_key_open = 3;
 
-    // Used when giving an exclusive upper bound for the range.
+    // Used when giving an inclusive upper bound for the range.
     bytes end_key_closed = 4;
   }
 }


### PR DESCRIPTION
This was bothering me and pretty confusing at first glance. Could be better to switch the order as well so that closed comes before open as in every other range key.