### PR TITLE
Improving getTable() performance.

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableInstanceName.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableInstanceName.java
@@ -29,7 +29,7 @@ public class BigtableInstanceName implements Serializable {
   private static final long serialVersionUID = 1L;
 
   public static final String BIGTABLE_V2_INSTANCE_FMT = "projects/%s/instances/%s";
-  public static final String TABLE_SEPARATOR = "tables";
+  public static final String TABLE_SEPARATOR = "/tables/";
 
   private final String instanceName;
 
@@ -53,7 +53,7 @@ public class BigtableInstanceName implements Serializable {
    */
   public String toTableId(String tableName) {
     Preconditions.checkNotNull(tableName, "Table name cannot be null");
-    String tablesPrefix = instanceName + "/" + TABLE_SEPARATOR + "/";
+    String tablesPrefix = instanceName + TABLE_SEPARATOR;
     Preconditions.checkState(tableName.startsWith(tablesPrefix),
         "'%s' does not start with '%s'", tableName, tablesPrefix);
     String tableId = tableName.substring(tablesPrefix.length()).trim();
@@ -62,7 +62,7 @@ public class BigtableInstanceName implements Serializable {
   }
 
   public String toTableNameStr(String tableId) {
-    return instanceName +  "/" + TABLE_SEPARATOR + "/" + tableId;
+    return instanceName +  TABLE_SEPARATOR + tableId;
   }
 
   public BigtableTableName toTableName(String tableId) {

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestBigtableInstanceName.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestBigtableInstanceName.java
@@ -58,7 +58,7 @@ public class TestBigtableInstanceName {
   @Test
   public void testGoodTableQualifier() {
     bigtableInstanceName
-        .toTableId(instanceName + "/" + BigtableInstanceName.TABLE_SEPARATOR + "/foo");
+        .toTableId(instanceName + BigtableInstanceName.TABLE_SEPARATOR + "foo");
   }
 
   @Test
@@ -70,20 +70,20 @@ public class TestBigtableInstanceName {
   @Test
   public void testBadQualifier() {
     expectedException.expect(IllegalStateException.class);
-    bigtableInstanceName.toTableId(instanceName.replace("some-instance", "another-instance") + "/"
-        + BigtableInstanceName.TABLE_SEPARATOR + "/foo");
+    bigtableInstanceName.toTableId(instanceName.replace("some-instance", "another-instance")
+        + BigtableInstanceName.TABLE_SEPARATOR + "foo");
   }
 
   @Test
   public void testBlankTableName() {
     expectedException.expect(IllegalStateException.class);
-    bigtableInstanceName.toTableId(instanceName + "/" + BigtableInstanceName.TABLE_SEPARATOR + "/");
+    bigtableInstanceName.toTableId(instanceName + BigtableInstanceName.TABLE_SEPARATOR);
   }
 
   @Test
   public void testNoTableName() {
     expectedException.expect(IllegalStateException.class);
-    bigtableInstanceName.toTableId(instanceName + "/" + BigtableInstanceName.TABLE_SEPARATOR);
+    bigtableInstanceName.toTableId(instanceName + BigtableInstanceName.TABLE_SEPARATOR);
   }
 
   @Test

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/io/ChannelPoolPerf.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/io/ChannelPoolPerf.java
@@ -99,7 +99,7 @@ public class ChannelPoolPerf {
         }
         long diff = System.nanoTime() - start;
         double nanosPerRow = diff / TEST_COUNT;
-        System.out.println(String.format("took %d ms.  %.0f", diff / 1_000_000, nanosPerRow));
+        System.out.println(String.format("took %d ms.  %.0f nanos/row", diff / 1_000_000, nanosPerRow));
         return null;
       }
     };

--- a/bigtable-hbase-parent/bigtable-hbase/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase/pom.xml
@@ -72,5 +72,10 @@ limitations under the License.
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-tcnative-boringssl-static</artifactId>
+            <classifier>${os.detected.classifier}</classifier>
+        </dependency>
     </dependencies>
 </project>

--- a/bigtable-hbase-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableTable.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableTable.java
@@ -87,9 +87,6 @@ public class TestBigtableTable {
   private BigtableDataClient mockClient;
 
   @Mock
-  private BatchExecutor mockBatchExecutor;
-
-  @Mock
   private ResultScanner<Row> mockResultScanner;
 
   public BigtableTable table;
@@ -118,8 +115,7 @@ public class TestBigtableTable {
     Mockito.when(mockConnection.getSession()).thenReturn(mockSession);
     Mockito.when(mockSession.getOptions()).thenReturn(options);
     Mockito.when(mockSession.getDataClient()).thenReturn(mockClient);
-    table =
-        new BigtableTable(mockConnection, tableName, hbaseAdapter, mockBatchExecutor);
+    table = new BigtableTable(mockConnection, hbaseAdapter);
   }
 
   @Test

--- a/bigtable-hbase-parent/bigtable-hbase/src/test/java/org/apache/hadoop/hbase/client/PutMicroBenchmark.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/test/java/org/apache/hadoop/hbase/client/PutMicroBenchmark.java
@@ -179,13 +179,12 @@ public class PutMicroBenchmark {
     print(start, putCount * roundCount);
   }
 
-
-  private static void print(long startTimeNanos, int putCount) {
+  private static void print(long startTimeNanos, int count) {
     long totalTime = System.nanoTime() - startTimeNanos;
 
     System.out.printf(
         "Put %d in %d ms.  %d nanos/put.  %,f put/sec",
-        putCount, totalTime / 1000000, totalTime / putCount, putCount * 1000000000.0 / totalTime);
+        count, totalTime / 1000000, totalTime / count, count * 1000000000.0 / totalTime);
     System.out.println(); 
   }
 


### PR DESCRIPTION
AbstractBigtableConnection.getTable() takes 1-2 microseconds.  Caching or deferring instantiation of objects reduces that to 100-300 nanoseconds.