### PR TITLE
Removing the generics in ReasponseQueueReader.

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataGrpcClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataGrpcClient.java
@@ -334,7 +334,7 @@ public class BigtableDataGrpcClient implements BigtableDataClient {
     ClientCall<ReadRowsRequest, ReadRowsResponse> readRowsCall =
         channelPool.newCall(BigtableGrpc.METHOD_READ_ROWS, CallOptions.DEFAULT);
 
-    ResponseQueueReader<Row> responseQueueReader = new ResponseQueueReader<>(
+    ResponseQueueReader responseQueueReader = new ResponseQueueReader(
         retryOptions.getReadPartialRowTimeoutMillis(), retryOptions.getStreamingBufferSize());
 
     StreamObserver<ReadRowsResponse> rowMerger = new RowMerger(responseQueueReader);

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/StreamingBigtableResultScanner.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/StreamingBigtableResultScanner.java
@@ -27,10 +27,9 @@ import com.google.common.base.Preconditions;
 public class StreamingBigtableResultScanner extends AbstractBigtableResultScanner {
 
   private final CancellationToken cancellationToken;
-  private final ResponseQueueReader<Row> responseQueueReader;
+  private final ResponseQueueReader responseQueueReader;
 
-  public StreamingBigtableResultScanner(
-      ResponseQueueReader<Row> responseQueueReader,
+  public StreamingBigtableResultScanner(ResponseQueueReader responseQueueReader,
       CancellationToken cancellationToken) {
     Preconditions.checkArgument(cancellationToken != null, "cancellationToken cannot be null");
     this.cancellationToken = cancellationToken;

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/scanner/StreamingBigtableResultScannerTest.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/scanner/StreamingBigtableResultScannerTest.java
@@ -27,14 +27,13 @@ import org.junit.runners.JUnit4;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import com.google.bigtable.v2.Row;
 import com.google.cloud.bigtable.grpc.io.CancellationToken;
 
 @RunWith(JUnit4.class)
 public class StreamingBigtableResultScannerTest {
 
   @Mock
-  ResponseQueueReader<Row> reader;
+  ResponseQueueReader reader;
 
   @Mock
   CancellationToken cancellationToken;


### PR DESCRIPTION
The generics in ReasponseQueueReader were needed for the v1 / v2 transition.  Removing them will help set the stage to create a more performat system that takes advantage of the v2 semantics.