### PR TITLE
Pushing out CallOptions settings to BigtableDataGrpcClient.

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataGrpcClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataGrpcClient.java
@@ -210,88 +210,93 @@ public class BigtableDataGrpcClient implements BigtableDataClient {
 
   @Override
   public MutateRowResponse mutateRow(MutateRowRequest request) throws ServiceException {
-    return getBlockingUnaryResult(request, mutateRowRpc);
+    return getBlockingUnaryResult(request, mutateRowRpc, CallOptions.DEFAULT);
   }
 
   @Override
   public ListenableFuture<MutateRowResponse> mutateRowAsync(MutateRowRequest request) {
-    return getUnaryFuture(request, mutateRowRpc);
+    return getUnaryFuture(request, mutateRowRpc, CallOptions.DEFAULT);
   }
 
   @Override
   public List<MutateRowsResponse> mutateRows(MutateRowsRequest request) throws ServiceException {
-    return getBlockingStreamingResult(request, mutateRowsRpc);
+    return getBlockingStreamingResult(request, mutateRowsRpc, CallOptions.DEFAULT);
   }
 
   @Override
   public ListenableFuture<List<MutateRowsResponse>> mutateRowsAsync(MutateRowsRequest request) {
-    return getStreamingFuture(request, mutateRowsRpc);
+    return getStreamingFuture(request, mutateRowsRpc, CallOptions.DEFAULT);
   }
 
   @Override
   public CheckAndMutateRowResponse checkAndMutateRow(CheckAndMutateRowRequest request)
       throws ServiceException {
-    return getBlockingUnaryResult(request, checkAndMutateRpc);
+    return getBlockingUnaryResult(request, checkAndMutateRpc, CallOptions.DEFAULT);
   }
 
   @Override
   public ListenableFuture<CheckAndMutateRowResponse> checkAndMutateRowAsync(
       CheckAndMutateRowRequest request) {
-    return getUnaryFuture(request, checkAndMutateRpc);
+    return getUnaryFuture(request, checkAndMutateRpc, CallOptions.DEFAULT);
   }
 
   @Override
   public ReadModifyWriteRowResponse readModifyWriteRow(ReadModifyWriteRowRequest request) {
-    return getBlockingUnaryResult(request, readWriteModifyRpc);
+    return getBlockingUnaryResult(request, readWriteModifyRpc, CallOptions.DEFAULT);
   }
 
   @Override
   public ListenableFuture<ReadModifyWriteRowResponse> readModifyWriteRowAsync(
       ReadModifyWriteRowRequest request) {
-    return getUnaryFuture(request, readWriteModifyRpc);
+    return getUnaryFuture(request, readWriteModifyRpc, CallOptions.DEFAULT);
   }
 
   @Override
   public ImmutableList<SampleRowKeysResponse> sampleRowKeys(SampleRowKeysRequest request) {
-    return ImmutableList.copyOf(getBlockingStreamingResult(request, sampleRowKeysAsync));
+    return ImmutableList.copyOf(
+        getBlockingStreamingResult(request, sampleRowKeysAsync, CallOptions.DEFAULT));
   }
 
   @Override
-  public ListenableFuture<List<SampleRowKeysResponse>>
-      sampleRowKeysAsync(SampleRowKeysRequest request) {
-    return getStreamingFuture(request, sampleRowKeysAsync);
+  public ListenableFuture<List<SampleRowKeysResponse>> sampleRowKeysAsync(
+      SampleRowKeysRequest request) {
+    return getStreamingFuture(request, sampleRowKeysAsync, CallOptions.DEFAULT);
   }
 
   @Override
   public ListenableFuture<List<Row>> readRowsAsync(ReadRowsRequest request) {
-    return Futures.transform(getStreamingFuture(request, readRowsAsync), ROW_TRANSFORMER);
+    return Futures.transform(
+        getStreamingFuture(request, readRowsAsync, CallOptions.DEFAULT), ROW_TRANSFORMER);
   }
 
   // Helper methods
-
-  protected <ReqT, RespT> ListenableFuture<List<RespT>> getStreamingFuture(ReqT request,
-      final BigtableAsyncRpc<ReqT, RespT> rpc) {
+  protected <ReqT, RespT> ListenableFuture<List<RespT>> getStreamingFuture(
+      ReqT request, BigtableAsyncRpc<ReqT, RespT> rpc, CallOptions callOptions) {
     return getCompletionFuture(
-      new RetryingCollectingClientCallListener<>(retryOptions, request, rpc, retryExecutorService));
+        new RetryingCollectingClientCallListener<>(
+            retryOptions, request, rpc, callOptions, retryExecutorService));
   }
 
-  private <ReqT, RespT> List<RespT> getBlockingStreamingResult(ReqT request,
-      BigtableAsyncRpc<ReqT, RespT> rpc) {
+  private <ReqT, RespT> List<RespT> getBlockingStreamingResult(
+      ReqT request, BigtableAsyncRpc<ReqT, RespT> rpc, CallOptions callOptions) {
     return getBlockingResult(
-      new RetryingCollectingClientCallListener<>(retryOptions, request, rpc, retryExecutorService));
+        new RetryingCollectingClientCallListener<>(
+            retryOptions, request, rpc, callOptions, retryExecutorService));
   }
 
-  private <ReqT, RespT> ListenableFuture<RespT> getUnaryFuture(ReqT request,
-      BigtableAsyncRpc<ReqT, RespT> rpc) {
+  private <ReqT, RespT> ListenableFuture<RespT> getUnaryFuture(
+      ReqT request, BigtableAsyncRpc<ReqT, RespT> rpc, CallOptions callOptions) {
     expandPoolIfNecessary(this.bigtableOptions.getChannelCount());
     return getCompletionFuture(
-      new RetryingUnaryRpcListener<>(retryOptions, request, rpc, retryExecutorService));
+        new RetryingUnaryRpcListener<>(
+            retryOptions, request, rpc, callOptions, retryExecutorService));
   }
 
-  private <ReqT, RespT> RespT getBlockingUnaryResult(ReqT request,
-      BigtableAsyncRpc<ReqT, RespT> rpc) {
+  private <ReqT, RespT> RespT getBlockingUnaryResult(
+      ReqT request, BigtableAsyncRpc<ReqT, RespT> rpc, CallOptions callOptions) {
     return getBlockingResult(
-      new RetryingUnaryRpcListener<>(retryOptions, request, rpc, retryExecutorService));
+        new RetryingUnaryRpcListener<>(
+            retryOptions, request, rpc, callOptions, retryExecutorService));
   }
 
   private static <ReqT, RespT, OutputT> ListenableFuture<OutputT>

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BigtableAsyncRpc.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BigtableAsyncRpc.java
@@ -15,13 +15,13 @@
  */
 package com.google.cloud.bigtable.grpc.async;
 
+import io.grpc.CallOptions;
 import io.grpc.ClientCall;
 
-/**
- * This interface represents a logical asynchronous RPC.
- */
+/** This interface represents a logical asynchronous RPC. */
 public interface BigtableAsyncRpc<REQUEST, RESPONSE> {
-  ClientCall<REQUEST, RESPONSE> call(REQUEST request, ClientCall.Listener<RESPONSE> listener);
+  ClientCall<REQUEST, RESPONSE> call(
+      REQUEST request, ClientCall.Listener<RESPONSE> listener, CallOptions callOptions);
 
   boolean isRetryable(REQUEST request);
 }

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BigtableAsyncUtilities.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BigtableAsyncUtilities.java
@@ -53,8 +53,9 @@ public interface BigtableAsyncUtilities {
         @Override
         public ClientCall<RequestT, ResponseT> call(
             RequestT request,
-            ClientCall.Listener<ResponseT> listener) {
-          return createCall(channel, method, request, listener, 1);
+            ClientCall.Listener<ResponseT> listener,
+            CallOptions callOptions) {
+          return createCall(channel, callOptions, method, request, listener, 1);
         }
 
         @Override
@@ -77,9 +78,8 @@ public interface BigtableAsyncUtilities {
 
         @Override
         public ClientCall<RequestT, ResponseT> call(
-            RequestT request,
-            ClientCall.Listener<ResponseT> listener) {
-          return createCall(channel, method, request, listener, 1);
+            RequestT request, ClientCall.Listener<ResponseT> listener, CallOptions callOptions) {
+          return createCall(channel, callOptions, method, request, listener, 1);
         }
       };
     }
@@ -96,11 +96,11 @@ public interface BigtableAsyncUtilities {
 
     private <RequestT, ResponseT> ClientCall<RequestT, ResponseT> createCall(
         Channel channel,
+        CallOptions callOptions,
         MethodDescriptor<RequestT, ResponseT> method,
         RequestT request,
-        ClientCall.Listener<ResponseT> listener,
-        int count) {
-      ClientCall<RequestT, ResponseT> call = channel.newCall(method, CallOptions.DEFAULT);
+        ClientCall.Listener<ResponseT> listener, int count) {
+      ClientCall<RequestT, ResponseT> call = channel.newCall(method, callOptions);
       start(call, request, listener, count);
       return call;
     }

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/RetryingCollectingClientCallListener.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/RetryingCollectingClientCallListener.java
@@ -21,6 +21,8 @@ import java.util.concurrent.ScheduledExecutorService;
 import com.google.cloud.bigtable.config.RetryOptions;
 import com.google.common.collect.ImmutableList;
 
+import io.grpc.CallOptions;
+
 public class RetryingCollectingClientCallListener<RequestT, ResponseT>
     extends AbstractRetryingRpcListener<RequestT, ResponseT, List<ResponseT>> {
 
@@ -30,8 +32,9 @@ public class RetryingCollectingClientCallListener<RequestT, ResponseT>
       RetryOptions retryOptions,
       RequestT request,
       BigtableAsyncRpc<RequestT, ResponseT> retryableRpc,
+      CallOptions callOptions,
       ScheduledExecutorService executorService) {
-    super(retryOptions, request, retryableRpc, executorService);
+    super(retryOptions, request, retryableRpc, callOptions, executorService);
   }
 
   @Override

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/RetryingUnaryRpcListener.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/RetryingUnaryRpcListener.java
@@ -20,6 +20,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import com.google.cloud.bigtable.config.RetryOptions;
 import com.google.common.util.concurrent.AsyncFunction;
 
+import io.grpc.CallOptions;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 
@@ -33,10 +34,13 @@ public class RetryingUnaryRpcListener<RequestT, ResponseT>
 
   private ResponseT value;
 
-  public RetryingUnaryRpcListener(RetryOptions retryOptions, RequestT request,
+  public RetryingUnaryRpcListener(
+      RetryOptions retryOptions,
+      RequestT request,
       BigtableAsyncRpc<RequestT, ResponseT> retryableRpc,
+      CallOptions callOptions,
       ScheduledExecutorService executorService) {
-    super(retryOptions, request, retryableRpc, executorService);
+    super(retryOptions, request, retryableRpc, callOptions, executorService);
   }
 
   @Override

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/BigtableDataGrpcClientTests.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/BigtableDataGrpcClientTests.java
@@ -230,11 +230,11 @@ public class BigtableDataGrpcClientTests {
         return null;
       }
     }).when(mockBigtableRpc).call(any(Object.class),
-      any(ClientCall.Listener.class));
+      any(ClientCall.Listener.class), CallOptions.DEFAULT);
   }
 
   private void verifyRequestCalled(Object request) {
     verify(mockBigtableRpc, times(1))
-        .call(eq(request), any(ClientCall.Listener.class));
+        .call(eq(request), any(ClientCall.Listener.class), CallOptions.DEFAULT);
   }
 }


### PR DESCRIPTION
There ought to be user control over timeouts. This change updates the
plumbing, but stops short of changing public interfaces that allow that
control.  The public interface changes will happen in a future PR.