### PR TITLE
Updating use of grpc cancel methods to new signature.

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataGrpcClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataGrpcClient.java
@@ -357,7 +357,7 @@ public class BigtableDataGrpcClient implements BigtableDataClient {
     cancellationToken.addListener(new Runnable() {
       @Override
       public void run() {
-        readRowsCall.cancel();
+        readRowsCall.cancel("User requested cancelation.", null);
       }
     }, MoreExecutors.directExecutor());
     return cancellationToken;

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AbstractRetryingRpcListener.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AbstractRetryingRpcListener.java
@@ -50,7 +50,7 @@ public abstract class AbstractRetryingRpcListener<RequestT, ResponseT, ResultT>
     @Override
     protected void interruptTask() {
       if (call != null) {
-        call.cancel();
+        call.cancel("Request interrupted.", null);
       }
     }
 
@@ -121,7 +121,13 @@ public abstract class AbstractRetryingRpcListener<RequestT, ResponseT, ResultT>
     }
     LOG.info("Retrying failed call. Failure #%d, got: %s", status.getCause(), failedCount, status);
 
-    cancel();
+    if (this.call != null) {
+      call.cancel(
+          String.format(
+              "Request being retried. Previous call failed with status %s.",
+              status.getCode().name()),
+          null);
+    }
     call = null;
 
     retryExecutorService.schedule(this, nextBackOff, TimeUnit.MILLISECONDS);
@@ -153,7 +159,7 @@ public abstract class AbstractRetryingRpcListener<RequestT, ResponseT, ResultT>
 
   public void cancel() {
     if (this.call != null) {
-      call.cancel();
+      call.cancel("User requested cancelation.", null);
     }
   }
 }

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BigtableAsyncUtilities.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BigtableAsyncUtilities.java
@@ -111,9 +111,14 @@ public interface BigtableAsyncUtilities {
       call.request(requestCount);
       try {
         call.sendMessage(request);
+      } catch (Throwable t) {
+        call.cancel("Exception in sendMessage.", t);
+        throw Throwables.propagate(t);
+      }
+      try {
         call.halfClose();
       } catch (Throwable t) {
-        call.cancel();
+        call.cancel("Exception in halfClose.", t);
         throw Throwables.propagate(t);
       }
     }


### PR DESCRIPTION
ClientCall.cancel() was deprecated in favor of ClentCall.cancel(message,
throwable).