### PR TITLE
Adding configuration based CallOptions generator.

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableOptions.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableOptions.java
@@ -73,9 +73,9 @@ public class BigtableOptions implements Serializable {
 
     private RetryOptions retryOptions = new RetryOptions.Builder().build();
     private CallOptionsConfig callOptionsConfig = new CallOptionsConfig.Builder().build();
-    // The default credentials get credential from well known locations, such as the GCE
-    // metdata service or gcloud configuration in other environments. A user can also override
-    // the default behavior with P12 or JSon configuration.
+    // CredentialOptions.defaultCredentials() gets credentials from well known locations, such as
+    // the GCE metdata service or gcloud configuration in other environments. A user can also
+    // override the default behavior with P12 or JSon configuration.
     private CredentialOptions credentialOptions = CredentialOptions.defaultCredentials();
 
     public Builder() {

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableOptions.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableOptions.java
@@ -66,17 +66,17 @@ public class BigtableOptions implements Serializable {
     private String instanceAdminHost = BIGTABLE_INSTANCE_ADMIN_HOST_DEFAULT;
     private int port = BIGTABLE_PORT_DEFAULT;
 
-    // The default credentials get credential from well known locations, such as the GCE
-    // metdata service or gcloud configuration in other environments. A user can also override
-    // the default behavior with P12 or JSon configuration.
-    private CredentialOptions credentialOptions = CredentialOptions.defaultCredentials();
-
-    // Performance tuning options.
-    private RetryOptions retryOptions = new RetryOptions.Builder().build();
     private int dataChannelCount = BIGTABLE_DATA_CHANNEL_COUNT_DEFAULT;
 
     private BulkOptions bulkOptions;
     private boolean usePlaintextNegotiation = false;
+
+    private RetryOptions retryOptions = new RetryOptions.Builder().build();
+    private CallOptionsConfig callOptionsConfig = new CallOptionsConfig.Builder().build();
+    // The default credentials get credential from well known locations, such as the GCE
+    // metdata service or gcloud configuration in other environments. A user can also override
+    // the default behavior with P12 or JSon configuration.
+    private CredentialOptions credentialOptions = CredentialOptions.defaultCredentials();
 
     public Builder() {
     }
@@ -94,6 +94,7 @@ public class BigtableOptions implements Serializable {
       this.dataChannelCount = original.dataChannelCount;
       this.bulkOptions = original.bulkOptions;
       this.usePlaintextNegotiation = original.usePlaintextNegotiation;
+      this.callOptionsConfig = original.callOptionsConfig;
     }
 
     public Builder setTableAdminHost(String tableAdminHost) {
@@ -160,6 +161,11 @@ public class BigtableOptions implements Serializable {
       return this;
     }
 
+    public Builder setCallOptionsConfig(CallOptionsConfig callOptionsConfig) {
+      this.callOptionsConfig = callOptionsConfig;
+      return this;
+    }
+
     public BigtableOptions build() {
       if (bulkOptions == null) {
         int maxInflightRpcs =
@@ -177,12 +183,13 @@ public class BigtableOptions implements Serializable {
           port,
           projectId,
           instanceId,
-          credentialOptions,
           userAgent,
-          retryOptions,
+          usePlaintextNegotiation,
           dataChannelCount,
           bulkOptions,
-          usePlaintextNegotiation);
+          callOptionsConfig,
+          credentialOptions,
+          retryOptions);
     }
   }
 
@@ -192,14 +199,16 @@ public class BigtableOptions implements Serializable {
   private final int port;
   private final String projectId;
   private final String instanceId;
-  private final CredentialOptions credentialOptions;
   private final String userAgent;
-  private final RetryOptions retryOptions;
   private final int dataChannelCount;
-  private final BigtableInstanceName instanceName;
-  private BulkOptions bulkOptions;
   private final boolean usePlaintextNegotiation;
 
+  private final BigtableInstanceName instanceName;
+
+  private final BulkOptions bulkOptions;
+  private final CallOptionsConfig callOptionsConfig;
+  private final CredentialOptions credentialOptions;
+  private final RetryOptions retryOptions;
 
   @VisibleForTesting
   BigtableOptions() {
@@ -209,12 +218,15 @@ public class BigtableOptions implements Serializable {
       port = 0;
       projectId = null;
       instanceId = null;
-      credentialOptions = null;
       userAgent = null;
-      retryOptions = null;
       dataChannelCount = 1;
       instanceName = null;
       usePlaintextNegotiation = false;
+
+      bulkOptions = null;
+      callOptionsConfig = null;
+      credentialOptions = null;
+      retryOptions = null;
   }
 
   private BigtableOptions(
@@ -224,12 +236,13 @@ public class BigtableOptions implements Serializable {
       int port,
       String projectId,
       String instanceId,
-      CredentialOptions credentialOptions,
       String userAgent,
-      RetryOptions retryOptions,
+      boolean usePlaintextNegotiation,
       int channelCount,
       BulkOptions bulkOptions,
-      boolean usePlaintextNegotiation) {
+      CallOptionsConfig callOptionsConfig,
+      CredentialOptions credentialOptions,
+      RetryOptions retryOptions) {
     Preconditions.checkArgument(channelCount > 0, "Channel count has to be at least 1.");
 
     this.tableAdminHost = Preconditions.checkNotNull(tableAdminHost);
@@ -244,6 +257,7 @@ public class BigtableOptions implements Serializable {
     this.dataChannelCount = channelCount;
     this.bulkOptions = bulkOptions;
     this.usePlaintextNegotiation = usePlaintextNegotiation;
+    this.callOptionsConfig = callOptionsConfig;
 
     if (!Strings.isNullOrEmpty(projectId)
         && !Strings.isNullOrEmpty(instanceId)) {
@@ -327,6 +341,10 @@ public class BigtableOptions implements Serializable {
     return usePlaintextNegotiation;
   }
 
+  public CallOptionsConfig getCallOptionsConfig() {
+    return callOptionsConfig;
+  }
+
   @Override
   public boolean equals(Object obj) {
     if (obj == null || obj.getClass() != BigtableOptions.class) {
@@ -347,7 +365,8 @@ public class BigtableOptions implements Serializable {
         && Objects.equals(userAgent, other.userAgent)
         && Objects.equals(credentialOptions, other.credentialOptions)
         && Objects.equals(retryOptions, other.retryOptions)
-        && Objects.equals(bulkOptions, other.bulkOptions);
+        && Objects.equals(bulkOptions, other.bulkOptions)
+        && Objects.equals(callOptionsConfig, other.callOptionsConfig);
   }
 
   @Override
@@ -365,6 +384,7 @@ public class BigtableOptions implements Serializable {
         .add("dataChannelCount", dataChannelCount)
         .add("retryOptions", retryOptions)
         .add("bulkOptions", bulkOptions)
+        .add("callOptionsConfig", callOptionsConfig)
         .add("usePlaintextNegotiation", usePlaintextNegotiation)
         .toString();
   }

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/CallOptionsConfig.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/CallOptionsConfig.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.config;
+
+import java.io.Serializable;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Preconditions;
+
+/**
+ * Experimental options to turn on timeout options and .
+ */
+public class CallOptionsConfig implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  public static final boolean USE_TIMEOUT_DEFAULT = false;
+
+  /**
+   * The default duration to wait before timing out RPCs. 1 minute is probably too long for most
+   * RPCs, but the intent is to have a conservative timeout by default and aim for user overrides.
+   */
+  public static final int TIMEOUT_MS_DEFAULT = 60_000;
+
+  public static class Builder {
+    private boolean useTimeout = USE_TIMEOUT_DEFAULT;
+    private int timeoutMs = TIMEOUT_MS_DEFAULT;
+
+    public Builder() {
+    }
+
+    private Builder(CallOptionsConfig original) {
+      this.useTimeout = original.useTimeout;
+      this.timeoutMs = original.timeoutMs;
+    }
+
+    public Builder setUseTimeout(boolean useTimeout) {
+      this.useTimeout = useTimeout;
+      return this;
+    }
+
+    public Builder setTimeoutMs(int timeoutMs) {
+      Preconditions.checkArgument(timeoutMs > 0, "Timeout ms has to be greater than 0");
+      this.timeoutMs = timeoutMs;
+      return this;
+    }
+
+    public CallOptionsConfig build() {
+      return new CallOptionsConfig(useTimeout, timeoutMs);
+    }
+  }
+
+  private final boolean useTimeout;
+  private final int timeoutMs;
+
+  public CallOptionsConfig(boolean useTimeout, int timeoutMs) {
+    this.useTimeout = useTimeout;
+    this.timeoutMs = timeoutMs;
+  }
+
+  public boolean isUseTimeout() {
+    return useTimeout;
+  }
+
+  public int getTimeoutMs() {
+    return timeoutMs;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == this) {
+      return true;
+    }
+    if (obj == null || obj.getClass() != CallOptionsConfig.class) {
+      return false;
+    }
+    CallOptionsConfig other = (CallOptionsConfig) obj;
+    return useTimeout == other.useTimeout 
+        && timeoutMs == other.timeoutMs;
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("useTimeout", useTimeout)
+        .add("timeoutMs", timeoutMs)
+        .toString();
+  }
+
+  public Builder toBuilder() {
+    return new Builder(this);
+  }
+}

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/CallOptionsConfig.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/CallOptionsConfig.java
@@ -20,8 +20,11 @@ import java.io.Serializable;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 
+import io.grpc.CallOptions;
+
 /**
- * Experimental options to turn on timeout options and .
+ * Experimental options to turn on timeout options. {@link CallOptions} supports other settings as
+ * well, which this configuration object could help set.
  */
 public class CallOptionsConfig implements Serializable {
 

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
@@ -266,7 +266,9 @@ public class BigtableSession implements Closeable {
     // More often than not, users want the dataClient. Create a new one in the constructor.
     this.dataClient =
         new BigtableDataGrpcClient(dataChannel, sharedPools.getRetryExecutor(), options);
-
+    dataClient.setCallOptionsFactory(
+      new CallOptionsFactory.ConfiguredCallOptionsFactory(options.getCallOptionsConfig()));
+    
     // Defer the creation of both the tableAdminClient until we need them.
 
     initializeResourceLimiter(options);

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/CallOptionsFactory.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/CallOptionsFactory.java
@@ -15,7 +15,13 @@
  */
 package com.google.cloud.bigtable.grpc;
 
+import java.util.concurrent.TimeUnit;
+
+import com.google.cloud.bigtable.config.CallOptionsConfig;
+
 import io.grpc.CallOptions;
+import io.grpc.Codec;
+import io.grpc.Deadline;
 import io.grpc.MethodDescriptor;
 
 /**
@@ -45,6 +51,29 @@ public interface CallOptionsFactory {
     public <RequestT> CallOptions create(MethodDescriptor<RequestT, ?> descriptor,
         RequestT request) {
       return CallOptions.DEFAULT;
+    }
+  }
+
+  /**
+   * Creates a new {@link CallOptions} based on a {@link CallOptionsConfig}. This factory assumes
+   * {@link CallOptionsConfig#isUseTimeout()} is true.
+   */
+  public static class ConfiguredCallOptionsFactory implements CallOptionsFactory {
+    private final CallOptionsConfig config;
+
+    public ConfiguredCallOptionsFactory(CallOptionsConfig config) {
+      this.config = config;
+    }
+
+    @Override
+    public <RequestT> CallOptions create(MethodDescriptor<RequestT, ?> descriptor,
+        RequestT request) {
+      if (config.isUseTimeout()) {
+        return CallOptions.DEFAULT
+            .withDeadline(Deadline.after(config.getTimeoutMs(), TimeUnit.MILLISECONDS));
+      } else {
+        return CallOptions.DEFAULT;
+      }
     }
   }
 }

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/CallOptionsFactory.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/CallOptionsFactory.java
@@ -20,12 +20,11 @@ import java.util.concurrent.TimeUnit;
 import com.google.cloud.bigtable.config.CallOptionsConfig;
 
 import io.grpc.CallOptions;
-import io.grpc.Codec;
 import io.grpc.Deadline;
 import io.grpc.MethodDescriptor;
 
 /**
- * A factory that creates {@link CallOption}s for use in {@link BigtableDataClient} RPCs.
+ * A factory that creates {@link CallOptions} for use in {@link BigtableDataClient} RPCs.
  */
 public interface CallOptionsFactory {
 
@@ -54,10 +53,7 @@ public interface CallOptionsFactory {
     }
   }
 
-  /**
-   * Creates a new {@link CallOptions} based on a {@link CallOptionsConfig}. This factory assumes
-   * {@link CallOptionsConfig#isUseTimeout()} is true.
-   */
+  /** Creates a new {@link CallOptions} based on a {@link CallOptionsConfig}. */
   public static class ConfiguredCallOptionsFactory implements CallOptionsFactory {
     private final CallOptionsConfig config;
 
@@ -66,11 +62,11 @@ public interface CallOptionsFactory {
     }
 
     @Override
-    public <RequestT> CallOptions create(MethodDescriptor<RequestT, ?> descriptor,
-        RequestT request) {
+    public <RequestT> CallOptions create(
+        MethodDescriptor<RequestT, ?> descriptor, RequestT request) {
       if (config.isUseTimeout()) {
-        return CallOptions.DEFAULT
-            .withDeadline(Deadline.after(config.getTimeoutMs(), TimeUnit.MILLISECONDS));
+        return CallOptions.DEFAULT.withDeadline(
+            Deadline.after(config.getTimeoutMs(), TimeUnit.MILLISECONDS));
       } else {
         return CallOptions.DEFAULT;
       }


### PR DESCRIPTION
We use the term Options to convey that an object is a configuration object (BigtableOptions, RetryOptions and etc).  That naming was a bit awkward when used as CallOptions configuration; CallOptionsOptions just doesn't sound right, so I used CallOptionsConfig.