### PR TITLE
PutAdapter performance improvement.

### DIFF
--- a/bigtable-hbase-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/DataGenerationHelper.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/DataGenerationHelper.java
@@ -28,9 +28,13 @@ public class DataGenerationHelper {
   }
 
   public byte[][] randomData(String prefix, int count) {
+    return randomData(prefix, count, 8);
+  }
+
+  public byte[][] randomData(String prefix, int count, int size) {
     byte[][] result = new byte[count][];
     for (int i = 0; i < count; ++i) {
-      result[i] = Bytes.toBytes(prefix + RandomStringUtils.randomAlphanumeric(8));
+      result[i] = Bytes.toBytes(prefix + RandomStringUtils.randomAlphanumeric(size));
     }
     return result;
   }

--- a/bigtable-hbase-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/PutAdapterPerf.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/PutAdapterPerf.java
@@ -37,15 +37,19 @@ public class PutAdapterPerf {
     byte[] value = RandomStringUtils.randomAlphanumeric(10000).getBytes();
     put.addColumn(Bytes.toBytes("Family1"), Bytes.toBytes("Qaulifier"), value);
 
+    BigtableOptions options = new BigtableOptions.Builder()
+        .setInstanceId("instanceId")
+        .setProjectId("projectId")
+        .build();
     HBaseRequestAdapter adapter =
-        new HBaseRequestAdapter(new BigtableOptions.Builder().build(),
+        new HBaseRequestAdapter(options,
             TableName.valueOf("tableName"), new Configuration());
     for (int i = 0; i < 10; i++) {
       putAdapterPerf(adapter, put);
     }
   }
 
-  static int count = 100000;
+  static int count = 1_000_000;
 
   private static void putAdapterPerf(HBaseRequestAdapter adapter, Put put) {
     System.out.println("Size: " + adapter.adapt(put).getSerializedSize());
@@ -57,7 +61,7 @@ public class PutAdapterPerf {
       }
       long time = System.nanoTime() - start;
       System.out.println(
-          String.format("RowMerger.readNext: %d rows merged in %d ms.  %d nanos per row.", count,
+          String.format("adapted: %,d rows merged in %,d ms.  %,d nanos per row.", count,
               time / 1000000, time / count));
     }
     System.gc();
@@ -69,7 +73,7 @@ public class PutAdapterPerf {
       }
       long time = System.nanoTime() - start;
       System.out.println(
-          String.format("RowMerger.readNext: %d rows merged in %d ms.  %d nanos per row.", count,
+          String.format("adapted, streamRequest: %,d rows merged in %,d ms.  %,d nanos per row.", count,
               time / 1000000, time / count));
     }
     System.gc();
@@ -81,9 +85,9 @@ public class PutAdapterPerf {
         BigtableGrpc.METHOD_MUTATE_ROW.streamRequest(adapted);
       }
       long time = System.nanoTime() - start;
-      System.out.println(
-          String.format("RowMerger.readNext / serialized size: %d rows merged in %d ms.  %d nanos per row.", count,
-              time / 1000000, time / count));
+      System.out.println(String.format(
+        "adapted, getSerializedSize, streamRequest: %,d rows merged in %,d ms.  %,d nanos per row.",
+        count, time / 1000000, time / count));
     }
   }
 }

--- a/bigtable-hbase-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/RowMergerPerf.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/RowMergerPerf.java
@@ -40,7 +40,7 @@ public class RowMergerPerf {
     return Arrays.asList(ReadRowsResponse.newBuilder().addChunks(contentChunk).build());
   }
 
-  static int count = 5000000;
+  static int count = 500_000;
 
   private static void rowMergerPerf(List<ReadRowsResponse> responses) {
     RowAdapter adapter = Adapters.ROW_ADAPTER;


### PR DESCRIPTION
Creating a proto with protoBuilder.addXXXBuilder() is slower than protoBuilder.addAllXXX(List<XXX>).  This makes me sad.  Also, cell.getXXXLength() methods are not simple getters; they do non trivial work, so caching the value saves some CPU time as well.

Our PutAdapterPerf test has a single Put with 100 small Cells in the same column family.  Before the two changes, that took 18-45 microseconds on my machine in various runs on my laptop; the results were varied depending on the CPU load, whether a parallel run happened right before.

After the change, that reliably took 9-14 microseconds, with more results toward the 9-11 us.