### PR TITLE
Switch <offlineLinks> -> <links> for javadoc

### DIFF
--- a/bigtable-dataflow-parent/bigtable-hbase-dataflow/pom.xml
+++ b/bigtable-dataflow-parent/bigtable-hbase-dataflow/pom.xml
@@ -122,16 +122,10 @@ limitations under the License.
                             <overview>../overview.html</overview>
                             <bottom><![CDATA[<br>]]></bottom>
 
-                            <offlineLinks>
-                                <offlineLink>
-                                    <url>https://cloud.google.com/dataflow/java-sdk/JavaDoc/</url>
-                                    <location>${basedir}/javadoc/dataflow-docs</location>
-                                </offlineLink>
-                                <offlineLink>
-                                    <url>https://hbase.apache.org/apidocs/</url>
-                                    <location>${basedir}/javadoc/hbase-docs</location>
-                                </offlineLink>
-                            </offlineLinks>
+                            <links>
+                                <link>https://cloud.google.com/dataflow/java-sdk/JavaDoc/</link>
+                                <link>https://hbase.apache.org/apidocs/</link>
+                            </links>
                         </configuration>
                         <executions>
                             <execution>

--- a/bigtable-hbase-parent/pom.xml
+++ b/bigtable-hbase-parent/pom.xml
@@ -27,7 +27,7 @@ limitations under the License.
     <packaging>pom</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>
-       This project is a parent project for the hbase Cloud Bigtable java client projects.
+        This project is a parent project for the hbase Cloud Bigtable java client projects.
     </description>
 
     <modules>
@@ -54,12 +54,9 @@ limitations under the License.
                             <bottom><![CDATA[<br>]]></bottom>
 
                             <detectLinks />
-                            <offlineLinks>
-                                <offlineLink>
-                                    <url>https://hbase.apache.org/apidocs/</url>
-                                    <location>${basedir}/javadoc/hbase-docs</location>
-                                </offlineLink>
-                            </offlineLinks>
+                            <links>
+                                <link>https://hbase.apache.org/apidocs/</link>
+                            </links>
                         </configuration>
                     </plugin>
                </plugins>


### PR DESCRIPTION
We don't have a particular need to use the <offlineLink>/-linkOffline
capability and it doesn't work as currently written so let's just use
regular <links> for now and we can revisit this later if we need to.

Testing Done:
- ran the javadoc:javadoc build, verified the link errors went away