### PR TITLE
Support for connecting to the gcloud bigtable emulator

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableOptions.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableOptions.java
@@ -182,10 +182,10 @@ public class BigtableOptions implements Serializable {
       }
 
       String[] hostPort = emulatorHost.split(":");
-      if (hostPort.length != 2) {
-        throw new RuntimeException("Malformed " + BIGTABLE_EMULATOR_HOST_ENV_VAR +
-            " environment variable: " + emulatorHost + ". Expecting host:port.");
-      }
+      Preconditions.checkArgument(hostPort.length == 2,
+          "Malformed " + BIGTABLE_EMULATOR_HOST_ENV_VAR + " environment variable: " +
+          emulatorHost + ". Expecting host:port.");
+
       int port;
       try {
         port = Integer.parseInt(hostPort[1]);


### PR DESCRIPTION
The BIGTABLE_EMULATOR_HOST environment variable can be set to the host:port of the emulator.

Note that, if set, the emulator host value will override any host, port or plaintext negotiation settings that the user overrode in other ways. The log message should make it clear that this is happening.