### PR TITLE
Replacing channel expand pool with pre-created pool.

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/io/ChannelPoolPerf.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/io/ChannelPoolPerf.java
@@ -82,13 +82,12 @@ public class ChannelPoolPerf {
     int threads = 10;
     int concurrent = 400;
     final ChannelPool cp = new ChannelPool(
-      Collections.<HeaderInterceptor>emptyList(), new ChannelPool.ChannelFactory() {
+      Collections.<HeaderInterceptor>emptyList(), 1, new ChannelPool.ChannelFactory() {
         @Override
         public ManagedChannel create() throws IOException {
           return channel;
         }
       });
-    cp.ensureChannelCount(40);
     ExecutorService es = Executors.newFixedThreadPool(threads);
     Callable<Void> runnable = new Callable<Void>() {
       @Override

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/io/ChannelPoolTest.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/io/ChannelPoolTest.java
@@ -88,7 +88,7 @@ public class ChannelPoolTest {
     MethodDescriptor descriptor = mock(MethodDescriptor.class);
     HeaderInterceptor interceptor = mock(HeaderInterceptor.class);
     ChannelPool pool =
-        new ChannelPool(Collections.singletonList(interceptor), new MockChannelFactory());
+        new ChannelPool(Collections.singletonList(interceptor), 1, new MockChannelFactory());
     ClientCall call = pool.newCall(descriptor, CallOptions.DEFAULT);
     Metadata headers = new Metadata();
     call.start(null, headers);
@@ -100,8 +100,7 @@ public class ChannelPoolTest {
     MockChannelFactory factory = new MockChannelFactory();
     MethodDescriptor descriptor = mock(MethodDescriptor.class);
     MockitoAnnotations.initMocks(this);
-    ChannelPool pool = new ChannelPool(null, factory);
-    pool.ensureChannelCount(2);
+    ChannelPool pool = new ChannelPool(null, 2, factory);
     pool.newCall(descriptor, CallOptions.DEFAULT);
     verify(factory.channels.get(0), times(1)).newCall(same(descriptor), same(CallOptions.DEFAULT));
     verify(factory.channels.get(1), times(0)).newCall(same(descriptor), same(CallOptions.DEFAULT));
@@ -113,8 +112,7 @@ public class ChannelPoolTest {
   @Test
   public void testEnsureCapcity() throws IOException {
     MockChannelFactory factory = new MockChannelFactory();
-    ChannelPool pool = new ChannelPool(null, factory);
-    pool.ensureChannelCount(4);
+    ChannelPool pool = new ChannelPool(null, 4, factory);
     Assert.assertEquals(4, factory.channels.size());
     Assert.assertEquals(4, pool.size());
   }
@@ -122,7 +120,7 @@ public class ChannelPoolTest {
   @Test
   public void testShutdown() throws IOException {
     MockChannelFactory factory = new MockChannelFactory();
-    new ChannelPool(null, factory).shutdown();
+    new ChannelPool(null, 4, factory).shutdown();
     for (ManagedChannel managedChannel : factory.channels) {
       verify(managedChannel, times(1)).shutdown();
     }
@@ -131,7 +129,7 @@ public class ChannelPoolTest {
   @Test
   public void testShutdownNow() throws IOException {
     MockChannelFactory factory = new MockChannelFactory();
-    new ChannelPool(null, factory).shutdownNow();
+    new ChannelPool(null, 4, factory).shutdownNow();
     for (ManagedChannel managedChannel : factory.channels) {
       verify(managedChannel, times(1)).shutdownNow();
     }
@@ -140,8 +138,7 @@ public class ChannelPoolTest {
   @Test
   public void testAwaitTermination() throws IOException, InterruptedException {
     MockChannelFactory factory = new MockChannelFactory();
-    ChannelPool pool = new ChannelPool(null, factory);
-    pool.ensureChannelCount(5);
+    ChannelPool pool = new ChannelPool(null, 5, factory);
     for (ManagedChannel managedChannel : factory.channels) {
       when(managedChannel.isTerminated()).thenReturn(true);
     }

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/io/TestGoogleCloudResourcePrefixInterceptor.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/io/TestGoogleCloudResourcePrefixInterceptor.java
@@ -54,6 +54,7 @@ public class TestGoogleCloudResourcePrefixInterceptor {
     
     cp = new ChannelPool(
         Arrays.<HeaderInterceptor>asList(new GoogleCloudResourcePrefixInterceptor(HEADER_VALUE)),
+        1,
         new ChannelFactory() {
           @Override
           public ManagedChannel create() throws IOException {

--- a/bigtable-hbase-parent/bigtable-hbase/src/test/java/org/apache/hadoop/hbase/client/PutMicroBenchmark.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/test/java/org/apache/hadoop/hbase/client/PutMicroBenchmark.java
@@ -50,7 +50,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 public class PutMicroBenchmark {
-  static final int NUM_CELLS = 10;
+  static final int NUM_CELLS = 100;
   private static final byte[] COLUMN_FAMILY = Bytes.toBytes("test_family");
   private final static int REAL_CHANNEL_PUT_COUNT = 100;
   private final static int FAKE_CHANNEL_PUT_COUNT = 100_000;
@@ -86,7 +86,9 @@ public class PutMicroBenchmark {
       return createNettyChannelPool();
     } else {
       return new ChannelPool(
-          ImmutableList.<HeaderInterceptor>of(prefixInterceptor()), createFakeChannels());
+          ImmutableList.<HeaderInterceptor>of(prefixInterceptor()),
+          options.getChannelCount(),
+          createFakeChannels());
     }
   }
 
@@ -94,6 +96,7 @@ public class PutMicroBenchmark {
       throws IOException, GeneralSecurityException {
     return new ChannelPool(
         getHeaders(),
+        options.getChannelCount(),
         new ChannelPool.ChannelFactory() {
           @Override
           public ManagedChannel create() throws IOException {


### PR DESCRIPTION
I've been meaning to remove the expand pool for a while.  I ran the client load test, and there was no discernible difference between a pre-created pool and one that gets created on demand.  I'm going to run the latency test before assigning a reviewer.