### PR TITLE
Updating the top level project to cloud-bigtable-client-parent.

### DIFF
--- a/bigtable-dataflow-parent/pom.xml
+++ b/bigtable-dataflow-parent/pom.xml
@@ -19,7 +19,7 @@ limitations under the License.
 
     <parent>
         <groupId>com.google.cloud.bigtable</groupId>
-        <artifactId>bigtable-client</artifactId>
+        <artifactId>bigtable-client-parent</artifactId>
         <version>0.9.2-SNAPSHOT</version>
     </parent>
 

--- a/bigtable-hbase-parent/pom.xml
+++ b/bigtable-hbase-parent/pom.xml
@@ -19,7 +19,7 @@ limitations under the License.
 
     <parent>
         <groupId>com.google.cloud.bigtable</groupId>
-        <artifactId>bigtable-client</artifactId>
+        <artifactId>bigtable-client-parent</artifactId>
         <version>0.9.2-SNAPSHOT</version>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@ limitations under the License.
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.google.cloud.bigtable</groupId>
-    <artifactId>bigtable-client</artifactId>
+    <artifactId>bigtable-client-parent</artifactId>
     <version>0.9.2-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>${project.groupId}:${project.artifactId}</name>


### PR DESCRIPTION
I'd like to use cloud-bigtable-client for the new API, so renaming the top level to include the '-parent' extension which is more maven-y.