### PR TITLE
Fix javadoc:aggregate-jar target

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,27 +75,9 @@ You can run the following command for Java 7:
         -Dgoogle.bigtable.project.id=[your cloud project id] \
         -Dgoogle.bigtable.instance.id=[your cloud bigtable instance id] \
 
-## Deploying
-**TODO**
-
-### How to setup the deployment environment
-**TODO**
-
-
-### How to deploy
-**TODO**
-
-
-## Troubleshooting & useful tools
-**TODO**
-
-### Examples of common tasks
-**TODO**
-
 ## Contributing changes
 
 * See [CONTRIBUTING.md](CONTRIBUTING.md)
-
 
 ## Licensing
 

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/ChannelPool.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/ChannelPool.java
@@ -74,7 +74,6 @@ public class ChannelPool extends ManagedChannel {
    * to configure metrics gathering even if the class loader loads the ChannelPool. If a user turns
    * on metrics after this class is loaded, these metrics should not have the NULL
    * implementation.
-   * @return
    */
   protected synchronized static Counter getActiveChannelCounter() {
     if (ACTIVE_CHANNEL_COUNTER == null) {

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ResumingStreamingResultScanner.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ResumingStreamingResultScanner.java
@@ -77,7 +77,7 @@ public class ResumingStreamingResultScanner extends AbstractBigtableResultScanne
    * @param retryOptions a {@link com.google.cloud.bigtable.config.RetryOptions} object.
    * @param originalRequest a {@link com.google.bigtable.v2.ReadRowsRequest} object.
    * @param scannerFactory a {@link com.google.cloud.bigtable.grpc.scanner.BigtableResultScannerFactory} object.
-   * @param rpcMetrics a{@link BigtableAsyncRpc.RpcMetrics} object to keep track of retries and failures.
+   * @param rpcMetrics a {@link com.google.cloud.bigtable.grpc.async.BigtableAsyncRpc.RpcMetrics} object to keep track of retries and failures.
    */
   public ResumingStreamingResultScanner(
     RetryOptions retryOptions,

--- a/pom.xml
+++ b/pom.xml
@@ -616,6 +616,29 @@ limitations under the License.
                     <artifactId>maven-shade-plugin</artifactId>
                     <version>2.4</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>2.10.4</version>
+                    <configuration>
+                        <!--
+                        javadoc excluded packages:
+                            com.google.cloud.bigtable.dataflow{import,}     (Breaks with javadoc:aggregate, handled separately)
+                            com.google.clooud.*                             (Ignore, a hack/workaround for separate maven issue)
+                        -->
+                        <excludePackageNames>com.google.cloud.bigtable.dataflow:com.google.cloud.bigtable.dataflowimport:com.google.clooud</excludePackageNames>
+                        <detectLinks />
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>attach-javadocs</id>
+                            <goals>
+                                <goal>aggregate-jar</goal>
+                            </goals>
+                            <phase>package</phase>
+                        </execution>
+                    </executions>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>
@@ -623,6 +646,9 @@ limitations under the License.
         <profile>
             <id>doclint-java8-disable</id>
             <activation>
+                <property>
+                    <name>!doclint</name>
+                </property>
                 <jdk>[1.8,)</jdk>
             </activation>
             <properties>
@@ -643,28 +669,6 @@ limitations under the License.
                                 <goals>
                                     <goal>jar</goal>
                                 </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>2.10.4</version>
-                        <configuration>
-                            <!--
-                              javadoc excluded packages:
-                                com.google.bigtable.v1 (Deprecated)
-                            -->
-                            <excludePackageNames>com.google.bigtable.v1</excludePackageNames>
-                            <detectLinks />
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>attach-javadocs</id>
-                                <goals>
-                                    <goal>jar</goal>
-                                </goals>
-                                <phase>package</phase>
                             </execution>
                         </executions>
                     </plugin>


### PR DESCRIPTION
This change makes the javadoc:aggregate-jar target work at the
top-level.

Doing this correclty is complicated because javadoc:aggregate is
confused by the repackaged/shadedPattern renaming of the bigtable client
in the dataflow submodules.

After a lot of experimentation, banging my head against the wall, and
discussions with Jeff I decided the best way to handle javadoc at
the top-level was simply to exclude the dataflow projects; we already
have a way to handle and publish those docs that we aren't going to
change, so we simply skip the com.google.cloud.bigtable.dataflow*
packages when doing a top-level javadoc:aggregate[-jar] for the main
project.

I also made a change to ensure that you can turn back on the doclint
behavior by passing -Ddoclint on the commandline if you want to inspect
it for any javadoc target, though it's still not particularly useful
given all the noise from grpc-java (and note that they have it disabled
in their build).

I also made some tweaks to the way we express configuration so the
javadoc stuff will apply for all profiles, and the aggregate-jar target
will be used during the package phase.

Finally I threw in a couple of fixes for new warnings that I noticed.