### PR TITLE
Upgrading grpc, netty and protobuf

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/CallOptionsConfig.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/CallOptionsConfig.java
@@ -20,8 +20,6 @@ import java.io.Serializable;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 
-import io.grpc.CallOptions;
-
 /**
  * Experimental options to turn on timeout options. {@link io.grpc.CallOptions} supports other settings as
  * well, which this configuration object could help set.

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataClient.java
@@ -34,8 +34,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.protobuf.ServiceException;
 
-import io.grpc.CallOptions;
-
 /**
  * Interface to access v2 Bigtable data service methods.
  *

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AsyncExecutor.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AsyncExecutor.java
@@ -32,7 +32,7 @@ import com.google.cloud.bigtable.config.Logger;
 import com.google.cloud.bigtable.grpc.BigtableDataClient;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.google.protobuf.GeneratedMessage;
+import com.google.protobuf.GeneratedMessageV3;
 
 /**
  * This class provides management of asynchronous Bigtable RPCs. It ensures that there aren't too
@@ -270,7 +270,7 @@ public class AsyncExecutor {
     return call(READ_ROWS_ASYNC, request);
   }
 
-  private <RequestT extends GeneratedMessage, ResponseT> ListenableFuture<ResponseT> call(
+  private <RequestT extends GeneratedMessageV3, ResponseT> ListenableFuture<ResponseT> call(
       AsyncCall<RequestT, ResponseT> rpc, RequestT request) throws InterruptedException {
     // Wait until both the memory and rpc count maximum requirements are achieved before getting a
     // unique id used to track this request.
@@ -278,7 +278,7 @@ public class AsyncExecutor {
     return call(rpc, request, id);
   }
 
-  private <ResponseT, RequestT extends GeneratedMessage> ListenableFuture<ResponseT>
+  private <ResponseT, RequestT extends GeneratedMessageV3> ListenableFuture<ResponseT>
       call(AsyncCall<RequestT, ResponseT> rpc, RequestT request, long id) {
     ListenableFuture<ResponseT> future;
     try {

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/RetryingUnaryRpcListener.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/RetryingUnaryRpcListener.java
@@ -18,7 +18,6 @@ package com.google.cloud.bigtable.grpc.async;
 import java.util.concurrent.ScheduledExecutorService;
 
 import com.google.cloud.bigtable.config.RetryOptions;
-import com.google.common.util.concurrent.AsyncFunction;
 
 import io.grpc.CallOptions;
 import io.grpc.Metadata;

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/api/AnnotationsProto.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/api/AnnotationsProto.java
@@ -6,8 +6,14 @@ package com.google.api;
 public final class AnnotationsProto {
   private AnnotationsProto() {}
   public static void registerAllExtensions(
-      com.google.protobuf.ExtensionRegistry registry) {
+      com.google.protobuf.ExtensionRegistryLite registry) {
     registry.add(com.google.api.AnnotationsProto.http);
+  }
+
+  public static void registerAllExtensions(
+      com.google.protobuf.ExtensionRegistry registry) {
+    registerAllExtensions(
+        (com.google.protobuf.ExtensionRegistryLite) registry);
   }
   public static final int HTTP_FIELD_NUMBER = 72295728;
   /**

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/api/CustomHttpPattern.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/api/CustomHttpPattern.java
@@ -11,11 +11,11 @@ package com.google.api;
  * Protobuf type {@code google.api.CustomHttpPattern}
  */
 public  final class CustomHttpPattern extends
-    com.google.protobuf.GeneratedMessage implements
+    com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:google.api.CustomHttpPattern)
     CustomHttpPatternOrBuilder {
   // Use CustomHttpPattern.newBuilder() to construct.
-  private CustomHttpPattern(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+  private CustomHttpPattern(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private CustomHttpPattern() {
@@ -76,7 +76,7 @@ public  final class CustomHttpPattern extends
     return com.google.api.HttpProto.internal_static_google_api_CustomHttpPattern_descriptor;
   }
 
-  protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.google.api.HttpProto.internal_static_google_api_CustomHttpPattern_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
@@ -180,10 +180,10 @@ public  final class CustomHttpPattern extends
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
     if (!getKindBytes().isEmpty()) {
-      com.google.protobuf.GeneratedMessage.writeString(output, 1, kind_);
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 1, kind_);
     }
     if (!getPathBytes().isEmpty()) {
-      com.google.protobuf.GeneratedMessage.writeString(output, 2, path_);
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 2, path_);
     }
   }
 
@@ -193,16 +193,50 @@ public  final class CustomHttpPattern extends
 
     size = 0;
     if (!getKindBytes().isEmpty()) {
-      size += com.google.protobuf.GeneratedMessage.computeStringSize(1, kind_);
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, kind_);
     }
     if (!getPathBytes().isEmpty()) {
-      size += com.google.protobuf.GeneratedMessage.computeStringSize(2, path_);
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, path_);
     }
     memoizedSize = size;
     return size;
   }
 
   private static final long serialVersionUID = 0L;
+  @java.lang.Override
+  public boolean equals(final java.lang.Object obj) {
+    if (obj == this) {
+     return true;
+    }
+    if (!(obj instanceof com.google.api.CustomHttpPattern)) {
+      return super.equals(obj);
+    }
+    com.google.api.CustomHttpPattern other = (com.google.api.CustomHttpPattern) obj;
+
+    boolean result = true;
+    result = result && getKind()
+        .equals(other.getKind());
+    result = result && getPath()
+        .equals(other.getPath());
+    return result;
+  }
+
+  @java.lang.Override
+  public int hashCode() {
+    if (memoizedHashCode != 0) {
+      return memoizedHashCode;
+    }
+    int hash = 41;
+    hash = (19 * hash) + getDescriptorForType().hashCode();
+    hash = (37 * hash) + KIND_FIELD_NUMBER;
+    hash = (53 * hash) + getKind().hashCode();
+    hash = (37 * hash) + PATH_FIELD_NUMBER;
+    hash = (53 * hash) + getPath().hashCode();
+    hash = (29 * hash) + unknownFields.hashCode();
+    memoizedHashCode = hash;
+    return hash;
+  }
+
   public static com.google.api.CustomHttpPattern parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -226,39 +260,39 @@ public  final class CustomHttpPattern extends
   }
   public static com.google.api.CustomHttpPattern parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.api.CustomHttpPattern parseFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.api.CustomHttpPattern parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
   public static com.google.api.CustomHttpPattern parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.api.CustomHttpPattern parseFrom(
       com.google.protobuf.CodedInputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.api.CustomHttpPattern parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
@@ -276,7 +310,7 @@ public  final class CustomHttpPattern extends
 
   @java.lang.Override
   protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
@@ -288,7 +322,7 @@ public  final class CustomHttpPattern extends
    * Protobuf type {@code google.api.CustomHttpPattern}
    */
   public static final class Builder extends
-      com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
       // @@protoc_insertion_point(builder_implements:google.api.CustomHttpPattern)
       com.google.api.CustomHttpPatternOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
@@ -296,7 +330,7 @@ public  final class CustomHttpPattern extends
       return com.google.api.HttpProto.internal_static_google_api_CustomHttpPattern_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.api.HttpProto.internal_static_google_api_CustomHttpPattern_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -309,12 +343,13 @@ public  final class CustomHttpPattern extends
     }
 
     private Builder(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
       }
     }
     public Builder clear() {
@@ -351,6 +386,32 @@ public  final class CustomHttpPattern extends
       return result;
     }
 
+    public Builder clone() {
+      return (Builder) super.clone();
+    }
+    public Builder setField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.setField(field, value);
+    }
+    public Builder clearField(
+        com.google.protobuf.Descriptors.FieldDescriptor field) {
+      return (Builder) super.clearField(field);
+    }
+    public Builder clearOneof(
+        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      return (Builder) super.clearOneof(oneof);
+    }
+    public Builder setRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        int index, Object value) {
+      return (Builder) super.setRepeatedField(field, index, value);
+    }
+    public Builder addRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.addRepeatedField(field, value);
+    }
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.api.CustomHttpPattern) {
         return mergeFrom((com.google.api.CustomHttpPattern)other);

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/api/HttpProto.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/api/HttpProto.java
@@ -6,17 +6,23 @@ package com.google.api;
 public final class HttpProto {
   private HttpProto() {}
   public static void registerAllExtensions(
+      com.google.protobuf.ExtensionRegistryLite registry) {
+  }
+
+  public static void registerAllExtensions(
       com.google.protobuf.ExtensionRegistry registry) {
+    registerAllExtensions(
+        (com.google.protobuf.ExtensionRegistryLite) registry);
   }
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_api_HttpRule_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_api_HttpRule_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_api_CustomHttpPattern_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_api_CustomHttpPattern_fieldAccessorTable;
 
   public static com.google.protobuf.Descriptors.FileDescriptor
@@ -52,13 +58,13 @@ public final class HttpProto {
     internal_static_google_api_HttpRule_descriptor =
       getDescriptor().getMessageTypes().get(0);
     internal_static_google_api_HttpRule_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_api_HttpRule_descriptor,
         new java.lang.String[] { "Get", "Put", "Post", "Delete", "Patch", "Custom", "Body", "AdditionalBindings", "Pattern", });
     internal_static_google_api_CustomHttpPattern_descriptor =
       getDescriptor().getMessageTypes().get(1);
     internal_static_google_api_CustomHttpPattern_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_api_CustomHttpPattern_descriptor,
         new java.lang.String[] { "Kind", "Path", });
   }

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/api/HttpRule.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/api/HttpRule.java
@@ -159,11 +159,11 @@ package com.google.api;
  * Protobuf type {@code google.api.HttpRule}
  */
 public  final class HttpRule extends
-    com.google.protobuf.GeneratedMessage implements
+    com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:google.api.HttpRule)
     HttpRuleOrBuilder {
   // Use HttpRule.newBuilder() to construct.
-  private HttpRule(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+  private HttpRule(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private HttpRule() {
@@ -251,7 +251,8 @@ public  final class HttpRule extends
               additionalBindings_ = new java.util.ArrayList<com.google.api.HttpRule>();
               mutable_bitField0_ |= 0x00000080;
             }
-            additionalBindings_.add(input.readMessage(com.google.api.HttpRule.parser(), extensionRegistry));
+            additionalBindings_.add(
+                input.readMessage(com.google.api.HttpRule.parser(), extensionRegistry));
             break;
           }
         }
@@ -273,7 +274,7 @@ public  final class HttpRule extends
     return com.google.api.HttpProto.internal_static_google_api_HttpRule_descriptor;
   }
 
-  protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.google.api.HttpProto.internal_static_google_api_HttpRule_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
@@ -734,22 +735,22 @@ public  final class HttpRule extends
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
     if (patternCase_ == 2) {
-      com.google.protobuf.GeneratedMessage.writeString(output, 2, pattern_);
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 2, pattern_);
     }
     if (patternCase_ == 3) {
-      com.google.protobuf.GeneratedMessage.writeString(output, 3, pattern_);
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 3, pattern_);
     }
     if (patternCase_ == 4) {
-      com.google.protobuf.GeneratedMessage.writeString(output, 4, pattern_);
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 4, pattern_);
     }
     if (patternCase_ == 5) {
-      com.google.protobuf.GeneratedMessage.writeString(output, 5, pattern_);
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 5, pattern_);
     }
     if (patternCase_ == 6) {
-      com.google.protobuf.GeneratedMessage.writeString(output, 6, pattern_);
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 6, pattern_);
     }
     if (!getBodyBytes().isEmpty()) {
-      com.google.protobuf.GeneratedMessage.writeString(output, 7, body_);
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 7, body_);
     }
     if (patternCase_ == 8) {
       output.writeMessage(8, (com.google.api.CustomHttpPattern) pattern_);
@@ -765,22 +766,22 @@ public  final class HttpRule extends
 
     size = 0;
     if (patternCase_ == 2) {
-      size += com.google.protobuf.GeneratedMessage.computeStringSize(2, pattern_);
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, pattern_);
     }
     if (patternCase_ == 3) {
-      size += com.google.protobuf.GeneratedMessage.computeStringSize(3, pattern_);
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, pattern_);
     }
     if (patternCase_ == 4) {
-      size += com.google.protobuf.GeneratedMessage.computeStringSize(4, pattern_);
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(4, pattern_);
     }
     if (patternCase_ == 5) {
-      size += com.google.protobuf.GeneratedMessage.computeStringSize(5, pattern_);
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(5, pattern_);
     }
     if (patternCase_ == 6) {
-      size += com.google.protobuf.GeneratedMessage.computeStringSize(6, pattern_);
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(6, pattern_);
     }
     if (!getBodyBytes().isEmpty()) {
-      size += com.google.protobuf.GeneratedMessage.computeStringSize(7, body_);
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(7, body_);
     }
     if (patternCase_ == 8) {
       size += com.google.protobuf.CodedOutputStream
@@ -795,6 +796,101 @@ public  final class HttpRule extends
   }
 
   private static final long serialVersionUID = 0L;
+  @java.lang.Override
+  public boolean equals(final java.lang.Object obj) {
+    if (obj == this) {
+     return true;
+    }
+    if (!(obj instanceof com.google.api.HttpRule)) {
+      return super.equals(obj);
+    }
+    com.google.api.HttpRule other = (com.google.api.HttpRule) obj;
+
+    boolean result = true;
+    result = result && getBody()
+        .equals(other.getBody());
+    result = result && getAdditionalBindingsList()
+        .equals(other.getAdditionalBindingsList());
+    result = result && getPatternCase().equals(
+        other.getPatternCase());
+    if (!result) return false;
+    switch (patternCase_) {
+      case 2:
+        result = result && getGet()
+            .equals(other.getGet());
+        break;
+      case 3:
+        result = result && getPut()
+            .equals(other.getPut());
+        break;
+      case 4:
+        result = result && getPost()
+            .equals(other.getPost());
+        break;
+      case 5:
+        result = result && getDelete()
+            .equals(other.getDelete());
+        break;
+      case 6:
+        result = result && getPatch()
+            .equals(other.getPatch());
+        break;
+      case 8:
+        result = result && getCustom()
+            .equals(other.getCustom());
+        break;
+      case 0:
+      default:
+    }
+    return result;
+  }
+
+  @java.lang.Override
+  public int hashCode() {
+    if (memoizedHashCode != 0) {
+      return memoizedHashCode;
+    }
+    int hash = 41;
+    hash = (19 * hash) + getDescriptorForType().hashCode();
+    hash = (37 * hash) + BODY_FIELD_NUMBER;
+    hash = (53 * hash) + getBody().hashCode();
+    if (getAdditionalBindingsCount() > 0) {
+      hash = (37 * hash) + ADDITIONAL_BINDINGS_FIELD_NUMBER;
+      hash = (53 * hash) + getAdditionalBindingsList().hashCode();
+    }
+    switch (patternCase_) {
+      case 2:
+        hash = (37 * hash) + GET_FIELD_NUMBER;
+        hash = (53 * hash) + getGet().hashCode();
+        break;
+      case 3:
+        hash = (37 * hash) + PUT_FIELD_NUMBER;
+        hash = (53 * hash) + getPut().hashCode();
+        break;
+      case 4:
+        hash = (37 * hash) + POST_FIELD_NUMBER;
+        hash = (53 * hash) + getPost().hashCode();
+        break;
+      case 5:
+        hash = (37 * hash) + DELETE_FIELD_NUMBER;
+        hash = (53 * hash) + getDelete().hashCode();
+        break;
+      case 6:
+        hash = (37 * hash) + PATCH_FIELD_NUMBER;
+        hash = (53 * hash) + getPatch().hashCode();
+        break;
+      case 8:
+        hash = (37 * hash) + CUSTOM_FIELD_NUMBER;
+        hash = (53 * hash) + getCustom().hashCode();
+        break;
+      case 0:
+      default:
+    }
+    hash = (29 * hash) + unknownFields.hashCode();
+    memoizedHashCode = hash;
+    return hash;
+  }
+
   public static com.google.api.HttpRule parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -818,39 +914,39 @@ public  final class HttpRule extends
   }
   public static com.google.api.HttpRule parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.api.HttpRule parseFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.api.HttpRule parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
   public static com.google.api.HttpRule parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.api.HttpRule parseFrom(
       com.google.protobuf.CodedInputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.api.HttpRule parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
@@ -868,7 +964,7 @@ public  final class HttpRule extends
 
   @java.lang.Override
   protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
@@ -1028,7 +1124,7 @@ public  final class HttpRule extends
    * Protobuf type {@code google.api.HttpRule}
    */
   public static final class Builder extends
-      com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
       // @@protoc_insertion_point(builder_implements:google.api.HttpRule)
       com.google.api.HttpRuleOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
@@ -1036,7 +1132,7 @@ public  final class HttpRule extends
       return com.google.api.HttpProto.internal_static_google_api_HttpRule_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.api.HttpProto.internal_static_google_api_HttpRule_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -1049,12 +1145,13 @@ public  final class HttpRule extends
     }
 
     private Builder(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
         getAdditionalBindingsFieldBuilder();
       }
     }
@@ -1132,6 +1229,32 @@ public  final class HttpRule extends
       return result;
     }
 
+    public Builder clone() {
+      return (Builder) super.clone();
+    }
+    public Builder setField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.setField(field, value);
+    }
+    public Builder clearField(
+        com.google.protobuf.Descriptors.FieldDescriptor field) {
+      return (Builder) super.clearField(field);
+    }
+    public Builder clearOneof(
+        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      return (Builder) super.clearOneof(oneof);
+    }
+    public Builder setRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        int index, Object value) {
+      return (Builder) super.setRepeatedField(field, index, value);
+    }
+    public Builder addRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.addRepeatedField(field, value);
+    }
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.api.HttpRule) {
         return mergeFrom((com.google.api.HttpRule)other);
@@ -1166,7 +1289,7 @@ public  final class HttpRule extends
             additionalBindings_ = other.additionalBindings_;
             bitField0_ = (bitField0_ & ~0x00000080);
             additionalBindingsBuilder_ = 
-              com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+              com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
                  getAdditionalBindingsFieldBuilder() : null;
           } else {
             additionalBindingsBuilder_.addAllMessages(other.additionalBindings_);
@@ -1754,7 +1877,7 @@ public  final class HttpRule extends
       return this;
     }
 
-    private com.google.protobuf.SingleFieldBuilder<
+    private com.google.protobuf.SingleFieldBuilderV3<
         com.google.api.CustomHttpPattern, com.google.api.CustomHttpPattern.Builder, com.google.api.CustomHttpPatternOrBuilder> customBuilder_;
     /**
      * <pre>
@@ -1897,14 +2020,14 @@ public  final class HttpRule extends
      *
      * <code>optional .google.api.CustomHttpPattern custom = 8;</code>
      */
-    private com.google.protobuf.SingleFieldBuilder<
+    private com.google.protobuf.SingleFieldBuilderV3<
         com.google.api.CustomHttpPattern, com.google.api.CustomHttpPattern.Builder, com.google.api.CustomHttpPatternOrBuilder> 
         getCustomFieldBuilder() {
       if (customBuilder_ == null) {
         if (!(patternCase_ == 8)) {
           pattern_ = com.google.api.CustomHttpPattern.getDefaultInstance();
         }
-        customBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+        customBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
             com.google.api.CustomHttpPattern, com.google.api.CustomHttpPattern.Builder, com.google.api.CustomHttpPatternOrBuilder>(
                 (com.google.api.CustomHttpPattern) pattern_,
                 getParentForChildren(),
@@ -2024,7 +2147,7 @@ public  final class HttpRule extends
        }
     }
 
-    private com.google.protobuf.RepeatedFieldBuilder<
+    private com.google.protobuf.RepeatedFieldBuilderV3<
         com.google.api.HttpRule, com.google.api.HttpRule.Builder, com.google.api.HttpRuleOrBuilder> additionalBindingsBuilder_;
 
     /**
@@ -2348,11 +2471,11 @@ public  final class HttpRule extends
          getAdditionalBindingsBuilderList() {
       return getAdditionalBindingsFieldBuilder().getBuilderList();
     }
-    private com.google.protobuf.RepeatedFieldBuilder<
+    private com.google.protobuf.RepeatedFieldBuilderV3<
         com.google.api.HttpRule, com.google.api.HttpRule.Builder, com.google.api.HttpRuleOrBuilder> 
         getAdditionalBindingsFieldBuilder() {
       if (additionalBindingsBuilder_ == null) {
-        additionalBindingsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
+        additionalBindingsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
             com.google.api.HttpRule, com.google.api.HttpRule.Builder, com.google.api.HttpRuleOrBuilder>(
                 additionalBindings_,
                 ((bitField0_ & 0x00000080) == 0x00000080),

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/BigtableInstanceAdminProto.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/BigtableInstanceAdminProto.java
@@ -6,72 +6,78 @@ package com.google.bigtable.admin.v2;
 public final class BigtableInstanceAdminProto {
   private BigtableInstanceAdminProto() {}
   public static void registerAllExtensions(
+      com.google.protobuf.ExtensionRegistryLite registry) {
+  }
+
+  public static void registerAllExtensions(
       com.google.protobuf.ExtensionRegistry registry) {
+    registerAllExtensions(
+        (com.google.protobuf.ExtensionRegistryLite) registry);
   }
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_bigtable_admin_v2_CreateInstanceRequest_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_bigtable_admin_v2_CreateInstanceRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_bigtable_admin_v2_CreateInstanceRequest_ClustersEntry_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_bigtable_admin_v2_CreateInstanceRequest_ClustersEntry_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_bigtable_admin_v2_GetInstanceRequest_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_bigtable_admin_v2_GetInstanceRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_bigtable_admin_v2_ListInstancesRequest_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_bigtable_admin_v2_ListInstancesRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_bigtable_admin_v2_ListInstancesResponse_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_bigtable_admin_v2_ListInstancesResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_bigtable_admin_v2_DeleteInstanceRequest_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_bigtable_admin_v2_DeleteInstanceRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_bigtable_admin_v2_CreateClusterRequest_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_bigtable_admin_v2_CreateClusterRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_bigtable_admin_v2_GetClusterRequest_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_bigtable_admin_v2_GetClusterRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_bigtable_admin_v2_ListClustersRequest_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_bigtable_admin_v2_ListClustersRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_bigtable_admin_v2_ListClustersResponse_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_bigtable_admin_v2_ListClustersResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_bigtable_admin_v2_DeleteClusterRequest_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_bigtable_admin_v2_DeleteClusterRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_bigtable_admin_v2_CreateInstanceMetadata_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_bigtable_admin_v2_CreateInstanceMetadata_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_bigtable_admin_v2_UpdateClusterMetadata_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_bigtable_admin_v2_UpdateClusterMetadata_fieldAccessorTable;
 
   public static com.google.protobuf.Descriptors.FileDescriptor
@@ -182,79 +188,79 @@ public final class BigtableInstanceAdminProto {
     internal_static_google_bigtable_admin_v2_CreateInstanceRequest_descriptor =
       getDescriptor().getMessageTypes().get(0);
     internal_static_google_bigtable_admin_v2_CreateInstanceRequest_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_bigtable_admin_v2_CreateInstanceRequest_descriptor,
         new java.lang.String[] { "Parent", "InstanceId", "Instance", "Clusters", });
     internal_static_google_bigtable_admin_v2_CreateInstanceRequest_ClustersEntry_descriptor =
       internal_static_google_bigtable_admin_v2_CreateInstanceRequest_descriptor.getNestedTypes().get(0);
     internal_static_google_bigtable_admin_v2_CreateInstanceRequest_ClustersEntry_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_bigtable_admin_v2_CreateInstanceRequest_ClustersEntry_descriptor,
         new java.lang.String[] { "Key", "Value", });
     internal_static_google_bigtable_admin_v2_GetInstanceRequest_descriptor =
       getDescriptor().getMessageTypes().get(1);
     internal_static_google_bigtable_admin_v2_GetInstanceRequest_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_bigtable_admin_v2_GetInstanceRequest_descriptor,
         new java.lang.String[] { "Name", });
     internal_static_google_bigtable_admin_v2_ListInstancesRequest_descriptor =
       getDescriptor().getMessageTypes().get(2);
     internal_static_google_bigtable_admin_v2_ListInstancesRequest_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_bigtable_admin_v2_ListInstancesRequest_descriptor,
         new java.lang.String[] { "Parent", "PageToken", });
     internal_static_google_bigtable_admin_v2_ListInstancesResponse_descriptor =
       getDescriptor().getMessageTypes().get(3);
     internal_static_google_bigtable_admin_v2_ListInstancesResponse_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_bigtable_admin_v2_ListInstancesResponse_descriptor,
         new java.lang.String[] { "Instances", "FailedLocations", "NextPageToken", });
     internal_static_google_bigtable_admin_v2_DeleteInstanceRequest_descriptor =
       getDescriptor().getMessageTypes().get(4);
     internal_static_google_bigtable_admin_v2_DeleteInstanceRequest_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_bigtable_admin_v2_DeleteInstanceRequest_descriptor,
         new java.lang.String[] { "Name", });
     internal_static_google_bigtable_admin_v2_CreateClusterRequest_descriptor =
       getDescriptor().getMessageTypes().get(5);
     internal_static_google_bigtable_admin_v2_CreateClusterRequest_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_bigtable_admin_v2_CreateClusterRequest_descriptor,
         new java.lang.String[] { "Parent", "ClusterId", "Cluster", });
     internal_static_google_bigtable_admin_v2_GetClusterRequest_descriptor =
       getDescriptor().getMessageTypes().get(6);
     internal_static_google_bigtable_admin_v2_GetClusterRequest_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_bigtable_admin_v2_GetClusterRequest_descriptor,
         new java.lang.String[] { "Name", });
     internal_static_google_bigtable_admin_v2_ListClustersRequest_descriptor =
       getDescriptor().getMessageTypes().get(7);
     internal_static_google_bigtable_admin_v2_ListClustersRequest_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_bigtable_admin_v2_ListClustersRequest_descriptor,
         new java.lang.String[] { "Parent", "PageToken", });
     internal_static_google_bigtable_admin_v2_ListClustersResponse_descriptor =
       getDescriptor().getMessageTypes().get(8);
     internal_static_google_bigtable_admin_v2_ListClustersResponse_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_bigtable_admin_v2_ListClustersResponse_descriptor,
         new java.lang.String[] { "Clusters", "FailedLocations", "NextPageToken", });
     internal_static_google_bigtable_admin_v2_DeleteClusterRequest_descriptor =
       getDescriptor().getMessageTypes().get(9);
     internal_static_google_bigtable_admin_v2_DeleteClusterRequest_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_bigtable_admin_v2_DeleteClusterRequest_descriptor,
         new java.lang.String[] { "Name", });
     internal_static_google_bigtable_admin_v2_CreateInstanceMetadata_descriptor =
       getDescriptor().getMessageTypes().get(10);
     internal_static_google_bigtable_admin_v2_CreateInstanceMetadata_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_bigtable_admin_v2_CreateInstanceMetadata_descriptor,
         new java.lang.String[] { "OriginalRequest", "RequestTime", "FinishTime", });
     internal_static_google_bigtable_admin_v2_UpdateClusterMetadata_descriptor =
       getDescriptor().getMessageTypes().get(11);
     internal_static_google_bigtable_admin_v2_UpdateClusterMetadata_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_bigtable_admin_v2_UpdateClusterMetadata_descriptor,
         new java.lang.String[] { "OriginalRequest", "RequestTime", "FinishTime", });
     com.google.protobuf.ExtensionRegistry registry =

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/BigtableTableAdminProto.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/BigtableTableAdminProto.java
@@ -6,52 +6,58 @@ package com.google.bigtable.admin.v2;
 public final class BigtableTableAdminProto {
   private BigtableTableAdminProto() {}
   public static void registerAllExtensions(
+      com.google.protobuf.ExtensionRegistryLite registry) {
+  }
+
+  public static void registerAllExtensions(
       com.google.protobuf.ExtensionRegistry registry) {
+    registerAllExtensions(
+        (com.google.protobuf.ExtensionRegistryLite) registry);
   }
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_bigtable_admin_v2_CreateTableRequest_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_bigtable_admin_v2_CreateTableRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_bigtable_admin_v2_CreateTableRequest_Split_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_bigtable_admin_v2_CreateTableRequest_Split_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_bigtable_admin_v2_DropRowRangeRequest_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_bigtable_admin_v2_DropRowRangeRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_bigtable_admin_v2_ListTablesRequest_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_bigtable_admin_v2_ListTablesRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_bigtable_admin_v2_ListTablesResponse_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_bigtable_admin_v2_ListTablesResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_bigtable_admin_v2_GetTableRequest_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_bigtable_admin_v2_GetTableRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_bigtable_admin_v2_DeleteTableRequest_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_bigtable_admin_v2_DeleteTableRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_bigtable_admin_v2_ModifyColumnFamiliesRequest_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_bigtable_admin_v2_ModifyColumnFamiliesRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_bigtable_admin_v2_ModifyColumnFamiliesRequest_Modification_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_bigtable_admin_v2_ModifyColumnFamiliesRequest_Modification_fieldAccessorTable;
 
   public static com.google.protobuf.Descriptors.FileDescriptor
@@ -135,55 +141,55 @@ public final class BigtableTableAdminProto {
     internal_static_google_bigtable_admin_v2_CreateTableRequest_descriptor =
       getDescriptor().getMessageTypes().get(0);
     internal_static_google_bigtable_admin_v2_CreateTableRequest_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_bigtable_admin_v2_CreateTableRequest_descriptor,
         new java.lang.String[] { "Parent", "TableId", "Table", "InitialSplits", });
     internal_static_google_bigtable_admin_v2_CreateTableRequest_Split_descriptor =
       internal_static_google_bigtable_admin_v2_CreateTableRequest_descriptor.getNestedTypes().get(0);
     internal_static_google_bigtable_admin_v2_CreateTableRequest_Split_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_bigtable_admin_v2_CreateTableRequest_Split_descriptor,
         new java.lang.String[] { "Key", });
     internal_static_google_bigtable_admin_v2_DropRowRangeRequest_descriptor =
       getDescriptor().getMessageTypes().get(1);
     internal_static_google_bigtable_admin_v2_DropRowRangeRequest_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_bigtable_admin_v2_DropRowRangeRequest_descriptor,
         new java.lang.String[] { "Name", "RowKeyPrefix", "DeleteAllDataFromTable", "Target", });
     internal_static_google_bigtable_admin_v2_ListTablesRequest_descriptor =
       getDescriptor().getMessageTypes().get(2);
     internal_static_google_bigtable_admin_v2_ListTablesRequest_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_bigtable_admin_v2_ListTablesRequest_descriptor,
         new java.lang.String[] { "Parent", "View", "PageToken", });
     internal_static_google_bigtable_admin_v2_ListTablesResponse_descriptor =
       getDescriptor().getMessageTypes().get(3);
     internal_static_google_bigtable_admin_v2_ListTablesResponse_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_bigtable_admin_v2_ListTablesResponse_descriptor,
         new java.lang.String[] { "Tables", "NextPageToken", });
     internal_static_google_bigtable_admin_v2_GetTableRequest_descriptor =
       getDescriptor().getMessageTypes().get(4);
     internal_static_google_bigtable_admin_v2_GetTableRequest_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_bigtable_admin_v2_GetTableRequest_descriptor,
         new java.lang.String[] { "Name", "View", });
     internal_static_google_bigtable_admin_v2_DeleteTableRequest_descriptor =
       getDescriptor().getMessageTypes().get(5);
     internal_static_google_bigtable_admin_v2_DeleteTableRequest_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_bigtable_admin_v2_DeleteTableRequest_descriptor,
         new java.lang.String[] { "Name", });
     internal_static_google_bigtable_admin_v2_ModifyColumnFamiliesRequest_descriptor =
       getDescriptor().getMessageTypes().get(6);
     internal_static_google_bigtable_admin_v2_ModifyColumnFamiliesRequest_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_bigtable_admin_v2_ModifyColumnFamiliesRequest_descriptor,
         new java.lang.String[] { "Name", "Modifications", });
     internal_static_google_bigtable_admin_v2_ModifyColumnFamiliesRequest_Modification_descriptor =
       internal_static_google_bigtable_admin_v2_ModifyColumnFamiliesRequest_descriptor.getNestedTypes().get(0);
     internal_static_google_bigtable_admin_v2_ModifyColumnFamiliesRequest_Modification_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_bigtable_admin_v2_ModifyColumnFamiliesRequest_Modification_descriptor,
         new java.lang.String[] { "Id", "Create", "Update", "Drop", "Mod", });
     com.google.protobuf.ExtensionRegistry registry =

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/Cluster.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/Cluster.java
@@ -13,11 +13,11 @@ package com.google.bigtable.admin.v2;
  * Protobuf type {@code google.bigtable.admin.v2.Cluster}
  */
 public  final class Cluster extends
-    com.google.protobuf.GeneratedMessage implements
+    com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:google.bigtable.admin.v2.Cluster)
     ClusterOrBuilder {
   // Use Cluster.newBuilder() to construct.
-  private Cluster(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+  private Cluster(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private Cluster() {
@@ -98,7 +98,7 @@ public  final class Cluster extends
     return com.google.bigtable.admin.v2.InstanceProto.internal_static_google_bigtable_admin_v2_Cluster_descriptor;
   }
 
-  protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.google.bigtable.admin.v2.InstanceProto.internal_static_google_bigtable_admin_v2_Cluster_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
@@ -404,7 +404,7 @@ public  final class Cluster extends
    * <code>optional .google.bigtable.admin.v2.Cluster.State state = 3;</code>
    */
   public com.google.bigtable.admin.v2.Cluster.State getState() {
-    com.google.bigtable.admin.v2.Cluster.State result = com.google.bigtable.admin.v2.Cluster.State.forNumber(state_);
+    com.google.bigtable.admin.v2.Cluster.State result = com.google.bigtable.admin.v2.Cluster.State.valueOf(state_);
     return result == null ? com.google.bigtable.admin.v2.Cluster.State.UNRECOGNIZED : result;
   }
 
@@ -446,7 +446,7 @@ public  final class Cluster extends
    * <code>optional .google.bigtable.admin.v2.StorageType default_storage_type = 5;</code>
    */
   public com.google.bigtable.admin.v2.StorageType getDefaultStorageType() {
-    com.google.bigtable.admin.v2.StorageType result = com.google.bigtable.admin.v2.StorageType.forNumber(defaultStorageType_);
+    com.google.bigtable.admin.v2.StorageType result = com.google.bigtable.admin.v2.StorageType.valueOf(defaultStorageType_);
     return result == null ? com.google.bigtable.admin.v2.StorageType.UNRECOGNIZED : result;
   }
 
@@ -463,10 +463,10 @@ public  final class Cluster extends
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
     if (!getNameBytes().isEmpty()) {
-      com.google.protobuf.GeneratedMessage.writeString(output, 1, name_);
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 1, name_);
     }
     if (!getLocationBytes().isEmpty()) {
-      com.google.protobuf.GeneratedMessage.writeString(output, 2, location_);
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 2, location_);
     }
     if (state_ != com.google.bigtable.admin.v2.Cluster.State.STATE_NOT_KNOWN.getNumber()) {
       output.writeEnum(3, state_);
@@ -485,10 +485,10 @@ public  final class Cluster extends
 
     size = 0;
     if (!getNameBytes().isEmpty()) {
-      size += com.google.protobuf.GeneratedMessage.computeStringSize(1, name_);
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, name_);
     }
     if (!getLocationBytes().isEmpty()) {
-      size += com.google.protobuf.GeneratedMessage.computeStringSize(2, location_);
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, location_);
     }
     if (state_ != com.google.bigtable.admin.v2.Cluster.State.STATE_NOT_KNOWN.getNumber()) {
       size += com.google.protobuf.CodedOutputStream
@@ -507,6 +507,50 @@ public  final class Cluster extends
   }
 
   private static final long serialVersionUID = 0L;
+  @java.lang.Override
+  public boolean equals(final java.lang.Object obj) {
+    if (obj == this) {
+     return true;
+    }
+    if (!(obj instanceof com.google.bigtable.admin.v2.Cluster)) {
+      return super.equals(obj);
+    }
+    com.google.bigtable.admin.v2.Cluster other = (com.google.bigtable.admin.v2.Cluster) obj;
+
+    boolean result = true;
+    result = result && getName()
+        .equals(other.getName());
+    result = result && getLocation()
+        .equals(other.getLocation());
+    result = result && state_ == other.state_;
+    result = result && (getServeNodes()
+        == other.getServeNodes());
+    result = result && defaultStorageType_ == other.defaultStorageType_;
+    return result;
+  }
+
+  @java.lang.Override
+  public int hashCode() {
+    if (memoizedHashCode != 0) {
+      return memoizedHashCode;
+    }
+    int hash = 41;
+    hash = (19 * hash) + getDescriptorForType().hashCode();
+    hash = (37 * hash) + NAME_FIELD_NUMBER;
+    hash = (53 * hash) + getName().hashCode();
+    hash = (37 * hash) + LOCATION_FIELD_NUMBER;
+    hash = (53 * hash) + getLocation().hashCode();
+    hash = (37 * hash) + STATE_FIELD_NUMBER;
+    hash = (53 * hash) + state_;
+    hash = (37 * hash) + SERVE_NODES_FIELD_NUMBER;
+    hash = (53 * hash) + getServeNodes();
+    hash = (37 * hash) + DEFAULT_STORAGE_TYPE_FIELD_NUMBER;
+    hash = (53 * hash) + defaultStorageType_;
+    hash = (29 * hash) + unknownFields.hashCode();
+    memoizedHashCode = hash;
+    return hash;
+  }
+
   public static com.google.bigtable.admin.v2.Cluster parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -530,39 +574,39 @@ public  final class Cluster extends
   }
   public static com.google.bigtable.admin.v2.Cluster parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.Cluster parseFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.admin.v2.Cluster parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.Cluster parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.admin.v2.Cluster parseFrom(
       com.google.protobuf.CodedInputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.Cluster parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
@@ -580,7 +624,7 @@ public  final class Cluster extends
 
   @java.lang.Override
   protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
@@ -594,7 +638,7 @@ public  final class Cluster extends
    * Protobuf type {@code google.bigtable.admin.v2.Cluster}
    */
   public static final class Builder extends
-      com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
       // @@protoc_insertion_point(builder_implements:google.bigtable.admin.v2.Cluster)
       com.google.bigtable.admin.v2.ClusterOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
@@ -602,7 +646,7 @@ public  final class Cluster extends
       return com.google.bigtable.admin.v2.InstanceProto.internal_static_google_bigtable_admin_v2_Cluster_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.bigtable.admin.v2.InstanceProto.internal_static_google_bigtable_admin_v2_Cluster_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -615,12 +659,13 @@ public  final class Cluster extends
     }
 
     private Builder(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
       }
     }
     public Builder clear() {
@@ -666,6 +711,32 @@ public  final class Cluster extends
       return result;
     }
 
+    public Builder clone() {
+      return (Builder) super.clone();
+    }
+    public Builder setField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.setField(field, value);
+    }
+    public Builder clearField(
+        com.google.protobuf.Descriptors.FieldDescriptor field) {
+      return (Builder) super.clearField(field);
+    }
+    public Builder clearOneof(
+        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      return (Builder) super.clearOneof(oneof);
+    }
+    public Builder setRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        int index, Object value) {
+      return (Builder) super.setRepeatedField(field, index, value);
+    }
+    public Builder addRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.addRepeatedField(field, value);
+    }
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.bigtable.admin.v2.Cluster) {
         return mergeFrom((com.google.bigtable.admin.v2.Cluster)other);
@@ -957,7 +1028,7 @@ public  final class Cluster extends
      * <code>optional .google.bigtable.admin.v2.Cluster.State state = 3;</code>
      */
     public com.google.bigtable.admin.v2.Cluster.State getState() {
-      com.google.bigtable.admin.v2.Cluster.State result = com.google.bigtable.admin.v2.Cluster.State.forNumber(state_);
+      com.google.bigtable.admin.v2.Cluster.State result = com.google.bigtable.admin.v2.Cluster.State.valueOf(state_);
       return result == null ? com.google.bigtable.admin.v2.Cluster.State.UNRECOGNIZED : result;
     }
     /**
@@ -1070,7 +1141,7 @@ public  final class Cluster extends
      * <code>optional .google.bigtable.admin.v2.StorageType default_storage_type = 5;</code>
      */
     public com.google.bigtable.admin.v2.StorageType getDefaultStorageType() {
-      com.google.bigtable.admin.v2.StorageType result = com.google.bigtable.admin.v2.StorageType.forNumber(defaultStorageType_);
+      com.google.bigtable.admin.v2.StorageType result = com.google.bigtable.admin.v2.StorageType.valueOf(defaultStorageType_);
       return result == null ? com.google.bigtable.admin.v2.StorageType.UNRECOGNIZED : result;
     }
     /**

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/ColumnFamily.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/ColumnFamily.java
@@ -11,11 +11,11 @@ package com.google.bigtable.admin.v2;
  * Protobuf type {@code google.bigtable.admin.v2.ColumnFamily}
  */
 public  final class ColumnFamily extends
-    com.google.protobuf.GeneratedMessage implements
+    com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:google.bigtable.admin.v2.ColumnFamily)
     ColumnFamilyOrBuilder {
   // Use ColumnFamily.newBuilder() to construct.
-  private ColumnFamily(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+  private ColumnFamily(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private ColumnFamily() {
@@ -75,7 +75,7 @@ public  final class ColumnFamily extends
     return com.google.bigtable.admin.v2.TableProto.internal_static_google_bigtable_admin_v2_ColumnFamily_descriptor;
   }
 
-  protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.google.bigtable.admin.v2.TableProto.internal_static_google_bigtable_admin_v2_ColumnFamily_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
@@ -158,6 +158,41 @@ public  final class ColumnFamily extends
   }
 
   private static final long serialVersionUID = 0L;
+  @java.lang.Override
+  public boolean equals(final java.lang.Object obj) {
+    if (obj == this) {
+     return true;
+    }
+    if (!(obj instanceof com.google.bigtable.admin.v2.ColumnFamily)) {
+      return super.equals(obj);
+    }
+    com.google.bigtable.admin.v2.ColumnFamily other = (com.google.bigtable.admin.v2.ColumnFamily) obj;
+
+    boolean result = true;
+    result = result && (hasGcRule() == other.hasGcRule());
+    if (hasGcRule()) {
+      result = result && getGcRule()
+          .equals(other.getGcRule());
+    }
+    return result;
+  }
+
+  @java.lang.Override
+  public int hashCode() {
+    if (memoizedHashCode != 0) {
+      return memoizedHashCode;
+    }
+    int hash = 41;
+    hash = (19 * hash) + getDescriptorForType().hashCode();
+    if (hasGcRule()) {
+      hash = (37 * hash) + GC_RULE_FIELD_NUMBER;
+      hash = (53 * hash) + getGcRule().hashCode();
+    }
+    hash = (29 * hash) + unknownFields.hashCode();
+    memoizedHashCode = hash;
+    return hash;
+  }
+
   public static com.google.bigtable.admin.v2.ColumnFamily parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -181,39 +216,39 @@ public  final class ColumnFamily extends
   }
   public static com.google.bigtable.admin.v2.ColumnFamily parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.ColumnFamily parseFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.admin.v2.ColumnFamily parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.ColumnFamily parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.admin.v2.ColumnFamily parseFrom(
       com.google.protobuf.CodedInputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.ColumnFamily parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
@@ -231,7 +266,7 @@ public  final class ColumnFamily extends
 
   @java.lang.Override
   protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
@@ -243,7 +278,7 @@ public  final class ColumnFamily extends
    * Protobuf type {@code google.bigtable.admin.v2.ColumnFamily}
    */
   public static final class Builder extends
-      com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
       // @@protoc_insertion_point(builder_implements:google.bigtable.admin.v2.ColumnFamily)
       com.google.bigtable.admin.v2.ColumnFamilyOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
@@ -251,7 +286,7 @@ public  final class ColumnFamily extends
       return com.google.bigtable.admin.v2.TableProto.internal_static_google_bigtable_admin_v2_ColumnFamily_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.bigtable.admin.v2.TableProto.internal_static_google_bigtable_admin_v2_ColumnFamily_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -264,12 +299,13 @@ public  final class ColumnFamily extends
     }
 
     private Builder(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
       }
     }
     public Builder clear() {
@@ -311,6 +347,32 @@ public  final class ColumnFamily extends
       return result;
     }
 
+    public Builder clone() {
+      return (Builder) super.clone();
+    }
+    public Builder setField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.setField(field, value);
+    }
+    public Builder clearField(
+        com.google.protobuf.Descriptors.FieldDescriptor field) {
+      return (Builder) super.clearField(field);
+    }
+    public Builder clearOneof(
+        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      return (Builder) super.clearOneof(oneof);
+    }
+    public Builder setRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        int index, Object value) {
+      return (Builder) super.setRepeatedField(field, index, value);
+    }
+    public Builder addRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.addRepeatedField(field, value);
+    }
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.bigtable.admin.v2.ColumnFamily) {
         return mergeFrom((com.google.bigtable.admin.v2.ColumnFamily)other);
@@ -352,7 +414,7 @@ public  final class ColumnFamily extends
     }
 
     private com.google.bigtable.admin.v2.GcRule gcRule_ = null;
-    private com.google.protobuf.SingleFieldBuilder<
+    private com.google.protobuf.SingleFieldBuilderV3<
         com.google.bigtable.admin.v2.GcRule, com.google.bigtable.admin.v2.GcRule.Builder, com.google.bigtable.admin.v2.GcRuleOrBuilder> gcRuleBuilder_;
     /**
      * <pre>
@@ -526,11 +588,11 @@ public  final class ColumnFamily extends
      *
      * <code>optional .google.bigtable.admin.v2.GcRule gc_rule = 1;</code>
      */
-    private com.google.protobuf.SingleFieldBuilder<
+    private com.google.protobuf.SingleFieldBuilderV3<
         com.google.bigtable.admin.v2.GcRule, com.google.bigtable.admin.v2.GcRule.Builder, com.google.bigtable.admin.v2.GcRuleOrBuilder> 
         getGcRuleFieldBuilder() {
       if (gcRuleBuilder_ == null) {
-        gcRuleBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+        gcRuleBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
             com.google.bigtable.admin.v2.GcRule, com.google.bigtable.admin.v2.GcRule.Builder, com.google.bigtable.admin.v2.GcRuleOrBuilder>(
                 getGcRule(),
                 getParentForChildren(),

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/CommonProto.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/CommonProto.java
@@ -6,7 +6,13 @@ package com.google.bigtable.admin.v2;
 public final class CommonProto {
   private CommonProto() {}
   public static void registerAllExtensions(
+      com.google.protobuf.ExtensionRegistryLite registry) {
+  }
+
+  public static void registerAllExtensions(
       com.google.protobuf.ExtensionRegistry registry) {
+    registerAllExtensions(
+        (com.google.protobuf.ExtensionRegistryLite) registry);
   }
 
   public static com.google.protobuf.Descriptors.FileDescriptor

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/CreateClusterRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/CreateClusterRequest.java
@@ -11,11 +11,11 @@ package com.google.bigtable.admin.v2;
  * Protobuf type {@code google.bigtable.admin.v2.CreateClusterRequest}
  */
 public  final class CreateClusterRequest extends
-    com.google.protobuf.GeneratedMessage implements
+    com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:google.bigtable.admin.v2.CreateClusterRequest)
     CreateClusterRequestOrBuilder {
   // Use CreateClusterRequest.newBuilder() to construct.
-  private CreateClusterRequest(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+  private CreateClusterRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private CreateClusterRequest() {
@@ -89,7 +89,7 @@ public  final class CreateClusterRequest extends
     return com.google.bigtable.admin.v2.BigtableInstanceAdminProto.internal_static_google_bigtable_admin_v2_CreateClusterRequest_descriptor;
   }
 
-  protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.google.bigtable.admin.v2.BigtableInstanceAdminProto.internal_static_google_bigtable_admin_v2_CreateClusterRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
@@ -237,10 +237,10 @@ public  final class CreateClusterRequest extends
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
     if (!getParentBytes().isEmpty()) {
-      com.google.protobuf.GeneratedMessage.writeString(output, 1, parent_);
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 1, parent_);
     }
     if (!getClusterIdBytes().isEmpty()) {
-      com.google.protobuf.GeneratedMessage.writeString(output, 2, clusterId_);
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 2, clusterId_);
     }
     if (cluster_ != null) {
       output.writeMessage(3, getCluster());
@@ -253,10 +253,10 @@ public  final class CreateClusterRequest extends
 
     size = 0;
     if (!getParentBytes().isEmpty()) {
-      size += com.google.protobuf.GeneratedMessage.computeStringSize(1, parent_);
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, parent_);
     }
     if (!getClusterIdBytes().isEmpty()) {
-      size += com.google.protobuf.GeneratedMessage.computeStringSize(2, clusterId_);
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, clusterId_);
     }
     if (cluster_ != null) {
       size += com.google.protobuf.CodedOutputStream
@@ -267,6 +267,49 @@ public  final class CreateClusterRequest extends
   }
 
   private static final long serialVersionUID = 0L;
+  @java.lang.Override
+  public boolean equals(final java.lang.Object obj) {
+    if (obj == this) {
+     return true;
+    }
+    if (!(obj instanceof com.google.bigtable.admin.v2.CreateClusterRequest)) {
+      return super.equals(obj);
+    }
+    com.google.bigtable.admin.v2.CreateClusterRequest other = (com.google.bigtable.admin.v2.CreateClusterRequest) obj;
+
+    boolean result = true;
+    result = result && getParent()
+        .equals(other.getParent());
+    result = result && getClusterId()
+        .equals(other.getClusterId());
+    result = result && (hasCluster() == other.hasCluster());
+    if (hasCluster()) {
+      result = result && getCluster()
+          .equals(other.getCluster());
+    }
+    return result;
+  }
+
+  @java.lang.Override
+  public int hashCode() {
+    if (memoizedHashCode != 0) {
+      return memoizedHashCode;
+    }
+    int hash = 41;
+    hash = (19 * hash) + getDescriptorForType().hashCode();
+    hash = (37 * hash) + PARENT_FIELD_NUMBER;
+    hash = (53 * hash) + getParent().hashCode();
+    hash = (37 * hash) + CLUSTER_ID_FIELD_NUMBER;
+    hash = (53 * hash) + getClusterId().hashCode();
+    if (hasCluster()) {
+      hash = (37 * hash) + CLUSTER_FIELD_NUMBER;
+      hash = (53 * hash) + getCluster().hashCode();
+    }
+    hash = (29 * hash) + unknownFields.hashCode();
+    memoizedHashCode = hash;
+    return hash;
+  }
+
   public static com.google.bigtable.admin.v2.CreateClusterRequest parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -290,39 +333,39 @@ public  final class CreateClusterRequest extends
   }
   public static com.google.bigtable.admin.v2.CreateClusterRequest parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.CreateClusterRequest parseFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.admin.v2.CreateClusterRequest parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.CreateClusterRequest parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.admin.v2.CreateClusterRequest parseFrom(
       com.google.protobuf.CodedInputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.CreateClusterRequest parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
@@ -340,7 +383,7 @@ public  final class CreateClusterRequest extends
 
   @java.lang.Override
   protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
@@ -352,7 +395,7 @@ public  final class CreateClusterRequest extends
    * Protobuf type {@code google.bigtable.admin.v2.CreateClusterRequest}
    */
   public static final class Builder extends
-      com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
       // @@protoc_insertion_point(builder_implements:google.bigtable.admin.v2.CreateClusterRequest)
       com.google.bigtable.admin.v2.CreateClusterRequestOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
@@ -360,7 +403,7 @@ public  final class CreateClusterRequest extends
       return com.google.bigtable.admin.v2.BigtableInstanceAdminProto.internal_static_google_bigtable_admin_v2_CreateClusterRequest_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.bigtable.admin.v2.BigtableInstanceAdminProto.internal_static_google_bigtable_admin_v2_CreateClusterRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -373,12 +416,13 @@ public  final class CreateClusterRequest extends
     }
 
     private Builder(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
       }
     }
     public Builder clear() {
@@ -426,6 +470,32 @@ public  final class CreateClusterRequest extends
       return result;
     }
 
+    public Builder clone() {
+      return (Builder) super.clone();
+    }
+    public Builder setField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.setField(field, value);
+    }
+    public Builder clearField(
+        com.google.protobuf.Descriptors.FieldDescriptor field) {
+      return (Builder) super.clearField(field);
+    }
+    public Builder clearOneof(
+        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      return (Builder) super.clearOneof(oneof);
+    }
+    public Builder setRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        int index, Object value) {
+      return (Builder) super.setRepeatedField(field, index, value);
+    }
+    public Builder addRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.addRepeatedField(field, value);
+    }
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.bigtable.admin.v2.CreateClusterRequest) {
         return mergeFrom((com.google.bigtable.admin.v2.CreateClusterRequest)other);
@@ -673,7 +743,7 @@ public  final class CreateClusterRequest extends
     }
 
     private com.google.bigtable.admin.v2.Cluster cluster_ = null;
-    private com.google.protobuf.SingleFieldBuilder<
+    private com.google.protobuf.SingleFieldBuilderV3<
         com.google.bigtable.admin.v2.Cluster, com.google.bigtable.admin.v2.Cluster.Builder, com.google.bigtable.admin.v2.ClusterOrBuilder> clusterBuilder_;
     /**
      * <pre>
@@ -820,11 +890,11 @@ public  final class CreateClusterRequest extends
      *
      * <code>optional .google.bigtable.admin.v2.Cluster cluster = 3;</code>
      */
-    private com.google.protobuf.SingleFieldBuilder<
+    private com.google.protobuf.SingleFieldBuilderV3<
         com.google.bigtable.admin.v2.Cluster, com.google.bigtable.admin.v2.Cluster.Builder, com.google.bigtable.admin.v2.ClusterOrBuilder> 
         getClusterFieldBuilder() {
       if (clusterBuilder_ == null) {
-        clusterBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+        clusterBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
             com.google.bigtable.admin.v2.Cluster, com.google.bigtable.admin.v2.Cluster.Builder, com.google.bigtable.admin.v2.ClusterOrBuilder>(
                 getCluster(),
                 getParentForChildren(),

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/CreateInstanceMetadata.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/CreateInstanceMetadata.java
@@ -11,11 +11,11 @@ package com.google.bigtable.admin.v2;
  * Protobuf type {@code google.bigtable.admin.v2.CreateInstanceMetadata}
  */
 public  final class CreateInstanceMetadata extends
-    com.google.protobuf.GeneratedMessage implements
+    com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:google.bigtable.admin.v2.CreateInstanceMetadata)
     CreateInstanceMetadataOrBuilder {
   // Use CreateInstanceMetadata.newBuilder() to construct.
-  private CreateInstanceMetadata(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+  private CreateInstanceMetadata(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private CreateInstanceMetadata() {
@@ -101,7 +101,7 @@ public  final class CreateInstanceMetadata extends
     return com.google.bigtable.admin.v2.BigtableInstanceAdminProto.internal_static_google_bigtable_admin_v2_CreateInstanceMetadata_descriptor;
   }
 
-  protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.google.bigtable.admin.v2.BigtableInstanceAdminProto.internal_static_google_bigtable_admin_v2_CreateInstanceMetadata_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
@@ -252,6 +252,59 @@ public  final class CreateInstanceMetadata extends
   }
 
   private static final long serialVersionUID = 0L;
+  @java.lang.Override
+  public boolean equals(final java.lang.Object obj) {
+    if (obj == this) {
+     return true;
+    }
+    if (!(obj instanceof com.google.bigtable.admin.v2.CreateInstanceMetadata)) {
+      return super.equals(obj);
+    }
+    com.google.bigtable.admin.v2.CreateInstanceMetadata other = (com.google.bigtable.admin.v2.CreateInstanceMetadata) obj;
+
+    boolean result = true;
+    result = result && (hasOriginalRequest() == other.hasOriginalRequest());
+    if (hasOriginalRequest()) {
+      result = result && getOriginalRequest()
+          .equals(other.getOriginalRequest());
+    }
+    result = result && (hasRequestTime() == other.hasRequestTime());
+    if (hasRequestTime()) {
+      result = result && getRequestTime()
+          .equals(other.getRequestTime());
+    }
+    result = result && (hasFinishTime() == other.hasFinishTime());
+    if (hasFinishTime()) {
+      result = result && getFinishTime()
+          .equals(other.getFinishTime());
+    }
+    return result;
+  }
+
+  @java.lang.Override
+  public int hashCode() {
+    if (memoizedHashCode != 0) {
+      return memoizedHashCode;
+    }
+    int hash = 41;
+    hash = (19 * hash) + getDescriptorForType().hashCode();
+    if (hasOriginalRequest()) {
+      hash = (37 * hash) + ORIGINAL_REQUEST_FIELD_NUMBER;
+      hash = (53 * hash) + getOriginalRequest().hashCode();
+    }
+    if (hasRequestTime()) {
+      hash = (37 * hash) + REQUEST_TIME_FIELD_NUMBER;
+      hash = (53 * hash) + getRequestTime().hashCode();
+    }
+    if (hasFinishTime()) {
+      hash = (37 * hash) + FINISH_TIME_FIELD_NUMBER;
+      hash = (53 * hash) + getFinishTime().hashCode();
+    }
+    hash = (29 * hash) + unknownFields.hashCode();
+    memoizedHashCode = hash;
+    return hash;
+  }
+
   public static com.google.bigtable.admin.v2.CreateInstanceMetadata parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -275,39 +328,39 @@ public  final class CreateInstanceMetadata extends
   }
   public static com.google.bigtable.admin.v2.CreateInstanceMetadata parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.CreateInstanceMetadata parseFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.admin.v2.CreateInstanceMetadata parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.CreateInstanceMetadata parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.admin.v2.CreateInstanceMetadata parseFrom(
       com.google.protobuf.CodedInputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.CreateInstanceMetadata parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
@@ -325,7 +378,7 @@ public  final class CreateInstanceMetadata extends
 
   @java.lang.Override
   protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
@@ -337,7 +390,7 @@ public  final class CreateInstanceMetadata extends
    * Protobuf type {@code google.bigtable.admin.v2.CreateInstanceMetadata}
    */
   public static final class Builder extends
-      com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
       // @@protoc_insertion_point(builder_implements:google.bigtable.admin.v2.CreateInstanceMetadata)
       com.google.bigtable.admin.v2.CreateInstanceMetadataOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
@@ -345,7 +398,7 @@ public  final class CreateInstanceMetadata extends
       return com.google.bigtable.admin.v2.BigtableInstanceAdminProto.internal_static_google_bigtable_admin_v2_CreateInstanceMetadata_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.bigtable.admin.v2.BigtableInstanceAdminProto.internal_static_google_bigtable_admin_v2_CreateInstanceMetadata_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -358,12 +411,13 @@ public  final class CreateInstanceMetadata extends
     }
 
     private Builder(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
       }
     }
     public Builder clear() {
@@ -427,6 +481,32 @@ public  final class CreateInstanceMetadata extends
       return result;
     }
 
+    public Builder clone() {
+      return (Builder) super.clone();
+    }
+    public Builder setField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.setField(field, value);
+    }
+    public Builder clearField(
+        com.google.protobuf.Descriptors.FieldDescriptor field) {
+      return (Builder) super.clearField(field);
+    }
+    public Builder clearOneof(
+        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      return (Builder) super.clearOneof(oneof);
+    }
+    public Builder setRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        int index, Object value) {
+      return (Builder) super.setRepeatedField(field, index, value);
+    }
+    public Builder addRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.addRepeatedField(field, value);
+    }
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.bigtable.admin.v2.CreateInstanceMetadata) {
         return mergeFrom((com.google.bigtable.admin.v2.CreateInstanceMetadata)other);
@@ -474,7 +554,7 @@ public  final class CreateInstanceMetadata extends
     }
 
     private com.google.bigtable.admin.v2.CreateInstanceRequest originalRequest_ = null;
-    private com.google.protobuf.SingleFieldBuilder<
+    private com.google.protobuf.SingleFieldBuilderV3<
         com.google.bigtable.admin.v2.CreateInstanceRequest, com.google.bigtable.admin.v2.CreateInstanceRequest.Builder, com.google.bigtable.admin.v2.CreateInstanceRequestOrBuilder> originalRequestBuilder_;
     /**
      * <pre>
@@ -612,11 +692,11 @@ public  final class CreateInstanceMetadata extends
      *
      * <code>optional .google.bigtable.admin.v2.CreateInstanceRequest original_request = 1;</code>
      */
-    private com.google.protobuf.SingleFieldBuilder<
+    private com.google.protobuf.SingleFieldBuilderV3<
         com.google.bigtable.admin.v2.CreateInstanceRequest, com.google.bigtable.admin.v2.CreateInstanceRequest.Builder, com.google.bigtable.admin.v2.CreateInstanceRequestOrBuilder> 
         getOriginalRequestFieldBuilder() {
       if (originalRequestBuilder_ == null) {
-        originalRequestBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+        originalRequestBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
             com.google.bigtable.admin.v2.CreateInstanceRequest, com.google.bigtable.admin.v2.CreateInstanceRequest.Builder, com.google.bigtable.admin.v2.CreateInstanceRequestOrBuilder>(
                 getOriginalRequest(),
                 getParentForChildren(),
@@ -627,7 +707,7 @@ public  final class CreateInstanceMetadata extends
     }
 
     private com.google.protobuf.Timestamp requestTime_ = null;
-    private com.google.protobuf.SingleFieldBuilder<
+    private com.google.protobuf.SingleFieldBuilderV3<
         com.google.protobuf.Timestamp, com.google.protobuf.Timestamp.Builder, com.google.protobuf.TimestampOrBuilder> requestTimeBuilder_;
     /**
      * <pre>
@@ -765,11 +845,11 @@ public  final class CreateInstanceMetadata extends
      *
      * <code>optional .google.protobuf.Timestamp request_time = 2;</code>
      */
-    private com.google.protobuf.SingleFieldBuilder<
+    private com.google.protobuf.SingleFieldBuilderV3<
         com.google.protobuf.Timestamp, com.google.protobuf.Timestamp.Builder, com.google.protobuf.TimestampOrBuilder> 
         getRequestTimeFieldBuilder() {
       if (requestTimeBuilder_ == null) {
-        requestTimeBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+        requestTimeBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
             com.google.protobuf.Timestamp, com.google.protobuf.Timestamp.Builder, com.google.protobuf.TimestampOrBuilder>(
                 getRequestTime(),
                 getParentForChildren(),
@@ -780,7 +860,7 @@ public  final class CreateInstanceMetadata extends
     }
 
     private com.google.protobuf.Timestamp finishTime_ = null;
-    private com.google.protobuf.SingleFieldBuilder<
+    private com.google.protobuf.SingleFieldBuilderV3<
         com.google.protobuf.Timestamp, com.google.protobuf.Timestamp.Builder, com.google.protobuf.TimestampOrBuilder> finishTimeBuilder_;
     /**
      * <pre>
@@ -918,11 +998,11 @@ public  final class CreateInstanceMetadata extends
      *
      * <code>optional .google.protobuf.Timestamp finish_time = 3;</code>
      */
-    private com.google.protobuf.SingleFieldBuilder<
+    private com.google.protobuf.SingleFieldBuilderV3<
         com.google.protobuf.Timestamp, com.google.protobuf.Timestamp.Builder, com.google.protobuf.TimestampOrBuilder> 
         getFinishTimeFieldBuilder() {
       if (finishTimeBuilder_ == null) {
-        finishTimeBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+        finishTimeBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
             com.google.protobuf.Timestamp, com.google.protobuf.Timestamp.Builder, com.google.protobuf.TimestampOrBuilder>(
                 getFinishTime(),
                 getParentForChildren(),

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/CreateInstanceRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/CreateInstanceRequest.java
@@ -11,11 +11,11 @@ package com.google.bigtable.admin.v2;
  * Protobuf type {@code google.bigtable.admin.v2.CreateInstanceRequest}
  */
 public  final class CreateInstanceRequest extends
-    com.google.protobuf.GeneratedMessage implements
+    com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:google.bigtable.admin.v2.CreateInstanceRequest)
     CreateInstanceRequestOrBuilder {
   // Use CreateInstanceRequest.newBuilder() to construct.
-  private CreateInstanceRequest(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+  private CreateInstanceRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private CreateInstanceRequest() {
@@ -112,7 +112,7 @@ public  final class CreateInstanceRequest extends
             "Invalid map field number: " + number);
     }
   }
-  protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.google.bigtable.admin.v2.BigtableInstanceAdminProto.internal_static_google_bigtable_admin_v2_CreateInstanceRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
@@ -268,6 +268,10 @@ public  final class CreateInstanceRequest extends
     }
     return clusters_;
   }
+
+  public int getClustersCount() {
+    return internalGetClusters().getMap().size();
+  }
   /**
    * <pre>
    * The clusters to be created within the instance, mapped by desired
@@ -280,8 +284,74 @@ public  final class CreateInstanceRequest extends
    * <code>map&lt;string, .google.bigtable.admin.v2.Cluster&gt; clusters = 4;</code>
    */
 
+  public boolean containsClusters(
+      java.lang.String key) {
+    if (key == null) { throw new java.lang.NullPointerException(); }
+    return internalGetClusters().getMap().containsKey(key);
+  }
+  /**
+   * Use {@link #getClustersMap()} instead.
+   */
+  @java.lang.Deprecated
   public java.util.Map<java.lang.String, com.google.bigtable.admin.v2.Cluster> getClusters() {
+    return getClustersMap();
+  }
+  /**
+   * <pre>
+   * The clusters to be created within the instance, mapped by desired
+   * cluster ID (e.g. just the "mycluster" part of the full name
+   * "projects/myproject/instances/myinstance/clusters/mycluster").
+   * Fields marked "&#64;OutputOnly" must be left blank.
+   * Currently exactly one cluster must be specified.
+   * </pre>
+   *
+   * <code>map&lt;string, .google.bigtable.admin.v2.Cluster&gt; clusters = 4;</code>
+   */
+
+  public java.util.Map<java.lang.String, com.google.bigtable.admin.v2.Cluster> getClustersMap() {
     return internalGetClusters().getMap();
+  }
+  /**
+   * <pre>
+   * The clusters to be created within the instance, mapped by desired
+   * cluster ID (e.g. just the "mycluster" part of the full name
+   * "projects/myproject/instances/myinstance/clusters/mycluster").
+   * Fields marked "&#64;OutputOnly" must be left blank.
+   * Currently exactly one cluster must be specified.
+   * </pre>
+   *
+   * <code>map&lt;string, .google.bigtable.admin.v2.Cluster&gt; clusters = 4;</code>
+   */
+
+  public com.google.bigtable.admin.v2.Cluster getClustersOrDefault(
+      java.lang.String key,
+      com.google.bigtable.admin.v2.Cluster defaultValue) {
+    if (key == null) { throw new java.lang.NullPointerException(); }
+    java.util.Map<java.lang.String, com.google.bigtable.admin.v2.Cluster> map =
+        internalGetClusters().getMap();
+    return map.containsKey(key) ? map.get(key) : defaultValue;
+  }
+  /**
+   * <pre>
+   * The clusters to be created within the instance, mapped by desired
+   * cluster ID (e.g. just the "mycluster" part of the full name
+   * "projects/myproject/instances/myinstance/clusters/mycluster").
+   * Fields marked "&#64;OutputOnly" must be left blank.
+   * Currently exactly one cluster must be specified.
+   * </pre>
+   *
+   * <code>map&lt;string, .google.bigtable.admin.v2.Cluster&gt; clusters = 4;</code>
+   */
+
+  public com.google.bigtable.admin.v2.Cluster getClustersOrThrow(
+      java.lang.String key) {
+    if (key == null) { throw new java.lang.NullPointerException(); }
+    java.util.Map<java.lang.String, com.google.bigtable.admin.v2.Cluster> map =
+        internalGetClusters().getMap();
+    if (!map.containsKey(key)) {
+      throw new java.lang.IllegalArgumentException();
+    }
+    return map.get(key);
   }
 
   private byte memoizedIsInitialized = -1;
@@ -297,10 +367,10 @@ public  final class CreateInstanceRequest extends
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
     if (!getParentBytes().isEmpty()) {
-      com.google.protobuf.GeneratedMessage.writeString(output, 1, parent_);
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 1, parent_);
     }
     if (!getInstanceIdBytes().isEmpty()) {
-      com.google.protobuf.GeneratedMessage.writeString(output, 2, instanceId_);
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 2, instanceId_);
     }
     if (instance_ != null) {
       output.writeMessage(3, getInstance());
@@ -322,10 +392,10 @@ public  final class CreateInstanceRequest extends
 
     size = 0;
     if (!getParentBytes().isEmpty()) {
-      size += com.google.protobuf.GeneratedMessage.computeStringSize(1, parent_);
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, parent_);
     }
     if (!getInstanceIdBytes().isEmpty()) {
-      size += com.google.protobuf.GeneratedMessage.computeStringSize(2, instanceId_);
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, instanceId_);
     }
     if (instance_ != null) {
       size += com.google.protobuf.CodedOutputStream
@@ -346,6 +416,55 @@ public  final class CreateInstanceRequest extends
   }
 
   private static final long serialVersionUID = 0L;
+  @java.lang.Override
+  public boolean equals(final java.lang.Object obj) {
+    if (obj == this) {
+     return true;
+    }
+    if (!(obj instanceof com.google.bigtable.admin.v2.CreateInstanceRequest)) {
+      return super.equals(obj);
+    }
+    com.google.bigtable.admin.v2.CreateInstanceRequest other = (com.google.bigtable.admin.v2.CreateInstanceRequest) obj;
+
+    boolean result = true;
+    result = result && getParent()
+        .equals(other.getParent());
+    result = result && getInstanceId()
+        .equals(other.getInstanceId());
+    result = result && (hasInstance() == other.hasInstance());
+    if (hasInstance()) {
+      result = result && getInstance()
+          .equals(other.getInstance());
+    }
+    result = result && internalGetClusters().equals(
+        other.internalGetClusters());
+    return result;
+  }
+
+  @java.lang.Override
+  public int hashCode() {
+    if (memoizedHashCode != 0) {
+      return memoizedHashCode;
+    }
+    int hash = 41;
+    hash = (19 * hash) + getDescriptorForType().hashCode();
+    hash = (37 * hash) + PARENT_FIELD_NUMBER;
+    hash = (53 * hash) + getParent().hashCode();
+    hash = (37 * hash) + INSTANCE_ID_FIELD_NUMBER;
+    hash = (53 * hash) + getInstanceId().hashCode();
+    if (hasInstance()) {
+      hash = (37 * hash) + INSTANCE_FIELD_NUMBER;
+      hash = (53 * hash) + getInstance().hashCode();
+    }
+    if (!internalGetClusters().getMap().isEmpty()) {
+      hash = (37 * hash) + CLUSTERS_FIELD_NUMBER;
+      hash = (53 * hash) + internalGetClusters().hashCode();
+    }
+    hash = (29 * hash) + unknownFields.hashCode();
+    memoizedHashCode = hash;
+    return hash;
+  }
+
   public static com.google.bigtable.admin.v2.CreateInstanceRequest parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -369,39 +488,39 @@ public  final class CreateInstanceRequest extends
   }
   public static com.google.bigtable.admin.v2.CreateInstanceRequest parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.CreateInstanceRequest parseFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.admin.v2.CreateInstanceRequest parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.CreateInstanceRequest parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.admin.v2.CreateInstanceRequest parseFrom(
       com.google.protobuf.CodedInputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.CreateInstanceRequest parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
@@ -419,7 +538,7 @@ public  final class CreateInstanceRequest extends
 
   @java.lang.Override
   protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
@@ -431,7 +550,7 @@ public  final class CreateInstanceRequest extends
    * Protobuf type {@code google.bigtable.admin.v2.CreateInstanceRequest}
    */
   public static final class Builder extends
-      com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
       // @@protoc_insertion_point(builder_implements:google.bigtable.admin.v2.CreateInstanceRequest)
       com.google.bigtable.admin.v2.CreateInstanceRequestOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
@@ -461,7 +580,7 @@ public  final class CreateInstanceRequest extends
               "Invalid map field number: " + number);
       }
     }
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.bigtable.admin.v2.BigtableInstanceAdminProto.internal_static_google_bigtable_admin_v2_CreateInstanceRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -474,12 +593,13 @@ public  final class CreateInstanceRequest extends
     }
 
     private Builder(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
       }
     }
     public Builder clear() {
@@ -533,6 +653,32 @@ public  final class CreateInstanceRequest extends
       return result;
     }
 
+    public Builder clone() {
+      return (Builder) super.clone();
+    }
+    public Builder setField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.setField(field, value);
+    }
+    public Builder clearField(
+        com.google.protobuf.Descriptors.FieldDescriptor field) {
+      return (Builder) super.clearField(field);
+    }
+    public Builder clearOneof(
+        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      return (Builder) super.clearOneof(oneof);
+    }
+    public Builder setRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        int index, Object value) {
+      return (Builder) super.setRepeatedField(field, index, value);
+    }
+    public Builder addRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.addRepeatedField(field, value);
+    }
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.bigtable.admin.v2.CreateInstanceRequest) {
         return mergeFrom((com.google.bigtable.admin.v2.CreateInstanceRequest)other);
@@ -778,7 +924,7 @@ public  final class CreateInstanceRequest extends
     }
 
     private com.google.bigtable.admin.v2.Instance instance_ = null;
-    private com.google.protobuf.SingleFieldBuilder<
+    private com.google.protobuf.SingleFieldBuilderV3<
         com.google.bigtable.admin.v2.Instance, com.google.bigtable.admin.v2.Instance.Builder, com.google.bigtable.admin.v2.InstanceOrBuilder> instanceBuilder_;
     /**
      * <pre>
@@ -925,11 +1071,11 @@ public  final class CreateInstanceRequest extends
      *
      * <code>optional .google.bigtable.admin.v2.Instance instance = 3;</code>
      */
-    private com.google.protobuf.SingleFieldBuilder<
+    private com.google.protobuf.SingleFieldBuilderV3<
         com.google.bigtable.admin.v2.Instance, com.google.bigtable.admin.v2.Instance.Builder, com.google.bigtable.admin.v2.InstanceOrBuilder> 
         getInstanceFieldBuilder() {
       if (instanceBuilder_ == null) {
-        instanceBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+        instanceBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
             com.google.bigtable.admin.v2.Instance, com.google.bigtable.admin.v2.Instance.Builder, com.google.bigtable.admin.v2.InstanceOrBuilder>(
                 getInstance(),
                 getParentForChildren(),
@@ -961,6 +1107,10 @@ public  final class CreateInstanceRequest extends
       }
       return clusters_;
     }
+
+    public int getClustersCount() {
+      return internalGetClusters().getMap().size();
+    }
     /**
      * <pre>
      * The clusters to be created within the instance, mapped by desired
@@ -972,7 +1122,32 @@ public  final class CreateInstanceRequest extends
      *
      * <code>map&lt;string, .google.bigtable.admin.v2.Cluster&gt; clusters = 4;</code>
      */
+
+    public boolean containsClusters(
+        java.lang.String key) {
+      if (key == null) { throw new java.lang.NullPointerException(); }
+      return internalGetClusters().getMap().containsKey(key);
+    }
+    /**
+     * Use {@link #getClustersMap()} instead.
+     */
+    @java.lang.Deprecated
     public java.util.Map<java.lang.String, com.google.bigtable.admin.v2.Cluster> getClusters() {
+      return getClustersMap();
+    }
+    /**
+     * <pre>
+     * The clusters to be created within the instance, mapped by desired
+     * cluster ID (e.g. just the "mycluster" part of the full name
+     * "projects/myproject/instances/myinstance/clusters/mycluster").
+     * Fields marked "&#64;OutputOnly" must be left blank.
+     * Currently exactly one cluster must be specified.
+     * </pre>
+     *
+     * <code>map&lt;string, .google.bigtable.admin.v2.Cluster&gt; clusters = 4;</code>
+     */
+
+    public java.util.Map<java.lang.String, com.google.bigtable.admin.v2.Cluster> getClustersMap() {
       return internalGetClusters().getMap();
     }
     /**
@@ -986,6 +1161,64 @@ public  final class CreateInstanceRequest extends
      *
      * <code>map&lt;string, .google.bigtable.admin.v2.Cluster&gt; clusters = 4;</code>
      */
+
+    public com.google.bigtable.admin.v2.Cluster getClustersOrDefault(
+        java.lang.String key,
+        com.google.bigtable.admin.v2.Cluster defaultValue) {
+      if (key == null) { throw new java.lang.NullPointerException(); }
+      java.util.Map<java.lang.String, com.google.bigtable.admin.v2.Cluster> map =
+          internalGetClusters().getMap();
+      return map.containsKey(key) ? map.get(key) : defaultValue;
+    }
+    /**
+     * <pre>
+     * The clusters to be created within the instance, mapped by desired
+     * cluster ID (e.g. just the "mycluster" part of the full name
+     * "projects/myproject/instances/myinstance/clusters/mycluster").
+     * Fields marked "&#64;OutputOnly" must be left blank.
+     * Currently exactly one cluster must be specified.
+     * </pre>
+     *
+     * <code>map&lt;string, .google.bigtable.admin.v2.Cluster&gt; clusters = 4;</code>
+     */
+
+    public com.google.bigtable.admin.v2.Cluster getClustersOrThrow(
+        java.lang.String key) {
+      if (key == null) { throw new java.lang.NullPointerException(); }
+      java.util.Map<java.lang.String, com.google.bigtable.admin.v2.Cluster> map =
+          internalGetClusters().getMap();
+      if (!map.containsKey(key)) {
+        throw new java.lang.IllegalArgumentException();
+      }
+      return map.get(key);
+    }
+
+    public Builder clearClusters() {
+      getMutableClusters().clear();
+      return this;
+    }
+    /**
+     * <pre>
+     * The clusters to be created within the instance, mapped by desired
+     * cluster ID (e.g. just the "mycluster" part of the full name
+     * "projects/myproject/instances/myinstance/clusters/mycluster").
+     * Fields marked "&#64;OutputOnly" must be left blank.
+     * Currently exactly one cluster must be specified.
+     * </pre>
+     *
+     * <code>map&lt;string, .google.bigtable.admin.v2.Cluster&gt; clusters = 4;</code>
+     */
+
+    public Builder removeClusters(
+        java.lang.String key) {
+      if (key == null) { throw new java.lang.NullPointerException(); }
+      getMutableClusters().remove(key);
+      return this;
+    }
+    /**
+     * Use alternate mutation accessors instead.
+     */
+    @java.lang.Deprecated
     public java.util.Map<java.lang.String, com.google.bigtable.admin.v2.Cluster>
     getMutableClusters() {
       return internalGetMutableClusters().getMutableMap();
@@ -1001,6 +1234,26 @@ public  final class CreateInstanceRequest extends
      *
      * <code>map&lt;string, .google.bigtable.admin.v2.Cluster&gt; clusters = 4;</code>
      */
+    public Builder putClusters(
+        java.lang.String key,
+        com.google.bigtable.admin.v2.Cluster value) {
+      if (key == null) { throw new java.lang.NullPointerException(); }
+      if (value == null) { throw new java.lang.NullPointerException(); }
+      getMutableClusters().put(key, value);
+      return this;
+    }
+    /**
+     * <pre>
+     * The clusters to be created within the instance, mapped by desired
+     * cluster ID (e.g. just the "mycluster" part of the full name
+     * "projects/myproject/instances/myinstance/clusters/mycluster").
+     * Fields marked "&#64;OutputOnly" must be left blank.
+     * Currently exactly one cluster must be specified.
+     * </pre>
+     *
+     * <code>map&lt;string, .google.bigtable.admin.v2.Cluster&gt; clusters = 4;</code>
+     */
+
     public Builder putAllClusters(
         java.util.Map<java.lang.String, com.google.bigtable.admin.v2.Cluster> values) {
       getMutableClusters().putAll(values);

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/CreateInstanceRequestOrBuilder.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/CreateInstanceRequestOrBuilder.java
@@ -88,6 +88,66 @@ public interface CreateInstanceRequestOrBuilder extends
    *
    * <code>map&lt;string, .google.bigtable.admin.v2.Cluster&gt; clusters = 4;</code>
    */
+  int getClustersCount();
+  /**
+   * <pre>
+   * The clusters to be created within the instance, mapped by desired
+   * cluster ID (e.g. just the "mycluster" part of the full name
+   * "projects/myproject/instances/myinstance/clusters/mycluster").
+   * Fields marked "&#64;OutputOnly" must be left blank.
+   * Currently exactly one cluster must be specified.
+   * </pre>
+   *
+   * <code>map&lt;string, .google.bigtable.admin.v2.Cluster&gt; clusters = 4;</code>
+   */
+  boolean containsClusters(
+      java.lang.String key);
+  /**
+   * Use {@link #getClustersMap()} instead.
+   */
+  @java.lang.Deprecated
   java.util.Map<java.lang.String, com.google.bigtable.admin.v2.Cluster>
   getClusters();
+  /**
+   * <pre>
+   * The clusters to be created within the instance, mapped by desired
+   * cluster ID (e.g. just the "mycluster" part of the full name
+   * "projects/myproject/instances/myinstance/clusters/mycluster").
+   * Fields marked "&#64;OutputOnly" must be left blank.
+   * Currently exactly one cluster must be specified.
+   * </pre>
+   *
+   * <code>map&lt;string, .google.bigtable.admin.v2.Cluster&gt; clusters = 4;</code>
+   */
+  java.util.Map<java.lang.String, com.google.bigtable.admin.v2.Cluster>
+  getClustersMap();
+  /**
+   * <pre>
+   * The clusters to be created within the instance, mapped by desired
+   * cluster ID (e.g. just the "mycluster" part of the full name
+   * "projects/myproject/instances/myinstance/clusters/mycluster").
+   * Fields marked "&#64;OutputOnly" must be left blank.
+   * Currently exactly one cluster must be specified.
+   * </pre>
+   *
+   * <code>map&lt;string, .google.bigtable.admin.v2.Cluster&gt; clusters = 4;</code>
+   */
+
+  com.google.bigtable.admin.v2.Cluster getClustersOrDefault(
+      java.lang.String key,
+      com.google.bigtable.admin.v2.Cluster defaultValue);
+  /**
+   * <pre>
+   * The clusters to be created within the instance, mapped by desired
+   * cluster ID (e.g. just the "mycluster" part of the full name
+   * "projects/myproject/instances/myinstance/clusters/mycluster").
+   * Fields marked "&#64;OutputOnly" must be left blank.
+   * Currently exactly one cluster must be specified.
+   * </pre>
+   *
+   * <code>map&lt;string, .google.bigtable.admin.v2.Cluster&gt; clusters = 4;</code>
+   */
+
+  com.google.bigtable.admin.v2.Cluster getClustersOrThrow(
+      java.lang.String key);
 }

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/CreateTableRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/CreateTableRequest.java
@@ -11,11 +11,11 @@ package com.google.bigtable.admin.v2;
  * Protobuf type {@code google.bigtable.admin.v2.CreateTableRequest}
  */
 public  final class CreateTableRequest extends
-    com.google.protobuf.GeneratedMessage implements
+    com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:google.bigtable.admin.v2.CreateTableRequest)
     CreateTableRequestOrBuilder {
   // Use CreateTableRequest.newBuilder() to construct.
-  private CreateTableRequest(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+  private CreateTableRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private CreateTableRequest() {
@@ -79,7 +79,8 @@ public  final class CreateTableRequest extends
               initialSplits_ = new java.util.ArrayList<com.google.bigtable.admin.v2.CreateTableRequest.Split>();
               mutable_bitField0_ |= 0x00000008;
             }
-            initialSplits_.add(input.readMessage(com.google.bigtable.admin.v2.CreateTableRequest.Split.parser(), extensionRegistry));
+            initialSplits_.add(
+                input.readMessage(com.google.bigtable.admin.v2.CreateTableRequest.Split.parser(), extensionRegistry));
             break;
           }
         }
@@ -101,7 +102,7 @@ public  final class CreateTableRequest extends
     return com.google.bigtable.admin.v2.BigtableTableAdminProto.internal_static_google_bigtable_admin_v2_CreateTableRequest_descriptor;
   }
 
-  protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.google.bigtable.admin.v2.BigtableTableAdminProto.internal_static_google_bigtable_admin_v2_CreateTableRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
@@ -129,11 +130,11 @@ public  final class CreateTableRequest extends
    * Protobuf type {@code google.bigtable.admin.v2.CreateTableRequest.Split}
    */
   public  static final class Split extends
-      com.google.protobuf.GeneratedMessage implements
+      com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:google.bigtable.admin.v2.CreateTableRequest.Split)
       SplitOrBuilder {
     // Use Split.newBuilder() to construct.
-    private Split(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+    private Split(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
     }
     private Split() {
@@ -186,7 +187,7 @@ public  final class CreateTableRequest extends
       return com.google.bigtable.admin.v2.BigtableTableAdminProto.internal_static_google_bigtable_admin_v2_CreateTableRequest_Split_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.bigtable.admin.v2.BigtableTableAdminProto.internal_static_google_bigtable_admin_v2_CreateTableRequest_Split_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -237,6 +238,36 @@ public  final class CreateTableRequest extends
     }
 
     private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.google.bigtable.admin.v2.CreateTableRequest.Split)) {
+        return super.equals(obj);
+      }
+      com.google.bigtable.admin.v2.CreateTableRequest.Split other = (com.google.bigtable.admin.v2.CreateTableRequest.Split) obj;
+
+      boolean result = true;
+      result = result && getKey()
+          .equals(other.getKey());
+      return result;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptorForType().hashCode();
+      hash = (37 * hash) + KEY_FIELD_NUMBER;
+      hash = (53 * hash) + getKey().hashCode();
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
     public static com.google.bigtable.admin.v2.CreateTableRequest.Split parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
@@ -260,39 +291,39 @@ public  final class CreateTableRequest extends
     }
     public static com.google.bigtable.admin.v2.CreateTableRequest.Split parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
     public static com.google.bigtable.admin.v2.CreateTableRequest.Split parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
     public static com.google.bigtable.admin.v2.CreateTableRequest.Split parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
     public static com.google.bigtable.admin.v2.CreateTableRequest.Split parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
     public static com.google.bigtable.admin.v2.CreateTableRequest.Split parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
     public static com.google.bigtable.admin.v2.CreateTableRequest.Split parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
@@ -310,7 +341,7 @@ public  final class CreateTableRequest extends
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -322,7 +353,7 @@ public  final class CreateTableRequest extends
      * Protobuf type {@code google.bigtable.admin.v2.CreateTableRequest.Split}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:google.bigtable.admin.v2.CreateTableRequest.Split)
         com.google.bigtable.admin.v2.CreateTableRequest.SplitOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -330,7 +361,7 @@ public  final class CreateTableRequest extends
         return com.google.bigtable.admin.v2.BigtableTableAdminProto.internal_static_google_bigtable_admin_v2_CreateTableRequest_Split_descriptor;
       }
 
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return com.google.bigtable.admin.v2.BigtableTableAdminProto.internal_static_google_bigtable_admin_v2_CreateTableRequest_Split_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -343,12 +374,13 @@ public  final class CreateTableRequest extends
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
       private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
         }
       }
       public Builder clear() {
@@ -382,6 +414,32 @@ public  final class CreateTableRequest extends
         return result;
       }
 
+      public Builder clone() {
+        return (Builder) super.clone();
+      }
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          Object value) {
+        return (Builder) super.setField(field, value);
+      }
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return (Builder) super.clearField(field);
+      }
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return (Builder) super.clearOneof(oneof);
+      }
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, Object value) {
+        return (Builder) super.setRepeatedField(field, index, value);
+      }
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          Object value) {
+        return (Builder) super.addRepeatedField(field, value);
+      }
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof com.google.bigtable.admin.v2.CreateTableRequest.Split) {
           return mergeFrom((com.google.bigtable.admin.v2.CreateTableRequest.Split)other);
@@ -766,10 +824,10 @@ public  final class CreateTableRequest extends
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
     if (!getParentBytes().isEmpty()) {
-      com.google.protobuf.GeneratedMessage.writeString(output, 1, parent_);
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 1, parent_);
     }
     if (!getTableIdBytes().isEmpty()) {
-      com.google.protobuf.GeneratedMessage.writeString(output, 2, tableId_);
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 2, tableId_);
     }
     if (table_ != null) {
       output.writeMessage(3, getTable());
@@ -785,10 +843,10 @@ public  final class CreateTableRequest extends
 
     size = 0;
     if (!getParentBytes().isEmpty()) {
-      size += com.google.protobuf.GeneratedMessage.computeStringSize(1, parent_);
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, parent_);
     }
     if (!getTableIdBytes().isEmpty()) {
-      size += com.google.protobuf.GeneratedMessage.computeStringSize(2, tableId_);
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, tableId_);
     }
     if (table_ != null) {
       size += com.google.protobuf.CodedOutputStream
@@ -803,6 +861,55 @@ public  final class CreateTableRequest extends
   }
 
   private static final long serialVersionUID = 0L;
+  @java.lang.Override
+  public boolean equals(final java.lang.Object obj) {
+    if (obj == this) {
+     return true;
+    }
+    if (!(obj instanceof com.google.bigtable.admin.v2.CreateTableRequest)) {
+      return super.equals(obj);
+    }
+    com.google.bigtable.admin.v2.CreateTableRequest other = (com.google.bigtable.admin.v2.CreateTableRequest) obj;
+
+    boolean result = true;
+    result = result && getParent()
+        .equals(other.getParent());
+    result = result && getTableId()
+        .equals(other.getTableId());
+    result = result && (hasTable() == other.hasTable());
+    if (hasTable()) {
+      result = result && getTable()
+          .equals(other.getTable());
+    }
+    result = result && getInitialSplitsList()
+        .equals(other.getInitialSplitsList());
+    return result;
+  }
+
+  @java.lang.Override
+  public int hashCode() {
+    if (memoizedHashCode != 0) {
+      return memoizedHashCode;
+    }
+    int hash = 41;
+    hash = (19 * hash) + getDescriptorForType().hashCode();
+    hash = (37 * hash) + PARENT_FIELD_NUMBER;
+    hash = (53 * hash) + getParent().hashCode();
+    hash = (37 * hash) + TABLE_ID_FIELD_NUMBER;
+    hash = (53 * hash) + getTableId().hashCode();
+    if (hasTable()) {
+      hash = (37 * hash) + TABLE_FIELD_NUMBER;
+      hash = (53 * hash) + getTable().hashCode();
+    }
+    if (getInitialSplitsCount() > 0) {
+      hash = (37 * hash) + INITIAL_SPLITS_FIELD_NUMBER;
+      hash = (53 * hash) + getInitialSplitsList().hashCode();
+    }
+    hash = (29 * hash) + unknownFields.hashCode();
+    memoizedHashCode = hash;
+    return hash;
+  }
+
   public static com.google.bigtable.admin.v2.CreateTableRequest parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -826,39 +933,39 @@ public  final class CreateTableRequest extends
   }
   public static com.google.bigtable.admin.v2.CreateTableRequest parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.CreateTableRequest parseFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.admin.v2.CreateTableRequest parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.CreateTableRequest parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.admin.v2.CreateTableRequest parseFrom(
       com.google.protobuf.CodedInputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.CreateTableRequest parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
@@ -876,7 +983,7 @@ public  final class CreateTableRequest extends
 
   @java.lang.Override
   protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
@@ -888,7 +995,7 @@ public  final class CreateTableRequest extends
    * Protobuf type {@code google.bigtable.admin.v2.CreateTableRequest}
    */
   public static final class Builder extends
-      com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
       // @@protoc_insertion_point(builder_implements:google.bigtable.admin.v2.CreateTableRequest)
       com.google.bigtable.admin.v2.CreateTableRequestOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
@@ -896,7 +1003,7 @@ public  final class CreateTableRequest extends
       return com.google.bigtable.admin.v2.BigtableTableAdminProto.internal_static_google_bigtable_admin_v2_CreateTableRequest_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.bigtable.admin.v2.BigtableTableAdminProto.internal_static_google_bigtable_admin_v2_CreateTableRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -909,12 +1016,13 @@ public  final class CreateTableRequest extends
     }
 
     private Builder(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
         getInitialSplitsFieldBuilder();
       }
     }
@@ -981,6 +1089,32 @@ public  final class CreateTableRequest extends
       return result;
     }
 
+    public Builder clone() {
+      return (Builder) super.clone();
+    }
+    public Builder setField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.setField(field, value);
+    }
+    public Builder clearField(
+        com.google.protobuf.Descriptors.FieldDescriptor field) {
+      return (Builder) super.clearField(field);
+    }
+    public Builder clearOneof(
+        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      return (Builder) super.clearOneof(oneof);
+    }
+    public Builder setRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        int index, Object value) {
+      return (Builder) super.setRepeatedField(field, index, value);
+    }
+    public Builder addRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.addRepeatedField(field, value);
+    }
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.bigtable.admin.v2.CreateTableRequest) {
         return mergeFrom((com.google.bigtable.admin.v2.CreateTableRequest)other);
@@ -1022,7 +1156,7 @@ public  final class CreateTableRequest extends
             initialSplits_ = other.initialSplits_;
             bitField0_ = (bitField0_ & ~0x00000008);
             initialSplitsBuilder_ = 
-              com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+              com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
                  getInitialSplitsFieldBuilder() : null;
           } else {
             initialSplitsBuilder_.addAllMessages(other.initialSplits_);
@@ -1245,7 +1379,7 @@ public  final class CreateTableRequest extends
     }
 
     private com.google.bigtable.admin.v2.Table table_ = null;
-    private com.google.protobuf.SingleFieldBuilder<
+    private com.google.protobuf.SingleFieldBuilderV3<
         com.google.bigtable.admin.v2.Table, com.google.bigtable.admin.v2.Table.Builder, com.google.bigtable.admin.v2.TableOrBuilder> tableBuilder_;
     /**
      * <pre>
@@ -1383,11 +1517,11 @@ public  final class CreateTableRequest extends
      *
      * <code>optional .google.bigtable.admin.v2.Table table = 3;</code>
      */
-    private com.google.protobuf.SingleFieldBuilder<
+    private com.google.protobuf.SingleFieldBuilderV3<
         com.google.bigtable.admin.v2.Table, com.google.bigtable.admin.v2.Table.Builder, com.google.bigtable.admin.v2.TableOrBuilder> 
         getTableFieldBuilder() {
       if (tableBuilder_ == null) {
-        tableBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+        tableBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
             com.google.bigtable.admin.v2.Table, com.google.bigtable.admin.v2.Table.Builder, com.google.bigtable.admin.v2.TableOrBuilder>(
                 getTable(),
                 getParentForChildren(),
@@ -1406,7 +1540,7 @@ public  final class CreateTableRequest extends
        }
     }
 
-    private com.google.protobuf.RepeatedFieldBuilder<
+    private com.google.protobuf.RepeatedFieldBuilderV3<
         com.google.bigtable.admin.v2.CreateTableRequest.Split, com.google.bigtable.admin.v2.CreateTableRequest.Split.Builder, com.google.bigtable.admin.v2.CreateTableRequest.SplitOrBuilder> initialSplitsBuilder_;
 
     /**
@@ -1928,11 +2062,11 @@ public  final class CreateTableRequest extends
          getInitialSplitsBuilderList() {
       return getInitialSplitsFieldBuilder().getBuilderList();
     }
-    private com.google.protobuf.RepeatedFieldBuilder<
+    private com.google.protobuf.RepeatedFieldBuilderV3<
         com.google.bigtable.admin.v2.CreateTableRequest.Split, com.google.bigtable.admin.v2.CreateTableRequest.Split.Builder, com.google.bigtable.admin.v2.CreateTableRequest.SplitOrBuilder> 
         getInitialSplitsFieldBuilder() {
       if (initialSplitsBuilder_ == null) {
-        initialSplitsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
+        initialSplitsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
             com.google.bigtable.admin.v2.CreateTableRequest.Split, com.google.bigtable.admin.v2.CreateTableRequest.Split.Builder, com.google.bigtable.admin.v2.CreateTableRequest.SplitOrBuilder>(
                 initialSplits_,
                 ((bitField0_ & 0x00000008) == 0x00000008),

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/DeleteClusterRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/DeleteClusterRequest.java
@@ -11,11 +11,11 @@ package com.google.bigtable.admin.v2;
  * Protobuf type {@code google.bigtable.admin.v2.DeleteClusterRequest}
  */
 public  final class DeleteClusterRequest extends
-    com.google.protobuf.GeneratedMessage implements
+    com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:google.bigtable.admin.v2.DeleteClusterRequest)
     DeleteClusterRequestOrBuilder {
   // Use DeleteClusterRequest.newBuilder() to construct.
-  private DeleteClusterRequest(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+  private DeleteClusterRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private DeleteClusterRequest() {
@@ -69,7 +69,7 @@ public  final class DeleteClusterRequest extends
     return com.google.bigtable.admin.v2.BigtableInstanceAdminProto.internal_static_google_bigtable_admin_v2_DeleteClusterRequest_descriptor;
   }
 
-  protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.google.bigtable.admin.v2.BigtableInstanceAdminProto.internal_static_google_bigtable_admin_v2_DeleteClusterRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
@@ -133,7 +133,7 @@ public  final class DeleteClusterRequest extends
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
     if (!getNameBytes().isEmpty()) {
-      com.google.protobuf.GeneratedMessage.writeString(output, 1, name_);
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 1, name_);
     }
   }
 
@@ -143,13 +143,43 @@ public  final class DeleteClusterRequest extends
 
     size = 0;
     if (!getNameBytes().isEmpty()) {
-      size += com.google.protobuf.GeneratedMessage.computeStringSize(1, name_);
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, name_);
     }
     memoizedSize = size;
     return size;
   }
 
   private static final long serialVersionUID = 0L;
+  @java.lang.Override
+  public boolean equals(final java.lang.Object obj) {
+    if (obj == this) {
+     return true;
+    }
+    if (!(obj instanceof com.google.bigtable.admin.v2.DeleteClusterRequest)) {
+      return super.equals(obj);
+    }
+    com.google.bigtable.admin.v2.DeleteClusterRequest other = (com.google.bigtable.admin.v2.DeleteClusterRequest) obj;
+
+    boolean result = true;
+    result = result && getName()
+        .equals(other.getName());
+    return result;
+  }
+
+  @java.lang.Override
+  public int hashCode() {
+    if (memoizedHashCode != 0) {
+      return memoizedHashCode;
+    }
+    int hash = 41;
+    hash = (19 * hash) + getDescriptorForType().hashCode();
+    hash = (37 * hash) + NAME_FIELD_NUMBER;
+    hash = (53 * hash) + getName().hashCode();
+    hash = (29 * hash) + unknownFields.hashCode();
+    memoizedHashCode = hash;
+    return hash;
+  }
+
   public static com.google.bigtable.admin.v2.DeleteClusterRequest parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -173,39 +203,39 @@ public  final class DeleteClusterRequest extends
   }
   public static com.google.bigtable.admin.v2.DeleteClusterRequest parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.DeleteClusterRequest parseFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.admin.v2.DeleteClusterRequest parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.DeleteClusterRequest parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.admin.v2.DeleteClusterRequest parseFrom(
       com.google.protobuf.CodedInputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.DeleteClusterRequest parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
@@ -223,7 +253,7 @@ public  final class DeleteClusterRequest extends
 
   @java.lang.Override
   protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
@@ -235,7 +265,7 @@ public  final class DeleteClusterRequest extends
    * Protobuf type {@code google.bigtable.admin.v2.DeleteClusterRequest}
    */
   public static final class Builder extends
-      com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
       // @@protoc_insertion_point(builder_implements:google.bigtable.admin.v2.DeleteClusterRequest)
       com.google.bigtable.admin.v2.DeleteClusterRequestOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
@@ -243,7 +273,7 @@ public  final class DeleteClusterRequest extends
       return com.google.bigtable.admin.v2.BigtableInstanceAdminProto.internal_static_google_bigtable_admin_v2_DeleteClusterRequest_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.bigtable.admin.v2.BigtableInstanceAdminProto.internal_static_google_bigtable_admin_v2_DeleteClusterRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -256,12 +286,13 @@ public  final class DeleteClusterRequest extends
     }
 
     private Builder(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
       }
     }
     public Builder clear() {
@@ -295,6 +326,32 @@ public  final class DeleteClusterRequest extends
       return result;
     }
 
+    public Builder clone() {
+      return (Builder) super.clone();
+    }
+    public Builder setField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.setField(field, value);
+    }
+    public Builder clearField(
+        com.google.protobuf.Descriptors.FieldDescriptor field) {
+      return (Builder) super.clearField(field);
+    }
+    public Builder clearOneof(
+        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      return (Builder) super.clearOneof(oneof);
+    }
+    public Builder setRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        int index, Object value) {
+      return (Builder) super.setRepeatedField(field, index, value);
+    }
+    public Builder addRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.addRepeatedField(field, value);
+    }
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.bigtable.admin.v2.DeleteClusterRequest) {
         return mergeFrom((com.google.bigtable.admin.v2.DeleteClusterRequest)other);

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/DeleteInstanceRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/DeleteInstanceRequest.java
@@ -11,11 +11,11 @@ package com.google.bigtable.admin.v2;
  * Protobuf type {@code google.bigtable.admin.v2.DeleteInstanceRequest}
  */
 public  final class DeleteInstanceRequest extends
-    com.google.protobuf.GeneratedMessage implements
+    com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:google.bigtable.admin.v2.DeleteInstanceRequest)
     DeleteInstanceRequestOrBuilder {
   // Use DeleteInstanceRequest.newBuilder() to construct.
-  private DeleteInstanceRequest(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+  private DeleteInstanceRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private DeleteInstanceRequest() {
@@ -69,7 +69,7 @@ public  final class DeleteInstanceRequest extends
     return com.google.bigtable.admin.v2.BigtableInstanceAdminProto.internal_static_google_bigtable_admin_v2_DeleteInstanceRequest_descriptor;
   }
 
-  protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.google.bigtable.admin.v2.BigtableInstanceAdminProto.internal_static_google_bigtable_admin_v2_DeleteInstanceRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
@@ -133,7 +133,7 @@ public  final class DeleteInstanceRequest extends
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
     if (!getNameBytes().isEmpty()) {
-      com.google.protobuf.GeneratedMessage.writeString(output, 1, name_);
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 1, name_);
     }
   }
 
@@ -143,13 +143,43 @@ public  final class DeleteInstanceRequest extends
 
     size = 0;
     if (!getNameBytes().isEmpty()) {
-      size += com.google.protobuf.GeneratedMessage.computeStringSize(1, name_);
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, name_);
     }
     memoizedSize = size;
     return size;
   }
 
   private static final long serialVersionUID = 0L;
+  @java.lang.Override
+  public boolean equals(final java.lang.Object obj) {
+    if (obj == this) {
+     return true;
+    }
+    if (!(obj instanceof com.google.bigtable.admin.v2.DeleteInstanceRequest)) {
+      return super.equals(obj);
+    }
+    com.google.bigtable.admin.v2.DeleteInstanceRequest other = (com.google.bigtable.admin.v2.DeleteInstanceRequest) obj;
+
+    boolean result = true;
+    result = result && getName()
+        .equals(other.getName());
+    return result;
+  }
+
+  @java.lang.Override
+  public int hashCode() {
+    if (memoizedHashCode != 0) {
+      return memoizedHashCode;
+    }
+    int hash = 41;
+    hash = (19 * hash) + getDescriptorForType().hashCode();
+    hash = (37 * hash) + NAME_FIELD_NUMBER;
+    hash = (53 * hash) + getName().hashCode();
+    hash = (29 * hash) + unknownFields.hashCode();
+    memoizedHashCode = hash;
+    return hash;
+  }
+
   public static com.google.bigtable.admin.v2.DeleteInstanceRequest parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -173,39 +203,39 @@ public  final class DeleteInstanceRequest extends
   }
   public static com.google.bigtable.admin.v2.DeleteInstanceRequest parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.DeleteInstanceRequest parseFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.admin.v2.DeleteInstanceRequest parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.DeleteInstanceRequest parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.admin.v2.DeleteInstanceRequest parseFrom(
       com.google.protobuf.CodedInputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.DeleteInstanceRequest parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
@@ -223,7 +253,7 @@ public  final class DeleteInstanceRequest extends
 
   @java.lang.Override
   protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
@@ -235,7 +265,7 @@ public  final class DeleteInstanceRequest extends
    * Protobuf type {@code google.bigtable.admin.v2.DeleteInstanceRequest}
    */
   public static final class Builder extends
-      com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
       // @@protoc_insertion_point(builder_implements:google.bigtable.admin.v2.DeleteInstanceRequest)
       com.google.bigtable.admin.v2.DeleteInstanceRequestOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
@@ -243,7 +273,7 @@ public  final class DeleteInstanceRequest extends
       return com.google.bigtable.admin.v2.BigtableInstanceAdminProto.internal_static_google_bigtable_admin_v2_DeleteInstanceRequest_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.bigtable.admin.v2.BigtableInstanceAdminProto.internal_static_google_bigtable_admin_v2_DeleteInstanceRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -256,12 +286,13 @@ public  final class DeleteInstanceRequest extends
     }
 
     private Builder(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
       }
     }
     public Builder clear() {
@@ -295,6 +326,32 @@ public  final class DeleteInstanceRequest extends
       return result;
     }
 
+    public Builder clone() {
+      return (Builder) super.clone();
+    }
+    public Builder setField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.setField(field, value);
+    }
+    public Builder clearField(
+        com.google.protobuf.Descriptors.FieldDescriptor field) {
+      return (Builder) super.clearField(field);
+    }
+    public Builder clearOneof(
+        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      return (Builder) super.clearOneof(oneof);
+    }
+    public Builder setRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        int index, Object value) {
+      return (Builder) super.setRepeatedField(field, index, value);
+    }
+    public Builder addRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.addRepeatedField(field, value);
+    }
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.bigtable.admin.v2.DeleteInstanceRequest) {
         return mergeFrom((com.google.bigtable.admin.v2.DeleteInstanceRequest)other);

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/DeleteTableRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/DeleteTableRequest.java
@@ -11,11 +11,11 @@ package com.google.bigtable.admin.v2;
  * Protobuf type {@code google.bigtable.admin.v2.DeleteTableRequest}
  */
 public  final class DeleteTableRequest extends
-    com.google.protobuf.GeneratedMessage implements
+    com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:google.bigtable.admin.v2.DeleteTableRequest)
     DeleteTableRequestOrBuilder {
   // Use DeleteTableRequest.newBuilder() to construct.
-  private DeleteTableRequest(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+  private DeleteTableRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private DeleteTableRequest() {
@@ -69,7 +69,7 @@ public  final class DeleteTableRequest extends
     return com.google.bigtable.admin.v2.BigtableTableAdminProto.internal_static_google_bigtable_admin_v2_DeleteTableRequest_descriptor;
   }
 
-  protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.google.bigtable.admin.v2.BigtableTableAdminProto.internal_static_google_bigtable_admin_v2_DeleteTableRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
@@ -133,7 +133,7 @@ public  final class DeleteTableRequest extends
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
     if (!getNameBytes().isEmpty()) {
-      com.google.protobuf.GeneratedMessage.writeString(output, 1, name_);
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 1, name_);
     }
   }
 
@@ -143,13 +143,43 @@ public  final class DeleteTableRequest extends
 
     size = 0;
     if (!getNameBytes().isEmpty()) {
-      size += com.google.protobuf.GeneratedMessage.computeStringSize(1, name_);
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, name_);
     }
     memoizedSize = size;
     return size;
   }
 
   private static final long serialVersionUID = 0L;
+  @java.lang.Override
+  public boolean equals(final java.lang.Object obj) {
+    if (obj == this) {
+     return true;
+    }
+    if (!(obj instanceof com.google.bigtable.admin.v2.DeleteTableRequest)) {
+      return super.equals(obj);
+    }
+    com.google.bigtable.admin.v2.DeleteTableRequest other = (com.google.bigtable.admin.v2.DeleteTableRequest) obj;
+
+    boolean result = true;
+    result = result && getName()
+        .equals(other.getName());
+    return result;
+  }
+
+  @java.lang.Override
+  public int hashCode() {
+    if (memoizedHashCode != 0) {
+      return memoizedHashCode;
+    }
+    int hash = 41;
+    hash = (19 * hash) + getDescriptorForType().hashCode();
+    hash = (37 * hash) + NAME_FIELD_NUMBER;
+    hash = (53 * hash) + getName().hashCode();
+    hash = (29 * hash) + unknownFields.hashCode();
+    memoizedHashCode = hash;
+    return hash;
+  }
+
   public static com.google.bigtable.admin.v2.DeleteTableRequest parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -173,39 +203,39 @@ public  final class DeleteTableRequest extends
   }
   public static com.google.bigtable.admin.v2.DeleteTableRequest parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.DeleteTableRequest parseFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.admin.v2.DeleteTableRequest parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.DeleteTableRequest parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.admin.v2.DeleteTableRequest parseFrom(
       com.google.protobuf.CodedInputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.DeleteTableRequest parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
@@ -223,7 +253,7 @@ public  final class DeleteTableRequest extends
 
   @java.lang.Override
   protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
@@ -235,7 +265,7 @@ public  final class DeleteTableRequest extends
    * Protobuf type {@code google.bigtable.admin.v2.DeleteTableRequest}
    */
   public static final class Builder extends
-      com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
       // @@protoc_insertion_point(builder_implements:google.bigtable.admin.v2.DeleteTableRequest)
       com.google.bigtable.admin.v2.DeleteTableRequestOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
@@ -243,7 +273,7 @@ public  final class DeleteTableRequest extends
       return com.google.bigtable.admin.v2.BigtableTableAdminProto.internal_static_google_bigtable_admin_v2_DeleteTableRequest_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.bigtable.admin.v2.BigtableTableAdminProto.internal_static_google_bigtable_admin_v2_DeleteTableRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -256,12 +286,13 @@ public  final class DeleteTableRequest extends
     }
 
     private Builder(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
       }
     }
     public Builder clear() {
@@ -295,6 +326,32 @@ public  final class DeleteTableRequest extends
       return result;
     }
 
+    public Builder clone() {
+      return (Builder) super.clone();
+    }
+    public Builder setField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.setField(field, value);
+    }
+    public Builder clearField(
+        com.google.protobuf.Descriptors.FieldDescriptor field) {
+      return (Builder) super.clearField(field);
+    }
+    public Builder clearOneof(
+        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      return (Builder) super.clearOneof(oneof);
+    }
+    public Builder setRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        int index, Object value) {
+      return (Builder) super.setRepeatedField(field, index, value);
+    }
+    public Builder addRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.addRepeatedField(field, value);
+    }
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.bigtable.admin.v2.DeleteTableRequest) {
         return mergeFrom((com.google.bigtable.admin.v2.DeleteTableRequest)other);

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/DropRowRangeRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/DropRowRangeRequest.java
@@ -11,11 +11,11 @@ package com.google.bigtable.admin.v2;
  * Protobuf type {@code google.bigtable.admin.v2.DropRowRangeRequest}
  */
 public  final class DropRowRangeRequest extends
-    com.google.protobuf.GeneratedMessage implements
+    com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:google.bigtable.admin.v2.DropRowRangeRequest)
     DropRowRangeRequestOrBuilder {
   // Use DropRowRangeRequest.newBuilder() to construct.
-  private DropRowRangeRequest(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+  private DropRowRangeRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private DropRowRangeRequest() {
@@ -79,7 +79,7 @@ public  final class DropRowRangeRequest extends
     return com.google.bigtable.admin.v2.BigtableTableAdminProto.internal_static_google_bigtable_admin_v2_DropRowRangeRequest_descriptor;
   }
 
-  protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.google.bigtable.admin.v2.BigtableTableAdminProto.internal_static_google_bigtable_admin_v2_DropRowRangeRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
@@ -212,7 +212,7 @@ public  final class DropRowRangeRequest extends
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
     if (!getNameBytes().isEmpty()) {
-      com.google.protobuf.GeneratedMessage.writeString(output, 1, name_);
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 1, name_);
     }
     if (targetCase_ == 2) {
       output.writeBytes(
@@ -230,7 +230,7 @@ public  final class DropRowRangeRequest extends
 
     size = 0;
     if (!getNameBytes().isEmpty()) {
-      size += com.google.protobuf.GeneratedMessage.computeStringSize(1, name_);
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, name_);
     }
     if (targetCase_ == 2) {
       size += com.google.protobuf.CodedOutputStream
@@ -247,6 +247,64 @@ public  final class DropRowRangeRequest extends
   }
 
   private static final long serialVersionUID = 0L;
+  @java.lang.Override
+  public boolean equals(final java.lang.Object obj) {
+    if (obj == this) {
+     return true;
+    }
+    if (!(obj instanceof com.google.bigtable.admin.v2.DropRowRangeRequest)) {
+      return super.equals(obj);
+    }
+    com.google.bigtable.admin.v2.DropRowRangeRequest other = (com.google.bigtable.admin.v2.DropRowRangeRequest) obj;
+
+    boolean result = true;
+    result = result && getName()
+        .equals(other.getName());
+    result = result && getTargetCase().equals(
+        other.getTargetCase());
+    if (!result) return false;
+    switch (targetCase_) {
+      case 2:
+        result = result && getRowKeyPrefix()
+            .equals(other.getRowKeyPrefix());
+        break;
+      case 3:
+        result = result && (getDeleteAllDataFromTable()
+            == other.getDeleteAllDataFromTable());
+        break;
+      case 0:
+      default:
+    }
+    return result;
+  }
+
+  @java.lang.Override
+  public int hashCode() {
+    if (memoizedHashCode != 0) {
+      return memoizedHashCode;
+    }
+    int hash = 41;
+    hash = (19 * hash) + getDescriptorForType().hashCode();
+    hash = (37 * hash) + NAME_FIELD_NUMBER;
+    hash = (53 * hash) + getName().hashCode();
+    switch (targetCase_) {
+      case 2:
+        hash = (37 * hash) + ROW_KEY_PREFIX_FIELD_NUMBER;
+        hash = (53 * hash) + getRowKeyPrefix().hashCode();
+        break;
+      case 3:
+        hash = (37 * hash) + DELETE_ALL_DATA_FROM_TABLE_FIELD_NUMBER;
+        hash = (53 * hash) + com.google.protobuf.Internal.hashBoolean(
+            getDeleteAllDataFromTable());
+        break;
+      case 0:
+      default:
+    }
+    hash = (29 * hash) + unknownFields.hashCode();
+    memoizedHashCode = hash;
+    return hash;
+  }
+
   public static com.google.bigtable.admin.v2.DropRowRangeRequest parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -270,39 +328,39 @@ public  final class DropRowRangeRequest extends
   }
   public static com.google.bigtable.admin.v2.DropRowRangeRequest parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.DropRowRangeRequest parseFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.admin.v2.DropRowRangeRequest parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.DropRowRangeRequest parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.admin.v2.DropRowRangeRequest parseFrom(
       com.google.protobuf.CodedInputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.DropRowRangeRequest parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
@@ -320,7 +378,7 @@ public  final class DropRowRangeRequest extends
 
   @java.lang.Override
   protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
@@ -332,7 +390,7 @@ public  final class DropRowRangeRequest extends
    * Protobuf type {@code google.bigtable.admin.v2.DropRowRangeRequest}
    */
   public static final class Builder extends
-      com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
       // @@protoc_insertion_point(builder_implements:google.bigtable.admin.v2.DropRowRangeRequest)
       com.google.bigtable.admin.v2.DropRowRangeRequestOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
@@ -340,7 +398,7 @@ public  final class DropRowRangeRequest extends
       return com.google.bigtable.admin.v2.BigtableTableAdminProto.internal_static_google_bigtable_admin_v2_DropRowRangeRequest_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.bigtable.admin.v2.BigtableTableAdminProto.internal_static_google_bigtable_admin_v2_DropRowRangeRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -353,12 +411,13 @@ public  final class DropRowRangeRequest extends
     }
 
     private Builder(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
       }
     }
     public Builder clear() {
@@ -401,6 +460,32 @@ public  final class DropRowRangeRequest extends
       return result;
     }
 
+    public Builder clone() {
+      return (Builder) super.clone();
+    }
+    public Builder setField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.setField(field, value);
+    }
+    public Builder clearField(
+        com.google.protobuf.Descriptors.FieldDescriptor field) {
+      return (Builder) super.clearField(field);
+    }
+    public Builder clearOneof(
+        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      return (Builder) super.clearOneof(oneof);
+    }
+    public Builder setRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        int index, Object value) {
+      return (Builder) super.setRepeatedField(field, index, value);
+    }
+    public Builder addRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.addRepeatedField(field, value);
+    }
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.bigtable.admin.v2.DropRowRangeRequest) {
         return mergeFrom((com.google.bigtable.admin.v2.DropRowRangeRequest)other);

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/GcRule.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/GcRule.java
@@ -11,11 +11,11 @@ package com.google.bigtable.admin.v2;
  * Protobuf type {@code google.bigtable.admin.v2.GcRule}
  */
 public  final class GcRule extends
-    com.google.protobuf.GeneratedMessage implements
+    com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:google.bigtable.admin.v2.GcRule)
     GcRuleOrBuilder {
   // Use GcRule.newBuilder() to construct.
-  private GcRule(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+  private GcRule(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private GcRule() {
@@ -109,7 +109,7 @@ public  final class GcRule extends
     return com.google.bigtable.admin.v2.TableProto.internal_static_google_bigtable_admin_v2_GcRule_descriptor;
   }
 
-  protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.google.bigtable.admin.v2.TableProto.internal_static_google_bigtable_admin_v2_GcRule_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
@@ -172,11 +172,11 @@ public  final class GcRule extends
    * Protobuf type {@code google.bigtable.admin.v2.GcRule.Intersection}
    */
   public  static final class Intersection extends
-      com.google.protobuf.GeneratedMessage implements
+      com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:google.bigtable.admin.v2.GcRule.Intersection)
       IntersectionOrBuilder {
     // Use Intersection.newBuilder() to construct.
-    private Intersection(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+    private Intersection(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
     }
     private Intersection() {
@@ -213,7 +213,8 @@ public  final class GcRule extends
                 rules_ = new java.util.ArrayList<com.google.bigtable.admin.v2.GcRule>();
                 mutable_bitField0_ |= 0x00000001;
               }
-              rules_.add(input.readMessage(com.google.bigtable.admin.v2.GcRule.parser(), extensionRegistry));
+              rules_.add(
+                  input.readMessage(com.google.bigtable.admin.v2.GcRule.parser(), extensionRegistry));
               break;
             }
           }
@@ -235,7 +236,7 @@ public  final class GcRule extends
       return com.google.bigtable.admin.v2.TableProto.internal_static_google_bigtable_admin_v2_GcRule_Intersection_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.bigtable.admin.v2.TableProto.internal_static_google_bigtable_admin_v2_GcRule_Intersection_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -328,6 +329,38 @@ public  final class GcRule extends
     }
 
     private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.google.bigtable.admin.v2.GcRule.Intersection)) {
+        return super.equals(obj);
+      }
+      com.google.bigtable.admin.v2.GcRule.Intersection other = (com.google.bigtable.admin.v2.GcRule.Intersection) obj;
+
+      boolean result = true;
+      result = result && getRulesList()
+          .equals(other.getRulesList());
+      return result;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptorForType().hashCode();
+      if (getRulesCount() > 0) {
+        hash = (37 * hash) + RULES_FIELD_NUMBER;
+        hash = (53 * hash) + getRulesList().hashCode();
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
     public static com.google.bigtable.admin.v2.GcRule.Intersection parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
@@ -351,39 +384,39 @@ public  final class GcRule extends
     }
     public static com.google.bigtable.admin.v2.GcRule.Intersection parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
     public static com.google.bigtable.admin.v2.GcRule.Intersection parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
     public static com.google.bigtable.admin.v2.GcRule.Intersection parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
     public static com.google.bigtable.admin.v2.GcRule.Intersection parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
     public static com.google.bigtable.admin.v2.GcRule.Intersection parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
     public static com.google.bigtable.admin.v2.GcRule.Intersection parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
@@ -401,7 +434,7 @@ public  final class GcRule extends
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -413,7 +446,7 @@ public  final class GcRule extends
      * Protobuf type {@code google.bigtable.admin.v2.GcRule.Intersection}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:google.bigtable.admin.v2.GcRule.Intersection)
         com.google.bigtable.admin.v2.GcRule.IntersectionOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -421,7 +454,7 @@ public  final class GcRule extends
         return com.google.bigtable.admin.v2.TableProto.internal_static_google_bigtable_admin_v2_GcRule_Intersection_descriptor;
       }
 
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return com.google.bigtable.admin.v2.TableProto.internal_static_google_bigtable_admin_v2_GcRule_Intersection_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -434,12 +467,13 @@ public  final class GcRule extends
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
       private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
           getRulesFieldBuilder();
         }
       }
@@ -487,6 +521,32 @@ public  final class GcRule extends
         return result;
       }
 
+      public Builder clone() {
+        return (Builder) super.clone();
+      }
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          Object value) {
+        return (Builder) super.setField(field, value);
+      }
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return (Builder) super.clearField(field);
+      }
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return (Builder) super.clearOneof(oneof);
+      }
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, Object value) {
+        return (Builder) super.setRepeatedField(field, index, value);
+      }
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          Object value) {
+        return (Builder) super.addRepeatedField(field, value);
+      }
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof com.google.bigtable.admin.v2.GcRule.Intersection) {
           return mergeFrom((com.google.bigtable.admin.v2.GcRule.Intersection)other);
@@ -517,7 +577,7 @@ public  final class GcRule extends
               rules_ = other.rules_;
               bitField0_ = (bitField0_ & ~0x00000001);
               rulesBuilder_ = 
-                com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+                com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
                    getRulesFieldBuilder() : null;
             } else {
               rulesBuilder_.addAllMessages(other.rules_);
@@ -560,7 +620,7 @@ public  final class GcRule extends
          }
       }
 
-      private com.google.protobuf.RepeatedFieldBuilder<
+      private com.google.protobuf.RepeatedFieldBuilderV3<
           com.google.bigtable.admin.v2.GcRule, com.google.bigtable.admin.v2.GcRule.Builder, com.google.bigtable.admin.v2.GcRuleOrBuilder> rulesBuilder_;
 
       /**
@@ -848,11 +908,11 @@ public  final class GcRule extends
            getRulesBuilderList() {
         return getRulesFieldBuilder().getBuilderList();
       }
-      private com.google.protobuf.RepeatedFieldBuilder<
+      private com.google.protobuf.RepeatedFieldBuilderV3<
           com.google.bigtable.admin.v2.GcRule, com.google.bigtable.admin.v2.GcRule.Builder, com.google.bigtable.admin.v2.GcRuleOrBuilder> 
           getRulesFieldBuilder() {
         if (rulesBuilder_ == null) {
-          rulesBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
+          rulesBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
               com.google.bigtable.admin.v2.GcRule, com.google.bigtable.admin.v2.GcRule.Builder, com.google.bigtable.admin.v2.GcRuleOrBuilder>(
                   rules_,
                   ((bitField0_ & 0x00000001) == 0x00000001),
@@ -967,11 +1027,11 @@ public  final class GcRule extends
    * Protobuf type {@code google.bigtable.admin.v2.GcRule.Union}
    */
   public  static final class Union extends
-      com.google.protobuf.GeneratedMessage implements
+      com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:google.bigtable.admin.v2.GcRule.Union)
       UnionOrBuilder {
     // Use Union.newBuilder() to construct.
-    private Union(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+    private Union(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
     }
     private Union() {
@@ -1008,7 +1068,8 @@ public  final class GcRule extends
                 rules_ = new java.util.ArrayList<com.google.bigtable.admin.v2.GcRule>();
                 mutable_bitField0_ |= 0x00000001;
               }
-              rules_.add(input.readMessage(com.google.bigtable.admin.v2.GcRule.parser(), extensionRegistry));
+              rules_.add(
+                  input.readMessage(com.google.bigtable.admin.v2.GcRule.parser(), extensionRegistry));
               break;
             }
           }
@@ -1030,7 +1091,7 @@ public  final class GcRule extends
       return com.google.bigtable.admin.v2.TableProto.internal_static_google_bigtable_admin_v2_GcRule_Union_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.bigtable.admin.v2.TableProto.internal_static_google_bigtable_admin_v2_GcRule_Union_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -1123,6 +1184,38 @@ public  final class GcRule extends
     }
 
     private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.google.bigtable.admin.v2.GcRule.Union)) {
+        return super.equals(obj);
+      }
+      com.google.bigtable.admin.v2.GcRule.Union other = (com.google.bigtable.admin.v2.GcRule.Union) obj;
+
+      boolean result = true;
+      result = result && getRulesList()
+          .equals(other.getRulesList());
+      return result;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptorForType().hashCode();
+      if (getRulesCount() > 0) {
+        hash = (37 * hash) + RULES_FIELD_NUMBER;
+        hash = (53 * hash) + getRulesList().hashCode();
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
     public static com.google.bigtable.admin.v2.GcRule.Union parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
@@ -1146,39 +1239,39 @@ public  final class GcRule extends
     }
     public static com.google.bigtable.admin.v2.GcRule.Union parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
     public static com.google.bigtable.admin.v2.GcRule.Union parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
     public static com.google.bigtable.admin.v2.GcRule.Union parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
     public static com.google.bigtable.admin.v2.GcRule.Union parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
     public static com.google.bigtable.admin.v2.GcRule.Union parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
     public static com.google.bigtable.admin.v2.GcRule.Union parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
@@ -1196,7 +1289,7 @@ public  final class GcRule extends
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -1208,7 +1301,7 @@ public  final class GcRule extends
      * Protobuf type {@code google.bigtable.admin.v2.GcRule.Union}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:google.bigtable.admin.v2.GcRule.Union)
         com.google.bigtable.admin.v2.GcRule.UnionOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -1216,7 +1309,7 @@ public  final class GcRule extends
         return com.google.bigtable.admin.v2.TableProto.internal_static_google_bigtable_admin_v2_GcRule_Union_descriptor;
       }
 
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return com.google.bigtable.admin.v2.TableProto.internal_static_google_bigtable_admin_v2_GcRule_Union_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -1229,12 +1322,13 @@ public  final class GcRule extends
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
       private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
           getRulesFieldBuilder();
         }
       }
@@ -1282,6 +1376,32 @@ public  final class GcRule extends
         return result;
       }
 
+      public Builder clone() {
+        return (Builder) super.clone();
+      }
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          Object value) {
+        return (Builder) super.setField(field, value);
+      }
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return (Builder) super.clearField(field);
+      }
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return (Builder) super.clearOneof(oneof);
+      }
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, Object value) {
+        return (Builder) super.setRepeatedField(field, index, value);
+      }
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          Object value) {
+        return (Builder) super.addRepeatedField(field, value);
+      }
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof com.google.bigtable.admin.v2.GcRule.Union) {
           return mergeFrom((com.google.bigtable.admin.v2.GcRule.Union)other);
@@ -1312,7 +1432,7 @@ public  final class GcRule extends
               rules_ = other.rules_;
               bitField0_ = (bitField0_ & ~0x00000001);
               rulesBuilder_ = 
-                com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+                com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
                    getRulesFieldBuilder() : null;
             } else {
               rulesBuilder_.addAllMessages(other.rules_);
@@ -1355,7 +1475,7 @@ public  final class GcRule extends
          }
       }
 
-      private com.google.protobuf.RepeatedFieldBuilder<
+      private com.google.protobuf.RepeatedFieldBuilderV3<
           com.google.bigtable.admin.v2.GcRule, com.google.bigtable.admin.v2.GcRule.Builder, com.google.bigtable.admin.v2.GcRuleOrBuilder> rulesBuilder_;
 
       /**
@@ -1643,11 +1763,11 @@ public  final class GcRule extends
            getRulesBuilderList() {
         return getRulesFieldBuilder().getBuilderList();
       }
-      private com.google.protobuf.RepeatedFieldBuilder<
+      private com.google.protobuf.RepeatedFieldBuilderV3<
           com.google.bigtable.admin.v2.GcRule, com.google.bigtable.admin.v2.GcRule.Builder, com.google.bigtable.admin.v2.GcRuleOrBuilder> 
           getRulesFieldBuilder() {
         if (rulesBuilder_ == null) {
-          rulesBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
+          rulesBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
               com.google.bigtable.admin.v2.GcRule, com.google.bigtable.admin.v2.GcRule.Builder, com.google.bigtable.admin.v2.GcRuleOrBuilder>(
                   rules_,
                   ((bitField0_ & 0x00000001) == 0x00000001),
@@ -1905,6 +2025,75 @@ public  final class GcRule extends
   }
 
   private static final long serialVersionUID = 0L;
+  @java.lang.Override
+  public boolean equals(final java.lang.Object obj) {
+    if (obj == this) {
+     return true;
+    }
+    if (!(obj instanceof com.google.bigtable.admin.v2.GcRule)) {
+      return super.equals(obj);
+    }
+    com.google.bigtable.admin.v2.GcRule other = (com.google.bigtable.admin.v2.GcRule) obj;
+
+    boolean result = true;
+    result = result && getRuleCase().equals(
+        other.getRuleCase());
+    if (!result) return false;
+    switch (ruleCase_) {
+      case 1:
+        result = result && (getMaxNumVersions()
+            == other.getMaxNumVersions());
+        break;
+      case 2:
+        result = result && getMaxAge()
+            .equals(other.getMaxAge());
+        break;
+      case 3:
+        result = result && getIntersection()
+            .equals(other.getIntersection());
+        break;
+      case 4:
+        result = result && getUnion()
+            .equals(other.getUnion());
+        break;
+      case 0:
+      default:
+    }
+    return result;
+  }
+
+  @java.lang.Override
+  public int hashCode() {
+    if (memoizedHashCode != 0) {
+      return memoizedHashCode;
+    }
+    int hash = 41;
+    hash = (19 * hash) + getDescriptorForType().hashCode();
+    switch (ruleCase_) {
+      case 1:
+        hash = (37 * hash) + MAX_NUM_VERSIONS_FIELD_NUMBER;
+        hash = (53 * hash) + getMaxNumVersions();
+        break;
+      case 2:
+        hash = (37 * hash) + MAX_AGE_FIELD_NUMBER;
+        hash = (53 * hash) + getMaxAge().hashCode();
+        break;
+      case 3:
+        hash = (37 * hash) + INTERSECTION_FIELD_NUMBER;
+        hash = (53 * hash) + getIntersection().hashCode();
+        break;
+      case 4:
+        hash = (37 * hash) + UNION_FIELD_NUMBER;
+        hash = (53 * hash) + getUnion().hashCode();
+        break;
+      case 0:
+      default:
+    }
+    hash = (29 * hash) + unknownFields.hashCode();
+    memoizedHashCode = hash;
+    return hash;
+  }
+
   public static com.google.bigtable.admin.v2.GcRule parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -1928,39 +2117,39 @@ public  final class GcRule extends
   }
   public static com.google.bigtable.admin.v2.GcRule parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.GcRule parseFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.admin.v2.GcRule parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.GcRule parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.admin.v2.GcRule parseFrom(
       com.google.protobuf.CodedInputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.GcRule parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
@@ -1978,7 +2167,7 @@ public  final class GcRule extends
 
   @java.lang.Override
   protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
@@ -1990,7 +2179,7 @@ public  final class GcRule extends
    * Protobuf type {@code google.bigtable.admin.v2.GcRule}
    */
   public static final class Builder extends
-      com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
       // @@protoc_insertion_point(builder_implements:google.bigtable.admin.v2.GcRule)
       com.google.bigtable.admin.v2.GcRuleOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
@@ -1998,7 +2187,7 @@ public  final class GcRule extends
       return com.google.bigtable.admin.v2.TableProto.internal_static_google_bigtable_admin_v2_GcRule_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.bigtable.admin.v2.TableProto.internal_static_google_bigtable_admin_v2_GcRule_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -2011,12 +2200,13 @@ public  final class GcRule extends
     }
 
     private Builder(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
       }
     }
     public Builder clear() {
@@ -2074,6 +2264,32 @@ public  final class GcRule extends
       return result;
     }
 
+    public Builder clone() {
+      return (Builder) super.clone();
+    }
+    public Builder setField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.setField(field, value);
+    }
+    public Builder clearField(
+        com.google.protobuf.Descriptors.FieldDescriptor field) {
+      return (Builder) super.clearField(field);
+    }
+    public Builder clearOneof(
+        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      return (Builder) super.clearOneof(oneof);
+    }
+    public Builder setRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        int index, Object value) {
+      return (Builder) super.setRepeatedField(field, index, value);
+    }
+    public Builder addRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.addRepeatedField(field, value);
+    }
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.bigtable.admin.v2.GcRule) {
         return mergeFrom((com.google.bigtable.admin.v2.GcRule)other);
@@ -2189,7 +2405,7 @@ public  final class GcRule extends
       return this;
     }
 
-    private com.google.protobuf.SingleFieldBuilder<
+    private com.google.protobuf.SingleFieldBuilderV3<
         com.google.protobuf.Duration, com.google.protobuf.Duration.Builder, com.google.protobuf.DurationOrBuilder> maxAgeBuilder_;
     /**
      * <pre>
@@ -2348,14 +2564,14 @@ public  final class GcRule extends
      *
      * <code>optional .google.protobuf.Duration max_age = 2;</code>
      */
-    private com.google.protobuf.SingleFieldBuilder<
+    private com.google.protobuf.SingleFieldBuilderV3<
         com.google.protobuf.Duration, com.google.protobuf.Duration.Builder, com.google.protobuf.DurationOrBuilder> 
         getMaxAgeFieldBuilder() {
       if (maxAgeBuilder_ == null) {
         if (!(ruleCase_ == 2)) {
           rule_ = com.google.protobuf.Duration.getDefaultInstance();
         }
-        maxAgeBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+        maxAgeBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
             com.google.protobuf.Duration, com.google.protobuf.Duration.Builder, com.google.protobuf.DurationOrBuilder>(
                 (com.google.protobuf.Duration) rule_,
                 getParentForChildren(),
@@ -2367,7 +2583,7 @@ public  final class GcRule extends
       return maxAgeBuilder_;
     }
 
-    private com.google.protobuf.SingleFieldBuilder<
+    private com.google.protobuf.SingleFieldBuilderV3<
         com.google.bigtable.admin.v2.GcRule.Intersection, com.google.bigtable.admin.v2.GcRule.Intersection.Builder, com.google.bigtable.admin.v2.GcRule.IntersectionOrBuilder> intersectionBuilder_;
     /**
      * <pre>
@@ -2510,14 +2726,14 @@ public  final class GcRule extends
      *
      * <code>optional .google.bigtable.admin.v2.GcRule.Intersection intersection = 3;</code>
      */
-    private com.google.protobuf.SingleFieldBuilder<
+    private com.google.protobuf.SingleFieldBuilderV3<
         com.google.bigtable.admin.v2.GcRule.Intersection, com.google.bigtable.admin.v2.GcRule.Intersection.Builder, com.google.bigtable.admin.v2.GcRule.IntersectionOrBuilder> 
         getIntersectionFieldBuilder() {
       if (intersectionBuilder_ == null) {
         if (!(ruleCase_ == 3)) {
           rule_ = com.google.bigtable.admin.v2.GcRule.Intersection.getDefaultInstance();
         }
-        intersectionBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+        intersectionBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
             com.google.bigtable.admin.v2.GcRule.Intersection, com.google.bigtable.admin.v2.GcRule.Intersection.Builder, com.google.bigtable.admin.v2.GcRule.IntersectionOrBuilder>(
                 (com.google.bigtable.admin.v2.GcRule.Intersection) rule_,
                 getParentForChildren(),
@@ -2529,7 +2745,7 @@ public  final class GcRule extends
       return intersectionBuilder_;
     }
 
-    private com.google.protobuf.SingleFieldBuilder<
+    private com.google.protobuf.SingleFieldBuilderV3<
         com.google.bigtable.admin.v2.GcRule.Union, com.google.bigtable.admin.v2.GcRule.Union.Builder, com.google.bigtable.admin.v2.GcRule.UnionOrBuilder> unionBuilder_;
     /**
      * <pre>
@@ -2672,14 +2888,14 @@ public  final class GcRule extends
      *
      * <code>optional .google.bigtable.admin.v2.GcRule.Union union = 4;</code>
      */
-    private com.google.protobuf.SingleFieldBuilder<
+    private com.google.protobuf.SingleFieldBuilderV3<
         com.google.bigtable.admin.v2.GcRule.Union, com.google.bigtable.admin.v2.GcRule.Union.Builder, com.google.bigtable.admin.v2.GcRule.UnionOrBuilder> 
         getUnionFieldBuilder() {
       if (unionBuilder_ == null) {
         if (!(ruleCase_ == 4)) {
           rule_ = com.google.bigtable.admin.v2.GcRule.Union.getDefaultInstance();
         }
-        unionBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+        unionBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
             com.google.bigtable.admin.v2.GcRule.Union, com.google.bigtable.admin.v2.GcRule.Union.Builder, com.google.bigtable.admin.v2.GcRule.UnionOrBuilder>(
                 (com.google.bigtable.admin.v2.GcRule.Union) rule_,
                 getParentForChildren(),

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/GetClusterRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/GetClusterRequest.java
@@ -11,11 +11,11 @@ package com.google.bigtable.admin.v2;
  * Protobuf type {@code google.bigtable.admin.v2.GetClusterRequest}
  */
 public  final class GetClusterRequest extends
-    com.google.protobuf.GeneratedMessage implements
+    com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:google.bigtable.admin.v2.GetClusterRequest)
     GetClusterRequestOrBuilder {
   // Use GetClusterRequest.newBuilder() to construct.
-  private GetClusterRequest(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+  private GetClusterRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private GetClusterRequest() {
@@ -69,7 +69,7 @@ public  final class GetClusterRequest extends
     return com.google.bigtable.admin.v2.BigtableInstanceAdminProto.internal_static_google_bigtable_admin_v2_GetClusterRequest_descriptor;
   }
 
-  protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.google.bigtable.admin.v2.BigtableInstanceAdminProto.internal_static_google_bigtable_admin_v2_GetClusterRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
@@ -133,7 +133,7 @@ public  final class GetClusterRequest extends
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
     if (!getNameBytes().isEmpty()) {
-      com.google.protobuf.GeneratedMessage.writeString(output, 1, name_);
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 1, name_);
     }
   }
 
@@ -143,13 +143,43 @@ public  final class GetClusterRequest extends
 
     size = 0;
     if (!getNameBytes().isEmpty()) {
-      size += com.google.protobuf.GeneratedMessage.computeStringSize(1, name_);
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, name_);
     }
     memoizedSize = size;
     return size;
   }
 
   private static final long serialVersionUID = 0L;
+  @java.lang.Override
+  public boolean equals(final java.lang.Object obj) {
+    if (obj == this) {
+     return true;
+    }
+    if (!(obj instanceof com.google.bigtable.admin.v2.GetClusterRequest)) {
+      return super.equals(obj);
+    }
+    com.google.bigtable.admin.v2.GetClusterRequest other = (com.google.bigtable.admin.v2.GetClusterRequest) obj;
+
+    boolean result = true;
+    result = result && getName()
+        .equals(other.getName());
+    return result;
+  }
+
+  @java.lang.Override
+  public int hashCode() {
+    if (memoizedHashCode != 0) {
+      return memoizedHashCode;
+    }
+    int hash = 41;
+    hash = (19 * hash) + getDescriptorForType().hashCode();
+    hash = (37 * hash) + NAME_FIELD_NUMBER;
+    hash = (53 * hash) + getName().hashCode();
+    hash = (29 * hash) + unknownFields.hashCode();
+    memoizedHashCode = hash;
+    return hash;
+  }
+
   public static com.google.bigtable.admin.v2.GetClusterRequest parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -173,39 +203,39 @@ public  final class GetClusterRequest extends
   }
   public static com.google.bigtable.admin.v2.GetClusterRequest parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.GetClusterRequest parseFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.admin.v2.GetClusterRequest parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.GetClusterRequest parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.admin.v2.GetClusterRequest parseFrom(
       com.google.protobuf.CodedInputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.GetClusterRequest parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
@@ -223,7 +253,7 @@ public  final class GetClusterRequest extends
 
   @java.lang.Override
   protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
@@ -235,7 +265,7 @@ public  final class GetClusterRequest extends
    * Protobuf type {@code google.bigtable.admin.v2.GetClusterRequest}
    */
   public static final class Builder extends
-      com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
       // @@protoc_insertion_point(builder_implements:google.bigtable.admin.v2.GetClusterRequest)
       com.google.bigtable.admin.v2.GetClusterRequestOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
@@ -243,7 +273,7 @@ public  final class GetClusterRequest extends
       return com.google.bigtable.admin.v2.BigtableInstanceAdminProto.internal_static_google_bigtable_admin_v2_GetClusterRequest_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.bigtable.admin.v2.BigtableInstanceAdminProto.internal_static_google_bigtable_admin_v2_GetClusterRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -256,12 +286,13 @@ public  final class GetClusterRequest extends
     }
 
     private Builder(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
       }
     }
     public Builder clear() {
@@ -295,6 +326,32 @@ public  final class GetClusterRequest extends
       return result;
     }
 
+    public Builder clone() {
+      return (Builder) super.clone();
+    }
+    public Builder setField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.setField(field, value);
+    }
+    public Builder clearField(
+        com.google.protobuf.Descriptors.FieldDescriptor field) {
+      return (Builder) super.clearField(field);
+    }
+    public Builder clearOneof(
+        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      return (Builder) super.clearOneof(oneof);
+    }
+    public Builder setRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        int index, Object value) {
+      return (Builder) super.setRepeatedField(field, index, value);
+    }
+    public Builder addRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.addRepeatedField(field, value);
+    }
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.bigtable.admin.v2.GetClusterRequest) {
         return mergeFrom((com.google.bigtable.admin.v2.GetClusterRequest)other);

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/GetInstanceRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/GetInstanceRequest.java
@@ -11,11 +11,11 @@ package com.google.bigtable.admin.v2;
  * Protobuf type {@code google.bigtable.admin.v2.GetInstanceRequest}
  */
 public  final class GetInstanceRequest extends
-    com.google.protobuf.GeneratedMessage implements
+    com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:google.bigtable.admin.v2.GetInstanceRequest)
     GetInstanceRequestOrBuilder {
   // Use GetInstanceRequest.newBuilder() to construct.
-  private GetInstanceRequest(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+  private GetInstanceRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private GetInstanceRequest() {
@@ -69,7 +69,7 @@ public  final class GetInstanceRequest extends
     return com.google.bigtable.admin.v2.BigtableInstanceAdminProto.internal_static_google_bigtable_admin_v2_GetInstanceRequest_descriptor;
   }
 
-  protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.google.bigtable.admin.v2.BigtableInstanceAdminProto.internal_static_google_bigtable_admin_v2_GetInstanceRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
@@ -133,7 +133,7 @@ public  final class GetInstanceRequest extends
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
     if (!getNameBytes().isEmpty()) {
-      com.google.protobuf.GeneratedMessage.writeString(output, 1, name_);
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 1, name_);
     }
   }
 
@@ -143,13 +143,43 @@ public  final class GetInstanceRequest extends
 
     size = 0;
     if (!getNameBytes().isEmpty()) {
-      size += com.google.protobuf.GeneratedMessage.computeStringSize(1, name_);
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, name_);
     }
     memoizedSize = size;
     return size;
   }
 
   private static final long serialVersionUID = 0L;
+  @java.lang.Override
+  public boolean equals(final java.lang.Object obj) {
+    if (obj == this) {
+     return true;
+    }
+    if (!(obj instanceof com.google.bigtable.admin.v2.GetInstanceRequest)) {
+      return super.equals(obj);
+    }
+    com.google.bigtable.admin.v2.GetInstanceRequest other = (com.google.bigtable.admin.v2.GetInstanceRequest) obj;
+
+    boolean result = true;
+    result = result && getName()
+        .equals(other.getName());
+    return result;
+  }
+
+  @java.lang.Override
+  public int hashCode() {
+    if (memoizedHashCode != 0) {
+      return memoizedHashCode;
+    }
+    int hash = 41;
+    hash = (19 * hash) + getDescriptorForType().hashCode();
+    hash = (37 * hash) + NAME_FIELD_NUMBER;
+    hash = (53 * hash) + getName().hashCode();
+    hash = (29 * hash) + unknownFields.hashCode();
+    memoizedHashCode = hash;
+    return hash;
+  }
+
   public static com.google.bigtable.admin.v2.GetInstanceRequest parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -173,39 +203,39 @@ public  final class GetInstanceRequest extends
   }
   public static com.google.bigtable.admin.v2.GetInstanceRequest parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.GetInstanceRequest parseFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.admin.v2.GetInstanceRequest parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.GetInstanceRequest parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.admin.v2.GetInstanceRequest parseFrom(
       com.google.protobuf.CodedInputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.GetInstanceRequest parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
@@ -223,7 +253,7 @@ public  final class GetInstanceRequest extends
 
   @java.lang.Override
   protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
@@ -235,7 +265,7 @@ public  final class GetInstanceRequest extends
    * Protobuf type {@code google.bigtable.admin.v2.GetInstanceRequest}
    */
   public static final class Builder extends
-      com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
       // @@protoc_insertion_point(builder_implements:google.bigtable.admin.v2.GetInstanceRequest)
       com.google.bigtable.admin.v2.GetInstanceRequestOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
@@ -243,7 +273,7 @@ public  final class GetInstanceRequest extends
       return com.google.bigtable.admin.v2.BigtableInstanceAdminProto.internal_static_google_bigtable_admin_v2_GetInstanceRequest_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.bigtable.admin.v2.BigtableInstanceAdminProto.internal_static_google_bigtable_admin_v2_GetInstanceRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -256,12 +286,13 @@ public  final class GetInstanceRequest extends
     }
 
     private Builder(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
       }
     }
     public Builder clear() {
@@ -295,6 +326,32 @@ public  final class GetInstanceRequest extends
       return result;
     }
 
+    public Builder clone() {
+      return (Builder) super.clone();
+    }
+    public Builder setField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.setField(field, value);
+    }
+    public Builder clearField(
+        com.google.protobuf.Descriptors.FieldDescriptor field) {
+      return (Builder) super.clearField(field);
+    }
+    public Builder clearOneof(
+        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      return (Builder) super.clearOneof(oneof);
+    }
+    public Builder setRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        int index, Object value) {
+      return (Builder) super.setRepeatedField(field, index, value);
+    }
+    public Builder addRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.addRepeatedField(field, value);
+    }
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.bigtable.admin.v2.GetInstanceRequest) {
         return mergeFrom((com.google.bigtable.admin.v2.GetInstanceRequest)other);

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/GetTableRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/GetTableRequest.java
@@ -11,11 +11,11 @@ package com.google.bigtable.admin.v2;
  * Protobuf type {@code google.bigtable.admin.v2.GetTableRequest}
  */
 public  final class GetTableRequest extends
-    com.google.protobuf.GeneratedMessage implements
+    com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:google.bigtable.admin.v2.GetTableRequest)
     GetTableRequestOrBuilder {
   // Use GetTableRequest.newBuilder() to construct.
-  private GetTableRequest(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+  private GetTableRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private GetTableRequest() {
@@ -76,7 +76,7 @@ public  final class GetTableRequest extends
     return com.google.bigtable.admin.v2.BigtableTableAdminProto.internal_static_google_bigtable_admin_v2_GetTableRequest_descriptor;
   }
 
-  protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.google.bigtable.admin.v2.BigtableTableAdminProto.internal_static_google_bigtable_admin_v2_GetTableRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
@@ -149,7 +149,7 @@ public  final class GetTableRequest extends
    * <code>optional .google.bigtable.admin.v2.Table.View view = 2;</code>
    */
   public com.google.bigtable.admin.v2.Table.View getView() {
-    com.google.bigtable.admin.v2.Table.View result = com.google.bigtable.admin.v2.Table.View.forNumber(view_);
+    com.google.bigtable.admin.v2.Table.View result = com.google.bigtable.admin.v2.Table.View.valueOf(view_);
     return result == null ? com.google.bigtable.admin.v2.Table.View.UNRECOGNIZED : result;
   }
 
@@ -166,7 +166,7 @@ public  final class GetTableRequest extends
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
     if (!getNameBytes().isEmpty()) {
-      com.google.protobuf.GeneratedMessage.writeString(output, 1, name_);
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 1, name_);
     }
     if (view_ != com.google.bigtable.admin.v2.Table.View.VIEW_UNSPECIFIED.getNumber()) {
       output.writeEnum(2, view_);
@@ -179,7 +179,7 @@ public  final class GetTableRequest extends
 
     size = 0;
     if (!getNameBytes().isEmpty()) {
-      size += com.google.protobuf.GeneratedMessage.computeStringSize(1, name_);
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, name_);
     }
     if (view_ != com.google.bigtable.admin.v2.Table.View.VIEW_UNSPECIFIED.getNumber()) {
       size += com.google.protobuf.CodedOutputStream
@@ -190,6 +190,39 @@ public  final class GetTableRequest extends
   }
 
   private static final long serialVersionUID = 0L;
+  @java.lang.Override
+  public boolean equals(final java.lang.Object obj) {
+    if (obj == this) {
+     return true;
+    }
+    if (!(obj instanceof com.google.bigtable.admin.v2.GetTableRequest)) {
+      return super.equals(obj);
+    }
+    com.google.bigtable.admin.v2.GetTableRequest other = (com.google.bigtable.admin.v2.GetTableRequest) obj;
+
+    boolean result = true;
+    result = result && getName()
+        .equals(other.getName());
+    result = result && view_ == other.view_;
+    return result;
+  }
+
+  @java.lang.Override
+  public int hashCode() {
+    if (memoizedHashCode != 0) {
+      return memoizedHashCode;
+    }
+    int hash = 41;
+    hash = (19 * hash) + getDescriptorForType().hashCode();
+    hash = (37 * hash) + NAME_FIELD_NUMBER;
+    hash = (53 * hash) + getName().hashCode();
+    hash = (37 * hash) + VIEW_FIELD_NUMBER;
+    hash = (53 * hash) + view_;
+    hash = (29 * hash) + unknownFields.hashCode();
+    memoizedHashCode = hash;
+    return hash;
+  }
+
   public static com.google.bigtable.admin.v2.GetTableRequest parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -213,39 +246,39 @@ public  final class GetTableRequest extends
   }
   public static com.google.bigtable.admin.v2.GetTableRequest parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.GetTableRequest parseFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.admin.v2.GetTableRequest parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.GetTableRequest parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.admin.v2.GetTableRequest parseFrom(
       com.google.protobuf.CodedInputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.GetTableRequest parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
@@ -263,7 +296,7 @@ public  final class GetTableRequest extends
 
   @java.lang.Override
   protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
@@ -275,7 +308,7 @@ public  final class GetTableRequest extends
    * Protobuf type {@code google.bigtable.admin.v2.GetTableRequest}
    */
   public static final class Builder extends
-      com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
       // @@protoc_insertion_point(builder_implements:google.bigtable.admin.v2.GetTableRequest)
       com.google.bigtable.admin.v2.GetTableRequestOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
@@ -283,7 +316,7 @@ public  final class GetTableRequest extends
       return com.google.bigtable.admin.v2.BigtableTableAdminProto.internal_static_google_bigtable_admin_v2_GetTableRequest_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.bigtable.admin.v2.BigtableTableAdminProto.internal_static_google_bigtable_admin_v2_GetTableRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -296,12 +329,13 @@ public  final class GetTableRequest extends
     }
 
     private Builder(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
       }
     }
     public Builder clear() {
@@ -338,6 +372,32 @@ public  final class GetTableRequest extends
       return result;
     }
 
+    public Builder clone() {
+      return (Builder) super.clone();
+    }
+    public Builder setField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.setField(field, value);
+    }
+    public Builder clearField(
+        com.google.protobuf.Descriptors.FieldDescriptor field) {
+      return (Builder) super.clearField(field);
+    }
+    public Builder clearOneof(
+        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      return (Builder) super.clearOneof(oneof);
+    }
+    public Builder setRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        int index, Object value) {
+      return (Builder) super.setRepeatedField(field, index, value);
+    }
+    public Builder addRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.addRepeatedField(field, value);
+    }
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.bigtable.admin.v2.GetTableRequest) {
         return mergeFrom((com.google.bigtable.admin.v2.GetTableRequest)other);
@@ -510,7 +570,7 @@ public  final class GetTableRequest extends
      * <code>optional .google.bigtable.admin.v2.Table.View view = 2;</code>
      */
     public com.google.bigtable.admin.v2.Table.View getView() {
-      com.google.bigtable.admin.v2.Table.View result = com.google.bigtable.admin.v2.Table.View.forNumber(view_);
+      com.google.bigtable.admin.v2.Table.View result = com.google.bigtable.admin.v2.Table.View.valueOf(view_);
       return result == null ? com.google.bigtable.admin.v2.Table.View.UNRECOGNIZED : result;
     }
     /**

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/Instance.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/Instance.java
@@ -14,11 +14,11 @@ package com.google.bigtable.admin.v2;
  * Protobuf type {@code google.bigtable.admin.v2.Instance}
  */
 public  final class Instance extends
-    com.google.protobuf.GeneratedMessage implements
+    com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:google.bigtable.admin.v2.Instance)
     InstanceOrBuilder {
   // Use Instance.newBuilder() to construct.
-  private Instance(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+  private Instance(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private Instance() {
@@ -86,7 +86,7 @@ public  final class Instance extends
     return com.google.bigtable.admin.v2.InstanceProto.internal_static_google_bigtable_admin_v2_Instance_descriptor;
   }
 
-  protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.google.bigtable.admin.v2.InstanceProto.internal_static_google_bigtable_admin_v2_Instance_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
@@ -344,7 +344,7 @@ public  final class Instance extends
    * <code>optional .google.bigtable.admin.v2.Instance.State state = 3;</code>
    */
   public com.google.bigtable.admin.v2.Instance.State getState() {
-    com.google.bigtable.admin.v2.Instance.State result = com.google.bigtable.admin.v2.Instance.State.forNumber(state_);
+    com.google.bigtable.admin.v2.Instance.State result = com.google.bigtable.admin.v2.Instance.State.valueOf(state_);
     return result == null ? com.google.bigtable.admin.v2.Instance.State.UNRECOGNIZED : result;
   }
 
@@ -361,10 +361,10 @@ public  final class Instance extends
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
     if (!getNameBytes().isEmpty()) {
-      com.google.protobuf.GeneratedMessage.writeString(output, 1, name_);
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 1, name_);
     }
     if (!getDisplayNameBytes().isEmpty()) {
-      com.google.protobuf.GeneratedMessage.writeString(output, 2, displayName_);
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 2, displayName_);
     }
     if (state_ != com.google.bigtable.admin.v2.Instance.State.STATE_NOT_KNOWN.getNumber()) {
       output.writeEnum(3, state_);
@@ -377,10 +377,10 @@ public  final class Instance extends
 
     size = 0;
     if (!getNameBytes().isEmpty()) {
-      size += com.google.protobuf.GeneratedMessage.computeStringSize(1, name_);
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, name_);
     }
     if (!getDisplayNameBytes().isEmpty()) {
-      size += com.google.protobuf.GeneratedMessage.computeStringSize(2, displayName_);
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, displayName_);
     }
     if (state_ != com.google.bigtable.admin.v2.Instance.State.STATE_NOT_KNOWN.getNumber()) {
       size += com.google.protobuf.CodedOutputStream
@@ -391,6 +391,43 @@ public  final class Instance extends
   }
 
   private static final long serialVersionUID = 0L;
+  @java.lang.Override
+  public boolean equals(final java.lang.Object obj) {
+    if (obj == this) {
+     return true;
+    }
+    if (!(obj instanceof com.google.bigtable.admin.v2.Instance)) {
+      return super.equals(obj);
+    }
+    com.google.bigtable.admin.v2.Instance other = (com.google.bigtable.admin.v2.Instance) obj;
+
+    boolean result = true;
+    result = result && getName()
+        .equals(other.getName());
+    result = result && getDisplayName()
+        .equals(other.getDisplayName());
+    result = result && state_ == other.state_;
+    return result;
+  }
+
+  @java.lang.Override
+  public int hashCode() {
+    if (memoizedHashCode != 0) {
+      return memoizedHashCode;
+    }
+    int hash = 41;
+    hash = (19 * hash) + getDescriptorForType().hashCode();
+    hash = (37 * hash) + NAME_FIELD_NUMBER;
+    hash = (53 * hash) + getName().hashCode();
+    hash = (37 * hash) + DISPLAY_NAME_FIELD_NUMBER;
+    hash = (53 * hash) + getDisplayName().hashCode();
+    hash = (37 * hash) + STATE_FIELD_NUMBER;
+    hash = (53 * hash) + state_;
+    hash = (29 * hash) + unknownFields.hashCode();
+    memoizedHashCode = hash;
+    return hash;
+  }
+
   public static com.google.bigtable.admin.v2.Instance parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -414,39 +451,39 @@ public  final class Instance extends
   }
   public static com.google.bigtable.admin.v2.Instance parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.Instance parseFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.admin.v2.Instance parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.Instance parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.admin.v2.Instance parseFrom(
       com.google.protobuf.CodedInputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.Instance parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
@@ -464,7 +501,7 @@ public  final class Instance extends
 
   @java.lang.Override
   protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
@@ -479,7 +516,7 @@ public  final class Instance extends
    * Protobuf type {@code google.bigtable.admin.v2.Instance}
    */
   public static final class Builder extends
-      com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
       // @@protoc_insertion_point(builder_implements:google.bigtable.admin.v2.Instance)
       com.google.bigtable.admin.v2.InstanceOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
@@ -487,7 +524,7 @@ public  final class Instance extends
       return com.google.bigtable.admin.v2.InstanceProto.internal_static_google_bigtable_admin_v2_Instance_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.bigtable.admin.v2.InstanceProto.internal_static_google_bigtable_admin_v2_Instance_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -500,12 +537,13 @@ public  final class Instance extends
     }
 
     private Builder(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
       }
     }
     public Builder clear() {
@@ -545,6 +583,32 @@ public  final class Instance extends
       return result;
     }
 
+    public Builder clone() {
+      return (Builder) super.clone();
+    }
+    public Builder setField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.setField(field, value);
+    }
+    public Builder clearField(
+        com.google.protobuf.Descriptors.FieldDescriptor field) {
+      return (Builder) super.clearField(field);
+    }
+    public Builder clearOneof(
+        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      return (Builder) super.clearOneof(oneof);
+    }
+    public Builder setRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        int index, Object value) {
+      return (Builder) super.setRepeatedField(field, index, value);
+    }
+    public Builder addRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.addRepeatedField(field, value);
+    }
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.bigtable.admin.v2.Instance) {
         return mergeFrom((com.google.bigtable.admin.v2.Instance)other);
@@ -822,7 +886,7 @@ public  final class Instance extends
      * <code>optional .google.bigtable.admin.v2.Instance.State state = 3;</code>
      */
     public com.google.bigtable.admin.v2.Instance.State getState() {
-      com.google.bigtable.admin.v2.Instance.State result = com.google.bigtable.admin.v2.Instance.State.forNumber(state_);
+      com.google.bigtable.admin.v2.Instance.State result = com.google.bigtable.admin.v2.Instance.State.valueOf(state_);
       return result == null ? com.google.bigtable.admin.v2.Instance.State.UNRECOGNIZED : result;
     }
     /**

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/InstanceProto.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/InstanceProto.java
@@ -6,17 +6,23 @@ package com.google.bigtable.admin.v2;
 public final class InstanceProto {
   private InstanceProto() {}
   public static void registerAllExtensions(
+      com.google.protobuf.ExtensionRegistryLite registry) {
+  }
+
+  public static void registerAllExtensions(
       com.google.protobuf.ExtensionRegistry registry) {
+    registerAllExtensions(
+        (com.google.protobuf.ExtensionRegistryLite) registry);
   }
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_bigtable_admin_v2_Instance_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_bigtable_admin_v2_Instance_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_bigtable_admin_v2_Cluster_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_bigtable_admin_v2_Cluster_fieldAccessorTable;
 
   public static com.google.protobuf.Descriptors.FileDescriptor
@@ -61,13 +67,13 @@ public final class InstanceProto {
     internal_static_google_bigtable_admin_v2_Instance_descriptor =
       getDescriptor().getMessageTypes().get(0);
     internal_static_google_bigtable_admin_v2_Instance_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_bigtable_admin_v2_Instance_descriptor,
         new java.lang.String[] { "Name", "DisplayName", "State", });
     internal_static_google_bigtable_admin_v2_Cluster_descriptor =
       getDescriptor().getMessageTypes().get(1);
     internal_static_google_bigtable_admin_v2_Cluster_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_bigtable_admin_v2_Cluster_descriptor,
         new java.lang.String[] { "Name", "Location", "State", "ServeNodes", "DefaultStorageType", });
     com.google.api.AnnotationsProto.getDescriptor();

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/ListClustersRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/ListClustersRequest.java
@@ -11,11 +11,11 @@ package com.google.bigtable.admin.v2;
  * Protobuf type {@code google.bigtable.admin.v2.ListClustersRequest}
  */
 public  final class ListClustersRequest extends
-    com.google.protobuf.GeneratedMessage implements
+    com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:google.bigtable.admin.v2.ListClustersRequest)
     ListClustersRequestOrBuilder {
   // Use ListClustersRequest.newBuilder() to construct.
-  private ListClustersRequest(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+  private ListClustersRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private ListClustersRequest() {
@@ -76,7 +76,7 @@ public  final class ListClustersRequest extends
     return com.google.bigtable.admin.v2.BigtableInstanceAdminProto.internal_static_google_bigtable_admin_v2_ListClustersRequest_descriptor;
   }
 
-  protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.google.bigtable.admin.v2.BigtableInstanceAdminProto.internal_static_google_bigtable_admin_v2_ListClustersRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
@@ -186,10 +186,10 @@ public  final class ListClustersRequest extends
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
     if (!getParentBytes().isEmpty()) {
-      com.google.protobuf.GeneratedMessage.writeString(output, 1, parent_);
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 1, parent_);
     }
     if (!getPageTokenBytes().isEmpty()) {
-      com.google.protobuf.GeneratedMessage.writeString(output, 2, pageToken_);
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 2, pageToken_);
     }
   }
 
@@ -199,16 +199,50 @@ public  final class ListClustersRequest extends
 
     size = 0;
     if (!getParentBytes().isEmpty()) {
-      size += com.google.protobuf.GeneratedMessage.computeStringSize(1, parent_);
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, parent_);
     }
     if (!getPageTokenBytes().isEmpty()) {
-      size += com.google.protobuf.GeneratedMessage.computeStringSize(2, pageToken_);
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, pageToken_);
     }
     memoizedSize = size;
     return size;
   }
 
   private static final long serialVersionUID = 0L;
+  @java.lang.Override
+  public boolean equals(final java.lang.Object obj) {
+    if (obj == this) {
+     return true;
+    }
+    if (!(obj instanceof com.google.bigtable.admin.v2.ListClustersRequest)) {
+      return super.equals(obj);
+    }
+    com.google.bigtable.admin.v2.ListClustersRequest other = (com.google.bigtable.admin.v2.ListClustersRequest) obj;
+
+    boolean result = true;
+    result = result && getParent()
+        .equals(other.getParent());
+    result = result && getPageToken()
+        .equals(other.getPageToken());
+    return result;
+  }
+
+  @java.lang.Override
+  public int hashCode() {
+    if (memoizedHashCode != 0) {
+      return memoizedHashCode;
+    }
+    int hash = 41;
+    hash = (19 * hash) + getDescriptorForType().hashCode();
+    hash = (37 * hash) + PARENT_FIELD_NUMBER;
+    hash = (53 * hash) + getParent().hashCode();
+    hash = (37 * hash) + PAGE_TOKEN_FIELD_NUMBER;
+    hash = (53 * hash) + getPageToken().hashCode();
+    hash = (29 * hash) + unknownFields.hashCode();
+    memoizedHashCode = hash;
+    return hash;
+  }
+
   public static com.google.bigtable.admin.v2.ListClustersRequest parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -232,39 +266,39 @@ public  final class ListClustersRequest extends
   }
   public static com.google.bigtable.admin.v2.ListClustersRequest parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.ListClustersRequest parseFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.admin.v2.ListClustersRequest parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.ListClustersRequest parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.admin.v2.ListClustersRequest parseFrom(
       com.google.protobuf.CodedInputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.ListClustersRequest parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
@@ -282,7 +316,7 @@ public  final class ListClustersRequest extends
 
   @java.lang.Override
   protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
@@ -294,7 +328,7 @@ public  final class ListClustersRequest extends
    * Protobuf type {@code google.bigtable.admin.v2.ListClustersRequest}
    */
   public static final class Builder extends
-      com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
       // @@protoc_insertion_point(builder_implements:google.bigtable.admin.v2.ListClustersRequest)
       com.google.bigtable.admin.v2.ListClustersRequestOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
@@ -302,7 +336,7 @@ public  final class ListClustersRequest extends
       return com.google.bigtable.admin.v2.BigtableInstanceAdminProto.internal_static_google_bigtable_admin_v2_ListClustersRequest_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.bigtable.admin.v2.BigtableInstanceAdminProto.internal_static_google_bigtable_admin_v2_ListClustersRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -315,12 +349,13 @@ public  final class ListClustersRequest extends
     }
 
     private Builder(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
       }
     }
     public Builder clear() {
@@ -357,6 +392,32 @@ public  final class ListClustersRequest extends
       return result;
     }
 
+    public Builder clone() {
+      return (Builder) super.clone();
+    }
+    public Builder setField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.setField(field, value);
+    }
+    public Builder clearField(
+        com.google.protobuf.Descriptors.FieldDescriptor field) {
+      return (Builder) super.clearField(field);
+    }
+    public Builder clearOneof(
+        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      return (Builder) super.clearOneof(oneof);
+    }
+    public Builder setRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        int index, Object value) {
+      return (Builder) super.setRepeatedField(field, index, value);
+    }
+    public Builder addRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.addRepeatedField(field, value);
+    }
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.bigtable.admin.v2.ListClustersRequest) {
         return mergeFrom((com.google.bigtable.admin.v2.ListClustersRequest)other);

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/ListClustersResponse.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/ListClustersResponse.java
@@ -11,11 +11,11 @@ package com.google.bigtable.admin.v2;
  * Protobuf type {@code google.bigtable.admin.v2.ListClustersResponse}
  */
 public  final class ListClustersResponse extends
-    com.google.protobuf.GeneratedMessage implements
+    com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:google.bigtable.admin.v2.ListClustersResponse)
     ListClustersResponseOrBuilder {
   // Use ListClustersResponse.newBuilder() to construct.
-  private ListClustersResponse(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+  private ListClustersResponse(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private ListClustersResponse() {
@@ -54,7 +54,8 @@ public  final class ListClustersResponse extends
               clusters_ = new java.util.ArrayList<com.google.bigtable.admin.v2.Cluster>();
               mutable_bitField0_ |= 0x00000001;
             }
-            clusters_.add(input.readMessage(com.google.bigtable.admin.v2.Cluster.parser(), extensionRegistry));
+            clusters_.add(
+                input.readMessage(com.google.bigtable.admin.v2.Cluster.parser(), extensionRegistry));
             break;
           }
           case 18: {
@@ -94,7 +95,7 @@ public  final class ListClustersResponse extends
     return com.google.bigtable.admin.v2.BigtableInstanceAdminProto.internal_static_google_bigtable_admin_v2_ListClustersResponse_descriptor;
   }
 
-  protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.google.bigtable.admin.v2.BigtableInstanceAdminProto.internal_static_google_bigtable_admin_v2_ListClustersResponse_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
@@ -276,10 +277,10 @@ public  final class ListClustersResponse extends
       output.writeMessage(1, clusters_.get(i));
     }
     for (int i = 0; i < failedLocations_.size(); i++) {
-      com.google.protobuf.GeneratedMessage.writeString(output, 2, failedLocations_.getRaw(i));
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 2, failedLocations_.getRaw(i));
     }
     if (!getNextPageTokenBytes().isEmpty()) {
-      com.google.protobuf.GeneratedMessage.writeString(output, 3, nextPageToken_);
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 3, nextPageToken_);
     }
   }
 
@@ -301,13 +302,55 @@ public  final class ListClustersResponse extends
       size += 1 * getFailedLocationsList().size();
     }
     if (!getNextPageTokenBytes().isEmpty()) {
-      size += com.google.protobuf.GeneratedMessage.computeStringSize(3, nextPageToken_);
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, nextPageToken_);
     }
     memoizedSize = size;
     return size;
   }
 
   private static final long serialVersionUID = 0L;
+  @java.lang.Override
+  public boolean equals(final java.lang.Object obj) {
+    if (obj == this) {
+     return true;
+    }
+    if (!(obj instanceof com.google.bigtable.admin.v2.ListClustersResponse)) {
+      return super.equals(obj);
+    }
+    com.google.bigtable.admin.v2.ListClustersResponse other = (com.google.bigtable.admin.v2.ListClustersResponse) obj;
+
+    boolean result = true;
+    result = result && getClustersList()
+        .equals(other.getClustersList());
+    result = result && getFailedLocationsList()
+        .equals(other.getFailedLocationsList());
+    result = result && getNextPageToken()
+        .equals(other.getNextPageToken());
+    return result;
+  }
+
+  @java.lang.Override
+  public int hashCode() {
+    if (memoizedHashCode != 0) {
+      return memoizedHashCode;
+    }
+    int hash = 41;
+    hash = (19 * hash) + getDescriptorForType().hashCode();
+    if (getClustersCount() > 0) {
+      hash = (37 * hash) + CLUSTERS_FIELD_NUMBER;
+      hash = (53 * hash) + getClustersList().hashCode();
+    }
+    if (getFailedLocationsCount() > 0) {
+      hash = (37 * hash) + FAILED_LOCATIONS_FIELD_NUMBER;
+      hash = (53 * hash) + getFailedLocationsList().hashCode();
+    }
+    hash = (37 * hash) + NEXT_PAGE_TOKEN_FIELD_NUMBER;
+    hash = (53 * hash) + getNextPageToken().hashCode();
+    hash = (29 * hash) + unknownFields.hashCode();
+    memoizedHashCode = hash;
+    return hash;
+  }
+
   public static com.google.bigtable.admin.v2.ListClustersResponse parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -331,39 +374,39 @@ public  final class ListClustersResponse extends
   }
   public static com.google.bigtable.admin.v2.ListClustersResponse parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.ListClustersResponse parseFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.admin.v2.ListClustersResponse parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.ListClustersResponse parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.admin.v2.ListClustersResponse parseFrom(
       com.google.protobuf.CodedInputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.ListClustersResponse parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
@@ -381,7 +424,7 @@ public  final class ListClustersResponse extends
 
   @java.lang.Override
   protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
@@ -393,7 +436,7 @@ public  final class ListClustersResponse extends
    * Protobuf type {@code google.bigtable.admin.v2.ListClustersResponse}
    */
   public static final class Builder extends
-      com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
       // @@protoc_insertion_point(builder_implements:google.bigtable.admin.v2.ListClustersResponse)
       com.google.bigtable.admin.v2.ListClustersResponseOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
@@ -401,7 +444,7 @@ public  final class ListClustersResponse extends
       return com.google.bigtable.admin.v2.BigtableInstanceAdminProto.internal_static_google_bigtable_admin_v2_ListClustersResponse_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.bigtable.admin.v2.BigtableInstanceAdminProto.internal_static_google_bigtable_admin_v2_ListClustersResponse_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -414,12 +457,13 @@ public  final class ListClustersResponse extends
     }
 
     private Builder(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
         getClustersFieldBuilder();
       }
     }
@@ -479,6 +523,32 @@ public  final class ListClustersResponse extends
       return result;
     }
 
+    public Builder clone() {
+      return (Builder) super.clone();
+    }
+    public Builder setField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.setField(field, value);
+    }
+    public Builder clearField(
+        com.google.protobuf.Descriptors.FieldDescriptor field) {
+      return (Builder) super.clearField(field);
+    }
+    public Builder clearOneof(
+        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      return (Builder) super.clearOneof(oneof);
+    }
+    public Builder setRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        int index, Object value) {
+      return (Builder) super.setRepeatedField(field, index, value);
+    }
+    public Builder addRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.addRepeatedField(field, value);
+    }
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.bigtable.admin.v2.ListClustersResponse) {
         return mergeFrom((com.google.bigtable.admin.v2.ListClustersResponse)other);
@@ -509,7 +579,7 @@ public  final class ListClustersResponse extends
             clusters_ = other.clusters_;
             bitField0_ = (bitField0_ & ~0x00000001);
             clustersBuilder_ = 
-              com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+              com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
                  getClustersFieldBuilder() : null;
           } else {
             clustersBuilder_.addAllMessages(other.clusters_);
@@ -566,7 +636,7 @@ public  final class ListClustersResponse extends
        }
     }
 
-    private com.google.protobuf.RepeatedFieldBuilder<
+    private com.google.protobuf.RepeatedFieldBuilderV3<
         com.google.bigtable.admin.v2.Cluster, com.google.bigtable.admin.v2.Cluster.Builder, com.google.bigtable.admin.v2.ClusterOrBuilder> clustersBuilder_;
 
     /**
@@ -854,11 +924,11 @@ public  final class ListClustersResponse extends
          getClustersBuilderList() {
       return getClustersFieldBuilder().getBuilderList();
     }
-    private com.google.protobuf.RepeatedFieldBuilder<
+    private com.google.protobuf.RepeatedFieldBuilderV3<
         com.google.bigtable.admin.v2.Cluster, com.google.bigtable.admin.v2.Cluster.Builder, com.google.bigtable.admin.v2.ClusterOrBuilder> 
         getClustersFieldBuilder() {
       if (clustersBuilder_ == null) {
-        clustersBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
+        clustersBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
             com.google.bigtable.admin.v2.Cluster, com.google.bigtable.admin.v2.Cluster.Builder, com.google.bigtable.admin.v2.ClusterOrBuilder>(
                 clusters_,
                 ((bitField0_ & 0x00000001) == 0x00000001),

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/ListClustersResponseOrBuilder.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/ListClustersResponseOrBuilder.java
@@ -61,7 +61,7 @@ public interface ListClustersResponseOrBuilder extends
    *
    * <code>repeated string failed_locations = 2;</code>
    */
-  com.google.protobuf.ProtocolStringList
+  java.util.List<java.lang.String>
       getFailedLocationsList();
   /**
    * <pre>

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/ListInstancesRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/ListInstancesRequest.java
@@ -11,11 +11,11 @@ package com.google.bigtable.admin.v2;
  * Protobuf type {@code google.bigtable.admin.v2.ListInstancesRequest}
  */
 public  final class ListInstancesRequest extends
-    com.google.protobuf.GeneratedMessage implements
+    com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:google.bigtable.admin.v2.ListInstancesRequest)
     ListInstancesRequestOrBuilder {
   // Use ListInstancesRequest.newBuilder() to construct.
-  private ListInstancesRequest(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+  private ListInstancesRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private ListInstancesRequest() {
@@ -76,7 +76,7 @@ public  final class ListInstancesRequest extends
     return com.google.bigtable.admin.v2.BigtableInstanceAdminProto.internal_static_google_bigtable_admin_v2_ListInstancesRequest_descriptor;
   }
 
-  protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.google.bigtable.admin.v2.BigtableInstanceAdminProto.internal_static_google_bigtable_admin_v2_ListInstancesRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
@@ -182,10 +182,10 @@ public  final class ListInstancesRequest extends
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
     if (!getParentBytes().isEmpty()) {
-      com.google.protobuf.GeneratedMessage.writeString(output, 1, parent_);
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 1, parent_);
     }
     if (!getPageTokenBytes().isEmpty()) {
-      com.google.protobuf.GeneratedMessage.writeString(output, 2, pageToken_);
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 2, pageToken_);
     }
   }
 
@@ -195,16 +195,50 @@ public  final class ListInstancesRequest extends
 
     size = 0;
     if (!getParentBytes().isEmpty()) {
-      size += com.google.protobuf.GeneratedMessage.computeStringSize(1, parent_);
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, parent_);
     }
     if (!getPageTokenBytes().isEmpty()) {
-      size += com.google.protobuf.GeneratedMessage.computeStringSize(2, pageToken_);
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, pageToken_);
     }
     memoizedSize = size;
     return size;
   }
 
   private static final long serialVersionUID = 0L;
+  @java.lang.Override
+  public boolean equals(final java.lang.Object obj) {
+    if (obj == this) {
+     return true;
+    }
+    if (!(obj instanceof com.google.bigtable.admin.v2.ListInstancesRequest)) {
+      return super.equals(obj);
+    }
+    com.google.bigtable.admin.v2.ListInstancesRequest other = (com.google.bigtable.admin.v2.ListInstancesRequest) obj;
+
+    boolean result = true;
+    result = result && getParent()
+        .equals(other.getParent());
+    result = result && getPageToken()
+        .equals(other.getPageToken());
+    return result;
+  }
+
+  @java.lang.Override
+  public int hashCode() {
+    if (memoizedHashCode != 0) {
+      return memoizedHashCode;
+    }
+    int hash = 41;
+    hash = (19 * hash) + getDescriptorForType().hashCode();
+    hash = (37 * hash) + PARENT_FIELD_NUMBER;
+    hash = (53 * hash) + getParent().hashCode();
+    hash = (37 * hash) + PAGE_TOKEN_FIELD_NUMBER;
+    hash = (53 * hash) + getPageToken().hashCode();
+    hash = (29 * hash) + unknownFields.hashCode();
+    memoizedHashCode = hash;
+    return hash;
+  }
+
   public static com.google.bigtable.admin.v2.ListInstancesRequest parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -228,39 +262,39 @@ public  final class ListInstancesRequest extends
   }
   public static com.google.bigtable.admin.v2.ListInstancesRequest parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.ListInstancesRequest parseFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.admin.v2.ListInstancesRequest parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.ListInstancesRequest parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.admin.v2.ListInstancesRequest parseFrom(
       com.google.protobuf.CodedInputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.ListInstancesRequest parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
@@ -278,7 +312,7 @@ public  final class ListInstancesRequest extends
 
   @java.lang.Override
   protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
@@ -290,7 +324,7 @@ public  final class ListInstancesRequest extends
    * Protobuf type {@code google.bigtable.admin.v2.ListInstancesRequest}
    */
   public static final class Builder extends
-      com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
       // @@protoc_insertion_point(builder_implements:google.bigtable.admin.v2.ListInstancesRequest)
       com.google.bigtable.admin.v2.ListInstancesRequestOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
@@ -298,7 +332,7 @@ public  final class ListInstancesRequest extends
       return com.google.bigtable.admin.v2.BigtableInstanceAdminProto.internal_static_google_bigtable_admin_v2_ListInstancesRequest_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.bigtable.admin.v2.BigtableInstanceAdminProto.internal_static_google_bigtable_admin_v2_ListInstancesRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -311,12 +345,13 @@ public  final class ListInstancesRequest extends
     }
 
     private Builder(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
       }
     }
     public Builder clear() {
@@ -353,6 +388,32 @@ public  final class ListInstancesRequest extends
       return result;
     }
 
+    public Builder clone() {
+      return (Builder) super.clone();
+    }
+    public Builder setField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.setField(field, value);
+    }
+    public Builder clearField(
+        com.google.protobuf.Descriptors.FieldDescriptor field) {
+      return (Builder) super.clearField(field);
+    }
+    public Builder clearOneof(
+        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      return (Builder) super.clearOneof(oneof);
+    }
+    public Builder setRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        int index, Object value) {
+      return (Builder) super.setRepeatedField(field, index, value);
+    }
+    public Builder addRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.addRepeatedField(field, value);
+    }
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.bigtable.admin.v2.ListInstancesRequest) {
         return mergeFrom((com.google.bigtable.admin.v2.ListInstancesRequest)other);

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/ListInstancesResponse.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/ListInstancesResponse.java
@@ -11,11 +11,11 @@ package com.google.bigtable.admin.v2;
  * Protobuf type {@code google.bigtable.admin.v2.ListInstancesResponse}
  */
 public  final class ListInstancesResponse extends
-    com.google.protobuf.GeneratedMessage implements
+    com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:google.bigtable.admin.v2.ListInstancesResponse)
     ListInstancesResponseOrBuilder {
   // Use ListInstancesResponse.newBuilder() to construct.
-  private ListInstancesResponse(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+  private ListInstancesResponse(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private ListInstancesResponse() {
@@ -54,7 +54,8 @@ public  final class ListInstancesResponse extends
               instances_ = new java.util.ArrayList<com.google.bigtable.admin.v2.Instance>();
               mutable_bitField0_ |= 0x00000001;
             }
-            instances_.add(input.readMessage(com.google.bigtable.admin.v2.Instance.parser(), extensionRegistry));
+            instances_.add(
+                input.readMessage(com.google.bigtable.admin.v2.Instance.parser(), extensionRegistry));
             break;
           }
           case 18: {
@@ -94,7 +95,7 @@ public  final class ListInstancesResponse extends
     return com.google.bigtable.admin.v2.BigtableInstanceAdminProto.internal_static_google_bigtable_admin_v2_ListInstancesResponse_descriptor;
   }
 
-  protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.google.bigtable.admin.v2.BigtableInstanceAdminProto.internal_static_google_bigtable_admin_v2_ListInstancesResponse_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
@@ -280,10 +281,10 @@ public  final class ListInstancesResponse extends
       output.writeMessage(1, instances_.get(i));
     }
     for (int i = 0; i < failedLocations_.size(); i++) {
-      com.google.protobuf.GeneratedMessage.writeString(output, 2, failedLocations_.getRaw(i));
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 2, failedLocations_.getRaw(i));
     }
     if (!getNextPageTokenBytes().isEmpty()) {
-      com.google.protobuf.GeneratedMessage.writeString(output, 3, nextPageToken_);
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 3, nextPageToken_);
     }
   }
 
@@ -305,13 +306,55 @@ public  final class ListInstancesResponse extends
       size += 1 * getFailedLocationsList().size();
     }
     if (!getNextPageTokenBytes().isEmpty()) {
-      size += com.google.protobuf.GeneratedMessage.computeStringSize(3, nextPageToken_);
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, nextPageToken_);
     }
     memoizedSize = size;
     return size;
   }
 
   private static final long serialVersionUID = 0L;
+  @java.lang.Override
+  public boolean equals(final java.lang.Object obj) {
+    if (obj == this) {
+     return true;
+    }
+    if (!(obj instanceof com.google.bigtable.admin.v2.ListInstancesResponse)) {
+      return super.equals(obj);
+    }
+    com.google.bigtable.admin.v2.ListInstancesResponse other = (com.google.bigtable.admin.v2.ListInstancesResponse) obj;
+
+    boolean result = true;
+    result = result && getInstancesList()
+        .equals(other.getInstancesList());
+    result = result && getFailedLocationsList()
+        .equals(other.getFailedLocationsList());
+    result = result && getNextPageToken()
+        .equals(other.getNextPageToken());
+    return result;
+  }
+
+  @java.lang.Override
+  public int hashCode() {
+    if (memoizedHashCode != 0) {
+      return memoizedHashCode;
+    }
+    int hash = 41;
+    hash = (19 * hash) + getDescriptorForType().hashCode();
+    if (getInstancesCount() > 0) {
+      hash = (37 * hash) + INSTANCES_FIELD_NUMBER;
+      hash = (53 * hash) + getInstancesList().hashCode();
+    }
+    if (getFailedLocationsCount() > 0) {
+      hash = (37 * hash) + FAILED_LOCATIONS_FIELD_NUMBER;
+      hash = (53 * hash) + getFailedLocationsList().hashCode();
+    }
+    hash = (37 * hash) + NEXT_PAGE_TOKEN_FIELD_NUMBER;
+    hash = (53 * hash) + getNextPageToken().hashCode();
+    hash = (29 * hash) + unknownFields.hashCode();
+    memoizedHashCode = hash;
+    return hash;
+  }
+
   public static com.google.bigtable.admin.v2.ListInstancesResponse parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -335,39 +378,39 @@ public  final class ListInstancesResponse extends
   }
   public static com.google.bigtable.admin.v2.ListInstancesResponse parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.ListInstancesResponse parseFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.admin.v2.ListInstancesResponse parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.ListInstancesResponse parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.admin.v2.ListInstancesResponse parseFrom(
       com.google.protobuf.CodedInputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.ListInstancesResponse parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
@@ -385,7 +428,7 @@ public  final class ListInstancesResponse extends
 
   @java.lang.Override
   protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
@@ -397,7 +440,7 @@ public  final class ListInstancesResponse extends
    * Protobuf type {@code google.bigtable.admin.v2.ListInstancesResponse}
    */
   public static final class Builder extends
-      com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
       // @@protoc_insertion_point(builder_implements:google.bigtable.admin.v2.ListInstancesResponse)
       com.google.bigtable.admin.v2.ListInstancesResponseOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
@@ -405,7 +448,7 @@ public  final class ListInstancesResponse extends
       return com.google.bigtable.admin.v2.BigtableInstanceAdminProto.internal_static_google_bigtable_admin_v2_ListInstancesResponse_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.bigtable.admin.v2.BigtableInstanceAdminProto.internal_static_google_bigtable_admin_v2_ListInstancesResponse_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -418,12 +461,13 @@ public  final class ListInstancesResponse extends
     }
 
     private Builder(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
         getInstancesFieldBuilder();
       }
     }
@@ -483,6 +527,32 @@ public  final class ListInstancesResponse extends
       return result;
     }
 
+    public Builder clone() {
+      return (Builder) super.clone();
+    }
+    public Builder setField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.setField(field, value);
+    }
+    public Builder clearField(
+        com.google.protobuf.Descriptors.FieldDescriptor field) {
+      return (Builder) super.clearField(field);
+    }
+    public Builder clearOneof(
+        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      return (Builder) super.clearOneof(oneof);
+    }
+    public Builder setRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        int index, Object value) {
+      return (Builder) super.setRepeatedField(field, index, value);
+    }
+    public Builder addRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.addRepeatedField(field, value);
+    }
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.bigtable.admin.v2.ListInstancesResponse) {
         return mergeFrom((com.google.bigtable.admin.v2.ListInstancesResponse)other);
@@ -513,7 +583,7 @@ public  final class ListInstancesResponse extends
             instances_ = other.instances_;
             bitField0_ = (bitField0_ & ~0x00000001);
             instancesBuilder_ = 
-              com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+              com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
                  getInstancesFieldBuilder() : null;
           } else {
             instancesBuilder_.addAllMessages(other.instances_);
@@ -570,7 +640,7 @@ public  final class ListInstancesResponse extends
        }
     }
 
-    private com.google.protobuf.RepeatedFieldBuilder<
+    private com.google.protobuf.RepeatedFieldBuilderV3<
         com.google.bigtable.admin.v2.Instance, com.google.bigtable.admin.v2.Instance.Builder, com.google.bigtable.admin.v2.InstanceOrBuilder> instancesBuilder_;
 
     /**
@@ -858,11 +928,11 @@ public  final class ListInstancesResponse extends
          getInstancesBuilderList() {
       return getInstancesFieldBuilder().getBuilderList();
     }
-    private com.google.protobuf.RepeatedFieldBuilder<
+    private com.google.protobuf.RepeatedFieldBuilderV3<
         com.google.bigtable.admin.v2.Instance, com.google.bigtable.admin.v2.Instance.Builder, com.google.bigtable.admin.v2.InstanceOrBuilder> 
         getInstancesFieldBuilder() {
       if (instancesBuilder_ == null) {
-        instancesBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
+        instancesBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
             com.google.bigtable.admin.v2.Instance, com.google.bigtable.admin.v2.Instance.Builder, com.google.bigtable.admin.v2.InstanceOrBuilder>(
                 instances_,
                 ((bitField0_ & 0x00000001) == 0x00000001),

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/ListInstancesResponseOrBuilder.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/ListInstancesResponseOrBuilder.java
@@ -62,7 +62,7 @@ public interface ListInstancesResponseOrBuilder extends
    *
    * <code>repeated string failed_locations = 2;</code>
    */
-  com.google.protobuf.ProtocolStringList
+  java.util.List<java.lang.String>
       getFailedLocationsList();
   /**
    * <pre>

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/ListTablesRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/ListTablesRequest.java
@@ -11,11 +11,11 @@ package com.google.bigtable.admin.v2;
  * Protobuf type {@code google.bigtable.admin.v2.ListTablesRequest}
  */
 public  final class ListTablesRequest extends
-    com.google.protobuf.GeneratedMessage implements
+    com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:google.bigtable.admin.v2.ListTablesRequest)
     ListTablesRequestOrBuilder {
   // Use ListTablesRequest.newBuilder() to construct.
-  private ListTablesRequest(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+  private ListTablesRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private ListTablesRequest() {
@@ -83,7 +83,7 @@ public  final class ListTablesRequest extends
     return com.google.bigtable.admin.v2.BigtableTableAdminProto.internal_static_google_bigtable_admin_v2_ListTablesRequest_descriptor;
   }
 
-  protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.google.bigtable.admin.v2.BigtableTableAdminProto.internal_static_google_bigtable_admin_v2_ListTablesRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
@@ -156,7 +156,7 @@ public  final class ListTablesRequest extends
    * <code>optional .google.bigtable.admin.v2.Table.View view = 2;</code>
    */
   public com.google.bigtable.admin.v2.Table.View getView() {
-    com.google.bigtable.admin.v2.Table.View result = com.google.bigtable.admin.v2.Table.View.forNumber(view_);
+    com.google.bigtable.admin.v2.Table.View result = com.google.bigtable.admin.v2.Table.View.valueOf(view_);
     return result == null ? com.google.bigtable.admin.v2.Table.View.UNRECOGNIZED : result;
   }
 
@@ -215,13 +215,13 @@ public  final class ListTablesRequest extends
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
     if (!getParentBytes().isEmpty()) {
-      com.google.protobuf.GeneratedMessage.writeString(output, 1, parent_);
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 1, parent_);
     }
     if (view_ != com.google.bigtable.admin.v2.Table.View.VIEW_UNSPECIFIED.getNumber()) {
       output.writeEnum(2, view_);
     }
     if (!getPageTokenBytes().isEmpty()) {
-      com.google.protobuf.GeneratedMessage.writeString(output, 3, pageToken_);
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 3, pageToken_);
     }
   }
 
@@ -231,20 +231,57 @@ public  final class ListTablesRequest extends
 
     size = 0;
     if (!getParentBytes().isEmpty()) {
-      size += com.google.protobuf.GeneratedMessage.computeStringSize(1, parent_);
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, parent_);
     }
     if (view_ != com.google.bigtable.admin.v2.Table.View.VIEW_UNSPECIFIED.getNumber()) {
       size += com.google.protobuf.CodedOutputStream
         .computeEnumSize(2, view_);
     }
     if (!getPageTokenBytes().isEmpty()) {
-      size += com.google.protobuf.GeneratedMessage.computeStringSize(3, pageToken_);
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, pageToken_);
     }
     memoizedSize = size;
     return size;
   }
 
   private static final long serialVersionUID = 0L;
+  @java.lang.Override
+  public boolean equals(final java.lang.Object obj) {
+    if (obj == this) {
+     return true;
+    }
+    if (!(obj instanceof com.google.bigtable.admin.v2.ListTablesRequest)) {
+      return super.equals(obj);
+    }
+    com.google.bigtable.admin.v2.ListTablesRequest other = (com.google.bigtable.admin.v2.ListTablesRequest) obj;
+
+    boolean result = true;
+    result = result && getParent()
+        .equals(other.getParent());
+    result = result && view_ == other.view_;
+    result = result && getPageToken()
+        .equals(other.getPageToken());
+    return result;
+  }
+
+  @java.lang.Override
+  public int hashCode() {
+    if (memoizedHashCode != 0) {
+      return memoizedHashCode;
+    }
+    int hash = 41;
+    hash = (19 * hash) + getDescriptorForType().hashCode();
+    hash = (37 * hash) + PARENT_FIELD_NUMBER;
+    hash = (53 * hash) + getParent().hashCode();
+    hash = (37 * hash) + VIEW_FIELD_NUMBER;
+    hash = (53 * hash) + view_;
+    hash = (37 * hash) + PAGE_TOKEN_FIELD_NUMBER;
+    hash = (53 * hash) + getPageToken().hashCode();
+    hash = (29 * hash) + unknownFields.hashCode();
+    memoizedHashCode = hash;
+    return hash;
+  }
+
   public static com.google.bigtable.admin.v2.ListTablesRequest parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -268,39 +305,39 @@ public  final class ListTablesRequest extends
   }
   public static com.google.bigtable.admin.v2.ListTablesRequest parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.ListTablesRequest parseFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.admin.v2.ListTablesRequest parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.ListTablesRequest parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.admin.v2.ListTablesRequest parseFrom(
       com.google.protobuf.CodedInputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.ListTablesRequest parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
@@ -318,7 +355,7 @@ public  final class ListTablesRequest extends
 
   @java.lang.Override
   protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
@@ -330,7 +367,7 @@ public  final class ListTablesRequest extends
    * Protobuf type {@code google.bigtable.admin.v2.ListTablesRequest}
    */
   public static final class Builder extends
-      com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
       // @@protoc_insertion_point(builder_implements:google.bigtable.admin.v2.ListTablesRequest)
       com.google.bigtable.admin.v2.ListTablesRequestOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
@@ -338,7 +375,7 @@ public  final class ListTablesRequest extends
       return com.google.bigtable.admin.v2.BigtableTableAdminProto.internal_static_google_bigtable_admin_v2_ListTablesRequest_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.bigtable.admin.v2.BigtableTableAdminProto.internal_static_google_bigtable_admin_v2_ListTablesRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -351,12 +388,13 @@ public  final class ListTablesRequest extends
     }
 
     private Builder(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
       }
     }
     public Builder clear() {
@@ -396,6 +434,32 @@ public  final class ListTablesRequest extends
       return result;
     }
 
+    public Builder clone() {
+      return (Builder) super.clone();
+    }
+    public Builder setField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.setField(field, value);
+    }
+    public Builder clearField(
+        com.google.protobuf.Descriptors.FieldDescriptor field) {
+      return (Builder) super.clearField(field);
+    }
+    public Builder clearOneof(
+        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      return (Builder) super.clearOneof(oneof);
+    }
+    public Builder setRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        int index, Object value) {
+      return (Builder) super.setRepeatedField(field, index, value);
+    }
+    public Builder addRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.addRepeatedField(field, value);
+    }
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.bigtable.admin.v2.ListTablesRequest) {
         return mergeFrom((com.google.bigtable.admin.v2.ListTablesRequest)other);
@@ -572,7 +636,7 @@ public  final class ListTablesRequest extends
      * <code>optional .google.bigtable.admin.v2.Table.View view = 2;</code>
      */
     public com.google.bigtable.admin.v2.Table.View getView() {
-      com.google.bigtable.admin.v2.Table.View result = com.google.bigtable.admin.v2.Table.View.forNumber(view_);
+      com.google.bigtable.admin.v2.Table.View result = com.google.bigtable.admin.v2.Table.View.valueOf(view_);
       return result == null ? com.google.bigtable.admin.v2.Table.View.UNRECOGNIZED : result;
     }
     /**

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/ListTablesResponse.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/ListTablesResponse.java
@@ -11,11 +11,11 @@ package com.google.bigtable.admin.v2;
  * Protobuf type {@code google.bigtable.admin.v2.ListTablesResponse}
  */
 public  final class ListTablesResponse extends
-    com.google.protobuf.GeneratedMessage implements
+    com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:google.bigtable.admin.v2.ListTablesResponse)
     ListTablesResponseOrBuilder {
   // Use ListTablesResponse.newBuilder() to construct.
-  private ListTablesResponse(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+  private ListTablesResponse(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private ListTablesResponse() {
@@ -53,7 +53,8 @@ public  final class ListTablesResponse extends
               tables_ = new java.util.ArrayList<com.google.bigtable.admin.v2.Table>();
               mutable_bitField0_ |= 0x00000001;
             }
-            tables_.add(input.readMessage(com.google.bigtable.admin.v2.Table.parser(), extensionRegistry));
+            tables_.add(
+                input.readMessage(com.google.bigtable.admin.v2.Table.parser(), extensionRegistry));
             break;
           }
           case 18: {
@@ -81,7 +82,7 @@ public  final class ListTablesResponse extends
     return com.google.bigtable.admin.v2.BigtableTableAdminProto.internal_static_google_bigtable_admin_v2_ListTablesResponse_descriptor;
   }
 
-  protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.google.bigtable.admin.v2.BigtableTableAdminProto.internal_static_google_bigtable_admin_v2_ListTablesResponse_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
@@ -206,7 +207,7 @@ public  final class ListTablesResponse extends
       output.writeMessage(1, tables_.get(i));
     }
     if (!getNextPageTokenBytes().isEmpty()) {
-      com.google.protobuf.GeneratedMessage.writeString(output, 2, nextPageToken_);
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 2, nextPageToken_);
     }
   }
 
@@ -220,13 +221,49 @@ public  final class ListTablesResponse extends
         .computeMessageSize(1, tables_.get(i));
     }
     if (!getNextPageTokenBytes().isEmpty()) {
-      size += com.google.protobuf.GeneratedMessage.computeStringSize(2, nextPageToken_);
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, nextPageToken_);
     }
     memoizedSize = size;
     return size;
   }
 
   private static final long serialVersionUID = 0L;
+  @java.lang.Override
+  public boolean equals(final java.lang.Object obj) {
+    if (obj == this) {
+     return true;
+    }
+    if (!(obj instanceof com.google.bigtable.admin.v2.ListTablesResponse)) {
+      return super.equals(obj);
+    }
+    com.google.bigtable.admin.v2.ListTablesResponse other = (com.google.bigtable.admin.v2.ListTablesResponse) obj;
+
+    boolean result = true;
+    result = result && getTablesList()
+        .equals(other.getTablesList());
+    result = result && getNextPageToken()
+        .equals(other.getNextPageToken());
+    return result;
+  }
+
+  @java.lang.Override
+  public int hashCode() {
+    if (memoizedHashCode != 0) {
+      return memoizedHashCode;
+    }
+    int hash = 41;
+    hash = (19 * hash) + getDescriptorForType().hashCode();
+    if (getTablesCount() > 0) {
+      hash = (37 * hash) + TABLES_FIELD_NUMBER;
+      hash = (53 * hash) + getTablesList().hashCode();
+    }
+    hash = (37 * hash) + NEXT_PAGE_TOKEN_FIELD_NUMBER;
+    hash = (53 * hash) + getNextPageToken().hashCode();
+    hash = (29 * hash) + unknownFields.hashCode();
+    memoizedHashCode = hash;
+    return hash;
+  }
+
   public static com.google.bigtable.admin.v2.ListTablesResponse parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -250,39 +287,39 @@ public  final class ListTablesResponse extends
   }
   public static com.google.bigtable.admin.v2.ListTablesResponse parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.ListTablesResponse parseFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.admin.v2.ListTablesResponse parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.ListTablesResponse parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.admin.v2.ListTablesResponse parseFrom(
       com.google.protobuf.CodedInputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.ListTablesResponse parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
@@ -300,7 +337,7 @@ public  final class ListTablesResponse extends
 
   @java.lang.Override
   protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
@@ -312,7 +349,7 @@ public  final class ListTablesResponse extends
    * Protobuf type {@code google.bigtable.admin.v2.ListTablesResponse}
    */
   public static final class Builder extends
-      com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
       // @@protoc_insertion_point(builder_implements:google.bigtable.admin.v2.ListTablesResponse)
       com.google.bigtable.admin.v2.ListTablesResponseOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
@@ -320,7 +357,7 @@ public  final class ListTablesResponse extends
       return com.google.bigtable.admin.v2.BigtableTableAdminProto.internal_static_google_bigtable_admin_v2_ListTablesResponse_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.bigtable.admin.v2.BigtableTableAdminProto.internal_static_google_bigtable_admin_v2_ListTablesResponse_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -333,12 +370,13 @@ public  final class ListTablesResponse extends
     }
 
     private Builder(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
         getTablesFieldBuilder();
       }
     }
@@ -391,6 +429,32 @@ public  final class ListTablesResponse extends
       return result;
     }
 
+    public Builder clone() {
+      return (Builder) super.clone();
+    }
+    public Builder setField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.setField(field, value);
+    }
+    public Builder clearField(
+        com.google.protobuf.Descriptors.FieldDescriptor field) {
+      return (Builder) super.clearField(field);
+    }
+    public Builder clearOneof(
+        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      return (Builder) super.clearOneof(oneof);
+    }
+    public Builder setRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        int index, Object value) {
+      return (Builder) super.setRepeatedField(field, index, value);
+    }
+    public Builder addRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.addRepeatedField(field, value);
+    }
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.bigtable.admin.v2.ListTablesResponse) {
         return mergeFrom((com.google.bigtable.admin.v2.ListTablesResponse)other);
@@ -421,7 +485,7 @@ public  final class ListTablesResponse extends
             tables_ = other.tables_;
             bitField0_ = (bitField0_ & ~0x00000001);
             tablesBuilder_ = 
-              com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+              com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
                  getTablesFieldBuilder() : null;
           } else {
             tablesBuilder_.addAllMessages(other.tables_);
@@ -468,7 +532,7 @@ public  final class ListTablesResponse extends
        }
     }
 
-    private com.google.protobuf.RepeatedFieldBuilder<
+    private com.google.protobuf.RepeatedFieldBuilderV3<
         com.google.bigtable.admin.v2.Table, com.google.bigtable.admin.v2.Table.Builder, com.google.bigtable.admin.v2.TableOrBuilder> tablesBuilder_;
 
     /**
@@ -756,11 +820,11 @@ public  final class ListTablesResponse extends
          getTablesBuilderList() {
       return getTablesFieldBuilder().getBuilderList();
     }
-    private com.google.protobuf.RepeatedFieldBuilder<
+    private com.google.protobuf.RepeatedFieldBuilderV3<
         com.google.bigtable.admin.v2.Table, com.google.bigtable.admin.v2.Table.Builder, com.google.bigtable.admin.v2.TableOrBuilder> 
         getTablesFieldBuilder() {
       if (tablesBuilder_ == null) {
-        tablesBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
+        tablesBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
             com.google.bigtable.admin.v2.Table, com.google.bigtable.admin.v2.Table.Builder, com.google.bigtable.admin.v2.TableOrBuilder>(
                 tables_,
                 ((bitField0_ & 0x00000001) == 0x00000001),

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/ModifyColumnFamiliesRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/ModifyColumnFamiliesRequest.java
@@ -11,11 +11,11 @@ package com.google.bigtable.admin.v2;
  * Protobuf type {@code google.bigtable.admin.v2.ModifyColumnFamiliesRequest}
  */
 public  final class ModifyColumnFamiliesRequest extends
-    com.google.protobuf.GeneratedMessage implements
+    com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:google.bigtable.admin.v2.ModifyColumnFamiliesRequest)
     ModifyColumnFamiliesRequestOrBuilder {
   // Use ModifyColumnFamiliesRequest.newBuilder() to construct.
-  private ModifyColumnFamiliesRequest(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+  private ModifyColumnFamiliesRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private ModifyColumnFamiliesRequest() {
@@ -59,7 +59,8 @@ public  final class ModifyColumnFamiliesRequest extends
               modifications_ = new java.util.ArrayList<com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest.Modification>();
               mutable_bitField0_ |= 0x00000002;
             }
-            modifications_.add(input.readMessage(com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest.Modification.parser(), extensionRegistry));
+            modifications_.add(
+                input.readMessage(com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest.Modification.parser(), extensionRegistry));
             break;
           }
         }
@@ -81,7 +82,7 @@ public  final class ModifyColumnFamiliesRequest extends
     return com.google.bigtable.admin.v2.BigtableTableAdminProto.internal_static_google_bigtable_admin_v2_ModifyColumnFamiliesRequest_descriptor;
   }
 
-  protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.google.bigtable.admin.v2.BigtableTableAdminProto.internal_static_google_bigtable_admin_v2_ModifyColumnFamiliesRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
@@ -168,11 +169,11 @@ public  final class ModifyColumnFamiliesRequest extends
    * Protobuf type {@code google.bigtable.admin.v2.ModifyColumnFamiliesRequest.Modification}
    */
   public  static final class Modification extends
-      com.google.protobuf.GeneratedMessage implements
+      com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:google.bigtable.admin.v2.ModifyColumnFamiliesRequest.Modification)
       ModificationOrBuilder {
     // Use Modification.newBuilder() to construct.
-    private Modification(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+    private Modification(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
     }
     private Modification() {
@@ -259,7 +260,7 @@ public  final class ModifyColumnFamiliesRequest extends
       return com.google.bigtable.admin.v2.BigtableTableAdminProto.internal_static_google_bigtable_admin_v2_ModifyColumnFamiliesRequest_Modification_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.bigtable.admin.v2.BigtableTableAdminProto.internal_static_google_bigtable_admin_v2_ModifyColumnFamiliesRequest_Modification_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -437,7 +438,7 @@ public  final class ModifyColumnFamiliesRequest extends
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (!getIdBytes().isEmpty()) {
-        com.google.protobuf.GeneratedMessage.writeString(output, 1, id_);
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, id_);
       }
       if (modCase_ == 2) {
         output.writeMessage(2, (com.google.bigtable.admin.v2.ColumnFamily) mod_);
@@ -457,7 +458,7 @@ public  final class ModifyColumnFamiliesRequest extends
 
       size = 0;
       if (!getIdBytes().isEmpty()) {
-        size += com.google.protobuf.GeneratedMessage.computeStringSize(1, id_);
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, id_);
       }
       if (modCase_ == 2) {
         size += com.google.protobuf.CodedOutputStream
@@ -477,6 +478,72 @@ public  final class ModifyColumnFamiliesRequest extends
     }
 
     private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest.Modification)) {
+        return super.equals(obj);
+      }
+      com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest.Modification other = (com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest.Modification) obj;
+
+      boolean result = true;
+      result = result && getId()
+          .equals(other.getId());
+      result = result && getModCase().equals(
+          other.getModCase());
+      if (!result) return false;
+      switch (modCase_) {
+        case 2:
+          result = result && getCreate()
+              .equals(other.getCreate());
+          break;
+        case 3:
+          result = result && getUpdate()
+              .equals(other.getUpdate());
+          break;
+        case 4:
+          result = result && (getDrop()
+              == other.getDrop());
+          break;
+        case 0:
+        default:
+      }
+      return result;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptorForType().hashCode();
+      hash = (37 * hash) + ID_FIELD_NUMBER;
+      hash = (53 * hash) + getId().hashCode();
+      switch (modCase_) {
+        case 2:
+          hash = (37 * hash) + CREATE_FIELD_NUMBER;
+          hash = (53 * hash) + getCreate().hashCode();
+          break;
+        case 3:
+          hash = (37 * hash) + UPDATE_FIELD_NUMBER;
+          hash = (53 * hash) + getUpdate().hashCode();
+          break;
+        case 4:
+          hash = (37 * hash) + DROP_FIELD_NUMBER;
+          hash = (53 * hash) + com.google.protobuf.Internal.hashBoolean(
+              getDrop());
+          break;
+        case 0:
+        default:
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
     public static com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest.Modification parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
@@ -500,39 +567,39 @@ public  final class ModifyColumnFamiliesRequest extends
     }
     public static com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest.Modification parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
     public static com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest.Modification parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
     public static com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest.Modification parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
     public static com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest.Modification parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
     public static com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest.Modification parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
     public static com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest.Modification parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
@@ -550,7 +617,7 @@ public  final class ModifyColumnFamiliesRequest extends
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -562,7 +629,7 @@ public  final class ModifyColumnFamiliesRequest extends
      * Protobuf type {@code google.bigtable.admin.v2.ModifyColumnFamiliesRequest.Modification}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:google.bigtable.admin.v2.ModifyColumnFamiliesRequest.Modification)
         com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest.ModificationOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -570,7 +637,7 @@ public  final class ModifyColumnFamiliesRequest extends
         return com.google.bigtable.admin.v2.BigtableTableAdminProto.internal_static_google_bigtable_admin_v2_ModifyColumnFamiliesRequest_Modification_descriptor;
       }
 
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return com.google.bigtable.admin.v2.BigtableTableAdminProto.internal_static_google_bigtable_admin_v2_ModifyColumnFamiliesRequest_Modification_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -583,12 +650,13 @@ public  final class ModifyColumnFamiliesRequest extends
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
       private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
         }
       }
       public Builder clear() {
@@ -642,6 +710,32 @@ public  final class ModifyColumnFamiliesRequest extends
         return result;
       }
 
+      public Builder clone() {
+        return (Builder) super.clone();
+      }
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          Object value) {
+        return (Builder) super.setField(field, value);
+      }
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return (Builder) super.clearField(field);
+      }
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return (Builder) super.clearOneof(oneof);
+      }
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, Object value) {
+        return (Builder) super.setRepeatedField(field, index, value);
+      }
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          Object value) {
+        return (Builder) super.addRepeatedField(field, value);
+      }
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest.Modification) {
           return mergeFrom((com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest.Modification)other);
@@ -804,7 +898,7 @@ public  final class ModifyColumnFamiliesRequest extends
         return this;
       }
 
-      private com.google.protobuf.SingleFieldBuilder<
+      private com.google.protobuf.SingleFieldBuilderV3<
           com.google.bigtable.admin.v2.ColumnFamily, com.google.bigtable.admin.v2.ColumnFamily.Builder, com.google.bigtable.admin.v2.ColumnFamilyOrBuilder> createBuilder_;
       /**
        * <pre>
@@ -955,14 +1049,14 @@ public  final class ModifyColumnFamiliesRequest extends
        *
        * <code>optional .google.bigtable.admin.v2.ColumnFamily create = 2;</code>
        */
-      private com.google.protobuf.SingleFieldBuilder<
+      private com.google.protobuf.SingleFieldBuilderV3<
           com.google.bigtable.admin.v2.ColumnFamily, com.google.bigtable.admin.v2.ColumnFamily.Builder, com.google.bigtable.admin.v2.ColumnFamilyOrBuilder> 
           getCreateFieldBuilder() {
         if (createBuilder_ == null) {
           if (!(modCase_ == 2)) {
             mod_ = com.google.bigtable.admin.v2.ColumnFamily.getDefaultInstance();
           }
-          createBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+          createBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
               com.google.bigtable.admin.v2.ColumnFamily, com.google.bigtable.admin.v2.ColumnFamily.Builder, com.google.bigtable.admin.v2.ColumnFamilyOrBuilder>(
                   (com.google.bigtable.admin.v2.ColumnFamily) mod_,
                   getParentForChildren(),
@@ -974,7 +1068,7 @@ public  final class ModifyColumnFamiliesRequest extends
         return createBuilder_;
       }
 
-      private com.google.protobuf.SingleFieldBuilder<
+      private com.google.protobuf.SingleFieldBuilderV3<
           com.google.bigtable.admin.v2.ColumnFamily, com.google.bigtable.admin.v2.ColumnFamily.Builder, com.google.bigtable.admin.v2.ColumnFamilyOrBuilder> updateBuilder_;
       /**
        * <pre>
@@ -1125,14 +1219,14 @@ public  final class ModifyColumnFamiliesRequest extends
        *
        * <code>optional .google.bigtable.admin.v2.ColumnFamily update = 3;</code>
        */
-      private com.google.protobuf.SingleFieldBuilder<
+      private com.google.protobuf.SingleFieldBuilderV3<
           com.google.bigtable.admin.v2.ColumnFamily, com.google.bigtable.admin.v2.ColumnFamily.Builder, com.google.bigtable.admin.v2.ColumnFamilyOrBuilder> 
           getUpdateFieldBuilder() {
         if (updateBuilder_ == null) {
           if (!(modCase_ == 3)) {
             mod_ = com.google.bigtable.admin.v2.ColumnFamily.getDefaultInstance();
           }
-          updateBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+          updateBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
               com.google.bigtable.admin.v2.ColumnFamily, com.google.bigtable.admin.v2.ColumnFamily.Builder, com.google.bigtable.admin.v2.ColumnFamilyOrBuilder>(
                   (com.google.bigtable.admin.v2.ColumnFamily) mod_,
                   getParentForChildren(),
@@ -1365,7 +1459,7 @@ public  final class ModifyColumnFamiliesRequest extends
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
     if (!getNameBytes().isEmpty()) {
-      com.google.protobuf.GeneratedMessage.writeString(output, 1, name_);
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 1, name_);
     }
     for (int i = 0; i < modifications_.size(); i++) {
       output.writeMessage(2, modifications_.get(i));
@@ -1378,7 +1472,7 @@ public  final class ModifyColumnFamiliesRequest extends
 
     size = 0;
     if (!getNameBytes().isEmpty()) {
-      size += com.google.protobuf.GeneratedMessage.computeStringSize(1, name_);
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, name_);
     }
     for (int i = 0; i < modifications_.size(); i++) {
       size += com.google.protobuf.CodedOutputStream
@@ -1389,6 +1483,42 @@ public  final class ModifyColumnFamiliesRequest extends
   }
 
   private static final long serialVersionUID = 0L;
+  @java.lang.Override
+  public boolean equals(final java.lang.Object obj) {
+    if (obj == this) {
+     return true;
+    }
+    if (!(obj instanceof com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest)) {
+      return super.equals(obj);
+    }
+    com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest other = (com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest) obj;
+
+    boolean result = true;
+    result = result && getName()
+        .equals(other.getName());
+    result = result && getModificationsList()
+        .equals(other.getModificationsList());
+    return result;
+  }
+
+  @java.lang.Override
+  public int hashCode() {
+    if (memoizedHashCode != 0) {
+      return memoizedHashCode;
+    }
+    int hash = 41;
+    hash = (19 * hash) + getDescriptorForType().hashCode();
+    hash = (37 * hash) + NAME_FIELD_NUMBER;
+    hash = (53 * hash) + getName().hashCode();
+    if (getModificationsCount() > 0) {
+      hash = (37 * hash) + MODIFICATIONS_FIELD_NUMBER;
+      hash = (53 * hash) + getModificationsList().hashCode();
+    }
+    hash = (29 * hash) + unknownFields.hashCode();
+    memoizedHashCode = hash;
+    return hash;
+  }
+
   public static com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -1412,39 +1542,39 @@ public  final class ModifyColumnFamiliesRequest extends
   }
   public static com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest parseFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest parseFrom(
       com.google.protobuf.CodedInputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
@@ -1462,7 +1592,7 @@ public  final class ModifyColumnFamiliesRequest extends
 
   @java.lang.Override
   protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
@@ -1474,7 +1604,7 @@ public  final class ModifyColumnFamiliesRequest extends
    * Protobuf type {@code google.bigtable.admin.v2.ModifyColumnFamiliesRequest}
    */
   public static final class Builder extends
-      com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
       // @@protoc_insertion_point(builder_implements:google.bigtable.admin.v2.ModifyColumnFamiliesRequest)
       com.google.bigtable.admin.v2.ModifyColumnFamiliesRequestOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
@@ -1482,7 +1612,7 @@ public  final class ModifyColumnFamiliesRequest extends
       return com.google.bigtable.admin.v2.BigtableTableAdminProto.internal_static_google_bigtable_admin_v2_ModifyColumnFamiliesRequest_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.bigtable.admin.v2.BigtableTableAdminProto.internal_static_google_bigtable_admin_v2_ModifyColumnFamiliesRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -1495,12 +1625,13 @@ public  final class ModifyColumnFamiliesRequest extends
     }
 
     private Builder(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
         getModificationsFieldBuilder();
       }
     }
@@ -1553,6 +1684,32 @@ public  final class ModifyColumnFamiliesRequest extends
       return result;
     }
 
+    public Builder clone() {
+      return (Builder) super.clone();
+    }
+    public Builder setField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.setField(field, value);
+    }
+    public Builder clearField(
+        com.google.protobuf.Descriptors.FieldDescriptor field) {
+      return (Builder) super.clearField(field);
+    }
+    public Builder clearOneof(
+        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      return (Builder) super.clearOneof(oneof);
+    }
+    public Builder setRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        int index, Object value) {
+      return (Builder) super.setRepeatedField(field, index, value);
+    }
+    public Builder addRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.addRepeatedField(field, value);
+    }
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest) {
         return mergeFrom((com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest)other);
@@ -1587,7 +1744,7 @@ public  final class ModifyColumnFamiliesRequest extends
             modifications_ = other.modifications_;
             bitField0_ = (bitField0_ & ~0x00000002);
             modificationsBuilder_ = 
-              com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+              com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
                  getModificationsFieldBuilder() : null;
           } else {
             modificationsBuilder_.addAllMessages(other.modifications_);
@@ -1724,7 +1881,7 @@ public  final class ModifyColumnFamiliesRequest extends
        }
     }
 
-    private com.google.protobuf.RepeatedFieldBuilder<
+    private com.google.protobuf.RepeatedFieldBuilderV3<
         com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest.Modification, com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest.Modification.Builder, com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest.ModificationOrBuilder> modificationsBuilder_;
 
     /**
@@ -2066,11 +2223,11 @@ public  final class ModifyColumnFamiliesRequest extends
          getModificationsBuilderList() {
       return getModificationsFieldBuilder().getBuilderList();
     }
-    private com.google.protobuf.RepeatedFieldBuilder<
+    private com.google.protobuf.RepeatedFieldBuilderV3<
         com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest.Modification, com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest.Modification.Builder, com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest.ModificationOrBuilder> 
         getModificationsFieldBuilder() {
       if (modificationsBuilder_ == null) {
-        modificationsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
+        modificationsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
             com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest.Modification, com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest.Modification.Builder, com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest.ModificationOrBuilder>(
                 modifications_,
                 ((bitField0_ & 0x00000002) == 0x00000002),

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/Table.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/Table.java
@@ -12,11 +12,11 @@ package com.google.bigtable.admin.v2;
  * Protobuf type {@code google.bigtable.admin.v2.Table}
  */
 public  final class Table extends
-    com.google.protobuf.GeneratedMessage implements
+    com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:google.bigtable.admin.v2.Table)
     TableOrBuilder {
   // Use Table.newBuilder() to construct.
-  private Table(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+  private Table(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private Table() {
@@ -100,7 +100,7 @@ public  final class Table extends
             "Invalid map field number: " + number);
     }
   }
-  protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.google.bigtable.admin.v2.TableProto.internal_static_google_bigtable_admin_v2_Table_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
@@ -451,6 +451,10 @@ public  final class Table extends
     }
     return columnFamilies_;
   }
+
+  public int getColumnFamiliesCount() {
+    return internalGetColumnFamilies().getMap().size();
+  }
   /**
    * <pre>
    * The column families configured for this table, mapped by column family ID.
@@ -461,8 +465,68 @@ public  final class Table extends
    * <code>map&lt;string, .google.bigtable.admin.v2.ColumnFamily&gt; column_families = 3;</code>
    */
 
+  public boolean containsColumnFamilies(
+      java.lang.String key) {
+    if (key == null) { throw new java.lang.NullPointerException(); }
+    return internalGetColumnFamilies().getMap().containsKey(key);
+  }
+  /**
+   * Use {@link #getColumnFamiliesMap()} instead.
+   */
+  @java.lang.Deprecated
   public java.util.Map<java.lang.String, com.google.bigtable.admin.v2.ColumnFamily> getColumnFamilies() {
+    return getColumnFamiliesMap();
+  }
+  /**
+   * <pre>
+   * The column families configured for this table, mapped by column family ID.
+   * Views: SCHEMA_VIEW, FULL
+   * &#64;CreationOnly
+   * </pre>
+   *
+   * <code>map&lt;string, .google.bigtable.admin.v2.ColumnFamily&gt; column_families = 3;</code>
+   */
+
+  public java.util.Map<java.lang.String, com.google.bigtable.admin.v2.ColumnFamily> getColumnFamiliesMap() {
     return internalGetColumnFamilies().getMap();
+  }
+  /**
+   * <pre>
+   * The column families configured for this table, mapped by column family ID.
+   * Views: SCHEMA_VIEW, FULL
+   * &#64;CreationOnly
+   * </pre>
+   *
+   * <code>map&lt;string, .google.bigtable.admin.v2.ColumnFamily&gt; column_families = 3;</code>
+   */
+
+  public com.google.bigtable.admin.v2.ColumnFamily getColumnFamiliesOrDefault(
+      java.lang.String key,
+      com.google.bigtable.admin.v2.ColumnFamily defaultValue) {
+    if (key == null) { throw new java.lang.NullPointerException(); }
+    java.util.Map<java.lang.String, com.google.bigtable.admin.v2.ColumnFamily> map =
+        internalGetColumnFamilies().getMap();
+    return map.containsKey(key) ? map.get(key) : defaultValue;
+  }
+  /**
+   * <pre>
+   * The column families configured for this table, mapped by column family ID.
+   * Views: SCHEMA_VIEW, FULL
+   * &#64;CreationOnly
+   * </pre>
+   *
+   * <code>map&lt;string, .google.bigtable.admin.v2.ColumnFamily&gt; column_families = 3;</code>
+   */
+
+  public com.google.bigtable.admin.v2.ColumnFamily getColumnFamiliesOrThrow(
+      java.lang.String key) {
+    if (key == null) { throw new java.lang.NullPointerException(); }
+    java.util.Map<java.lang.String, com.google.bigtable.admin.v2.ColumnFamily> map =
+        internalGetColumnFamilies().getMap();
+    if (!map.containsKey(key)) {
+      throw new java.lang.IllegalArgumentException();
+    }
+    return map.get(key);
   }
 
   public static final int GRANULARITY_FIELD_NUMBER = 4;
@@ -493,7 +557,7 @@ public  final class Table extends
    * <code>optional .google.bigtable.admin.v2.Table.TimestampGranularity granularity = 4;</code>
    */
   public com.google.bigtable.admin.v2.Table.TimestampGranularity getGranularity() {
-    com.google.bigtable.admin.v2.Table.TimestampGranularity result = com.google.bigtable.admin.v2.Table.TimestampGranularity.forNumber(granularity_);
+    com.google.bigtable.admin.v2.Table.TimestampGranularity result = com.google.bigtable.admin.v2.Table.TimestampGranularity.valueOf(granularity_);
     return result == null ? com.google.bigtable.admin.v2.Table.TimestampGranularity.UNRECOGNIZED : result;
   }
 
@@ -510,7 +574,7 @@ public  final class Table extends
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
     if (!getNameBytes().isEmpty()) {
-      com.google.protobuf.GeneratedMessage.writeString(output, 1, name_);
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 1, name_);
     }
     for (java.util.Map.Entry<java.lang.String, com.google.bigtable.admin.v2.ColumnFamily> entry
          : internalGetColumnFamilies().getMap().entrySet()) {
@@ -532,7 +596,7 @@ public  final class Table extends
 
     size = 0;
     if (!getNameBytes().isEmpty()) {
-      size += com.google.protobuf.GeneratedMessage.computeStringSize(1, name_);
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, name_);
     }
     for (java.util.Map.Entry<java.lang.String, com.google.bigtable.admin.v2.ColumnFamily> entry
          : internalGetColumnFamilies().getMap().entrySet()) {
@@ -553,6 +617,45 @@ public  final class Table extends
   }
 
   private static final long serialVersionUID = 0L;
+  @java.lang.Override
+  public boolean equals(final java.lang.Object obj) {
+    if (obj == this) {
+     return true;
+    }
+    if (!(obj instanceof com.google.bigtable.admin.v2.Table)) {
+      return super.equals(obj);
+    }
+    com.google.bigtable.admin.v2.Table other = (com.google.bigtable.admin.v2.Table) obj;
+
+    boolean result = true;
+    result = result && getName()
+        .equals(other.getName());
+    result = result && internalGetColumnFamilies().equals(
+        other.internalGetColumnFamilies());
+    result = result && granularity_ == other.granularity_;
+    return result;
+  }
+
+  @java.lang.Override
+  public int hashCode() {
+    if (memoizedHashCode != 0) {
+      return memoizedHashCode;
+    }
+    int hash = 41;
+    hash = (19 * hash) + getDescriptorForType().hashCode();
+    hash = (37 * hash) + NAME_FIELD_NUMBER;
+    hash = (53 * hash) + getName().hashCode();
+    if (!internalGetColumnFamilies().getMap().isEmpty()) {
+      hash = (37 * hash) + COLUMN_FAMILIES_FIELD_NUMBER;
+      hash = (53 * hash) + internalGetColumnFamilies().hashCode();
+    }
+    hash = (37 * hash) + GRANULARITY_FIELD_NUMBER;
+    hash = (53 * hash) + granularity_;
+    hash = (29 * hash) + unknownFields.hashCode();
+    memoizedHashCode = hash;
+    return hash;
+  }
+
   public static com.google.bigtable.admin.v2.Table parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -576,39 +679,39 @@ public  final class Table extends
   }
   public static com.google.bigtable.admin.v2.Table parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.Table parseFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.admin.v2.Table parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.Table parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.admin.v2.Table parseFrom(
       com.google.protobuf.CodedInputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.Table parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
@@ -626,7 +729,7 @@ public  final class Table extends
 
   @java.lang.Override
   protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
@@ -639,7 +742,7 @@ public  final class Table extends
    * Protobuf type {@code google.bigtable.admin.v2.Table}
    */
   public static final class Builder extends
-      com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
       // @@protoc_insertion_point(builder_implements:google.bigtable.admin.v2.Table)
       com.google.bigtable.admin.v2.TableOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
@@ -669,7 +772,7 @@ public  final class Table extends
               "Invalid map field number: " + number);
       }
     }
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.bigtable.admin.v2.TableProto.internal_static_google_bigtable_admin_v2_Table_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -682,12 +785,13 @@ public  final class Table extends
     }
 
     private Builder(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
       }
     }
     public Builder clear() {
@@ -730,6 +834,32 @@ public  final class Table extends
       return result;
     }
 
+    public Builder clone() {
+      return (Builder) super.clone();
+    }
+    public Builder setField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.setField(field, value);
+    }
+    public Builder clearField(
+        com.google.protobuf.Descriptors.FieldDescriptor field) {
+      return (Builder) super.clearField(field);
+    }
+    public Builder clearOneof(
+        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      return (Builder) super.clearOneof(oneof);
+    }
+    public Builder setRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        int index, Object value) {
+      return (Builder) super.setRepeatedField(field, index, value);
+    }
+    public Builder addRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.addRepeatedField(field, value);
+    }
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.bigtable.admin.v2.Table) {
         return mergeFrom((com.google.bigtable.admin.v2.Table)other);
@@ -903,6 +1033,10 @@ public  final class Table extends
       }
       return columnFamilies_;
     }
+
+    public int getColumnFamiliesCount() {
+      return internalGetColumnFamilies().getMap().size();
+    }
     /**
      * <pre>
      * The column families configured for this table, mapped by column family ID.
@@ -912,7 +1046,30 @@ public  final class Table extends
      *
      * <code>map&lt;string, .google.bigtable.admin.v2.ColumnFamily&gt; column_families = 3;</code>
      */
+
+    public boolean containsColumnFamilies(
+        java.lang.String key) {
+      if (key == null) { throw new java.lang.NullPointerException(); }
+      return internalGetColumnFamilies().getMap().containsKey(key);
+    }
+    /**
+     * Use {@link #getColumnFamiliesMap()} instead.
+     */
+    @java.lang.Deprecated
     public java.util.Map<java.lang.String, com.google.bigtable.admin.v2.ColumnFamily> getColumnFamilies() {
+      return getColumnFamiliesMap();
+    }
+    /**
+     * <pre>
+     * The column families configured for this table, mapped by column family ID.
+     * Views: SCHEMA_VIEW, FULL
+     * &#64;CreationOnly
+     * </pre>
+     *
+     * <code>map&lt;string, .google.bigtable.admin.v2.ColumnFamily&gt; column_families = 3;</code>
+     */
+
+    public java.util.Map<java.lang.String, com.google.bigtable.admin.v2.ColumnFamily> getColumnFamiliesMap() {
       return internalGetColumnFamilies().getMap();
     }
     /**
@@ -924,6 +1081,60 @@ public  final class Table extends
      *
      * <code>map&lt;string, .google.bigtable.admin.v2.ColumnFamily&gt; column_families = 3;</code>
      */
+
+    public com.google.bigtable.admin.v2.ColumnFamily getColumnFamiliesOrDefault(
+        java.lang.String key,
+        com.google.bigtable.admin.v2.ColumnFamily defaultValue) {
+      if (key == null) { throw new java.lang.NullPointerException(); }
+      java.util.Map<java.lang.String, com.google.bigtable.admin.v2.ColumnFamily> map =
+          internalGetColumnFamilies().getMap();
+      return map.containsKey(key) ? map.get(key) : defaultValue;
+    }
+    /**
+     * <pre>
+     * The column families configured for this table, mapped by column family ID.
+     * Views: SCHEMA_VIEW, FULL
+     * &#64;CreationOnly
+     * </pre>
+     *
+     * <code>map&lt;string, .google.bigtable.admin.v2.ColumnFamily&gt; column_families = 3;</code>
+     */
+
+    public com.google.bigtable.admin.v2.ColumnFamily getColumnFamiliesOrThrow(
+        java.lang.String key) {
+      if (key == null) { throw new java.lang.NullPointerException(); }
+      java.util.Map<java.lang.String, com.google.bigtable.admin.v2.ColumnFamily> map =
+          internalGetColumnFamilies().getMap();
+      if (!map.containsKey(key)) {
+        throw new java.lang.IllegalArgumentException();
+      }
+      return map.get(key);
+    }
+
+    public Builder clearColumnFamilies() {
+      getMutableColumnFamilies().clear();
+      return this;
+    }
+    /**
+     * <pre>
+     * The column families configured for this table, mapped by column family ID.
+     * Views: SCHEMA_VIEW, FULL
+     * &#64;CreationOnly
+     * </pre>
+     *
+     * <code>map&lt;string, .google.bigtable.admin.v2.ColumnFamily&gt; column_families = 3;</code>
+     */
+
+    public Builder removeColumnFamilies(
+        java.lang.String key) {
+      if (key == null) { throw new java.lang.NullPointerException(); }
+      getMutableColumnFamilies().remove(key);
+      return this;
+    }
+    /**
+     * Use alternate mutation accessors instead.
+     */
+    @java.lang.Deprecated
     public java.util.Map<java.lang.String, com.google.bigtable.admin.v2.ColumnFamily>
     getMutableColumnFamilies() {
       return internalGetMutableColumnFamilies().getMutableMap();
@@ -937,6 +1148,24 @@ public  final class Table extends
      *
      * <code>map&lt;string, .google.bigtable.admin.v2.ColumnFamily&gt; column_families = 3;</code>
      */
+    public Builder putColumnFamilies(
+        java.lang.String key,
+        com.google.bigtable.admin.v2.ColumnFamily value) {
+      if (key == null) { throw new java.lang.NullPointerException(); }
+      if (value == null) { throw new java.lang.NullPointerException(); }
+      getMutableColumnFamilies().put(key, value);
+      return this;
+    }
+    /**
+     * <pre>
+     * The column families configured for this table, mapped by column family ID.
+     * Views: SCHEMA_VIEW, FULL
+     * &#64;CreationOnly
+     * </pre>
+     *
+     * <code>map&lt;string, .google.bigtable.admin.v2.ColumnFamily&gt; column_families = 3;</code>
+     */
+
     public Builder putAllColumnFamilies(
         java.util.Map<java.lang.String, com.google.bigtable.admin.v2.ColumnFamily> values) {
       getMutableColumnFamilies().putAll(values);
@@ -986,7 +1215,7 @@ public  final class Table extends
      * <code>optional .google.bigtable.admin.v2.Table.TimestampGranularity granularity = 4;</code>
      */
     public com.google.bigtable.admin.v2.Table.TimestampGranularity getGranularity() {
-      com.google.bigtable.admin.v2.Table.TimestampGranularity result = com.google.bigtable.admin.v2.Table.TimestampGranularity.forNumber(granularity_);
+      com.google.bigtable.admin.v2.Table.TimestampGranularity result = com.google.bigtable.admin.v2.Table.TimestampGranularity.valueOf(granularity_);
       return result == null ? com.google.bigtable.admin.v2.Table.TimestampGranularity.UNRECOGNIZED : result;
     }
     /**

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/TableOrBuilder.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/TableOrBuilder.java
@@ -40,8 +40,60 @@ public interface TableOrBuilder extends
    *
    * <code>map&lt;string, .google.bigtable.admin.v2.ColumnFamily&gt; column_families = 3;</code>
    */
+  int getColumnFamiliesCount();
+  /**
+   * <pre>
+   * The column families configured for this table, mapped by column family ID.
+   * Views: SCHEMA_VIEW, FULL
+   * &#64;CreationOnly
+   * </pre>
+   *
+   * <code>map&lt;string, .google.bigtable.admin.v2.ColumnFamily&gt; column_families = 3;</code>
+   */
+  boolean containsColumnFamilies(
+      java.lang.String key);
+  /**
+   * Use {@link #getColumnFamiliesMap()} instead.
+   */
+  @java.lang.Deprecated
   java.util.Map<java.lang.String, com.google.bigtable.admin.v2.ColumnFamily>
   getColumnFamilies();
+  /**
+   * <pre>
+   * The column families configured for this table, mapped by column family ID.
+   * Views: SCHEMA_VIEW, FULL
+   * &#64;CreationOnly
+   * </pre>
+   *
+   * <code>map&lt;string, .google.bigtable.admin.v2.ColumnFamily&gt; column_families = 3;</code>
+   */
+  java.util.Map<java.lang.String, com.google.bigtable.admin.v2.ColumnFamily>
+  getColumnFamiliesMap();
+  /**
+   * <pre>
+   * The column families configured for this table, mapped by column family ID.
+   * Views: SCHEMA_VIEW, FULL
+   * &#64;CreationOnly
+   * </pre>
+   *
+   * <code>map&lt;string, .google.bigtable.admin.v2.ColumnFamily&gt; column_families = 3;</code>
+   */
+
+  com.google.bigtable.admin.v2.ColumnFamily getColumnFamiliesOrDefault(
+      java.lang.String key,
+      com.google.bigtable.admin.v2.ColumnFamily defaultValue);
+  /**
+   * <pre>
+   * The column families configured for this table, mapped by column family ID.
+   * Views: SCHEMA_VIEW, FULL
+   * &#64;CreationOnly
+   * </pre>
+   *
+   * <code>map&lt;string, .google.bigtable.admin.v2.ColumnFamily&gt; column_families = 3;</code>
+   */
+
+  com.google.bigtable.admin.v2.ColumnFamily getColumnFamiliesOrThrow(
+      java.lang.String key);
 
   /**
    * <pre>

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/TableProto.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/TableProto.java
@@ -6,37 +6,43 @@ package com.google.bigtable.admin.v2;
 public final class TableProto {
   private TableProto() {}
   public static void registerAllExtensions(
+      com.google.protobuf.ExtensionRegistryLite registry) {
+  }
+
+  public static void registerAllExtensions(
       com.google.protobuf.ExtensionRegistry registry) {
+    registerAllExtensions(
+        (com.google.protobuf.ExtensionRegistryLite) registry);
   }
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_bigtable_admin_v2_Table_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_bigtable_admin_v2_Table_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_bigtable_admin_v2_Table_ColumnFamiliesEntry_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_bigtable_admin_v2_Table_ColumnFamiliesEntry_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_bigtable_admin_v2_ColumnFamily_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_bigtable_admin_v2_ColumnFamily_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_bigtable_admin_v2_GcRule_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_bigtable_admin_v2_GcRule_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_bigtable_admin_v2_GcRule_Intersection_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_bigtable_admin_v2_GcRule_Intersection_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_bigtable_admin_v2_GcRule_Union_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_bigtable_admin_v2_GcRule_Union_fieldAccessorTable;
 
   public static com.google.protobuf.Descriptors.FileDescriptor
@@ -91,37 +97,37 @@ public final class TableProto {
     internal_static_google_bigtable_admin_v2_Table_descriptor =
       getDescriptor().getMessageTypes().get(0);
     internal_static_google_bigtable_admin_v2_Table_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_bigtable_admin_v2_Table_descriptor,
         new java.lang.String[] { "Name", "ColumnFamilies", "Granularity", });
     internal_static_google_bigtable_admin_v2_Table_ColumnFamiliesEntry_descriptor =
       internal_static_google_bigtable_admin_v2_Table_descriptor.getNestedTypes().get(0);
     internal_static_google_bigtable_admin_v2_Table_ColumnFamiliesEntry_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_bigtable_admin_v2_Table_ColumnFamiliesEntry_descriptor,
         new java.lang.String[] { "Key", "Value", });
     internal_static_google_bigtable_admin_v2_ColumnFamily_descriptor =
       getDescriptor().getMessageTypes().get(1);
     internal_static_google_bigtable_admin_v2_ColumnFamily_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_bigtable_admin_v2_ColumnFamily_descriptor,
         new java.lang.String[] { "GcRule", });
     internal_static_google_bigtable_admin_v2_GcRule_descriptor =
       getDescriptor().getMessageTypes().get(2);
     internal_static_google_bigtable_admin_v2_GcRule_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_bigtable_admin_v2_GcRule_descriptor,
         new java.lang.String[] { "MaxNumVersions", "MaxAge", "Intersection", "Union", "Rule", });
     internal_static_google_bigtable_admin_v2_GcRule_Intersection_descriptor =
       internal_static_google_bigtable_admin_v2_GcRule_descriptor.getNestedTypes().get(0);
     internal_static_google_bigtable_admin_v2_GcRule_Intersection_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_bigtable_admin_v2_GcRule_Intersection_descriptor,
         new java.lang.String[] { "Rules", });
     internal_static_google_bigtable_admin_v2_GcRule_Union_descriptor =
       internal_static_google_bigtable_admin_v2_GcRule_descriptor.getNestedTypes().get(1);
     internal_static_google_bigtable_admin_v2_GcRule_Union_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_bigtable_admin_v2_GcRule_Union_descriptor,
         new java.lang.String[] { "Rules", });
     com.google.api.AnnotationsProto.getDescriptor();

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/UpdateClusterMetadata.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/admin/v2/UpdateClusterMetadata.java
@@ -11,11 +11,11 @@ package com.google.bigtable.admin.v2;
  * Protobuf type {@code google.bigtable.admin.v2.UpdateClusterMetadata}
  */
 public  final class UpdateClusterMetadata extends
-    com.google.protobuf.GeneratedMessage implements
+    com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:google.bigtable.admin.v2.UpdateClusterMetadata)
     UpdateClusterMetadataOrBuilder {
   // Use UpdateClusterMetadata.newBuilder() to construct.
-  private UpdateClusterMetadata(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+  private UpdateClusterMetadata(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private UpdateClusterMetadata() {
@@ -101,7 +101,7 @@ public  final class UpdateClusterMetadata extends
     return com.google.bigtable.admin.v2.BigtableInstanceAdminProto.internal_static_google_bigtable_admin_v2_UpdateClusterMetadata_descriptor;
   }
 
-  protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.google.bigtable.admin.v2.BigtableInstanceAdminProto.internal_static_google_bigtable_admin_v2_UpdateClusterMetadata_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
@@ -252,6 +252,59 @@ public  final class UpdateClusterMetadata extends
   }
 
   private static final long serialVersionUID = 0L;
+  @java.lang.Override
+  public boolean equals(final java.lang.Object obj) {
+    if (obj == this) {
+     return true;
+    }
+    if (!(obj instanceof com.google.bigtable.admin.v2.UpdateClusterMetadata)) {
+      return super.equals(obj);
+    }
+    com.google.bigtable.admin.v2.UpdateClusterMetadata other = (com.google.bigtable.admin.v2.UpdateClusterMetadata) obj;
+
+    boolean result = true;
+    result = result && (hasOriginalRequest() == other.hasOriginalRequest());
+    if (hasOriginalRequest()) {
+      result = result && getOriginalRequest()
+          .equals(other.getOriginalRequest());
+    }
+    result = result && (hasRequestTime() == other.hasRequestTime());
+    if (hasRequestTime()) {
+      result = result && getRequestTime()
+          .equals(other.getRequestTime());
+    }
+    result = result && (hasFinishTime() == other.hasFinishTime());
+    if (hasFinishTime()) {
+      result = result && getFinishTime()
+          .equals(other.getFinishTime());
+    }
+    return result;
+  }
+
+  @java.lang.Override
+  public int hashCode() {
+    if (memoizedHashCode != 0) {
+      return memoizedHashCode;
+    }
+    int hash = 41;
+    hash = (19 * hash) + getDescriptorForType().hashCode();
+    if (hasOriginalRequest()) {
+      hash = (37 * hash) + ORIGINAL_REQUEST_FIELD_NUMBER;
+      hash = (53 * hash) + getOriginalRequest().hashCode();
+    }
+    if (hasRequestTime()) {
+      hash = (37 * hash) + REQUEST_TIME_FIELD_NUMBER;
+      hash = (53 * hash) + getRequestTime().hashCode();
+    }
+    if (hasFinishTime()) {
+      hash = (37 * hash) + FINISH_TIME_FIELD_NUMBER;
+      hash = (53 * hash) + getFinishTime().hashCode();
+    }
+    hash = (29 * hash) + unknownFields.hashCode();
+    memoizedHashCode = hash;
+    return hash;
+  }
+
   public static com.google.bigtable.admin.v2.UpdateClusterMetadata parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -275,39 +328,39 @@ public  final class UpdateClusterMetadata extends
   }
   public static com.google.bigtable.admin.v2.UpdateClusterMetadata parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.UpdateClusterMetadata parseFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.admin.v2.UpdateClusterMetadata parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.UpdateClusterMetadata parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.admin.v2.UpdateClusterMetadata parseFrom(
       com.google.protobuf.CodedInputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.admin.v2.UpdateClusterMetadata parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
@@ -325,7 +378,7 @@ public  final class UpdateClusterMetadata extends
 
   @java.lang.Override
   protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
@@ -337,7 +390,7 @@ public  final class UpdateClusterMetadata extends
    * Protobuf type {@code google.bigtable.admin.v2.UpdateClusterMetadata}
    */
   public static final class Builder extends
-      com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
       // @@protoc_insertion_point(builder_implements:google.bigtable.admin.v2.UpdateClusterMetadata)
       com.google.bigtable.admin.v2.UpdateClusterMetadataOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
@@ -345,7 +398,7 @@ public  final class UpdateClusterMetadata extends
       return com.google.bigtable.admin.v2.BigtableInstanceAdminProto.internal_static_google_bigtable_admin_v2_UpdateClusterMetadata_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.bigtable.admin.v2.BigtableInstanceAdminProto.internal_static_google_bigtable_admin_v2_UpdateClusterMetadata_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -358,12 +411,13 @@ public  final class UpdateClusterMetadata extends
     }
 
     private Builder(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
       }
     }
     public Builder clear() {
@@ -427,6 +481,32 @@ public  final class UpdateClusterMetadata extends
       return result;
     }
 
+    public Builder clone() {
+      return (Builder) super.clone();
+    }
+    public Builder setField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.setField(field, value);
+    }
+    public Builder clearField(
+        com.google.protobuf.Descriptors.FieldDescriptor field) {
+      return (Builder) super.clearField(field);
+    }
+    public Builder clearOneof(
+        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      return (Builder) super.clearOneof(oneof);
+    }
+    public Builder setRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        int index, Object value) {
+      return (Builder) super.setRepeatedField(field, index, value);
+    }
+    public Builder addRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.addRepeatedField(field, value);
+    }
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.bigtable.admin.v2.UpdateClusterMetadata) {
         return mergeFrom((com.google.bigtable.admin.v2.UpdateClusterMetadata)other);
@@ -474,7 +554,7 @@ public  final class UpdateClusterMetadata extends
     }
 
     private com.google.bigtable.admin.v2.Cluster originalRequest_ = null;
-    private com.google.protobuf.SingleFieldBuilder<
+    private com.google.protobuf.SingleFieldBuilderV3<
         com.google.bigtable.admin.v2.Cluster, com.google.bigtable.admin.v2.Cluster.Builder, com.google.bigtable.admin.v2.ClusterOrBuilder> originalRequestBuilder_;
     /**
      * <pre>
@@ -612,11 +692,11 @@ public  final class UpdateClusterMetadata extends
      *
      * <code>optional .google.bigtable.admin.v2.Cluster original_request = 1;</code>
      */
-    private com.google.protobuf.SingleFieldBuilder<
+    private com.google.protobuf.SingleFieldBuilderV3<
         com.google.bigtable.admin.v2.Cluster, com.google.bigtable.admin.v2.Cluster.Builder, com.google.bigtable.admin.v2.ClusterOrBuilder> 
         getOriginalRequestFieldBuilder() {
       if (originalRequestBuilder_ == null) {
-        originalRequestBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+        originalRequestBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
             com.google.bigtable.admin.v2.Cluster, com.google.bigtable.admin.v2.Cluster.Builder, com.google.bigtable.admin.v2.ClusterOrBuilder>(
                 getOriginalRequest(),
                 getParentForChildren(),
@@ -627,7 +707,7 @@ public  final class UpdateClusterMetadata extends
     }
 
     private com.google.protobuf.Timestamp requestTime_ = null;
-    private com.google.protobuf.SingleFieldBuilder<
+    private com.google.protobuf.SingleFieldBuilderV3<
         com.google.protobuf.Timestamp, com.google.protobuf.Timestamp.Builder, com.google.protobuf.TimestampOrBuilder> requestTimeBuilder_;
     /**
      * <pre>
@@ -765,11 +845,11 @@ public  final class UpdateClusterMetadata extends
      *
      * <code>optional .google.protobuf.Timestamp request_time = 2;</code>
      */
-    private com.google.protobuf.SingleFieldBuilder<
+    private com.google.protobuf.SingleFieldBuilderV3<
         com.google.protobuf.Timestamp, com.google.protobuf.Timestamp.Builder, com.google.protobuf.TimestampOrBuilder> 
         getRequestTimeFieldBuilder() {
       if (requestTimeBuilder_ == null) {
-        requestTimeBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+        requestTimeBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
             com.google.protobuf.Timestamp, com.google.protobuf.Timestamp.Builder, com.google.protobuf.TimestampOrBuilder>(
                 getRequestTime(),
                 getParentForChildren(),
@@ -780,7 +860,7 @@ public  final class UpdateClusterMetadata extends
     }
 
     private com.google.protobuf.Timestamp finishTime_ = null;
-    private com.google.protobuf.SingleFieldBuilder<
+    private com.google.protobuf.SingleFieldBuilderV3<
         com.google.protobuf.Timestamp, com.google.protobuf.Timestamp.Builder, com.google.protobuf.TimestampOrBuilder> finishTimeBuilder_;
     /**
      * <pre>
@@ -918,11 +998,11 @@ public  final class UpdateClusterMetadata extends
      *
      * <code>optional .google.protobuf.Timestamp finish_time = 3;</code>
      */
-    private com.google.protobuf.SingleFieldBuilder<
+    private com.google.protobuf.SingleFieldBuilderV3<
         com.google.protobuf.Timestamp, com.google.protobuf.Timestamp.Builder, com.google.protobuf.TimestampOrBuilder> 
         getFinishTimeFieldBuilder() {
       if (finishTimeBuilder_ == null) {
-        finishTimeBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+        finishTimeBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
             com.google.protobuf.Timestamp, com.google.protobuf.Timestamp.Builder, com.google.protobuf.TimestampOrBuilder>(
                 getFinishTime(),
                 getParentForChildren(),

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/BigtableProto.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/BigtableProto.java
@@ -6,82 +6,88 @@ package com.google.bigtable.v2;
 public final class BigtableProto {
   private BigtableProto() {}
   public static void registerAllExtensions(
+      com.google.protobuf.ExtensionRegistryLite registry) {
+  }
+
+  public static void registerAllExtensions(
       com.google.protobuf.ExtensionRegistry registry) {
+    registerAllExtensions(
+        (com.google.protobuf.ExtensionRegistryLite) registry);
   }
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_bigtable_v2_ReadRowsRequest_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_bigtable_v2_ReadRowsRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_bigtable_v2_ReadRowsResponse_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_bigtable_v2_ReadRowsResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_bigtable_v2_ReadRowsResponse_CellChunk_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_bigtable_v2_ReadRowsResponse_CellChunk_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_bigtable_v2_SampleRowKeysRequest_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_bigtable_v2_SampleRowKeysRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_bigtable_v2_SampleRowKeysResponse_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_bigtable_v2_SampleRowKeysResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_bigtable_v2_MutateRowRequest_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_bigtable_v2_MutateRowRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_bigtable_v2_MutateRowResponse_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_bigtable_v2_MutateRowResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_bigtable_v2_MutateRowsRequest_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_bigtable_v2_MutateRowsRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_bigtable_v2_MutateRowsRequest_Entry_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_bigtable_v2_MutateRowsRequest_Entry_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_bigtable_v2_MutateRowsResponse_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_bigtable_v2_MutateRowsResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_bigtable_v2_MutateRowsResponse_Entry_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_bigtable_v2_MutateRowsResponse_Entry_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_bigtable_v2_CheckAndMutateRowRequest_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_bigtable_v2_CheckAndMutateRowRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_bigtable_v2_CheckAndMutateRowResponse_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_bigtable_v2_CheckAndMutateRowResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_bigtable_v2_ReadModifyWriteRowRequest_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_bigtable_v2_ReadModifyWriteRowRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_bigtable_v2_ReadModifyWriteRowResponse_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_bigtable_v2_ReadModifyWriteRowResponse_fieldAccessorTable;
 
   public static com.google.protobuf.Descriptors.FileDescriptor
@@ -184,91 +190,91 @@ public final class BigtableProto {
     internal_static_google_bigtable_v2_ReadRowsRequest_descriptor =
       getDescriptor().getMessageTypes().get(0);
     internal_static_google_bigtable_v2_ReadRowsRequest_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_bigtable_v2_ReadRowsRequest_descriptor,
         new java.lang.String[] { "TableName", "Rows", "Filter", "RowsLimit", });
     internal_static_google_bigtable_v2_ReadRowsResponse_descriptor =
       getDescriptor().getMessageTypes().get(1);
     internal_static_google_bigtable_v2_ReadRowsResponse_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_bigtable_v2_ReadRowsResponse_descriptor,
         new java.lang.String[] { "Chunks", "LastScannedRowKey", });
     internal_static_google_bigtable_v2_ReadRowsResponse_CellChunk_descriptor =
       internal_static_google_bigtable_v2_ReadRowsResponse_descriptor.getNestedTypes().get(0);
     internal_static_google_bigtable_v2_ReadRowsResponse_CellChunk_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_bigtable_v2_ReadRowsResponse_CellChunk_descriptor,
         new java.lang.String[] { "RowKey", "FamilyName", "Qualifier", "TimestampMicros", "Labels", "Value", "ValueSize", "ResetRow", "CommitRow", "RowStatus", });
     internal_static_google_bigtable_v2_SampleRowKeysRequest_descriptor =
       getDescriptor().getMessageTypes().get(2);
     internal_static_google_bigtable_v2_SampleRowKeysRequest_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_bigtable_v2_SampleRowKeysRequest_descriptor,
         new java.lang.String[] { "TableName", });
     internal_static_google_bigtable_v2_SampleRowKeysResponse_descriptor =
       getDescriptor().getMessageTypes().get(3);
     internal_static_google_bigtable_v2_SampleRowKeysResponse_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_bigtable_v2_SampleRowKeysResponse_descriptor,
         new java.lang.String[] { "RowKey", "OffsetBytes", });
     internal_static_google_bigtable_v2_MutateRowRequest_descriptor =
       getDescriptor().getMessageTypes().get(4);
     internal_static_google_bigtable_v2_MutateRowRequest_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_bigtable_v2_MutateRowRequest_descriptor,
         new java.lang.String[] { "TableName", "RowKey", "Mutations", });
     internal_static_google_bigtable_v2_MutateRowResponse_descriptor =
       getDescriptor().getMessageTypes().get(5);
     internal_static_google_bigtable_v2_MutateRowResponse_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_bigtable_v2_MutateRowResponse_descriptor,
         new java.lang.String[] { });
     internal_static_google_bigtable_v2_MutateRowsRequest_descriptor =
       getDescriptor().getMessageTypes().get(6);
     internal_static_google_bigtable_v2_MutateRowsRequest_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_bigtable_v2_MutateRowsRequest_descriptor,
         new java.lang.String[] { "TableName", "Entries", });
     internal_static_google_bigtable_v2_MutateRowsRequest_Entry_descriptor =
       internal_static_google_bigtable_v2_MutateRowsRequest_descriptor.getNestedTypes().get(0);
     internal_static_google_bigtable_v2_MutateRowsRequest_Entry_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_bigtable_v2_MutateRowsRequest_Entry_descriptor,
         new java.lang.String[] { "RowKey", "Mutations", });
     internal_static_google_bigtable_v2_MutateRowsResponse_descriptor =
       getDescriptor().getMessageTypes().get(7);
     internal_static_google_bigtable_v2_MutateRowsResponse_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_bigtable_v2_MutateRowsResponse_descriptor,
         new java.lang.String[] { "Entries", });
     internal_static_google_bigtable_v2_MutateRowsResponse_Entry_descriptor =
       internal_static_google_bigtable_v2_MutateRowsResponse_descriptor.getNestedTypes().get(0);
     internal_static_google_bigtable_v2_MutateRowsResponse_Entry_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_bigtable_v2_MutateRowsResponse_Entry_descriptor,
         new java.lang.String[] { "Index", "Status", });
     internal_static_google_bigtable_v2_CheckAndMutateRowRequest_descriptor =
       getDescriptor().getMessageTypes().get(8);
     internal_static_google_bigtable_v2_CheckAndMutateRowRequest_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_bigtable_v2_CheckAndMutateRowRequest_descriptor,
         new java.lang.String[] { "TableName", "RowKey", "PredicateFilter", "TrueMutations", "FalseMutations", });
     internal_static_google_bigtable_v2_CheckAndMutateRowResponse_descriptor =
       getDescriptor().getMessageTypes().get(9);
     internal_static_google_bigtable_v2_CheckAndMutateRowResponse_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_bigtable_v2_CheckAndMutateRowResponse_descriptor,
         new java.lang.String[] { "PredicateMatched", });
     internal_static_google_bigtable_v2_ReadModifyWriteRowRequest_descriptor =
       getDescriptor().getMessageTypes().get(10);
     internal_static_google_bigtable_v2_ReadModifyWriteRowRequest_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_bigtable_v2_ReadModifyWriteRowRequest_descriptor,
         new java.lang.String[] { "TableName", "RowKey", "Rules", });
     internal_static_google_bigtable_v2_ReadModifyWriteRowResponse_descriptor =
       getDescriptor().getMessageTypes().get(11);
     internal_static_google_bigtable_v2_ReadModifyWriteRowResponse_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_bigtable_v2_ReadModifyWriteRowResponse_descriptor,
         new java.lang.String[] { "Row", });
     com.google.protobuf.ExtensionRegistry registry =

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/Cell.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/Cell.java
@@ -11,11 +11,11 @@ package com.google.bigtable.v2;
  * Protobuf type {@code google.bigtable.v2.Cell}
  */
 public  final class Cell extends
-    com.google.protobuf.GeneratedMessage implements
+    com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:google.bigtable.v2.Cell)
     CellOrBuilder {
   // Use Cell.newBuilder() to construct.
-  private Cell(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+  private Cell(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private Cell() {
@@ -87,7 +87,7 @@ public  final class Cell extends
     return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_Cell_descriptor;
   }
 
-  protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_Cell_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
@@ -192,7 +192,7 @@ public  final class Cell extends
       output.writeBytes(2, value_);
     }
     for (int i = 0; i < labels_.size(); i++) {
-      com.google.protobuf.GeneratedMessage.writeString(output, 3, labels_.getRaw(i));
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 3, labels_.getRaw(i));
     }
   }
 
@@ -222,6 +222,47 @@ public  final class Cell extends
   }
 
   private static final long serialVersionUID = 0L;
+  @java.lang.Override
+  public boolean equals(final java.lang.Object obj) {
+    if (obj == this) {
+     return true;
+    }
+    if (!(obj instanceof com.google.bigtable.v2.Cell)) {
+      return super.equals(obj);
+    }
+    com.google.bigtable.v2.Cell other = (com.google.bigtable.v2.Cell) obj;
+
+    boolean result = true;
+    result = result && (getTimestampMicros()
+        == other.getTimestampMicros());
+    result = result && getValue()
+        .equals(other.getValue());
+    result = result && getLabelsList()
+        .equals(other.getLabelsList());
+    return result;
+  }
+
+  @java.lang.Override
+  public int hashCode() {
+    if (memoizedHashCode != 0) {
+      return memoizedHashCode;
+    }
+    int hash = 41;
+    hash = (19 * hash) + getDescriptorForType().hashCode();
+    hash = (37 * hash) + TIMESTAMP_MICROS_FIELD_NUMBER;
+    hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
+        getTimestampMicros());
+    hash = (37 * hash) + VALUE_FIELD_NUMBER;
+    hash = (53 * hash) + getValue().hashCode();
+    if (getLabelsCount() > 0) {
+      hash = (37 * hash) + LABELS_FIELD_NUMBER;
+      hash = (53 * hash) + getLabelsList().hashCode();
+    }
+    hash = (29 * hash) + unknownFields.hashCode();
+    memoizedHashCode = hash;
+    return hash;
+  }
+
   public static com.google.bigtable.v2.Cell parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -245,39 +286,39 @@ public  final class Cell extends
   }
   public static com.google.bigtable.v2.Cell parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.Cell parseFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.v2.Cell parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.Cell parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.v2.Cell parseFrom(
       com.google.protobuf.CodedInputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.Cell parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
@@ -295,7 +336,7 @@ public  final class Cell extends
 
   @java.lang.Override
   protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
@@ -307,7 +348,7 @@ public  final class Cell extends
    * Protobuf type {@code google.bigtable.v2.Cell}
    */
   public static final class Builder extends
-      com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
       // @@protoc_insertion_point(builder_implements:google.bigtable.v2.Cell)
       com.google.bigtable.v2.CellOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
@@ -315,7 +356,7 @@ public  final class Cell extends
       return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_Cell_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_Cell_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -328,12 +369,13 @@ public  final class Cell extends
     }
 
     private Builder(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
       }
     }
     public Builder clear() {
@@ -380,6 +422,32 @@ public  final class Cell extends
       return result;
     }
 
+    public Builder clone() {
+      return (Builder) super.clone();
+    }
+    public Builder setField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.setField(field, value);
+    }
+    public Builder clearField(
+        com.google.protobuf.Descriptors.FieldDescriptor field) {
+      return (Builder) super.clearField(field);
+    }
+    public Builder clearOneof(
+        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      return (Builder) super.clearOneof(oneof);
+    }
+    public Builder setRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        int index, Object value) {
+      return (Builder) super.setRepeatedField(field, index, value);
+    }
+    public Builder addRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.addRepeatedField(field, value);
+    }
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.bigtable.v2.Cell) {
         return mergeFrom((com.google.bigtable.v2.Cell)other);

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/CellOrBuilder.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/CellOrBuilder.java
@@ -39,7 +39,7 @@ public interface CellOrBuilder extends
    *
    * <code>repeated string labels = 3;</code>
    */
-  com.google.protobuf.ProtocolStringList
+  java.util.List<java.lang.String>
       getLabelsList();
   /**
    * <pre>

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/CheckAndMutateRowRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/CheckAndMutateRowRequest.java
@@ -11,11 +11,11 @@ package com.google.bigtable.v2;
  * Protobuf type {@code google.bigtable.v2.CheckAndMutateRowRequest}
  */
 public  final class CheckAndMutateRowRequest extends
-    com.google.protobuf.GeneratedMessage implements
+    com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:google.bigtable.v2.CheckAndMutateRowRequest)
     CheckAndMutateRowRequestOrBuilder {
   // Use CheckAndMutateRowRequest.newBuilder() to construct.
-  private CheckAndMutateRowRequest(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+  private CheckAndMutateRowRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private CheckAndMutateRowRequest() {
@@ -66,7 +66,8 @@ public  final class CheckAndMutateRowRequest extends
               trueMutations_ = new java.util.ArrayList<com.google.bigtable.v2.Mutation>();
               mutable_bitField0_ |= 0x00000008;
             }
-            trueMutations_.add(input.readMessage(com.google.bigtable.v2.Mutation.parser(), extensionRegistry));
+            trueMutations_.add(
+                input.readMessage(com.google.bigtable.v2.Mutation.parser(), extensionRegistry));
             break;
           }
           case 42: {
@@ -74,7 +75,8 @@ public  final class CheckAndMutateRowRequest extends
               falseMutations_ = new java.util.ArrayList<com.google.bigtable.v2.Mutation>();
               mutable_bitField0_ |= 0x00000010;
             }
-            falseMutations_.add(input.readMessage(com.google.bigtable.v2.Mutation.parser(), extensionRegistry));
+            falseMutations_.add(
+                input.readMessage(com.google.bigtable.v2.Mutation.parser(), extensionRegistry));
             break;
           }
           case 50: {
@@ -112,7 +114,7 @@ public  final class CheckAndMutateRowRequest extends
     return com.google.bigtable.v2.BigtableProto.internal_static_google_bigtable_v2_CheckAndMutateRowRequest_descriptor;
   }
 
-  protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.google.bigtable.v2.BigtableProto.internal_static_google_bigtable_v2_CheckAndMutateRowRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
@@ -386,7 +388,7 @@ public  final class CheckAndMutateRowRequest extends
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
     if (!getTableNameBytes().isEmpty()) {
-      com.google.protobuf.GeneratedMessage.writeString(output, 1, tableName_);
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 1, tableName_);
     }
     if (!rowKey_.isEmpty()) {
       output.writeBytes(2, rowKey_);
@@ -408,7 +410,7 @@ public  final class CheckAndMutateRowRequest extends
 
     size = 0;
     if (!getTableNameBytes().isEmpty()) {
-      size += com.google.protobuf.GeneratedMessage.computeStringSize(1, tableName_);
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, tableName_);
     }
     if (!rowKey_.isEmpty()) {
       size += com.google.protobuf.CodedOutputStream
@@ -431,6 +433,61 @@ public  final class CheckAndMutateRowRequest extends
   }
 
   private static final long serialVersionUID = 0L;
+  @java.lang.Override
+  public boolean equals(final java.lang.Object obj) {
+    if (obj == this) {
+     return true;
+    }
+    if (!(obj instanceof com.google.bigtable.v2.CheckAndMutateRowRequest)) {
+      return super.equals(obj);
+    }
+    com.google.bigtable.v2.CheckAndMutateRowRequest other = (com.google.bigtable.v2.CheckAndMutateRowRequest) obj;
+
+    boolean result = true;
+    result = result && getTableName()
+        .equals(other.getTableName());
+    result = result && getRowKey()
+        .equals(other.getRowKey());
+    result = result && (hasPredicateFilter() == other.hasPredicateFilter());
+    if (hasPredicateFilter()) {
+      result = result && getPredicateFilter()
+          .equals(other.getPredicateFilter());
+    }
+    result = result && getTrueMutationsList()
+        .equals(other.getTrueMutationsList());
+    result = result && getFalseMutationsList()
+        .equals(other.getFalseMutationsList());
+    return result;
+  }
+
+  @java.lang.Override
+  public int hashCode() {
+    if (memoizedHashCode != 0) {
+      return memoizedHashCode;
+    }
+    int hash = 41;
+    hash = (19 * hash) + getDescriptorForType().hashCode();
+    hash = (37 * hash) + TABLE_NAME_FIELD_NUMBER;
+    hash = (53 * hash) + getTableName().hashCode();
+    hash = (37 * hash) + ROW_KEY_FIELD_NUMBER;
+    hash = (53 * hash) + getRowKey().hashCode();
+    if (hasPredicateFilter()) {
+      hash = (37 * hash) + PREDICATE_FILTER_FIELD_NUMBER;
+      hash = (53 * hash) + getPredicateFilter().hashCode();
+    }
+    if (getTrueMutationsCount() > 0) {
+      hash = (37 * hash) + TRUE_MUTATIONS_FIELD_NUMBER;
+      hash = (53 * hash) + getTrueMutationsList().hashCode();
+    }
+    if (getFalseMutationsCount() > 0) {
+      hash = (37 * hash) + FALSE_MUTATIONS_FIELD_NUMBER;
+      hash = (53 * hash) + getFalseMutationsList().hashCode();
+    }
+    hash = (29 * hash) + unknownFields.hashCode();
+    memoizedHashCode = hash;
+    return hash;
+  }
+
   public static com.google.bigtable.v2.CheckAndMutateRowRequest parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -454,39 +511,39 @@ public  final class CheckAndMutateRowRequest extends
   }
   public static com.google.bigtable.v2.CheckAndMutateRowRequest parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.CheckAndMutateRowRequest parseFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.v2.CheckAndMutateRowRequest parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.CheckAndMutateRowRequest parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.v2.CheckAndMutateRowRequest parseFrom(
       com.google.protobuf.CodedInputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.CheckAndMutateRowRequest parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
@@ -504,7 +561,7 @@ public  final class CheckAndMutateRowRequest extends
 
   @java.lang.Override
   protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
@@ -516,7 +573,7 @@ public  final class CheckAndMutateRowRequest extends
    * Protobuf type {@code google.bigtable.v2.CheckAndMutateRowRequest}
    */
   public static final class Builder extends
-      com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
       // @@protoc_insertion_point(builder_implements:google.bigtable.v2.CheckAndMutateRowRequest)
       com.google.bigtable.v2.CheckAndMutateRowRequestOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
@@ -524,7 +581,7 @@ public  final class CheckAndMutateRowRequest extends
       return com.google.bigtable.v2.BigtableProto.internal_static_google_bigtable_v2_CheckAndMutateRowRequest_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.bigtable.v2.BigtableProto.internal_static_google_bigtable_v2_CheckAndMutateRowRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -537,12 +594,13 @@ public  final class CheckAndMutateRowRequest extends
     }
 
     private Builder(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
         getTrueMutationsFieldBuilder();
         getFalseMutationsFieldBuilder();
       }
@@ -625,6 +683,32 @@ public  final class CheckAndMutateRowRequest extends
       return result;
     }
 
+    public Builder clone() {
+      return (Builder) super.clone();
+    }
+    public Builder setField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.setField(field, value);
+    }
+    public Builder clearField(
+        com.google.protobuf.Descriptors.FieldDescriptor field) {
+      return (Builder) super.clearField(field);
+    }
+    public Builder clearOneof(
+        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      return (Builder) super.clearOneof(oneof);
+    }
+    public Builder setRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        int index, Object value) {
+      return (Builder) super.setRepeatedField(field, index, value);
+    }
+    public Builder addRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.addRepeatedField(field, value);
+    }
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.bigtable.v2.CheckAndMutateRowRequest) {
         return mergeFrom((com.google.bigtable.v2.CheckAndMutateRowRequest)other);
@@ -665,7 +749,7 @@ public  final class CheckAndMutateRowRequest extends
             trueMutations_ = other.trueMutations_;
             bitField0_ = (bitField0_ & ~0x00000008);
             trueMutationsBuilder_ = 
-              com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+              com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
                  getTrueMutationsFieldBuilder() : null;
           } else {
             trueMutationsBuilder_.addAllMessages(other.trueMutations_);
@@ -691,7 +775,7 @@ public  final class CheckAndMutateRowRequest extends
             falseMutations_ = other.falseMutations_;
             bitField0_ = (bitField0_ & ~0x00000010);
             falseMutationsBuilder_ = 
-              com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+              com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
                  getFalseMutationsFieldBuilder() : null;
           } else {
             falseMutationsBuilder_.addAllMessages(other.falseMutations_);
@@ -871,7 +955,7 @@ public  final class CheckAndMutateRowRequest extends
     }
 
     private com.google.bigtable.v2.RowFilter predicateFilter_ = null;
-    private com.google.protobuf.SingleFieldBuilder<
+    private com.google.protobuf.SingleFieldBuilderV3<
         com.google.bigtable.v2.RowFilter, com.google.bigtable.v2.RowFilter.Builder, com.google.bigtable.v2.RowFilterOrBuilder> predicateFilterBuilder_;
     /**
      * <pre>
@@ -1036,11 +1120,11 @@ public  final class CheckAndMutateRowRequest extends
      *
      * <code>optional .google.bigtable.v2.RowFilter predicate_filter = 6;</code>
      */
-    private com.google.protobuf.SingleFieldBuilder<
+    private com.google.protobuf.SingleFieldBuilderV3<
         com.google.bigtable.v2.RowFilter, com.google.bigtable.v2.RowFilter.Builder, com.google.bigtable.v2.RowFilterOrBuilder> 
         getPredicateFilterFieldBuilder() {
       if (predicateFilterBuilder_ == null) {
-        predicateFilterBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+        predicateFilterBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
             com.google.bigtable.v2.RowFilter, com.google.bigtable.v2.RowFilter.Builder, com.google.bigtable.v2.RowFilterOrBuilder>(
                 getPredicateFilter(),
                 getParentForChildren(),
@@ -1059,7 +1143,7 @@ public  final class CheckAndMutateRowRequest extends
        }
     }
 
-    private com.google.protobuf.RepeatedFieldBuilder<
+    private com.google.protobuf.RepeatedFieldBuilderV3<
         com.google.bigtable.v2.Mutation, com.google.bigtable.v2.Mutation.Builder, com.google.bigtable.v2.MutationOrBuilder> trueMutationsBuilder_;
 
     /**
@@ -1419,11 +1503,11 @@ public  final class CheckAndMutateRowRequest extends
          getTrueMutationsBuilderList() {
       return getTrueMutationsFieldBuilder().getBuilderList();
     }
-    private com.google.protobuf.RepeatedFieldBuilder<
+    private com.google.protobuf.RepeatedFieldBuilderV3<
         com.google.bigtable.v2.Mutation, com.google.bigtable.v2.Mutation.Builder, com.google.bigtable.v2.MutationOrBuilder> 
         getTrueMutationsFieldBuilder() {
       if (trueMutationsBuilder_ == null) {
-        trueMutationsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
+        trueMutationsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
             com.google.bigtable.v2.Mutation, com.google.bigtable.v2.Mutation.Builder, com.google.bigtable.v2.MutationOrBuilder>(
                 trueMutations_,
                 ((bitField0_ & 0x00000008) == 0x00000008),
@@ -1443,7 +1527,7 @@ public  final class CheckAndMutateRowRequest extends
        }
     }
 
-    private com.google.protobuf.RepeatedFieldBuilder<
+    private com.google.protobuf.RepeatedFieldBuilderV3<
         com.google.bigtable.v2.Mutation, com.google.bigtable.v2.Mutation.Builder, com.google.bigtable.v2.MutationOrBuilder> falseMutationsBuilder_;
 
     /**
@@ -1803,11 +1887,11 @@ public  final class CheckAndMutateRowRequest extends
          getFalseMutationsBuilderList() {
       return getFalseMutationsFieldBuilder().getBuilderList();
     }
-    private com.google.protobuf.RepeatedFieldBuilder<
+    private com.google.protobuf.RepeatedFieldBuilderV3<
         com.google.bigtable.v2.Mutation, com.google.bigtable.v2.Mutation.Builder, com.google.bigtable.v2.MutationOrBuilder> 
         getFalseMutationsFieldBuilder() {
       if (falseMutationsBuilder_ == null) {
-        falseMutationsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
+        falseMutationsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
             com.google.bigtable.v2.Mutation, com.google.bigtable.v2.Mutation.Builder, com.google.bigtable.v2.MutationOrBuilder>(
                 falseMutations_,
                 ((bitField0_ & 0x00000010) == 0x00000010),

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/CheckAndMutateRowResponse.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/CheckAndMutateRowResponse.java
@@ -11,11 +11,11 @@ package com.google.bigtable.v2;
  * Protobuf type {@code google.bigtable.v2.CheckAndMutateRowResponse}
  */
 public  final class CheckAndMutateRowResponse extends
-    com.google.protobuf.GeneratedMessage implements
+    com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:google.bigtable.v2.CheckAndMutateRowResponse)
     CheckAndMutateRowResponseOrBuilder {
   // Use CheckAndMutateRowResponse.newBuilder() to construct.
-  private CheckAndMutateRowResponse(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+  private CheckAndMutateRowResponse(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private CheckAndMutateRowResponse() {
@@ -68,7 +68,7 @@ public  final class CheckAndMutateRowResponse extends
     return com.google.bigtable.v2.BigtableProto.internal_static_google_bigtable_v2_CheckAndMutateRowResponse_descriptor;
   }
 
-  protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.google.bigtable.v2.BigtableProto.internal_static_google_bigtable_v2_CheckAndMutateRowResponse_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
@@ -120,6 +120,37 @@ public  final class CheckAndMutateRowResponse extends
   }
 
   private static final long serialVersionUID = 0L;
+  @java.lang.Override
+  public boolean equals(final java.lang.Object obj) {
+    if (obj == this) {
+     return true;
+    }
+    if (!(obj instanceof com.google.bigtable.v2.CheckAndMutateRowResponse)) {
+      return super.equals(obj);
+    }
+    com.google.bigtable.v2.CheckAndMutateRowResponse other = (com.google.bigtable.v2.CheckAndMutateRowResponse) obj;
+
+    boolean result = true;
+    result = result && (getPredicateMatched()
+        == other.getPredicateMatched());
+    return result;
+  }
+
+  @java.lang.Override
+  public int hashCode() {
+    if (memoizedHashCode != 0) {
+      return memoizedHashCode;
+    }
+    int hash = 41;
+    hash = (19 * hash) + getDescriptorForType().hashCode();
+    hash = (37 * hash) + PREDICATE_MATCHED_FIELD_NUMBER;
+    hash = (53 * hash) + com.google.protobuf.Internal.hashBoolean(
+        getPredicateMatched());
+    hash = (29 * hash) + unknownFields.hashCode();
+    memoizedHashCode = hash;
+    return hash;
+  }
+
   public static com.google.bigtable.v2.CheckAndMutateRowResponse parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -143,39 +174,39 @@ public  final class CheckAndMutateRowResponse extends
   }
   public static com.google.bigtable.v2.CheckAndMutateRowResponse parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.CheckAndMutateRowResponse parseFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.v2.CheckAndMutateRowResponse parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.CheckAndMutateRowResponse parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.v2.CheckAndMutateRowResponse parseFrom(
       com.google.protobuf.CodedInputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.CheckAndMutateRowResponse parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
@@ -193,7 +224,7 @@ public  final class CheckAndMutateRowResponse extends
 
   @java.lang.Override
   protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
@@ -205,7 +236,7 @@ public  final class CheckAndMutateRowResponse extends
    * Protobuf type {@code google.bigtable.v2.CheckAndMutateRowResponse}
    */
   public static final class Builder extends
-      com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
       // @@protoc_insertion_point(builder_implements:google.bigtable.v2.CheckAndMutateRowResponse)
       com.google.bigtable.v2.CheckAndMutateRowResponseOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
@@ -213,7 +244,7 @@ public  final class CheckAndMutateRowResponse extends
       return com.google.bigtable.v2.BigtableProto.internal_static_google_bigtable_v2_CheckAndMutateRowResponse_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.bigtable.v2.BigtableProto.internal_static_google_bigtable_v2_CheckAndMutateRowResponse_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -226,12 +257,13 @@ public  final class CheckAndMutateRowResponse extends
     }
 
     private Builder(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
       }
     }
     public Builder clear() {
@@ -265,6 +297,32 @@ public  final class CheckAndMutateRowResponse extends
       return result;
     }
 
+    public Builder clone() {
+      return (Builder) super.clone();
+    }
+    public Builder setField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.setField(field, value);
+    }
+    public Builder clearField(
+        com.google.protobuf.Descriptors.FieldDescriptor field) {
+      return (Builder) super.clearField(field);
+    }
+    public Builder clearOneof(
+        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      return (Builder) super.clearOneof(oneof);
+    }
+    public Builder setRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        int index, Object value) {
+      return (Builder) super.setRepeatedField(field, index, value);
+    }
+    public Builder addRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.addRepeatedField(field, value);
+    }
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.bigtable.v2.CheckAndMutateRowResponse) {
         return mergeFrom((com.google.bigtable.v2.CheckAndMutateRowResponse)other);

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/Column.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/Column.java
@@ -12,11 +12,11 @@ package com.google.bigtable.v2;
  * Protobuf type {@code google.bigtable.v2.Column}
  */
 public  final class Column extends
-    com.google.protobuf.GeneratedMessage implements
+    com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:google.bigtable.v2.Column)
     ColumnOrBuilder {
   // Use Column.newBuilder() to construct.
-  private Column(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+  private Column(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private Column() {
@@ -59,7 +59,8 @@ public  final class Column extends
               cells_ = new java.util.ArrayList<com.google.bigtable.v2.Cell>();
               mutable_bitField0_ |= 0x00000002;
             }
-            cells_.add(input.readMessage(com.google.bigtable.v2.Cell.parser(), extensionRegistry));
+            cells_.add(
+                input.readMessage(com.google.bigtable.v2.Cell.parser(), extensionRegistry));
             break;
           }
         }
@@ -81,7 +82,7 @@ public  final class Column extends
     return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_Column_descriptor;
   }
 
-  protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_Column_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
@@ -199,6 +200,42 @@ public  final class Column extends
   }
 
   private static final long serialVersionUID = 0L;
+  @java.lang.Override
+  public boolean equals(final java.lang.Object obj) {
+    if (obj == this) {
+     return true;
+    }
+    if (!(obj instanceof com.google.bigtable.v2.Column)) {
+      return super.equals(obj);
+    }
+    com.google.bigtable.v2.Column other = (com.google.bigtable.v2.Column) obj;
+
+    boolean result = true;
+    result = result && getQualifier()
+        .equals(other.getQualifier());
+    result = result && getCellsList()
+        .equals(other.getCellsList());
+    return result;
+  }
+
+  @java.lang.Override
+  public int hashCode() {
+    if (memoizedHashCode != 0) {
+      return memoizedHashCode;
+    }
+    int hash = 41;
+    hash = (19 * hash) + getDescriptorForType().hashCode();
+    hash = (37 * hash) + QUALIFIER_FIELD_NUMBER;
+    hash = (53 * hash) + getQualifier().hashCode();
+    if (getCellsCount() > 0) {
+      hash = (37 * hash) + CELLS_FIELD_NUMBER;
+      hash = (53 * hash) + getCellsList().hashCode();
+    }
+    hash = (29 * hash) + unknownFields.hashCode();
+    memoizedHashCode = hash;
+    return hash;
+  }
+
   public static com.google.bigtable.v2.Column parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -222,39 +259,39 @@ public  final class Column extends
   }
   public static com.google.bigtable.v2.Column parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.Column parseFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.v2.Column parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.Column parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.v2.Column parseFrom(
       com.google.protobuf.CodedInputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.Column parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
@@ -272,7 +309,7 @@ public  final class Column extends
 
   @java.lang.Override
   protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
@@ -285,7 +322,7 @@ public  final class Column extends
    * Protobuf type {@code google.bigtable.v2.Column}
    */
   public static final class Builder extends
-      com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
       // @@protoc_insertion_point(builder_implements:google.bigtable.v2.Column)
       com.google.bigtable.v2.ColumnOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
@@ -293,7 +330,7 @@ public  final class Column extends
       return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_Column_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_Column_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -306,12 +343,13 @@ public  final class Column extends
     }
 
     private Builder(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
         getCellsFieldBuilder();
       }
     }
@@ -364,6 +402,32 @@ public  final class Column extends
       return result;
     }
 
+    public Builder clone() {
+      return (Builder) super.clone();
+    }
+    public Builder setField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.setField(field, value);
+    }
+    public Builder clearField(
+        com.google.protobuf.Descriptors.FieldDescriptor field) {
+      return (Builder) super.clearField(field);
+    }
+    public Builder clearOneof(
+        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      return (Builder) super.clearOneof(oneof);
+    }
+    public Builder setRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        int index, Object value) {
+      return (Builder) super.setRepeatedField(field, index, value);
+    }
+    public Builder addRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.addRepeatedField(field, value);
+    }
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.bigtable.v2.Column) {
         return mergeFrom((com.google.bigtable.v2.Column)other);
@@ -397,7 +461,7 @@ public  final class Column extends
             cells_ = other.cells_;
             bitField0_ = (bitField0_ & ~0x00000002);
             cellsBuilder_ = 
-              com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+              com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
                  getCellsFieldBuilder() : null;
           } else {
             cellsBuilder_.addAllMessages(other.cells_);
@@ -493,7 +557,7 @@ public  final class Column extends
        }
     }
 
-    private com.google.protobuf.RepeatedFieldBuilder<
+    private com.google.protobuf.RepeatedFieldBuilderV3<
         com.google.bigtable.v2.Cell, com.google.bigtable.v2.Cell.Builder, com.google.bigtable.v2.CellOrBuilder> cellsBuilder_;
 
     /**
@@ -781,11 +845,11 @@ public  final class Column extends
          getCellsBuilderList() {
       return getCellsFieldBuilder().getBuilderList();
     }
-    private com.google.protobuf.RepeatedFieldBuilder<
+    private com.google.protobuf.RepeatedFieldBuilderV3<
         com.google.bigtable.v2.Cell, com.google.bigtable.v2.Cell.Builder, com.google.bigtable.v2.CellOrBuilder> 
         getCellsFieldBuilder() {
       if (cellsBuilder_ == null) {
-        cellsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
+        cellsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
             com.google.bigtable.v2.Cell, com.google.bigtable.v2.Cell.Builder, com.google.bigtable.v2.CellOrBuilder>(
                 cells_,
                 ((bitField0_ & 0x00000002) == 0x00000002),

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/ColumnRange.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/ColumnRange.java
@@ -14,11 +14,11 @@ package com.google.bigtable.v2;
  * Protobuf type {@code google.bigtable.v2.ColumnRange}
  */
 public  final class ColumnRange extends
-    com.google.protobuf.GeneratedMessage implements
+    com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:google.bigtable.v2.ColumnRange)
     ColumnRangeOrBuilder {
   // Use ColumnRange.newBuilder() to construct.
-  private ColumnRange(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+  private ColumnRange(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private ColumnRange() {
@@ -92,7 +92,7 @@ public  final class ColumnRange extends
     return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_ColumnRange_descriptor;
   }
 
-  protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_ColumnRange_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
@@ -290,7 +290,7 @@ public  final class ColumnRange extends
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
     if (!getFamilyNameBytes().isEmpty()) {
-      com.google.protobuf.GeneratedMessage.writeString(output, 1, familyName_);
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 1, familyName_);
     }
     if (startQualifierCase_ == 2) {
       output.writeBytes(
@@ -316,7 +316,7 @@ public  final class ColumnRange extends
 
     size = 0;
     if (!getFamilyNameBytes().isEmpty()) {
-      size += com.google.protobuf.GeneratedMessage.computeStringSize(1, familyName_);
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, familyName_);
     }
     if (startQualifierCase_ == 2) {
       size += com.google.protobuf.CodedOutputStream
@@ -343,6 +343,90 @@ public  final class ColumnRange extends
   }
 
   private static final long serialVersionUID = 0L;
+  @java.lang.Override
+  public boolean equals(final java.lang.Object obj) {
+    if (obj == this) {
+     return true;
+    }
+    if (!(obj instanceof com.google.bigtable.v2.ColumnRange)) {
+      return super.equals(obj);
+    }
+    com.google.bigtable.v2.ColumnRange other = (com.google.bigtable.v2.ColumnRange) obj;
+
+    boolean result = true;
+    result = result && getFamilyName()
+        .equals(other.getFamilyName());
+    result = result && getStartQualifierCase().equals(
+        other.getStartQualifierCase());
+    if (!result) return false;
+    switch (startQualifierCase_) {
+      case 2:
+        result = result && getStartQualifierClosed()
+            .equals(other.getStartQualifierClosed());
+        break;
+      case 3:
+        result = result && getStartQualifierOpen()
+            .equals(other.getStartQualifierOpen());
+        break;
+      case 0:
+      default:
+    }
+    result = result && getEndQualifierCase().equals(
+        other.getEndQualifierCase());
+    if (!result) return false;
+    switch (endQualifierCase_) {
+      case 4:
+        result = result && getEndQualifierClosed()
+            .equals(other.getEndQualifierClosed());
+        break;
+      case 5:
+        result = result && getEndQualifierOpen()
+            .equals(other.getEndQualifierOpen());
+        break;
+      case 0:
+      default:
+    }
+    return result;
+  }
+
+  @java.lang.Override
+  public int hashCode() {
+    if (memoizedHashCode != 0) {
+      return memoizedHashCode;
+    }
+    int hash = 41;
+    hash = (19 * hash) + getDescriptorForType().hashCode();
+    hash = (37 * hash) + FAMILY_NAME_FIELD_NUMBER;
+    hash = (53 * hash) + getFamilyName().hashCode();
+    switch (startQualifierCase_) {
+      case 2:
+        hash = (37 * hash) + START_QUALIFIER_CLOSED_FIELD_NUMBER;
+        hash = (53 * hash) + getStartQualifierClosed().hashCode();
+        break;
+      case 3:
+        hash = (37 * hash) + START_QUALIFIER_OPEN_FIELD_NUMBER;
+        hash = (53 * hash) + getStartQualifierOpen().hashCode();
+        break;
+      case 0:
+      default:
+    }
+    switch (endQualifierCase_) {
+      case 4:
+        hash = (37 * hash) + END_QUALIFIER_CLOSED_FIELD_NUMBER;
+        hash = (53 * hash) + getEndQualifierClosed().hashCode();
+        break;
+      case 5:
+        hash = (37 * hash) + END_QUALIFIER_OPEN_FIELD_NUMBER;
+        hash = (53 * hash) + getEndQualifierOpen().hashCode();
+        break;
+      case 0:
+      default:
+    }
+    hash = (29 * hash) + unknownFields.hashCode();
+    memoizedHashCode = hash;
+    return hash;
+  }
+
   public static com.google.bigtable.v2.ColumnRange parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -366,39 +450,39 @@ public  final class ColumnRange extends
   }
   public static com.google.bigtable.v2.ColumnRange parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.ColumnRange parseFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.v2.ColumnRange parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.ColumnRange parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.v2.ColumnRange parseFrom(
       com.google.protobuf.CodedInputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.ColumnRange parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
@@ -416,7 +500,7 @@ public  final class ColumnRange extends
 
   @java.lang.Override
   protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
@@ -431,7 +515,7 @@ public  final class ColumnRange extends
    * Protobuf type {@code google.bigtable.v2.ColumnRange}
    */
   public static final class Builder extends
-      com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
       // @@protoc_insertion_point(builder_implements:google.bigtable.v2.ColumnRange)
       com.google.bigtable.v2.ColumnRangeOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
@@ -439,7 +523,7 @@ public  final class ColumnRange extends
       return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_ColumnRange_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_ColumnRange_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -452,12 +536,13 @@ public  final class ColumnRange extends
     }
 
     private Builder(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
       }
     }
     public Builder clear() {
@@ -509,6 +594,32 @@ public  final class ColumnRange extends
       return result;
     }
 
+    public Builder clone() {
+      return (Builder) super.clone();
+    }
+    public Builder setField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.setField(field, value);
+    }
+    public Builder clearField(
+        com.google.protobuf.Descriptors.FieldDescriptor field) {
+      return (Builder) super.clearField(field);
+    }
+    public Builder clearOneof(
+        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      return (Builder) super.clearOneof(oneof);
+    }
+    public Builder setRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        int index, Object value) {
+      return (Builder) super.setRepeatedField(field, index, value);
+    }
+    public Builder addRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.addRepeatedField(field, value);
+    }
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.bigtable.v2.ColumnRange) {
         return mergeFrom((com.google.bigtable.v2.ColumnRange)other);

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/DataProto.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/DataProto.java
@@ -6,102 +6,108 @@ package com.google.bigtable.v2;
 public final class DataProto {
   private DataProto() {}
   public static void registerAllExtensions(
+      com.google.protobuf.ExtensionRegistryLite registry) {
+  }
+
+  public static void registerAllExtensions(
       com.google.protobuf.ExtensionRegistry registry) {
+    registerAllExtensions(
+        (com.google.protobuf.ExtensionRegistryLite) registry);
   }
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_bigtable_v2_Row_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_bigtable_v2_Row_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_bigtable_v2_Family_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_bigtable_v2_Family_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_bigtable_v2_Column_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_bigtable_v2_Column_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_bigtable_v2_Cell_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_bigtable_v2_Cell_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_bigtable_v2_RowRange_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_bigtable_v2_RowRange_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_bigtable_v2_RowSet_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_bigtable_v2_RowSet_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_bigtable_v2_ColumnRange_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_bigtable_v2_ColumnRange_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_bigtable_v2_TimestampRange_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_bigtable_v2_TimestampRange_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_bigtable_v2_ValueRange_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_bigtable_v2_ValueRange_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_bigtable_v2_RowFilter_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_bigtable_v2_RowFilter_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_bigtable_v2_RowFilter_Chain_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_bigtable_v2_RowFilter_Chain_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_bigtable_v2_RowFilter_Interleave_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_bigtable_v2_RowFilter_Interleave_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_bigtable_v2_RowFilter_Condition_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_bigtable_v2_RowFilter_Condition_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_bigtable_v2_Mutation_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_bigtable_v2_Mutation_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_bigtable_v2_Mutation_SetCell_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_bigtable_v2_Mutation_SetCell_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_bigtable_v2_Mutation_DeleteFromColumn_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_bigtable_v2_Mutation_DeleteFromColumn_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_bigtable_v2_Mutation_DeleteFromFamily_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_bigtable_v2_Mutation_DeleteFromFamily_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_bigtable_v2_Mutation_DeleteFromRow_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_bigtable_v2_Mutation_DeleteFromRow_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_bigtable_v2_ReadModifyWriteRule_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_bigtable_v2_ReadModifyWriteRule_fieldAccessorTable;
 
   public static com.google.protobuf.Descriptors.FileDescriptor
@@ -200,115 +206,115 @@ public final class DataProto {
     internal_static_google_bigtable_v2_Row_descriptor =
       getDescriptor().getMessageTypes().get(0);
     internal_static_google_bigtable_v2_Row_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_bigtable_v2_Row_descriptor,
         new java.lang.String[] { "Key", "Families", });
     internal_static_google_bigtable_v2_Family_descriptor =
       getDescriptor().getMessageTypes().get(1);
     internal_static_google_bigtable_v2_Family_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_bigtable_v2_Family_descriptor,
         new java.lang.String[] { "Name", "Columns", });
     internal_static_google_bigtable_v2_Column_descriptor =
       getDescriptor().getMessageTypes().get(2);
     internal_static_google_bigtable_v2_Column_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_bigtable_v2_Column_descriptor,
         new java.lang.String[] { "Qualifier", "Cells", });
     internal_static_google_bigtable_v2_Cell_descriptor =
       getDescriptor().getMessageTypes().get(3);
     internal_static_google_bigtable_v2_Cell_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_bigtable_v2_Cell_descriptor,
         new java.lang.String[] { "TimestampMicros", "Value", "Labels", });
     internal_static_google_bigtable_v2_RowRange_descriptor =
       getDescriptor().getMessageTypes().get(4);
     internal_static_google_bigtable_v2_RowRange_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_bigtable_v2_RowRange_descriptor,
         new java.lang.String[] { "StartKeyClosed", "StartKeyOpen", "EndKeyOpen", "EndKeyClosed", "StartKey", "EndKey", });
     internal_static_google_bigtable_v2_RowSet_descriptor =
       getDescriptor().getMessageTypes().get(5);
     internal_static_google_bigtable_v2_RowSet_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_bigtable_v2_RowSet_descriptor,
         new java.lang.String[] { "RowKeys", "RowRanges", });
     internal_static_google_bigtable_v2_ColumnRange_descriptor =
       getDescriptor().getMessageTypes().get(6);
     internal_static_google_bigtable_v2_ColumnRange_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_bigtable_v2_ColumnRange_descriptor,
         new java.lang.String[] { "FamilyName", "StartQualifierClosed", "StartQualifierOpen", "EndQualifierClosed", "EndQualifierOpen", "StartQualifier", "EndQualifier", });
     internal_static_google_bigtable_v2_TimestampRange_descriptor =
       getDescriptor().getMessageTypes().get(7);
     internal_static_google_bigtable_v2_TimestampRange_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_bigtable_v2_TimestampRange_descriptor,
         new java.lang.String[] { "StartTimestampMicros", "EndTimestampMicros", });
     internal_static_google_bigtable_v2_ValueRange_descriptor =
       getDescriptor().getMessageTypes().get(8);
     internal_static_google_bigtable_v2_ValueRange_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_bigtable_v2_ValueRange_descriptor,
         new java.lang.String[] { "StartValueClosed", "StartValueOpen", "EndValueClosed", "EndValueOpen", "StartValue", "EndValue", });
     internal_static_google_bigtable_v2_RowFilter_descriptor =
       getDescriptor().getMessageTypes().get(9);
     internal_static_google_bigtable_v2_RowFilter_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_bigtable_v2_RowFilter_descriptor,
         new java.lang.String[] { "Chain", "Interleave", "Condition", "Sink", "PassAllFilter", "BlockAllFilter", "RowKeyRegexFilter", "RowSampleFilter", "FamilyNameRegexFilter", "ColumnQualifierRegexFilter", "ColumnRangeFilter", "TimestampRangeFilter", "ValueRegexFilter", "ValueRangeFilter", "CellsPerRowOffsetFilter", "CellsPerRowLimitFilter", "CellsPerColumnLimitFilter", "StripValueTransformer", "ApplyLabelTransformer", "Filter", });
     internal_static_google_bigtable_v2_RowFilter_Chain_descriptor =
       internal_static_google_bigtable_v2_RowFilter_descriptor.getNestedTypes().get(0);
     internal_static_google_bigtable_v2_RowFilter_Chain_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_bigtable_v2_RowFilter_Chain_descriptor,
         new java.lang.String[] { "Filters", });
     internal_static_google_bigtable_v2_RowFilter_Interleave_descriptor =
       internal_static_google_bigtable_v2_RowFilter_descriptor.getNestedTypes().get(1);
     internal_static_google_bigtable_v2_RowFilter_Interleave_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_bigtable_v2_RowFilter_Interleave_descriptor,
         new java.lang.String[] { "Filters", });
     internal_static_google_bigtable_v2_RowFilter_Condition_descriptor =
       internal_static_google_bigtable_v2_RowFilter_descriptor.getNestedTypes().get(2);
     internal_static_google_bigtable_v2_RowFilter_Condition_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_bigtable_v2_RowFilter_Condition_descriptor,
         new java.lang.String[] { "PredicateFilter", "TrueFilter", "FalseFilter", });
     internal_static_google_bigtable_v2_Mutation_descriptor =
       getDescriptor().getMessageTypes().get(10);
     internal_static_google_bigtable_v2_Mutation_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_bigtable_v2_Mutation_descriptor,
         new java.lang.String[] { "SetCell", "DeleteFromColumn", "DeleteFromFamily", "DeleteFromRow", "Mutation", });
     internal_static_google_bigtable_v2_Mutation_SetCell_descriptor =
       internal_static_google_bigtable_v2_Mutation_descriptor.getNestedTypes().get(0);
     internal_static_google_bigtable_v2_Mutation_SetCell_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_bigtable_v2_Mutation_SetCell_descriptor,
         new java.lang.String[] { "FamilyName", "ColumnQualifier", "TimestampMicros", "Value", });
     internal_static_google_bigtable_v2_Mutation_DeleteFromColumn_descriptor =
       internal_static_google_bigtable_v2_Mutation_descriptor.getNestedTypes().get(1);
     internal_static_google_bigtable_v2_Mutation_DeleteFromColumn_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_bigtable_v2_Mutation_DeleteFromColumn_descriptor,
         new java.lang.String[] { "FamilyName", "ColumnQualifier", "TimeRange", });
     internal_static_google_bigtable_v2_Mutation_DeleteFromFamily_descriptor =
       internal_static_google_bigtable_v2_Mutation_descriptor.getNestedTypes().get(2);
     internal_static_google_bigtable_v2_Mutation_DeleteFromFamily_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_bigtable_v2_Mutation_DeleteFromFamily_descriptor,
         new java.lang.String[] { "FamilyName", });
     internal_static_google_bigtable_v2_Mutation_DeleteFromRow_descriptor =
       internal_static_google_bigtable_v2_Mutation_descriptor.getNestedTypes().get(3);
     internal_static_google_bigtable_v2_Mutation_DeleteFromRow_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_bigtable_v2_Mutation_DeleteFromRow_descriptor,
         new java.lang.String[] { });
     internal_static_google_bigtable_v2_ReadModifyWriteRule_descriptor =
       getDescriptor().getMessageTypes().get(11);
     internal_static_google_bigtable_v2_ReadModifyWriteRule_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_bigtable_v2_ReadModifyWriteRule_descriptor,
         new java.lang.String[] { "FamilyName", "ColumnQualifier", "AppendValue", "IncrementAmount", "Rule", });
   }

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/Family.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/Family.java
@@ -12,11 +12,11 @@ package com.google.bigtable.v2;
  * Protobuf type {@code google.bigtable.v2.Family}
  */
 public  final class Family extends
-    com.google.protobuf.GeneratedMessage implements
+    com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:google.bigtable.v2.Family)
     FamilyOrBuilder {
   // Use Family.newBuilder() to construct.
-  private Family(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+  private Family(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private Family() {
@@ -60,7 +60,8 @@ public  final class Family extends
               columns_ = new java.util.ArrayList<com.google.bigtable.v2.Column>();
               mutable_bitField0_ |= 0x00000002;
             }
-            columns_.add(input.readMessage(com.google.bigtable.v2.Column.parser(), extensionRegistry));
+            columns_.add(
+                input.readMessage(com.google.bigtable.v2.Column.parser(), extensionRegistry));
             break;
           }
         }
@@ -82,7 +83,7 @@ public  final class Family extends
     return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_Family_descriptor;
   }
 
-  protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_Family_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
@@ -210,7 +211,7 @@ public  final class Family extends
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
     if (!getNameBytes().isEmpty()) {
-      com.google.protobuf.GeneratedMessage.writeString(output, 1, name_);
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 1, name_);
     }
     for (int i = 0; i < columns_.size(); i++) {
       output.writeMessage(2, columns_.get(i));
@@ -223,7 +224,7 @@ public  final class Family extends
 
     size = 0;
     if (!getNameBytes().isEmpty()) {
-      size += com.google.protobuf.GeneratedMessage.computeStringSize(1, name_);
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, name_);
     }
     for (int i = 0; i < columns_.size(); i++) {
       size += com.google.protobuf.CodedOutputStream
@@ -234,6 +235,42 @@ public  final class Family extends
   }
 
   private static final long serialVersionUID = 0L;
+  @java.lang.Override
+  public boolean equals(final java.lang.Object obj) {
+    if (obj == this) {
+     return true;
+    }
+    if (!(obj instanceof com.google.bigtable.v2.Family)) {
+      return super.equals(obj);
+    }
+    com.google.bigtable.v2.Family other = (com.google.bigtable.v2.Family) obj;
+
+    boolean result = true;
+    result = result && getName()
+        .equals(other.getName());
+    result = result && getColumnsList()
+        .equals(other.getColumnsList());
+    return result;
+  }
+
+  @java.lang.Override
+  public int hashCode() {
+    if (memoizedHashCode != 0) {
+      return memoizedHashCode;
+    }
+    int hash = 41;
+    hash = (19 * hash) + getDescriptorForType().hashCode();
+    hash = (37 * hash) + NAME_FIELD_NUMBER;
+    hash = (53 * hash) + getName().hashCode();
+    if (getColumnsCount() > 0) {
+      hash = (37 * hash) + COLUMNS_FIELD_NUMBER;
+      hash = (53 * hash) + getColumnsList().hashCode();
+    }
+    hash = (29 * hash) + unknownFields.hashCode();
+    memoizedHashCode = hash;
+    return hash;
+  }
+
   public static com.google.bigtable.v2.Family parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -257,39 +294,39 @@ public  final class Family extends
   }
   public static com.google.bigtable.v2.Family parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.Family parseFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.v2.Family parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.Family parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.v2.Family parseFrom(
       com.google.protobuf.CodedInputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.Family parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
@@ -307,7 +344,7 @@ public  final class Family extends
 
   @java.lang.Override
   protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
@@ -320,7 +357,7 @@ public  final class Family extends
    * Protobuf type {@code google.bigtable.v2.Family}
    */
   public static final class Builder extends
-      com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
       // @@protoc_insertion_point(builder_implements:google.bigtable.v2.Family)
       com.google.bigtable.v2.FamilyOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
@@ -328,7 +365,7 @@ public  final class Family extends
       return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_Family_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_Family_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -341,12 +378,13 @@ public  final class Family extends
     }
 
     private Builder(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
         getColumnsFieldBuilder();
       }
     }
@@ -399,6 +437,32 @@ public  final class Family extends
       return result;
     }
 
+    public Builder clone() {
+      return (Builder) super.clone();
+    }
+    public Builder setField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.setField(field, value);
+    }
+    public Builder clearField(
+        com.google.protobuf.Descriptors.FieldDescriptor field) {
+      return (Builder) super.clearField(field);
+    }
+    public Builder clearOneof(
+        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      return (Builder) super.clearOneof(oneof);
+    }
+    public Builder setRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        int index, Object value) {
+      return (Builder) super.setRepeatedField(field, index, value);
+    }
+    public Builder addRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.addRepeatedField(field, value);
+    }
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.bigtable.v2.Family) {
         return mergeFrom((com.google.bigtable.v2.Family)other);
@@ -433,7 +497,7 @@ public  final class Family extends
             columns_ = other.columns_;
             bitField0_ = (bitField0_ & ~0x00000002);
             columnsBuilder_ = 
-              com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+              com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
                  getColumnsFieldBuilder() : null;
           } else {
             columnsBuilder_.addAllMessages(other.columns_);
@@ -590,7 +654,7 @@ public  final class Family extends
        }
     }
 
-    private com.google.protobuf.RepeatedFieldBuilder<
+    private com.google.protobuf.RepeatedFieldBuilderV3<
         com.google.bigtable.v2.Column, com.google.bigtable.v2.Column.Builder, com.google.bigtable.v2.ColumnOrBuilder> columnsBuilder_;
 
     /**
@@ -878,11 +942,11 @@ public  final class Family extends
          getColumnsBuilderList() {
       return getColumnsFieldBuilder().getBuilderList();
     }
-    private com.google.protobuf.RepeatedFieldBuilder<
+    private com.google.protobuf.RepeatedFieldBuilderV3<
         com.google.bigtable.v2.Column, com.google.bigtable.v2.Column.Builder, com.google.bigtable.v2.ColumnOrBuilder> 
         getColumnsFieldBuilder() {
       if (columnsBuilder_ == null) {
-        columnsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
+        columnsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
             com.google.bigtable.v2.Column, com.google.bigtable.v2.Column.Builder, com.google.bigtable.v2.ColumnOrBuilder>(
                 columns_,
                 ((bitField0_ & 0x00000002) == 0x00000002),

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/MutateRowRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/MutateRowRequest.java
@@ -11,11 +11,11 @@ package com.google.bigtable.v2;
  * Protobuf type {@code google.bigtable.v2.MutateRowRequest}
  */
 public  final class MutateRowRequest extends
-    com.google.protobuf.GeneratedMessage implements
+    com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:google.bigtable.v2.MutateRowRequest)
     MutateRowRequestOrBuilder {
   // Use MutateRowRequest.newBuilder() to construct.
-  private MutateRowRequest(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+  private MutateRowRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private MutateRowRequest() {
@@ -65,7 +65,8 @@ public  final class MutateRowRequest extends
               mutations_ = new java.util.ArrayList<com.google.bigtable.v2.Mutation>();
               mutable_bitField0_ |= 0x00000004;
             }
-            mutations_.add(input.readMessage(com.google.bigtable.v2.Mutation.parser(), extensionRegistry));
+            mutations_.add(
+                input.readMessage(com.google.bigtable.v2.Mutation.parser(), extensionRegistry));
             break;
           }
         }
@@ -87,7 +88,7 @@ public  final class MutateRowRequest extends
     return com.google.bigtable.v2.BigtableProto.internal_static_google_bigtable_v2_MutateRowRequest_descriptor;
   }
 
-  protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.google.bigtable.v2.BigtableProto.internal_static_google_bigtable_v2_MutateRowRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
@@ -232,7 +233,7 @@ public  final class MutateRowRequest extends
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
     if (!getTableNameBytes().isEmpty()) {
-      com.google.protobuf.GeneratedMessage.writeString(output, 1, tableName_);
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 1, tableName_);
     }
     if (!rowKey_.isEmpty()) {
       output.writeBytes(2, rowKey_);
@@ -248,7 +249,7 @@ public  final class MutateRowRequest extends
 
     size = 0;
     if (!getTableNameBytes().isEmpty()) {
-      size += com.google.protobuf.GeneratedMessage.computeStringSize(1, tableName_);
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, tableName_);
     }
     if (!rowKey_.isEmpty()) {
       size += com.google.protobuf.CodedOutputStream
@@ -263,6 +264,46 @@ public  final class MutateRowRequest extends
   }
 
   private static final long serialVersionUID = 0L;
+  @java.lang.Override
+  public boolean equals(final java.lang.Object obj) {
+    if (obj == this) {
+     return true;
+    }
+    if (!(obj instanceof com.google.bigtable.v2.MutateRowRequest)) {
+      return super.equals(obj);
+    }
+    com.google.bigtable.v2.MutateRowRequest other = (com.google.bigtable.v2.MutateRowRequest) obj;
+
+    boolean result = true;
+    result = result && getTableName()
+        .equals(other.getTableName());
+    result = result && getRowKey()
+        .equals(other.getRowKey());
+    result = result && getMutationsList()
+        .equals(other.getMutationsList());
+    return result;
+  }
+
+  @java.lang.Override
+  public int hashCode() {
+    if (memoizedHashCode != 0) {
+      return memoizedHashCode;
+    }
+    int hash = 41;
+    hash = (19 * hash) + getDescriptorForType().hashCode();
+    hash = (37 * hash) + TABLE_NAME_FIELD_NUMBER;
+    hash = (53 * hash) + getTableName().hashCode();
+    hash = (37 * hash) + ROW_KEY_FIELD_NUMBER;
+    hash = (53 * hash) + getRowKey().hashCode();
+    if (getMutationsCount() > 0) {
+      hash = (37 * hash) + MUTATIONS_FIELD_NUMBER;
+      hash = (53 * hash) + getMutationsList().hashCode();
+    }
+    hash = (29 * hash) + unknownFields.hashCode();
+    memoizedHashCode = hash;
+    return hash;
+  }
+
   public static com.google.bigtable.v2.MutateRowRequest parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -286,39 +327,39 @@ public  final class MutateRowRequest extends
   }
   public static com.google.bigtable.v2.MutateRowRequest parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.MutateRowRequest parseFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.v2.MutateRowRequest parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.MutateRowRequest parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.v2.MutateRowRequest parseFrom(
       com.google.protobuf.CodedInputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.MutateRowRequest parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
@@ -336,7 +377,7 @@ public  final class MutateRowRequest extends
 
   @java.lang.Override
   protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
@@ -348,7 +389,7 @@ public  final class MutateRowRequest extends
    * Protobuf type {@code google.bigtable.v2.MutateRowRequest}
    */
   public static final class Builder extends
-      com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
       // @@protoc_insertion_point(builder_implements:google.bigtable.v2.MutateRowRequest)
       com.google.bigtable.v2.MutateRowRequestOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
@@ -356,7 +397,7 @@ public  final class MutateRowRequest extends
       return com.google.bigtable.v2.BigtableProto.internal_static_google_bigtable_v2_MutateRowRequest_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.bigtable.v2.BigtableProto.internal_static_google_bigtable_v2_MutateRowRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -369,12 +410,13 @@ public  final class MutateRowRequest extends
     }
 
     private Builder(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
         getMutationsFieldBuilder();
       }
     }
@@ -430,6 +472,32 @@ public  final class MutateRowRequest extends
       return result;
     }
 
+    public Builder clone() {
+      return (Builder) super.clone();
+    }
+    public Builder setField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.setField(field, value);
+    }
+    public Builder clearField(
+        com.google.protobuf.Descriptors.FieldDescriptor field) {
+      return (Builder) super.clearField(field);
+    }
+    public Builder clearOneof(
+        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      return (Builder) super.clearOneof(oneof);
+    }
+    public Builder setRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        int index, Object value) {
+      return (Builder) super.setRepeatedField(field, index, value);
+    }
+    public Builder addRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.addRepeatedField(field, value);
+    }
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.bigtable.v2.MutateRowRequest) {
         return mergeFrom((com.google.bigtable.v2.MutateRowRequest)other);
@@ -467,7 +535,7 @@ public  final class MutateRowRequest extends
             mutations_ = other.mutations_;
             bitField0_ = (bitField0_ & ~0x00000004);
             mutationsBuilder_ = 
-              com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+              com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
                  getMutationsFieldBuilder() : null;
           } else {
             mutationsBuilder_.addAllMessages(other.mutations_);
@@ -650,7 +718,7 @@ public  final class MutateRowRequest extends
        }
     }
 
-    private com.google.protobuf.RepeatedFieldBuilder<
+    private com.google.protobuf.RepeatedFieldBuilderV3<
         com.google.bigtable.v2.Mutation, com.google.bigtable.v2.Mutation.Builder, com.google.bigtable.v2.MutationOrBuilder> mutationsBuilder_;
 
     /**
@@ -974,11 +1042,11 @@ public  final class MutateRowRequest extends
          getMutationsBuilderList() {
       return getMutationsFieldBuilder().getBuilderList();
     }
-    private com.google.protobuf.RepeatedFieldBuilder<
+    private com.google.protobuf.RepeatedFieldBuilderV3<
         com.google.bigtable.v2.Mutation, com.google.bigtable.v2.Mutation.Builder, com.google.bigtable.v2.MutationOrBuilder> 
         getMutationsFieldBuilder() {
       if (mutationsBuilder_ == null) {
-        mutationsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
+        mutationsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
             com.google.bigtable.v2.Mutation, com.google.bigtable.v2.Mutation.Builder, com.google.bigtable.v2.MutationOrBuilder>(
                 mutations_,
                 ((bitField0_ & 0x00000004) == 0x00000004),

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/MutateRowResponse.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/MutateRowResponse.java
@@ -11,11 +11,11 @@ package com.google.bigtable.v2;
  * Protobuf type {@code google.bigtable.v2.MutateRowResponse}
  */
 public  final class MutateRowResponse extends
-    com.google.protobuf.GeneratedMessage implements
+    com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:google.bigtable.v2.MutateRowResponse)
     MutateRowResponseOrBuilder {
   // Use MutateRowResponse.newBuilder() to construct.
-  private MutateRowResponse(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+  private MutateRowResponse(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private MutateRowResponse() {
@@ -61,7 +61,7 @@ public  final class MutateRowResponse extends
     return com.google.bigtable.v2.BigtableProto.internal_static_google_bigtable_v2_MutateRowResponse_descriptor;
   }
 
-  protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.google.bigtable.v2.BigtableProto.internal_static_google_bigtable_v2_MutateRowResponse_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
@@ -92,6 +92,32 @@ public  final class MutateRowResponse extends
   }
 
   private static final long serialVersionUID = 0L;
+  @java.lang.Override
+  public boolean equals(final java.lang.Object obj) {
+    if (obj == this) {
+     return true;
+    }
+    if (!(obj instanceof com.google.bigtable.v2.MutateRowResponse)) {
+      return super.equals(obj);
+    }
+    com.google.bigtable.v2.MutateRowResponse other = (com.google.bigtable.v2.MutateRowResponse) obj;
+
+    boolean result = true;
+    return result;
+  }
+
+  @java.lang.Override
+  public int hashCode() {
+    if (memoizedHashCode != 0) {
+      return memoizedHashCode;
+    }
+    int hash = 41;
+    hash = (19 * hash) + getDescriptorForType().hashCode();
+    hash = (29 * hash) + unknownFields.hashCode();
+    memoizedHashCode = hash;
+    return hash;
+  }
+
   public static com.google.bigtable.v2.MutateRowResponse parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -115,39 +141,39 @@ public  final class MutateRowResponse extends
   }
   public static com.google.bigtable.v2.MutateRowResponse parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.MutateRowResponse parseFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.v2.MutateRowResponse parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.MutateRowResponse parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.v2.MutateRowResponse parseFrom(
       com.google.protobuf.CodedInputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.MutateRowResponse parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
@@ -165,7 +191,7 @@ public  final class MutateRowResponse extends
 
   @java.lang.Override
   protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
@@ -177,7 +203,7 @@ public  final class MutateRowResponse extends
    * Protobuf type {@code google.bigtable.v2.MutateRowResponse}
    */
   public static final class Builder extends
-      com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
       // @@protoc_insertion_point(builder_implements:google.bigtable.v2.MutateRowResponse)
       com.google.bigtable.v2.MutateRowResponseOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
@@ -185,7 +211,7 @@ public  final class MutateRowResponse extends
       return com.google.bigtable.v2.BigtableProto.internal_static_google_bigtable_v2_MutateRowResponse_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.bigtable.v2.BigtableProto.internal_static_google_bigtable_v2_MutateRowResponse_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -198,12 +224,13 @@ public  final class MutateRowResponse extends
     }
 
     private Builder(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
       }
     }
     public Builder clear() {
@@ -234,6 +261,32 @@ public  final class MutateRowResponse extends
       return result;
     }
 
+    public Builder clone() {
+      return (Builder) super.clone();
+    }
+    public Builder setField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.setField(field, value);
+    }
+    public Builder clearField(
+        com.google.protobuf.Descriptors.FieldDescriptor field) {
+      return (Builder) super.clearField(field);
+    }
+    public Builder clearOneof(
+        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      return (Builder) super.clearOneof(oneof);
+    }
+    public Builder setRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        int index, Object value) {
+      return (Builder) super.setRepeatedField(field, index, value);
+    }
+    public Builder addRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.addRepeatedField(field, value);
+    }
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.bigtable.v2.MutateRowResponse) {
         return mergeFrom((com.google.bigtable.v2.MutateRowResponse)other);

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/MutateRowsRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/MutateRowsRequest.java
@@ -11,11 +11,11 @@ package com.google.bigtable.v2;
  * Protobuf type {@code google.bigtable.v2.MutateRowsRequest}
  */
 public  final class MutateRowsRequest extends
-    com.google.protobuf.GeneratedMessage implements
+    com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:google.bigtable.v2.MutateRowsRequest)
     MutateRowsRequestOrBuilder {
   // Use MutateRowsRequest.newBuilder() to construct.
-  private MutateRowsRequest(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+  private MutateRowsRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private MutateRowsRequest() {
@@ -59,7 +59,8 @@ public  final class MutateRowsRequest extends
               entries_ = new java.util.ArrayList<com.google.bigtable.v2.MutateRowsRequest.Entry>();
               mutable_bitField0_ |= 0x00000002;
             }
-            entries_.add(input.readMessage(com.google.bigtable.v2.MutateRowsRequest.Entry.parser(), extensionRegistry));
+            entries_.add(
+                input.readMessage(com.google.bigtable.v2.MutateRowsRequest.Entry.parser(), extensionRegistry));
             break;
           }
         }
@@ -81,7 +82,7 @@ public  final class MutateRowsRequest extends
     return com.google.bigtable.v2.BigtableProto.internal_static_google_bigtable_v2_MutateRowsRequest_descriptor;
   }
 
-  protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.google.bigtable.v2.BigtableProto.internal_static_google_bigtable_v2_MutateRowsRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
@@ -164,11 +165,11 @@ public  final class MutateRowsRequest extends
    * Protobuf type {@code google.bigtable.v2.MutateRowsRequest.Entry}
    */
   public  static final class Entry extends
-      com.google.protobuf.GeneratedMessage implements
+      com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:google.bigtable.v2.MutateRowsRequest.Entry)
       EntryOrBuilder {
     // Use Entry.newBuilder() to construct.
-    private Entry(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+    private Entry(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
     }
     private Entry() {
@@ -211,7 +212,8 @@ public  final class MutateRowsRequest extends
                 mutations_ = new java.util.ArrayList<com.google.bigtable.v2.Mutation>();
                 mutable_bitField0_ |= 0x00000002;
               }
-              mutations_.add(input.readMessage(com.google.bigtable.v2.Mutation.parser(), extensionRegistry));
+              mutations_.add(
+                  input.readMessage(com.google.bigtable.v2.Mutation.parser(), extensionRegistry));
               break;
             }
           }
@@ -233,7 +235,7 @@ public  final class MutateRowsRequest extends
       return com.google.bigtable.v2.BigtableProto.internal_static_google_bigtable_v2_MutateRowsRequest_Entry_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.bigtable.v2.BigtableProto.internal_static_google_bigtable_v2_MutateRowsRequest_Entry_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -362,6 +364,42 @@ public  final class MutateRowsRequest extends
     }
 
     private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.google.bigtable.v2.MutateRowsRequest.Entry)) {
+        return super.equals(obj);
+      }
+      com.google.bigtable.v2.MutateRowsRequest.Entry other = (com.google.bigtable.v2.MutateRowsRequest.Entry) obj;
+
+      boolean result = true;
+      result = result && getRowKey()
+          .equals(other.getRowKey());
+      result = result && getMutationsList()
+          .equals(other.getMutationsList());
+      return result;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptorForType().hashCode();
+      hash = (37 * hash) + ROW_KEY_FIELD_NUMBER;
+      hash = (53 * hash) + getRowKey().hashCode();
+      if (getMutationsCount() > 0) {
+        hash = (37 * hash) + MUTATIONS_FIELD_NUMBER;
+        hash = (53 * hash) + getMutationsList().hashCode();
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
     public static com.google.bigtable.v2.MutateRowsRequest.Entry parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
@@ -385,39 +423,39 @@ public  final class MutateRowsRequest extends
     }
     public static com.google.bigtable.v2.MutateRowsRequest.Entry parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
     public static com.google.bigtable.v2.MutateRowsRequest.Entry parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
     public static com.google.bigtable.v2.MutateRowsRequest.Entry parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
     public static com.google.bigtable.v2.MutateRowsRequest.Entry parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
     public static com.google.bigtable.v2.MutateRowsRequest.Entry parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
     public static com.google.bigtable.v2.MutateRowsRequest.Entry parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
@@ -435,7 +473,7 @@ public  final class MutateRowsRequest extends
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -443,7 +481,7 @@ public  final class MutateRowsRequest extends
      * Protobuf type {@code google.bigtable.v2.MutateRowsRequest.Entry}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:google.bigtable.v2.MutateRowsRequest.Entry)
         com.google.bigtable.v2.MutateRowsRequest.EntryOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -451,7 +489,7 @@ public  final class MutateRowsRequest extends
         return com.google.bigtable.v2.BigtableProto.internal_static_google_bigtable_v2_MutateRowsRequest_Entry_descriptor;
       }
 
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return com.google.bigtable.v2.BigtableProto.internal_static_google_bigtable_v2_MutateRowsRequest_Entry_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -464,12 +502,13 @@ public  final class MutateRowsRequest extends
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
       private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
           getMutationsFieldBuilder();
         }
       }
@@ -522,6 +561,32 @@ public  final class MutateRowsRequest extends
         return result;
       }
 
+      public Builder clone() {
+        return (Builder) super.clone();
+      }
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          Object value) {
+        return (Builder) super.setField(field, value);
+      }
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return (Builder) super.clearField(field);
+      }
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return (Builder) super.clearOneof(oneof);
+      }
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, Object value) {
+        return (Builder) super.setRepeatedField(field, index, value);
+      }
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          Object value) {
+        return (Builder) super.addRepeatedField(field, value);
+      }
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof com.google.bigtable.v2.MutateRowsRequest.Entry) {
           return mergeFrom((com.google.bigtable.v2.MutateRowsRequest.Entry)other);
@@ -555,7 +620,7 @@ public  final class MutateRowsRequest extends
               mutations_ = other.mutations_;
               bitField0_ = (bitField0_ & ~0x00000002);
               mutationsBuilder_ = 
-                com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+                com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
                    getMutationsFieldBuilder() : null;
             } else {
               mutationsBuilder_.addAllMessages(other.mutations_);
@@ -639,7 +704,7 @@ public  final class MutateRowsRequest extends
          }
       }
 
-      private com.google.protobuf.RepeatedFieldBuilder<
+      private com.google.protobuf.RepeatedFieldBuilderV3<
           com.google.bigtable.v2.Mutation, com.google.bigtable.v2.Mutation.Builder, com.google.bigtable.v2.MutationOrBuilder> mutationsBuilder_;
 
       /**
@@ -981,11 +1046,11 @@ public  final class MutateRowsRequest extends
            getMutationsBuilderList() {
         return getMutationsFieldBuilder().getBuilderList();
       }
-      private com.google.protobuf.RepeatedFieldBuilder<
+      private com.google.protobuf.RepeatedFieldBuilderV3<
           com.google.bigtable.v2.Mutation, com.google.bigtable.v2.Mutation.Builder, com.google.bigtable.v2.MutationOrBuilder> 
           getMutationsFieldBuilder() {
         if (mutationsBuilder_ == null) {
-          mutationsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
+          mutationsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
               com.google.bigtable.v2.Mutation, com.google.bigtable.v2.Mutation.Builder, com.google.bigtable.v2.MutationOrBuilder>(
                   mutations_,
                   ((bitField0_ & 0x00000002) == 0x00000002),
@@ -1175,7 +1240,7 @@ public  final class MutateRowsRequest extends
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
     if (!getTableNameBytes().isEmpty()) {
-      com.google.protobuf.GeneratedMessage.writeString(output, 1, tableName_);
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 1, tableName_);
     }
     for (int i = 0; i < entries_.size(); i++) {
       output.writeMessage(2, entries_.get(i));
@@ -1188,7 +1253,7 @@ public  final class MutateRowsRequest extends
 
     size = 0;
     if (!getTableNameBytes().isEmpty()) {
-      size += com.google.protobuf.GeneratedMessage.computeStringSize(1, tableName_);
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, tableName_);
     }
     for (int i = 0; i < entries_.size(); i++) {
       size += com.google.protobuf.CodedOutputStream
@@ -1199,6 +1264,42 @@ public  final class MutateRowsRequest extends
   }
 
   private static final long serialVersionUID = 0L;
+  @java.lang.Override
+  public boolean equals(final java.lang.Object obj) {
+    if (obj == this) {
+     return true;
+    }
+    if (!(obj instanceof com.google.bigtable.v2.MutateRowsRequest)) {
+      return super.equals(obj);
+    }
+    com.google.bigtable.v2.MutateRowsRequest other = (com.google.bigtable.v2.MutateRowsRequest) obj;
+
+    boolean result = true;
+    result = result && getTableName()
+        .equals(other.getTableName());
+    result = result && getEntriesList()
+        .equals(other.getEntriesList());
+    return result;
+  }
+
+  @java.lang.Override
+  public int hashCode() {
+    if (memoizedHashCode != 0) {
+      return memoizedHashCode;
+    }
+    int hash = 41;
+    hash = (19 * hash) + getDescriptorForType().hashCode();
+    hash = (37 * hash) + TABLE_NAME_FIELD_NUMBER;
+    hash = (53 * hash) + getTableName().hashCode();
+    if (getEntriesCount() > 0) {
+      hash = (37 * hash) + ENTRIES_FIELD_NUMBER;
+      hash = (53 * hash) + getEntriesList().hashCode();
+    }
+    hash = (29 * hash) + unknownFields.hashCode();
+    memoizedHashCode = hash;
+    return hash;
+  }
+
   public static com.google.bigtable.v2.MutateRowsRequest parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -1222,39 +1323,39 @@ public  final class MutateRowsRequest extends
   }
   public static com.google.bigtable.v2.MutateRowsRequest parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.MutateRowsRequest parseFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.v2.MutateRowsRequest parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.MutateRowsRequest parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.v2.MutateRowsRequest parseFrom(
       com.google.protobuf.CodedInputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.MutateRowsRequest parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
@@ -1272,7 +1373,7 @@ public  final class MutateRowsRequest extends
 
   @java.lang.Override
   protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
@@ -1284,7 +1385,7 @@ public  final class MutateRowsRequest extends
    * Protobuf type {@code google.bigtable.v2.MutateRowsRequest}
    */
   public static final class Builder extends
-      com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
       // @@protoc_insertion_point(builder_implements:google.bigtable.v2.MutateRowsRequest)
       com.google.bigtable.v2.MutateRowsRequestOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
@@ -1292,7 +1393,7 @@ public  final class MutateRowsRequest extends
       return com.google.bigtable.v2.BigtableProto.internal_static_google_bigtable_v2_MutateRowsRequest_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.bigtable.v2.BigtableProto.internal_static_google_bigtable_v2_MutateRowsRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -1305,12 +1406,13 @@ public  final class MutateRowsRequest extends
     }
 
     private Builder(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
         getEntriesFieldBuilder();
       }
     }
@@ -1363,6 +1465,32 @@ public  final class MutateRowsRequest extends
       return result;
     }
 
+    public Builder clone() {
+      return (Builder) super.clone();
+    }
+    public Builder setField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.setField(field, value);
+    }
+    public Builder clearField(
+        com.google.protobuf.Descriptors.FieldDescriptor field) {
+      return (Builder) super.clearField(field);
+    }
+    public Builder clearOneof(
+        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      return (Builder) super.clearOneof(oneof);
+    }
+    public Builder setRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        int index, Object value) {
+      return (Builder) super.setRepeatedField(field, index, value);
+    }
+    public Builder addRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.addRepeatedField(field, value);
+    }
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.bigtable.v2.MutateRowsRequest) {
         return mergeFrom((com.google.bigtable.v2.MutateRowsRequest)other);
@@ -1397,7 +1525,7 @@ public  final class MutateRowsRequest extends
             entries_ = other.entries_;
             bitField0_ = (bitField0_ & ~0x00000002);
             entriesBuilder_ = 
-              com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+              com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
                  getEntriesFieldBuilder() : null;
           } else {
             entriesBuilder_.addAllMessages(other.entries_);
@@ -1529,7 +1657,7 @@ public  final class MutateRowsRequest extends
        }
     }
 
-    private com.google.protobuf.RepeatedFieldBuilder<
+    private com.google.protobuf.RepeatedFieldBuilderV3<
         com.google.bigtable.v2.MutateRowsRequest.Entry, com.google.bigtable.v2.MutateRowsRequest.Entry.Builder, com.google.bigtable.v2.MutateRowsRequest.EntryOrBuilder> entriesBuilder_;
 
     /**
@@ -1889,11 +2017,11 @@ public  final class MutateRowsRequest extends
          getEntriesBuilderList() {
       return getEntriesFieldBuilder().getBuilderList();
     }
-    private com.google.protobuf.RepeatedFieldBuilder<
+    private com.google.protobuf.RepeatedFieldBuilderV3<
         com.google.bigtable.v2.MutateRowsRequest.Entry, com.google.bigtable.v2.MutateRowsRequest.Entry.Builder, com.google.bigtable.v2.MutateRowsRequest.EntryOrBuilder> 
         getEntriesFieldBuilder() {
       if (entriesBuilder_ == null) {
-        entriesBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
+        entriesBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
             com.google.bigtable.v2.MutateRowsRequest.Entry, com.google.bigtable.v2.MutateRowsRequest.Entry.Builder, com.google.bigtable.v2.MutateRowsRequest.EntryOrBuilder>(
                 entries_,
                 ((bitField0_ & 0x00000002) == 0x00000002),

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/MutateRowsResponse.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/MutateRowsResponse.java
@@ -11,11 +11,11 @@ package com.google.bigtable.v2;
  * Protobuf type {@code google.bigtable.v2.MutateRowsResponse}
  */
 public  final class MutateRowsResponse extends
-    com.google.protobuf.GeneratedMessage implements
+    com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:google.bigtable.v2.MutateRowsResponse)
     MutateRowsResponseOrBuilder {
   // Use MutateRowsResponse.newBuilder() to construct.
-  private MutateRowsResponse(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+  private MutateRowsResponse(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private MutateRowsResponse() {
@@ -52,7 +52,8 @@ public  final class MutateRowsResponse extends
               entries_ = new java.util.ArrayList<com.google.bigtable.v2.MutateRowsResponse.Entry>();
               mutable_bitField0_ |= 0x00000001;
             }
-            entries_.add(input.readMessage(com.google.bigtable.v2.MutateRowsResponse.Entry.parser(), extensionRegistry));
+            entries_.add(
+                input.readMessage(com.google.bigtable.v2.MutateRowsResponse.Entry.parser(), extensionRegistry));
             break;
           }
         }
@@ -74,7 +75,7 @@ public  final class MutateRowsResponse extends
     return com.google.bigtable.v2.BigtableProto.internal_static_google_bigtable_v2_MutateRowsResponse_descriptor;
   }
 
-  protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.google.bigtable.v2.BigtableProto.internal_static_google_bigtable_v2_MutateRowsResponse_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
@@ -133,11 +134,11 @@ public  final class MutateRowsResponse extends
    * Protobuf type {@code google.bigtable.v2.MutateRowsResponse.Entry}
    */
   public  static final class Entry extends
-      com.google.protobuf.GeneratedMessage implements
+      com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:google.bigtable.v2.MutateRowsResponse.Entry)
       EntryOrBuilder {
     // Use Entry.newBuilder() to construct.
-    private Entry(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+    private Entry(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
     }
     private Entry() {
@@ -203,7 +204,7 @@ public  final class MutateRowsResponse extends
       return com.google.bigtable.v2.BigtableProto.internal_static_google_bigtable_v2_MutateRowsResponse_Entry_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.bigtable.v2.BigtableProto.internal_static_google_bigtable_v2_MutateRowsResponse_Entry_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -304,6 +305,46 @@ public  final class MutateRowsResponse extends
     }
 
     private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.google.bigtable.v2.MutateRowsResponse.Entry)) {
+        return super.equals(obj);
+      }
+      com.google.bigtable.v2.MutateRowsResponse.Entry other = (com.google.bigtable.v2.MutateRowsResponse.Entry) obj;
+
+      boolean result = true;
+      result = result && (getIndex()
+          == other.getIndex());
+      result = result && (hasStatus() == other.hasStatus());
+      if (hasStatus()) {
+        result = result && getStatus()
+            .equals(other.getStatus());
+      }
+      return result;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptorForType().hashCode();
+      hash = (37 * hash) + INDEX_FIELD_NUMBER;
+      hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
+          getIndex());
+      if (hasStatus()) {
+        hash = (37 * hash) + STATUS_FIELD_NUMBER;
+        hash = (53 * hash) + getStatus().hashCode();
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
     public static com.google.bigtable.v2.MutateRowsResponse.Entry parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
@@ -327,39 +368,39 @@ public  final class MutateRowsResponse extends
     }
     public static com.google.bigtable.v2.MutateRowsResponse.Entry parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
     public static com.google.bigtable.v2.MutateRowsResponse.Entry parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
     public static com.google.bigtable.v2.MutateRowsResponse.Entry parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
     public static com.google.bigtable.v2.MutateRowsResponse.Entry parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
     public static com.google.bigtable.v2.MutateRowsResponse.Entry parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
     public static com.google.bigtable.v2.MutateRowsResponse.Entry parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
@@ -377,7 +418,7 @@ public  final class MutateRowsResponse extends
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -385,7 +426,7 @@ public  final class MutateRowsResponse extends
      * Protobuf type {@code google.bigtable.v2.MutateRowsResponse.Entry}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:google.bigtable.v2.MutateRowsResponse.Entry)
         com.google.bigtable.v2.MutateRowsResponse.EntryOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -393,7 +434,7 @@ public  final class MutateRowsResponse extends
         return com.google.bigtable.v2.BigtableProto.internal_static_google_bigtable_v2_MutateRowsResponse_Entry_descriptor;
       }
 
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return com.google.bigtable.v2.BigtableProto.internal_static_google_bigtable_v2_MutateRowsResponse_Entry_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -406,12 +447,13 @@ public  final class MutateRowsResponse extends
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
       private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
         }
       }
       public Builder clear() {
@@ -456,6 +498,32 @@ public  final class MutateRowsResponse extends
         return result;
       }
 
+      public Builder clone() {
+        return (Builder) super.clone();
+      }
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          Object value) {
+        return (Builder) super.setField(field, value);
+      }
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return (Builder) super.clearField(field);
+      }
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return (Builder) super.clearOneof(oneof);
+      }
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, Object value) {
+        return (Builder) super.setRepeatedField(field, index, value);
+      }
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          Object value) {
+        return (Builder) super.addRepeatedField(field, value);
+      }
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof com.google.bigtable.v2.MutateRowsResponse.Entry) {
           return mergeFrom((com.google.bigtable.v2.MutateRowsResponse.Entry)other);
@@ -541,7 +609,7 @@ public  final class MutateRowsResponse extends
       }
 
       private com.google.rpc.Status status_ = null;
-      private com.google.protobuf.SingleFieldBuilder<
+      private com.google.protobuf.SingleFieldBuilderV3<
           com.google.rpc.Status, com.google.rpc.Status.Builder, com.google.rpc.StatusOrBuilder> statusBuilder_;
       /**
        * <pre>
@@ -706,11 +774,11 @@ public  final class MutateRowsResponse extends
        *
        * <code>optional .google.rpc.Status status = 2;</code>
        */
-      private com.google.protobuf.SingleFieldBuilder<
+      private com.google.protobuf.SingleFieldBuilderV3<
           com.google.rpc.Status, com.google.rpc.Status.Builder, com.google.rpc.StatusOrBuilder> 
           getStatusFieldBuilder() {
         if (statusBuilder_ == null) {
-          statusBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+          statusBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
               com.google.rpc.Status, com.google.rpc.Status.Builder, com.google.rpc.StatusOrBuilder>(
                   getStatus(),
                   getParentForChildren(),
@@ -854,6 +922,38 @@ public  final class MutateRowsResponse extends
   }
 
   private static final long serialVersionUID = 0L;
+  @java.lang.Override
+  public boolean equals(final java.lang.Object obj) {
+    if (obj == this) {
+     return true;
+    }
+    if (!(obj instanceof com.google.bigtable.v2.MutateRowsResponse)) {
+      return super.equals(obj);
+    }
+    com.google.bigtable.v2.MutateRowsResponse other = (com.google.bigtable.v2.MutateRowsResponse) obj;
+
+    boolean result = true;
+    result = result && getEntriesList()
+        .equals(other.getEntriesList());
+    return result;
+  }
+
+  @java.lang.Override
+  public int hashCode() {
+    if (memoizedHashCode != 0) {
+      return memoizedHashCode;
+    }
+    int hash = 41;
+    hash = (19 * hash) + getDescriptorForType().hashCode();
+    if (getEntriesCount() > 0) {
+      hash = (37 * hash) + ENTRIES_FIELD_NUMBER;
+      hash = (53 * hash) + getEntriesList().hashCode();
+    }
+    hash = (29 * hash) + unknownFields.hashCode();
+    memoizedHashCode = hash;
+    return hash;
+  }
+
   public static com.google.bigtable.v2.MutateRowsResponse parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -877,39 +977,39 @@ public  final class MutateRowsResponse extends
   }
   public static com.google.bigtable.v2.MutateRowsResponse parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.MutateRowsResponse parseFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.v2.MutateRowsResponse parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.MutateRowsResponse parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.v2.MutateRowsResponse parseFrom(
       com.google.protobuf.CodedInputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.MutateRowsResponse parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
@@ -927,7 +1027,7 @@ public  final class MutateRowsResponse extends
 
   @java.lang.Override
   protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
@@ -939,7 +1039,7 @@ public  final class MutateRowsResponse extends
    * Protobuf type {@code google.bigtable.v2.MutateRowsResponse}
    */
   public static final class Builder extends
-      com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
       // @@protoc_insertion_point(builder_implements:google.bigtable.v2.MutateRowsResponse)
       com.google.bigtable.v2.MutateRowsResponseOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
@@ -947,7 +1047,7 @@ public  final class MutateRowsResponse extends
       return com.google.bigtable.v2.BigtableProto.internal_static_google_bigtable_v2_MutateRowsResponse_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.bigtable.v2.BigtableProto.internal_static_google_bigtable_v2_MutateRowsResponse_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -960,12 +1060,13 @@ public  final class MutateRowsResponse extends
     }
 
     private Builder(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
         getEntriesFieldBuilder();
       }
     }
@@ -1013,6 +1114,32 @@ public  final class MutateRowsResponse extends
       return result;
     }
 
+    public Builder clone() {
+      return (Builder) super.clone();
+    }
+    public Builder setField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.setField(field, value);
+    }
+    public Builder clearField(
+        com.google.protobuf.Descriptors.FieldDescriptor field) {
+      return (Builder) super.clearField(field);
+    }
+    public Builder clearOneof(
+        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      return (Builder) super.clearOneof(oneof);
+    }
+    public Builder setRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        int index, Object value) {
+      return (Builder) super.setRepeatedField(field, index, value);
+    }
+    public Builder addRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.addRepeatedField(field, value);
+    }
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.bigtable.v2.MutateRowsResponse) {
         return mergeFrom((com.google.bigtable.v2.MutateRowsResponse)other);
@@ -1043,7 +1170,7 @@ public  final class MutateRowsResponse extends
             entries_ = other.entries_;
             bitField0_ = (bitField0_ & ~0x00000001);
             entriesBuilder_ = 
-              com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+              com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
                  getEntriesFieldBuilder() : null;
           } else {
             entriesBuilder_.addAllMessages(other.entries_);
@@ -1086,7 +1213,7 @@ public  final class MutateRowsResponse extends
        }
     }
 
-    private com.google.protobuf.RepeatedFieldBuilder<
+    private com.google.protobuf.RepeatedFieldBuilderV3<
         com.google.bigtable.v2.MutateRowsResponse.Entry, com.google.bigtable.v2.MutateRowsResponse.Entry.Builder, com.google.bigtable.v2.MutateRowsResponse.EntryOrBuilder> entriesBuilder_;
 
     /**
@@ -1374,11 +1501,11 @@ public  final class MutateRowsResponse extends
          getEntriesBuilderList() {
       return getEntriesFieldBuilder().getBuilderList();
     }
-    private com.google.protobuf.RepeatedFieldBuilder<
+    private com.google.protobuf.RepeatedFieldBuilderV3<
         com.google.bigtable.v2.MutateRowsResponse.Entry, com.google.bigtable.v2.MutateRowsResponse.Entry.Builder, com.google.bigtable.v2.MutateRowsResponse.EntryOrBuilder> 
         getEntriesFieldBuilder() {
       if (entriesBuilder_ == null) {
-        entriesBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
+        entriesBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
             com.google.bigtable.v2.MutateRowsResponse.Entry, com.google.bigtable.v2.MutateRowsResponse.Entry.Builder, com.google.bigtable.v2.MutateRowsResponse.EntryOrBuilder>(
                 entries_,
                 ((bitField0_ & 0x00000001) == 0x00000001),

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/Mutation.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/Mutation.java
@@ -11,11 +11,11 @@ package com.google.bigtable.v2;
  * Protobuf type {@code google.bigtable.v2.Mutation}
  */
 public  final class Mutation extends
-    com.google.protobuf.GeneratedMessage implements
+    com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:google.bigtable.v2.Mutation)
     MutationOrBuilder {
   // Use Mutation.newBuilder() to construct.
-  private Mutation(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+  private Mutation(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private Mutation() {
@@ -118,7 +118,7 @@ public  final class Mutation extends
     return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_Mutation_descriptor;
   }
 
-  protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_Mutation_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
@@ -189,11 +189,11 @@ public  final class Mutation extends
    * Protobuf type {@code google.bigtable.v2.Mutation.SetCell}
    */
   public  static final class SetCell extends
-      com.google.protobuf.GeneratedMessage implements
+      com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:google.bigtable.v2.Mutation.SetCell)
       SetCellOrBuilder {
     // Use SetCell.newBuilder() to construct.
-    private SetCell(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+    private SetCell(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
     }
     private SetCell() {
@@ -265,7 +265,7 @@ public  final class Mutation extends
       return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_Mutation_SetCell_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_Mutation_SetCell_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -373,7 +373,7 @@ public  final class Mutation extends
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (!getFamilyNameBytes().isEmpty()) {
-        com.google.protobuf.GeneratedMessage.writeString(output, 1, familyName_);
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, familyName_);
       }
       if (!columnQualifier_.isEmpty()) {
         output.writeBytes(2, columnQualifier_);
@@ -392,7 +392,7 @@ public  final class Mutation extends
 
       size = 0;
       if (!getFamilyNameBytes().isEmpty()) {
-        size += com.google.protobuf.GeneratedMessage.computeStringSize(1, familyName_);
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, familyName_);
       }
       if (!columnQualifier_.isEmpty()) {
         size += com.google.protobuf.CodedOutputStream
@@ -411,6 +411,49 @@ public  final class Mutation extends
     }
 
     private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.google.bigtable.v2.Mutation.SetCell)) {
+        return super.equals(obj);
+      }
+      com.google.bigtable.v2.Mutation.SetCell other = (com.google.bigtable.v2.Mutation.SetCell) obj;
+
+      boolean result = true;
+      result = result && getFamilyName()
+          .equals(other.getFamilyName());
+      result = result && getColumnQualifier()
+          .equals(other.getColumnQualifier());
+      result = result && (getTimestampMicros()
+          == other.getTimestampMicros());
+      result = result && getValue()
+          .equals(other.getValue());
+      return result;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptorForType().hashCode();
+      hash = (37 * hash) + FAMILY_NAME_FIELD_NUMBER;
+      hash = (53 * hash) + getFamilyName().hashCode();
+      hash = (37 * hash) + COLUMN_QUALIFIER_FIELD_NUMBER;
+      hash = (53 * hash) + getColumnQualifier().hashCode();
+      hash = (37 * hash) + TIMESTAMP_MICROS_FIELD_NUMBER;
+      hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
+          getTimestampMicros());
+      hash = (37 * hash) + VALUE_FIELD_NUMBER;
+      hash = (53 * hash) + getValue().hashCode();
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
     public static com.google.bigtable.v2.Mutation.SetCell parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
@@ -434,39 +477,39 @@ public  final class Mutation extends
     }
     public static com.google.bigtable.v2.Mutation.SetCell parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
     public static com.google.bigtable.v2.Mutation.SetCell parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
     public static com.google.bigtable.v2.Mutation.SetCell parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
     public static com.google.bigtable.v2.Mutation.SetCell parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
     public static com.google.bigtable.v2.Mutation.SetCell parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
     public static com.google.bigtable.v2.Mutation.SetCell parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
@@ -484,7 +527,7 @@ public  final class Mutation extends
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -496,7 +539,7 @@ public  final class Mutation extends
      * Protobuf type {@code google.bigtable.v2.Mutation.SetCell}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:google.bigtable.v2.Mutation.SetCell)
         com.google.bigtable.v2.Mutation.SetCellOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -504,7 +547,7 @@ public  final class Mutation extends
         return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_Mutation_SetCell_descriptor;
       }
 
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_Mutation_SetCell_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -517,12 +560,13 @@ public  final class Mutation extends
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
       private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
         }
       }
       public Builder clear() {
@@ -565,6 +609,32 @@ public  final class Mutation extends
         return result;
       }
 
+      public Builder clone() {
+        return (Builder) super.clone();
+      }
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          Object value) {
+        return (Builder) super.setField(field, value);
+      }
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return (Builder) super.clearField(field);
+      }
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return (Builder) super.clearOneof(oneof);
+      }
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, Object value) {
+        return (Builder) super.setRepeatedField(field, index, value);
+      }
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          Object value) {
+        return (Builder) super.addRepeatedField(field, value);
+      }
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof com.google.bigtable.v2.Mutation.SetCell) {
           return mergeFrom((com.google.bigtable.v2.Mutation.SetCell)other);
@@ -960,11 +1030,11 @@ public  final class Mutation extends
    * Protobuf type {@code google.bigtable.v2.Mutation.DeleteFromColumn}
    */
   public  static final class DeleteFromColumn extends
-      com.google.protobuf.GeneratedMessage implements
+      com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:google.bigtable.v2.Mutation.DeleteFromColumn)
       DeleteFromColumnOrBuilder {
     // Use DeleteFromColumn.newBuilder() to construct.
-    private DeleteFromColumn(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+    private DeleteFromColumn(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
     }
     private DeleteFromColumn() {
@@ -1037,7 +1107,7 @@ public  final class Mutation extends
       return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_Mutation_DeleteFromColumn_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_Mutation_DeleteFromColumn_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -1148,7 +1218,7 @@ public  final class Mutation extends
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (!getFamilyNameBytes().isEmpty()) {
-        com.google.protobuf.GeneratedMessage.writeString(output, 1, familyName_);
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, familyName_);
       }
       if (!columnQualifier_.isEmpty()) {
         output.writeBytes(2, columnQualifier_);
@@ -1164,7 +1234,7 @@ public  final class Mutation extends
 
       size = 0;
       if (!getFamilyNameBytes().isEmpty()) {
-        size += com.google.protobuf.GeneratedMessage.computeStringSize(1, familyName_);
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, familyName_);
       }
       if (!columnQualifier_.isEmpty()) {
         size += com.google.protobuf.CodedOutputStream
@@ -1179,6 +1249,49 @@ public  final class Mutation extends
     }
 
     private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.google.bigtable.v2.Mutation.DeleteFromColumn)) {
+        return super.equals(obj);
+      }
+      com.google.bigtable.v2.Mutation.DeleteFromColumn other = (com.google.bigtable.v2.Mutation.DeleteFromColumn) obj;
+
+      boolean result = true;
+      result = result && getFamilyName()
+          .equals(other.getFamilyName());
+      result = result && getColumnQualifier()
+          .equals(other.getColumnQualifier());
+      result = result && (hasTimeRange() == other.hasTimeRange());
+      if (hasTimeRange()) {
+        result = result && getTimeRange()
+            .equals(other.getTimeRange());
+      }
+      return result;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptorForType().hashCode();
+      hash = (37 * hash) + FAMILY_NAME_FIELD_NUMBER;
+      hash = (53 * hash) + getFamilyName().hashCode();
+      hash = (37 * hash) + COLUMN_QUALIFIER_FIELD_NUMBER;
+      hash = (53 * hash) + getColumnQualifier().hashCode();
+      if (hasTimeRange()) {
+        hash = (37 * hash) + TIME_RANGE_FIELD_NUMBER;
+        hash = (53 * hash) + getTimeRange().hashCode();
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
     public static com.google.bigtable.v2.Mutation.DeleteFromColumn parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
@@ -1202,39 +1315,39 @@ public  final class Mutation extends
     }
     public static com.google.bigtable.v2.Mutation.DeleteFromColumn parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
     public static com.google.bigtable.v2.Mutation.DeleteFromColumn parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
     public static com.google.bigtable.v2.Mutation.DeleteFromColumn parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
     public static com.google.bigtable.v2.Mutation.DeleteFromColumn parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
     public static com.google.bigtable.v2.Mutation.DeleteFromColumn parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
     public static com.google.bigtable.v2.Mutation.DeleteFromColumn parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
@@ -1252,7 +1365,7 @@ public  final class Mutation extends
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -1265,7 +1378,7 @@ public  final class Mutation extends
      * Protobuf type {@code google.bigtable.v2.Mutation.DeleteFromColumn}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:google.bigtable.v2.Mutation.DeleteFromColumn)
         com.google.bigtable.v2.Mutation.DeleteFromColumnOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -1273,7 +1386,7 @@ public  final class Mutation extends
         return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_Mutation_DeleteFromColumn_descriptor;
       }
 
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_Mutation_DeleteFromColumn_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -1286,12 +1399,13 @@ public  final class Mutation extends
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
       private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
         }
       }
       public Builder clear() {
@@ -1339,6 +1453,32 @@ public  final class Mutation extends
         return result;
       }
 
+      public Builder clone() {
+        return (Builder) super.clone();
+      }
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          Object value) {
+        return (Builder) super.setField(field, value);
+      }
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return (Builder) super.clearField(field);
+      }
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return (Builder) super.clearOneof(oneof);
+      }
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, Object value) {
+        return (Builder) super.setRepeatedField(field, index, value);
+      }
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          Object value) {
+        return (Builder) super.addRepeatedField(field, value);
+      }
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof com.google.bigtable.v2.Mutation.DeleteFromColumn) {
           return mergeFrom((com.google.bigtable.v2.Mutation.DeleteFromColumn)other);
@@ -1525,7 +1665,7 @@ public  final class Mutation extends
       }
 
       private com.google.bigtable.v2.TimestampRange timeRange_ = null;
-      private com.google.protobuf.SingleFieldBuilder<
+      private com.google.protobuf.SingleFieldBuilderV3<
           com.google.bigtable.v2.TimestampRange, com.google.bigtable.v2.TimestampRange.Builder, com.google.bigtable.v2.TimestampRangeOrBuilder> timeRangeBuilder_;
       /**
        * <pre>
@@ -1663,11 +1803,11 @@ public  final class Mutation extends
        *
        * <code>optional .google.bigtable.v2.TimestampRange time_range = 3;</code>
        */
-      private com.google.protobuf.SingleFieldBuilder<
+      private com.google.protobuf.SingleFieldBuilderV3<
           com.google.bigtable.v2.TimestampRange, com.google.bigtable.v2.TimestampRange.Builder, com.google.bigtable.v2.TimestampRangeOrBuilder> 
           getTimeRangeFieldBuilder() {
         if (timeRangeBuilder_ == null) {
-          timeRangeBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+          timeRangeBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
               com.google.bigtable.v2.TimestampRange, com.google.bigtable.v2.TimestampRange.Builder, com.google.bigtable.v2.TimestampRangeOrBuilder>(
                   getTimeRange(),
                   getParentForChildren(),
@@ -1757,11 +1897,11 @@ public  final class Mutation extends
    * Protobuf type {@code google.bigtable.v2.Mutation.DeleteFromFamily}
    */
   public  static final class DeleteFromFamily extends
-      com.google.protobuf.GeneratedMessage implements
+      com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:google.bigtable.v2.Mutation.DeleteFromFamily)
       DeleteFromFamilyOrBuilder {
     // Use DeleteFromFamily.newBuilder() to construct.
-    private DeleteFromFamily(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+    private DeleteFromFamily(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
     }
     private DeleteFromFamily() {
@@ -1815,7 +1955,7 @@ public  final class Mutation extends
       return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_Mutation_DeleteFromFamily_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_Mutation_DeleteFromFamily_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -1879,7 +2019,7 @@ public  final class Mutation extends
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (!getFamilyNameBytes().isEmpty()) {
-        com.google.protobuf.GeneratedMessage.writeString(output, 1, familyName_);
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, familyName_);
       }
     }
 
@@ -1889,13 +2029,43 @@ public  final class Mutation extends
 
       size = 0;
       if (!getFamilyNameBytes().isEmpty()) {
-        size += com.google.protobuf.GeneratedMessage.computeStringSize(1, familyName_);
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, familyName_);
       }
       memoizedSize = size;
       return size;
     }
 
     private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.google.bigtable.v2.Mutation.DeleteFromFamily)) {
+        return super.equals(obj);
+      }
+      com.google.bigtable.v2.Mutation.DeleteFromFamily other = (com.google.bigtable.v2.Mutation.DeleteFromFamily) obj;
+
+      boolean result = true;
+      result = result && getFamilyName()
+          .equals(other.getFamilyName());
+      return result;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptorForType().hashCode();
+      hash = (37 * hash) + FAMILY_NAME_FIELD_NUMBER;
+      hash = (53 * hash) + getFamilyName().hashCode();
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
     public static com.google.bigtable.v2.Mutation.DeleteFromFamily parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
@@ -1919,39 +2089,39 @@ public  final class Mutation extends
     }
     public static com.google.bigtable.v2.Mutation.DeleteFromFamily parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
     public static com.google.bigtable.v2.Mutation.DeleteFromFamily parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
     public static com.google.bigtable.v2.Mutation.DeleteFromFamily parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
     public static com.google.bigtable.v2.Mutation.DeleteFromFamily parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
     public static com.google.bigtable.v2.Mutation.DeleteFromFamily parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
     public static com.google.bigtable.v2.Mutation.DeleteFromFamily parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
@@ -1969,7 +2139,7 @@ public  final class Mutation extends
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -1981,7 +2151,7 @@ public  final class Mutation extends
      * Protobuf type {@code google.bigtable.v2.Mutation.DeleteFromFamily}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:google.bigtable.v2.Mutation.DeleteFromFamily)
         com.google.bigtable.v2.Mutation.DeleteFromFamilyOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -1989,7 +2159,7 @@ public  final class Mutation extends
         return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_Mutation_DeleteFromFamily_descriptor;
       }
 
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_Mutation_DeleteFromFamily_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -2002,12 +2172,13 @@ public  final class Mutation extends
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
       private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
         }
       }
       public Builder clear() {
@@ -2041,6 +2212,32 @@ public  final class Mutation extends
         return result;
       }
 
+      public Builder clone() {
+        return (Builder) super.clone();
+      }
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          Object value) {
+        return (Builder) super.setField(field, value);
+      }
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return (Builder) super.clearField(field);
+      }
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return (Builder) super.clearOneof(oneof);
+      }
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, Object value) {
+        return (Builder) super.setRepeatedField(field, index, value);
+      }
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          Object value) {
+        return (Builder) super.addRepeatedField(field, value);
+      }
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof com.google.bigtable.v2.Mutation.DeleteFromFamily) {
           return mergeFrom((com.google.bigtable.v2.Mutation.DeleteFromFamily)other);
@@ -2236,11 +2433,11 @@ public  final class Mutation extends
    * Protobuf type {@code google.bigtable.v2.Mutation.DeleteFromRow}
    */
   public  static final class DeleteFromRow extends
-      com.google.protobuf.GeneratedMessage implements
+      com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:google.bigtable.v2.Mutation.DeleteFromRow)
       DeleteFromRowOrBuilder {
     // Use DeleteFromRow.newBuilder() to construct.
-    private DeleteFromRow(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+    private DeleteFromRow(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
     }
     private DeleteFromRow() {
@@ -2286,7 +2483,7 @@ public  final class Mutation extends
       return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_Mutation_DeleteFromRow_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_Mutation_DeleteFromRow_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -2317,6 +2514,32 @@ public  final class Mutation extends
     }
 
     private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.google.bigtable.v2.Mutation.DeleteFromRow)) {
+        return super.equals(obj);
+      }
+      com.google.bigtable.v2.Mutation.DeleteFromRow other = (com.google.bigtable.v2.Mutation.DeleteFromRow) obj;
+
+      boolean result = true;
+      return result;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptorForType().hashCode();
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
     public static com.google.bigtable.v2.Mutation.DeleteFromRow parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
@@ -2340,39 +2563,39 @@ public  final class Mutation extends
     }
     public static com.google.bigtable.v2.Mutation.DeleteFromRow parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
     public static com.google.bigtable.v2.Mutation.DeleteFromRow parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
     public static com.google.bigtable.v2.Mutation.DeleteFromRow parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
     public static com.google.bigtable.v2.Mutation.DeleteFromRow parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
     public static com.google.bigtable.v2.Mutation.DeleteFromRow parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
     public static com.google.bigtable.v2.Mutation.DeleteFromRow parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
@@ -2390,7 +2613,7 @@ public  final class Mutation extends
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -2402,7 +2625,7 @@ public  final class Mutation extends
      * Protobuf type {@code google.bigtable.v2.Mutation.DeleteFromRow}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:google.bigtable.v2.Mutation.DeleteFromRow)
         com.google.bigtable.v2.Mutation.DeleteFromRowOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -2410,7 +2633,7 @@ public  final class Mutation extends
         return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_Mutation_DeleteFromRow_descriptor;
       }
 
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_Mutation_DeleteFromRow_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -2423,12 +2646,13 @@ public  final class Mutation extends
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
       private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
         }
       }
       public Builder clear() {
@@ -2459,6 +2683,32 @@ public  final class Mutation extends
         return result;
       }
 
+      public Builder clone() {
+        return (Builder) super.clone();
+      }
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          Object value) {
+        return (Builder) super.setField(field, value);
+      }
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return (Builder) super.clearField(field);
+      }
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return (Builder) super.clearOneof(oneof);
+      }
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, Object value) {
+        return (Builder) super.setRepeatedField(field, index, value);
+      }
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          Object value) {
+        return (Builder) super.addRepeatedField(field, value);
+      }
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof com.google.bigtable.v2.Mutation.DeleteFromRow) {
           return mergeFrom((com.google.bigtable.v2.Mutation.DeleteFromRow)other);
@@ -2750,6 +3000,75 @@ public  final class Mutation extends
   }
 
   private static final long serialVersionUID = 0L;
+  @java.lang.Override
+  public boolean equals(final java.lang.Object obj) {
+    if (obj == this) {
+     return true;
+    }
+    if (!(obj instanceof com.google.bigtable.v2.Mutation)) {
+      return super.equals(obj);
+    }
+    com.google.bigtable.v2.Mutation other = (com.google.bigtable.v2.Mutation) obj;
+
+    boolean result = true;
+    result = result && getMutationCase().equals(
+        other.getMutationCase());
+    if (!result) return false;
+    switch (mutationCase_) {
+      case 1:
+        result = result && getSetCell()
+            .equals(other.getSetCell());
+        break;
+      case 2:
+        result = result && getDeleteFromColumn()
+            .equals(other.getDeleteFromColumn());
+        break;
+      case 3:
+        result = result && getDeleteFromFamily()
+            .equals(other.getDeleteFromFamily());
+        break;
+      case 4:
+        result = result && getDeleteFromRow()
+            .equals(other.getDeleteFromRow());
+        break;
+      case 0:
+      default:
+    }
+    return result;
+  }
+
+  @java.lang.Override
+  public int hashCode() {
+    if (memoizedHashCode != 0) {
+      return memoizedHashCode;
+    }
+    int hash = 41;
+    hash = (19 * hash) + getDescriptorForType().hashCode();
+    switch (mutationCase_) {
+      case 1:
+        hash = (37 * hash) + SET_CELL_FIELD_NUMBER;
+        hash = (53 * hash) + getSetCell().hashCode();
+        break;
+      case 2:
+        hash = (37 * hash) + DELETE_FROM_COLUMN_FIELD_NUMBER;
+        hash = (53 * hash) + getDeleteFromColumn().hashCode();
+        break;
+      case 3:
+        hash = (37 * hash) + DELETE_FROM_FAMILY_FIELD_NUMBER;
+        hash = (53 * hash) + getDeleteFromFamily().hashCode();
+        break;
+      case 4:
+        hash = (37 * hash) + DELETE_FROM_ROW_FIELD_NUMBER;
+        hash = (53 * hash) + getDeleteFromRow().hashCode();
+        break;
+      case 0:
+      default:
+    }
+    hash = (29 * hash) + unknownFields.hashCode();
+    memoizedHashCode = hash;
+    return hash;
+  }
+
   public static com.google.bigtable.v2.Mutation parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -2773,39 +3092,39 @@ public  final class Mutation extends
   }
   public static com.google.bigtable.v2.Mutation parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.Mutation parseFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.v2.Mutation parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.Mutation parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.v2.Mutation parseFrom(
       com.google.protobuf.CodedInputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.Mutation parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
@@ -2823,7 +3142,7 @@ public  final class Mutation extends
 
   @java.lang.Override
   protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
@@ -2835,7 +3154,7 @@ public  final class Mutation extends
    * Protobuf type {@code google.bigtable.v2.Mutation}
    */
   public static final class Builder extends
-      com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
       // @@protoc_insertion_point(builder_implements:google.bigtable.v2.Mutation)
       com.google.bigtable.v2.MutationOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
@@ -2843,7 +3162,7 @@ public  final class Mutation extends
       return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_Mutation_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_Mutation_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -2856,12 +3175,13 @@ public  final class Mutation extends
     }
 
     private Builder(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
       }
     }
     public Builder clear() {
@@ -2923,6 +3243,32 @@ public  final class Mutation extends
       return result;
     }
 
+    public Builder clone() {
+      return (Builder) super.clone();
+    }
+    public Builder setField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.setField(field, value);
+    }
+    public Builder clearField(
+        com.google.protobuf.Descriptors.FieldDescriptor field) {
+      return (Builder) super.clearField(field);
+    }
+    public Builder clearOneof(
+        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      return (Builder) super.clearOneof(oneof);
+    }
+    public Builder setRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        int index, Object value) {
+      return (Builder) super.setRepeatedField(field, index, value);
+    }
+    public Builder addRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.addRepeatedField(field, value);
+    }
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.bigtable.v2.Mutation) {
         return mergeFrom((com.google.bigtable.v2.Mutation)other);
@@ -2996,7 +3342,7 @@ public  final class Mutation extends
     }
 
 
-    private com.google.protobuf.SingleFieldBuilder<
+    private com.google.protobuf.SingleFieldBuilderV3<
         com.google.bigtable.v2.Mutation.SetCell, com.google.bigtable.v2.Mutation.SetCell.Builder, com.google.bigtable.v2.Mutation.SetCellOrBuilder> setCellBuilder_;
     /**
      * <pre>
@@ -3139,14 +3485,14 @@ public  final class Mutation extends
      *
      * <code>optional .google.bigtable.v2.Mutation.SetCell set_cell = 1;</code>
      */
-    private com.google.protobuf.SingleFieldBuilder<
+    private com.google.protobuf.SingleFieldBuilderV3<
         com.google.bigtable.v2.Mutation.SetCell, com.google.bigtable.v2.Mutation.SetCell.Builder, com.google.bigtable.v2.Mutation.SetCellOrBuilder> 
         getSetCellFieldBuilder() {
       if (setCellBuilder_ == null) {
         if (!(mutationCase_ == 1)) {
           mutation_ = com.google.bigtable.v2.Mutation.SetCell.getDefaultInstance();
         }
-        setCellBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+        setCellBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
             com.google.bigtable.v2.Mutation.SetCell, com.google.bigtable.v2.Mutation.SetCell.Builder, com.google.bigtable.v2.Mutation.SetCellOrBuilder>(
                 (com.google.bigtable.v2.Mutation.SetCell) mutation_,
                 getParentForChildren(),
@@ -3158,7 +3504,7 @@ public  final class Mutation extends
       return setCellBuilder_;
     }
 
-    private com.google.protobuf.SingleFieldBuilder<
+    private com.google.protobuf.SingleFieldBuilderV3<
         com.google.bigtable.v2.Mutation.DeleteFromColumn, com.google.bigtable.v2.Mutation.DeleteFromColumn.Builder, com.google.bigtable.v2.Mutation.DeleteFromColumnOrBuilder> deleteFromColumnBuilder_;
     /**
      * <pre>
@@ -3301,14 +3647,14 @@ public  final class Mutation extends
      *
      * <code>optional .google.bigtable.v2.Mutation.DeleteFromColumn delete_from_column = 2;</code>
      */
-    private com.google.protobuf.SingleFieldBuilder<
+    private com.google.protobuf.SingleFieldBuilderV3<
         com.google.bigtable.v2.Mutation.DeleteFromColumn, com.google.bigtable.v2.Mutation.DeleteFromColumn.Builder, com.google.bigtable.v2.Mutation.DeleteFromColumnOrBuilder> 
         getDeleteFromColumnFieldBuilder() {
       if (deleteFromColumnBuilder_ == null) {
         if (!(mutationCase_ == 2)) {
           mutation_ = com.google.bigtable.v2.Mutation.DeleteFromColumn.getDefaultInstance();
         }
-        deleteFromColumnBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+        deleteFromColumnBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
             com.google.bigtable.v2.Mutation.DeleteFromColumn, com.google.bigtable.v2.Mutation.DeleteFromColumn.Builder, com.google.bigtable.v2.Mutation.DeleteFromColumnOrBuilder>(
                 (com.google.bigtable.v2.Mutation.DeleteFromColumn) mutation_,
                 getParentForChildren(),
@@ -3320,7 +3666,7 @@ public  final class Mutation extends
       return deleteFromColumnBuilder_;
     }
 
-    private com.google.protobuf.SingleFieldBuilder<
+    private com.google.protobuf.SingleFieldBuilderV3<
         com.google.bigtable.v2.Mutation.DeleteFromFamily, com.google.bigtable.v2.Mutation.DeleteFromFamily.Builder, com.google.bigtable.v2.Mutation.DeleteFromFamilyOrBuilder> deleteFromFamilyBuilder_;
     /**
      * <pre>
@@ -3463,14 +3809,14 @@ public  final class Mutation extends
      *
      * <code>optional .google.bigtable.v2.Mutation.DeleteFromFamily delete_from_family = 3;</code>
      */
-    private com.google.protobuf.SingleFieldBuilder<
+    private com.google.protobuf.SingleFieldBuilderV3<
         com.google.bigtable.v2.Mutation.DeleteFromFamily, com.google.bigtable.v2.Mutation.DeleteFromFamily.Builder, com.google.bigtable.v2.Mutation.DeleteFromFamilyOrBuilder> 
         getDeleteFromFamilyFieldBuilder() {
       if (deleteFromFamilyBuilder_ == null) {
         if (!(mutationCase_ == 3)) {
           mutation_ = com.google.bigtable.v2.Mutation.DeleteFromFamily.getDefaultInstance();
         }
-        deleteFromFamilyBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+        deleteFromFamilyBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
             com.google.bigtable.v2.Mutation.DeleteFromFamily, com.google.bigtable.v2.Mutation.DeleteFromFamily.Builder, com.google.bigtable.v2.Mutation.DeleteFromFamilyOrBuilder>(
                 (com.google.bigtable.v2.Mutation.DeleteFromFamily) mutation_,
                 getParentForChildren(),
@@ -3482,7 +3828,7 @@ public  final class Mutation extends
       return deleteFromFamilyBuilder_;
     }
 
-    private com.google.protobuf.SingleFieldBuilder<
+    private com.google.protobuf.SingleFieldBuilderV3<
         com.google.bigtable.v2.Mutation.DeleteFromRow, com.google.bigtable.v2.Mutation.DeleteFromRow.Builder, com.google.bigtable.v2.Mutation.DeleteFromRowOrBuilder> deleteFromRowBuilder_;
     /**
      * <pre>
@@ -3625,14 +3971,14 @@ public  final class Mutation extends
      *
      * <code>optional .google.bigtable.v2.Mutation.DeleteFromRow delete_from_row = 4;</code>
      */
-    private com.google.protobuf.SingleFieldBuilder<
+    private com.google.protobuf.SingleFieldBuilderV3<
         com.google.bigtable.v2.Mutation.DeleteFromRow, com.google.bigtable.v2.Mutation.DeleteFromRow.Builder, com.google.bigtable.v2.Mutation.DeleteFromRowOrBuilder> 
         getDeleteFromRowFieldBuilder() {
       if (deleteFromRowBuilder_ == null) {
         if (!(mutationCase_ == 4)) {
           mutation_ = com.google.bigtable.v2.Mutation.DeleteFromRow.getDefaultInstance();
         }
-        deleteFromRowBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+        deleteFromRowBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
             com.google.bigtable.v2.Mutation.DeleteFromRow, com.google.bigtable.v2.Mutation.DeleteFromRow.Builder, com.google.bigtable.v2.Mutation.DeleteFromRowOrBuilder>(
                 (com.google.bigtable.v2.Mutation.DeleteFromRow) mutation_,
                 getParentForChildren(),

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/ReadModifyWriteRowRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/ReadModifyWriteRowRequest.java
@@ -11,11 +11,11 @@ package com.google.bigtable.v2;
  * Protobuf type {@code google.bigtable.v2.ReadModifyWriteRowRequest}
  */
 public  final class ReadModifyWriteRowRequest extends
-    com.google.protobuf.GeneratedMessage implements
+    com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:google.bigtable.v2.ReadModifyWriteRowRequest)
     ReadModifyWriteRowRequestOrBuilder {
   // Use ReadModifyWriteRowRequest.newBuilder() to construct.
-  private ReadModifyWriteRowRequest(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+  private ReadModifyWriteRowRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private ReadModifyWriteRowRequest() {
@@ -65,7 +65,8 @@ public  final class ReadModifyWriteRowRequest extends
               rules_ = new java.util.ArrayList<com.google.bigtable.v2.ReadModifyWriteRule>();
               mutable_bitField0_ |= 0x00000004;
             }
-            rules_.add(input.readMessage(com.google.bigtable.v2.ReadModifyWriteRule.parser(), extensionRegistry));
+            rules_.add(
+                input.readMessage(com.google.bigtable.v2.ReadModifyWriteRule.parser(), extensionRegistry));
             break;
           }
         }
@@ -87,7 +88,7 @@ public  final class ReadModifyWriteRowRequest extends
     return com.google.bigtable.v2.BigtableProto.internal_static_google_bigtable_v2_ReadModifyWriteRowRequest_descriptor;
   }
 
-  protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.google.bigtable.v2.BigtableProto.internal_static_google_bigtable_v2_ReadModifyWriteRowRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
@@ -234,7 +235,7 @@ public  final class ReadModifyWriteRowRequest extends
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
     if (!getTableNameBytes().isEmpty()) {
-      com.google.protobuf.GeneratedMessage.writeString(output, 1, tableName_);
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 1, tableName_);
     }
     if (!rowKey_.isEmpty()) {
       output.writeBytes(2, rowKey_);
@@ -250,7 +251,7 @@ public  final class ReadModifyWriteRowRequest extends
 
     size = 0;
     if (!getTableNameBytes().isEmpty()) {
-      size += com.google.protobuf.GeneratedMessage.computeStringSize(1, tableName_);
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, tableName_);
     }
     if (!rowKey_.isEmpty()) {
       size += com.google.protobuf.CodedOutputStream
@@ -265,6 +266,46 @@ public  final class ReadModifyWriteRowRequest extends
   }
 
   private static final long serialVersionUID = 0L;
+  @java.lang.Override
+  public boolean equals(final java.lang.Object obj) {
+    if (obj == this) {
+     return true;
+    }
+    if (!(obj instanceof com.google.bigtable.v2.ReadModifyWriteRowRequest)) {
+      return super.equals(obj);
+    }
+    com.google.bigtable.v2.ReadModifyWriteRowRequest other = (com.google.bigtable.v2.ReadModifyWriteRowRequest) obj;
+
+    boolean result = true;
+    result = result && getTableName()
+        .equals(other.getTableName());
+    result = result && getRowKey()
+        .equals(other.getRowKey());
+    result = result && getRulesList()
+        .equals(other.getRulesList());
+    return result;
+  }
+
+  @java.lang.Override
+  public int hashCode() {
+    if (memoizedHashCode != 0) {
+      return memoizedHashCode;
+    }
+    int hash = 41;
+    hash = (19 * hash) + getDescriptorForType().hashCode();
+    hash = (37 * hash) + TABLE_NAME_FIELD_NUMBER;
+    hash = (53 * hash) + getTableName().hashCode();
+    hash = (37 * hash) + ROW_KEY_FIELD_NUMBER;
+    hash = (53 * hash) + getRowKey().hashCode();
+    if (getRulesCount() > 0) {
+      hash = (37 * hash) + RULES_FIELD_NUMBER;
+      hash = (53 * hash) + getRulesList().hashCode();
+    }
+    hash = (29 * hash) + unknownFields.hashCode();
+    memoizedHashCode = hash;
+    return hash;
+  }
+
   public static com.google.bigtable.v2.ReadModifyWriteRowRequest parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -288,39 +329,39 @@ public  final class ReadModifyWriteRowRequest extends
   }
   public static com.google.bigtable.v2.ReadModifyWriteRowRequest parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.ReadModifyWriteRowRequest parseFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.v2.ReadModifyWriteRowRequest parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.ReadModifyWriteRowRequest parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.v2.ReadModifyWriteRowRequest parseFrom(
       com.google.protobuf.CodedInputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.ReadModifyWriteRowRequest parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
@@ -338,7 +379,7 @@ public  final class ReadModifyWriteRowRequest extends
 
   @java.lang.Override
   protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
@@ -350,7 +391,7 @@ public  final class ReadModifyWriteRowRequest extends
    * Protobuf type {@code google.bigtable.v2.ReadModifyWriteRowRequest}
    */
   public static final class Builder extends
-      com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
       // @@protoc_insertion_point(builder_implements:google.bigtable.v2.ReadModifyWriteRowRequest)
       com.google.bigtable.v2.ReadModifyWriteRowRequestOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
@@ -358,7 +399,7 @@ public  final class ReadModifyWriteRowRequest extends
       return com.google.bigtable.v2.BigtableProto.internal_static_google_bigtable_v2_ReadModifyWriteRowRequest_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.bigtable.v2.BigtableProto.internal_static_google_bigtable_v2_ReadModifyWriteRowRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -371,12 +412,13 @@ public  final class ReadModifyWriteRowRequest extends
     }
 
     private Builder(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
         getRulesFieldBuilder();
       }
     }
@@ -432,6 +474,32 @@ public  final class ReadModifyWriteRowRequest extends
       return result;
     }
 
+    public Builder clone() {
+      return (Builder) super.clone();
+    }
+    public Builder setField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.setField(field, value);
+    }
+    public Builder clearField(
+        com.google.protobuf.Descriptors.FieldDescriptor field) {
+      return (Builder) super.clearField(field);
+    }
+    public Builder clearOneof(
+        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      return (Builder) super.clearOneof(oneof);
+    }
+    public Builder setRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        int index, Object value) {
+      return (Builder) super.setRepeatedField(field, index, value);
+    }
+    public Builder addRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.addRepeatedField(field, value);
+    }
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.bigtable.v2.ReadModifyWriteRowRequest) {
         return mergeFrom((com.google.bigtable.v2.ReadModifyWriteRowRequest)other);
@@ -469,7 +537,7 @@ public  final class ReadModifyWriteRowRequest extends
             rules_ = other.rules_;
             bitField0_ = (bitField0_ & ~0x00000004);
             rulesBuilder_ = 
-              com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+              com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
                  getRulesFieldBuilder() : null;
           } else {
             rulesBuilder_.addAllMessages(other.rules_);
@@ -657,7 +725,7 @@ public  final class ReadModifyWriteRowRequest extends
        }
     }
 
-    private com.google.protobuf.RepeatedFieldBuilder<
+    private com.google.protobuf.RepeatedFieldBuilderV3<
         com.google.bigtable.v2.ReadModifyWriteRule, com.google.bigtable.v2.ReadModifyWriteRule.Builder, com.google.bigtable.v2.ReadModifyWriteRuleOrBuilder> rulesBuilder_;
 
     /**
@@ -981,11 +1049,11 @@ public  final class ReadModifyWriteRowRequest extends
          getRulesBuilderList() {
       return getRulesFieldBuilder().getBuilderList();
     }
-    private com.google.protobuf.RepeatedFieldBuilder<
+    private com.google.protobuf.RepeatedFieldBuilderV3<
         com.google.bigtable.v2.ReadModifyWriteRule, com.google.bigtable.v2.ReadModifyWriteRule.Builder, com.google.bigtable.v2.ReadModifyWriteRuleOrBuilder> 
         getRulesFieldBuilder() {
       if (rulesBuilder_ == null) {
-        rulesBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
+        rulesBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
             com.google.bigtable.v2.ReadModifyWriteRule, com.google.bigtable.v2.ReadModifyWriteRule.Builder, com.google.bigtable.v2.ReadModifyWriteRuleOrBuilder>(
                 rules_,
                 ((bitField0_ & 0x00000004) == 0x00000004),

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/ReadModifyWriteRowResponse.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/ReadModifyWriteRowResponse.java
@@ -11,11 +11,11 @@ package com.google.bigtable.v2;
  * Protobuf type {@code google.bigtable.v2.ReadModifyWriteRowResponse}
  */
 public  final class ReadModifyWriteRowResponse extends
-    com.google.protobuf.GeneratedMessage implements
+    com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:google.bigtable.v2.ReadModifyWriteRowResponse)
     ReadModifyWriteRowResponseOrBuilder {
   // Use ReadModifyWriteRowResponse.newBuilder() to construct.
-  private ReadModifyWriteRowResponse(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+  private ReadModifyWriteRowResponse(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private ReadModifyWriteRowResponse() {
@@ -75,7 +75,7 @@ public  final class ReadModifyWriteRowResponse extends
     return com.google.bigtable.v2.BigtableProto.internal_static_google_bigtable_v2_ReadModifyWriteRowResponse_descriptor;
   }
 
-  protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.google.bigtable.v2.BigtableProto.internal_static_google_bigtable_v2_ReadModifyWriteRowResponse_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
@@ -146,6 +146,41 @@ public  final class ReadModifyWriteRowResponse extends
   }
 
   private static final long serialVersionUID = 0L;
+  @java.lang.Override
+  public boolean equals(final java.lang.Object obj) {
+    if (obj == this) {
+     return true;
+    }
+    if (!(obj instanceof com.google.bigtable.v2.ReadModifyWriteRowResponse)) {
+      return super.equals(obj);
+    }
+    com.google.bigtable.v2.ReadModifyWriteRowResponse other = (com.google.bigtable.v2.ReadModifyWriteRowResponse) obj;
+
+    boolean result = true;
+    result = result && (hasRow() == other.hasRow());
+    if (hasRow()) {
+      result = result && getRow()
+          .equals(other.getRow());
+    }
+    return result;
+  }
+
+  @java.lang.Override
+  public int hashCode() {
+    if (memoizedHashCode != 0) {
+      return memoizedHashCode;
+    }
+    int hash = 41;
+    hash = (19 * hash) + getDescriptorForType().hashCode();
+    if (hasRow()) {
+      hash = (37 * hash) + ROW_FIELD_NUMBER;
+      hash = (53 * hash) + getRow().hashCode();
+    }
+    hash = (29 * hash) + unknownFields.hashCode();
+    memoizedHashCode = hash;
+    return hash;
+  }
+
   public static com.google.bigtable.v2.ReadModifyWriteRowResponse parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -169,39 +204,39 @@ public  final class ReadModifyWriteRowResponse extends
   }
   public static com.google.bigtable.v2.ReadModifyWriteRowResponse parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.ReadModifyWriteRowResponse parseFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.v2.ReadModifyWriteRowResponse parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.ReadModifyWriteRowResponse parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.v2.ReadModifyWriteRowResponse parseFrom(
       com.google.protobuf.CodedInputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.ReadModifyWriteRowResponse parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
@@ -219,7 +254,7 @@ public  final class ReadModifyWriteRowResponse extends
 
   @java.lang.Override
   protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
@@ -231,7 +266,7 @@ public  final class ReadModifyWriteRowResponse extends
    * Protobuf type {@code google.bigtable.v2.ReadModifyWriteRowResponse}
    */
   public static final class Builder extends
-      com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
       // @@protoc_insertion_point(builder_implements:google.bigtable.v2.ReadModifyWriteRowResponse)
       com.google.bigtable.v2.ReadModifyWriteRowResponseOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
@@ -239,7 +274,7 @@ public  final class ReadModifyWriteRowResponse extends
       return com.google.bigtable.v2.BigtableProto.internal_static_google_bigtable_v2_ReadModifyWriteRowResponse_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.bigtable.v2.BigtableProto.internal_static_google_bigtable_v2_ReadModifyWriteRowResponse_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -252,12 +287,13 @@ public  final class ReadModifyWriteRowResponse extends
     }
 
     private Builder(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
       }
     }
     public Builder clear() {
@@ -299,6 +335,32 @@ public  final class ReadModifyWriteRowResponse extends
       return result;
     }
 
+    public Builder clone() {
+      return (Builder) super.clone();
+    }
+    public Builder setField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.setField(field, value);
+    }
+    public Builder clearField(
+        com.google.protobuf.Descriptors.FieldDescriptor field) {
+      return (Builder) super.clearField(field);
+    }
+    public Builder clearOneof(
+        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      return (Builder) super.clearOneof(oneof);
+    }
+    public Builder setRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        int index, Object value) {
+      return (Builder) super.setRepeatedField(field, index, value);
+    }
+    public Builder addRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.addRepeatedField(field, value);
+    }
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.bigtable.v2.ReadModifyWriteRowResponse) {
         return mergeFrom((com.google.bigtable.v2.ReadModifyWriteRowResponse)other);
@@ -340,7 +402,7 @@ public  final class ReadModifyWriteRowResponse extends
     }
 
     private com.google.bigtable.v2.Row row_ = null;
-    private com.google.protobuf.SingleFieldBuilder<
+    private com.google.protobuf.SingleFieldBuilderV3<
         com.google.bigtable.v2.Row, com.google.bigtable.v2.Row.Builder, com.google.bigtable.v2.RowOrBuilder> rowBuilder_;
     /**
      * <pre>
@@ -478,11 +540,11 @@ public  final class ReadModifyWriteRowResponse extends
      *
      * <code>optional .google.bigtable.v2.Row row = 1;</code>
      */
-    private com.google.protobuf.SingleFieldBuilder<
+    private com.google.protobuf.SingleFieldBuilderV3<
         com.google.bigtable.v2.Row, com.google.bigtable.v2.Row.Builder, com.google.bigtable.v2.RowOrBuilder> 
         getRowFieldBuilder() {
       if (rowBuilder_ == null) {
-        rowBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+        rowBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
             com.google.bigtable.v2.Row, com.google.bigtable.v2.Row.Builder, com.google.bigtable.v2.RowOrBuilder>(
                 getRow(),
                 getParentForChildren(),

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/ReadModifyWriteRule.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/ReadModifyWriteRule.java
@@ -12,11 +12,11 @@ package com.google.bigtable.v2;
  * Protobuf type {@code google.bigtable.v2.ReadModifyWriteRule}
  */
 public  final class ReadModifyWriteRule extends
-    com.google.protobuf.GeneratedMessage implements
+    com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:google.bigtable.v2.ReadModifyWriteRule)
     ReadModifyWriteRuleOrBuilder {
   // Use ReadModifyWriteRule.newBuilder() to construct.
-  private ReadModifyWriteRule(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+  private ReadModifyWriteRule(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private ReadModifyWriteRule() {
@@ -86,7 +86,7 @@ public  final class ReadModifyWriteRule extends
     return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_ReadModifyWriteRule_descriptor;
   }
 
-  protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_ReadModifyWriteRule_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
@@ -238,7 +238,7 @@ public  final class ReadModifyWriteRule extends
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
     if (!getFamilyNameBytes().isEmpty()) {
-      com.google.protobuf.GeneratedMessage.writeString(output, 1, familyName_);
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 1, familyName_);
     }
     if (!columnQualifier_.isEmpty()) {
       output.writeBytes(2, columnQualifier_);
@@ -259,7 +259,7 @@ public  final class ReadModifyWriteRule extends
 
     size = 0;
     if (!getFamilyNameBytes().isEmpty()) {
-      size += com.google.protobuf.GeneratedMessage.computeStringSize(1, familyName_);
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, familyName_);
     }
     if (!columnQualifier_.isEmpty()) {
       size += com.google.protobuf.CodedOutputStream
@@ -280,6 +280,68 @@ public  final class ReadModifyWriteRule extends
   }
 
   private static final long serialVersionUID = 0L;
+  @java.lang.Override
+  public boolean equals(final java.lang.Object obj) {
+    if (obj == this) {
+     return true;
+    }
+    if (!(obj instanceof com.google.bigtable.v2.ReadModifyWriteRule)) {
+      return super.equals(obj);
+    }
+    com.google.bigtable.v2.ReadModifyWriteRule other = (com.google.bigtable.v2.ReadModifyWriteRule) obj;
+
+    boolean result = true;
+    result = result && getFamilyName()
+        .equals(other.getFamilyName());
+    result = result && getColumnQualifier()
+        .equals(other.getColumnQualifier());
+    result = result && getRuleCase().equals(
+        other.getRuleCase());
+    if (!result) return false;
+    switch (ruleCase_) {
+      case 3:
+        result = result && getAppendValue()
+            .equals(other.getAppendValue());
+        break;
+      case 4:
+        result = result && (getIncrementAmount()
+            == other.getIncrementAmount());
+        break;
+      case 0:
+      default:
+    }
+    return result;
+  }
+
+  @java.lang.Override
+  public int hashCode() {
+    if (memoizedHashCode != 0) {
+      return memoizedHashCode;
+    }
+    int hash = 41;
+    hash = (19 * hash) + getDescriptorForType().hashCode();
+    hash = (37 * hash) + FAMILY_NAME_FIELD_NUMBER;
+    hash = (53 * hash) + getFamilyName().hashCode();
+    hash = (37 * hash) + COLUMN_QUALIFIER_FIELD_NUMBER;
+    hash = (53 * hash) + getColumnQualifier().hashCode();
+    switch (ruleCase_) {
+      case 3:
+        hash = (37 * hash) + APPEND_VALUE_FIELD_NUMBER;
+        hash = (53 * hash) + getAppendValue().hashCode();
+        break;
+      case 4:
+        hash = (37 * hash) + INCREMENT_AMOUNT_FIELD_NUMBER;
+        hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
+            getIncrementAmount());
+        break;
+      case 0:
+      default:
+    }
+    hash = (29 * hash) + unknownFields.hashCode();
+    memoizedHashCode = hash;
+    return hash;
+  }
+
   public static com.google.bigtable.v2.ReadModifyWriteRule parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -303,39 +365,39 @@ public  final class ReadModifyWriteRule extends
   }
   public static com.google.bigtable.v2.ReadModifyWriteRule parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.ReadModifyWriteRule parseFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.v2.ReadModifyWriteRule parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.ReadModifyWriteRule parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.v2.ReadModifyWriteRule parseFrom(
       com.google.protobuf.CodedInputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.ReadModifyWriteRule parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
@@ -353,7 +415,7 @@ public  final class ReadModifyWriteRule extends
 
   @java.lang.Override
   protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
@@ -366,7 +428,7 @@ public  final class ReadModifyWriteRule extends
    * Protobuf type {@code google.bigtable.v2.ReadModifyWriteRule}
    */
   public static final class Builder extends
-      com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
       // @@protoc_insertion_point(builder_implements:google.bigtable.v2.ReadModifyWriteRule)
       com.google.bigtable.v2.ReadModifyWriteRuleOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
@@ -374,7 +436,7 @@ public  final class ReadModifyWriteRule extends
       return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_ReadModifyWriteRule_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_ReadModifyWriteRule_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -387,12 +449,13 @@ public  final class ReadModifyWriteRule extends
     }
 
     private Builder(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
       }
     }
     public Builder clear() {
@@ -438,6 +501,32 @@ public  final class ReadModifyWriteRule extends
       return result;
     }
 
+    public Builder clone() {
+      return (Builder) super.clone();
+    }
+    public Builder setField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.setField(field, value);
+    }
+    public Builder clearField(
+        com.google.protobuf.Descriptors.FieldDescriptor field) {
+      return (Builder) super.clearField(field);
+    }
+    public Builder clearOneof(
+        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      return (Builder) super.clearOneof(oneof);
+    }
+    public Builder setRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        int index, Object value) {
+      return (Builder) super.setRepeatedField(field, index, value);
+    }
+    public Builder addRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.addRepeatedField(field, value);
+    }
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.bigtable.v2.ReadModifyWriteRule) {
         return mergeFrom((com.google.bigtable.v2.ReadModifyWriteRule)other);

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/ReadRowsRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/ReadRowsRequest.java
@@ -11,11 +11,11 @@ package com.google.bigtable.v2;
  * Protobuf type {@code google.bigtable.v2.ReadRowsRequest}
  */
 public  final class ReadRowsRequest extends
-    com.google.protobuf.GeneratedMessage implements
+    com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:google.bigtable.v2.ReadRowsRequest)
     ReadRowsRequestOrBuilder {
   // Use ReadRowsRequest.newBuilder() to construct.
-  private ReadRowsRequest(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+  private ReadRowsRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private ReadRowsRequest() {
@@ -101,7 +101,7 @@ public  final class ReadRowsRequest extends
     return com.google.bigtable.v2.BigtableProto.internal_static_google_bigtable_v2_ReadRowsRequest_descriptor;
   }
 
-  protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.google.bigtable.v2.BigtableProto.internal_static_google_bigtable_v2_ReadRowsRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
@@ -250,7 +250,7 @@ public  final class ReadRowsRequest extends
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
     if (!getTableNameBytes().isEmpty()) {
-      com.google.protobuf.GeneratedMessage.writeString(output, 1, tableName_);
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 1, tableName_);
     }
     if (rows_ != null) {
       output.writeMessage(2, getRows());
@@ -269,7 +269,7 @@ public  final class ReadRowsRequest extends
 
     size = 0;
     if (!getTableNameBytes().isEmpty()) {
-      size += com.google.protobuf.GeneratedMessage.computeStringSize(1, tableName_);
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, tableName_);
     }
     if (rows_ != null) {
       size += com.google.protobuf.CodedOutputStream
@@ -288,6 +288,59 @@ public  final class ReadRowsRequest extends
   }
 
   private static final long serialVersionUID = 0L;
+  @java.lang.Override
+  public boolean equals(final java.lang.Object obj) {
+    if (obj == this) {
+     return true;
+    }
+    if (!(obj instanceof com.google.bigtable.v2.ReadRowsRequest)) {
+      return super.equals(obj);
+    }
+    com.google.bigtable.v2.ReadRowsRequest other = (com.google.bigtable.v2.ReadRowsRequest) obj;
+
+    boolean result = true;
+    result = result && getTableName()
+        .equals(other.getTableName());
+    result = result && (hasRows() == other.hasRows());
+    if (hasRows()) {
+      result = result && getRows()
+          .equals(other.getRows());
+    }
+    result = result && (hasFilter() == other.hasFilter());
+    if (hasFilter()) {
+      result = result && getFilter()
+          .equals(other.getFilter());
+    }
+    result = result && (getRowsLimit()
+        == other.getRowsLimit());
+    return result;
+  }
+
+  @java.lang.Override
+  public int hashCode() {
+    if (memoizedHashCode != 0) {
+      return memoizedHashCode;
+    }
+    int hash = 41;
+    hash = (19 * hash) + getDescriptorForType().hashCode();
+    hash = (37 * hash) + TABLE_NAME_FIELD_NUMBER;
+    hash = (53 * hash) + getTableName().hashCode();
+    if (hasRows()) {
+      hash = (37 * hash) + ROWS_FIELD_NUMBER;
+      hash = (53 * hash) + getRows().hashCode();
+    }
+    if (hasFilter()) {
+      hash = (37 * hash) + FILTER_FIELD_NUMBER;
+      hash = (53 * hash) + getFilter().hashCode();
+    }
+    hash = (37 * hash) + ROWS_LIMIT_FIELD_NUMBER;
+    hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
+        getRowsLimit());
+    hash = (29 * hash) + unknownFields.hashCode();
+    memoizedHashCode = hash;
+    return hash;
+  }
+
   public static com.google.bigtable.v2.ReadRowsRequest parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -311,39 +364,39 @@ public  final class ReadRowsRequest extends
   }
   public static com.google.bigtable.v2.ReadRowsRequest parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.ReadRowsRequest parseFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.v2.ReadRowsRequest parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.ReadRowsRequest parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.v2.ReadRowsRequest parseFrom(
       com.google.protobuf.CodedInputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.ReadRowsRequest parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
@@ -361,7 +414,7 @@ public  final class ReadRowsRequest extends
 
   @java.lang.Override
   protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
@@ -373,7 +426,7 @@ public  final class ReadRowsRequest extends
    * Protobuf type {@code google.bigtable.v2.ReadRowsRequest}
    */
   public static final class Builder extends
-      com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
       // @@protoc_insertion_point(builder_implements:google.bigtable.v2.ReadRowsRequest)
       com.google.bigtable.v2.ReadRowsRequestOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
@@ -381,7 +434,7 @@ public  final class ReadRowsRequest extends
       return com.google.bigtable.v2.BigtableProto.internal_static_google_bigtable_v2_ReadRowsRequest_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.bigtable.v2.BigtableProto.internal_static_google_bigtable_v2_ReadRowsRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -394,12 +447,13 @@ public  final class ReadRowsRequest extends
     }
 
     private Builder(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
       }
     }
     public Builder clear() {
@@ -458,6 +512,32 @@ public  final class ReadRowsRequest extends
       return result;
     }
 
+    public Builder clone() {
+      return (Builder) super.clone();
+    }
+    public Builder setField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.setField(field, value);
+    }
+    public Builder clearField(
+        com.google.protobuf.Descriptors.FieldDescriptor field) {
+      return (Builder) super.clearField(field);
+    }
+    public Builder clearOneof(
+        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      return (Builder) super.clearOneof(oneof);
+    }
+    public Builder setRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        int index, Object value) {
+      return (Builder) super.setRepeatedField(field, index, value);
+    }
+    public Builder addRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.addRepeatedField(field, value);
+    }
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.bigtable.v2.ReadRowsRequest) {
         return mergeFrom((com.google.bigtable.v2.ReadRowsRequest)other);
@@ -608,7 +688,7 @@ public  final class ReadRowsRequest extends
     }
 
     private com.google.bigtable.v2.RowSet rows_ = null;
-    private com.google.protobuf.SingleFieldBuilder<
+    private com.google.protobuf.SingleFieldBuilderV3<
         com.google.bigtable.v2.RowSet, com.google.bigtable.v2.RowSet.Builder, com.google.bigtable.v2.RowSetOrBuilder> rowsBuilder_;
     /**
      * <pre>
@@ -746,11 +826,11 @@ public  final class ReadRowsRequest extends
      *
      * <code>optional .google.bigtable.v2.RowSet rows = 2;</code>
      */
-    private com.google.protobuf.SingleFieldBuilder<
+    private com.google.protobuf.SingleFieldBuilderV3<
         com.google.bigtable.v2.RowSet, com.google.bigtable.v2.RowSet.Builder, com.google.bigtable.v2.RowSetOrBuilder> 
         getRowsFieldBuilder() {
       if (rowsBuilder_ == null) {
-        rowsBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+        rowsBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
             com.google.bigtable.v2.RowSet, com.google.bigtable.v2.RowSet.Builder, com.google.bigtable.v2.RowSetOrBuilder>(
                 getRows(),
                 getParentForChildren(),
@@ -761,7 +841,7 @@ public  final class ReadRowsRequest extends
     }
 
     private com.google.bigtable.v2.RowFilter filter_ = null;
-    private com.google.protobuf.SingleFieldBuilder<
+    private com.google.protobuf.SingleFieldBuilderV3<
         com.google.bigtable.v2.RowFilter, com.google.bigtable.v2.RowFilter.Builder, com.google.bigtable.v2.RowFilterOrBuilder> filterBuilder_;
     /**
      * <pre>
@@ -908,11 +988,11 @@ public  final class ReadRowsRequest extends
      *
      * <code>optional .google.bigtable.v2.RowFilter filter = 3;</code>
      */
-    private com.google.protobuf.SingleFieldBuilder<
+    private com.google.protobuf.SingleFieldBuilderV3<
         com.google.bigtable.v2.RowFilter, com.google.bigtable.v2.RowFilter.Builder, com.google.bigtable.v2.RowFilterOrBuilder> 
         getFilterFieldBuilder() {
       if (filterBuilder_ == null) {
-        filterBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+        filterBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
             com.google.bigtable.v2.RowFilter, com.google.bigtable.v2.RowFilter.Builder, com.google.bigtable.v2.RowFilterOrBuilder>(
                 getFilter(),
                 getParentForChildren(),

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/ReadRowsResponse.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/ReadRowsResponse.java
@@ -11,11 +11,11 @@ package com.google.bigtable.v2;
  * Protobuf type {@code google.bigtable.v2.ReadRowsResponse}
  */
 public  final class ReadRowsResponse extends
-    com.google.protobuf.GeneratedMessage implements
+    com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:google.bigtable.v2.ReadRowsResponse)
     ReadRowsResponseOrBuilder {
   // Use ReadRowsResponse.newBuilder() to construct.
-  private ReadRowsResponse(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+  private ReadRowsResponse(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private ReadRowsResponse() {
@@ -53,7 +53,8 @@ public  final class ReadRowsResponse extends
               chunks_ = new java.util.ArrayList<com.google.bigtable.v2.ReadRowsResponse.CellChunk>();
               mutable_bitField0_ |= 0x00000001;
             }
-            chunks_.add(input.readMessage(com.google.bigtable.v2.ReadRowsResponse.CellChunk.parser(), extensionRegistry));
+            chunks_.add(
+                input.readMessage(com.google.bigtable.v2.ReadRowsResponse.CellChunk.parser(), extensionRegistry));
             break;
           }
           case 18: {
@@ -80,7 +81,7 @@ public  final class ReadRowsResponse extends
     return com.google.bigtable.v2.BigtableProto.internal_static_google_bigtable_v2_ReadRowsResponse_descriptor;
   }
 
-  protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.google.bigtable.v2.BigtableProto.internal_static_google_bigtable_v2_ReadRowsResponse_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
@@ -205,7 +206,7 @@ public  final class ReadRowsResponse extends
      *
      * <code>repeated string labels = 5;</code>
      */
-    com.google.protobuf.ProtocolStringList
+    java.util.List<java.lang.String>
         getLabelsList();
     /**
      * <pre>
@@ -295,11 +296,11 @@ public  final class ReadRowsResponse extends
    * Protobuf type {@code google.bigtable.v2.ReadRowsResponse.CellChunk}
    */
   public  static final class CellChunk extends
-      com.google.protobuf.GeneratedMessage implements
+      com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:google.bigtable.v2.ReadRowsResponse.CellChunk)
       CellChunkOrBuilder {
     // Use CellChunk.newBuilder() to construct.
-    private CellChunk(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+    private CellChunk(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
     }
     private CellChunk() {
@@ -419,7 +420,7 @@ public  final class ReadRowsResponse extends
       return com.google.bigtable.v2.BigtableProto.internal_static_google_bigtable_v2_ReadRowsResponse_CellChunk_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.bigtable.v2.BigtableProto.internal_static_google_bigtable_v2_ReadRowsResponse_CellChunk_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -737,7 +738,7 @@ public  final class ReadRowsResponse extends
         output.writeInt64(4, timestampMicros_);
       }
       for (int i = 0; i < labels_.size(); i++) {
-        com.google.protobuf.GeneratedMessage.writeString(output, 5, labels_.getRaw(i));
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 5, labels_.getRaw(i));
       }
       if (!value_.isEmpty()) {
         output.writeBytes(6, value_);
@@ -807,6 +808,102 @@ public  final class ReadRowsResponse extends
     }
 
     private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.google.bigtable.v2.ReadRowsResponse.CellChunk)) {
+        return super.equals(obj);
+      }
+      com.google.bigtable.v2.ReadRowsResponse.CellChunk other = (com.google.bigtable.v2.ReadRowsResponse.CellChunk) obj;
+
+      boolean result = true;
+      result = result && getRowKey()
+          .equals(other.getRowKey());
+      result = result && (hasFamilyName() == other.hasFamilyName());
+      if (hasFamilyName()) {
+        result = result && getFamilyName()
+            .equals(other.getFamilyName());
+      }
+      result = result && (hasQualifier() == other.hasQualifier());
+      if (hasQualifier()) {
+        result = result && getQualifier()
+            .equals(other.getQualifier());
+      }
+      result = result && (getTimestampMicros()
+          == other.getTimestampMicros());
+      result = result && getLabelsList()
+          .equals(other.getLabelsList());
+      result = result && getValue()
+          .equals(other.getValue());
+      result = result && (getValueSize()
+          == other.getValueSize());
+      result = result && getRowStatusCase().equals(
+          other.getRowStatusCase());
+      if (!result) return false;
+      switch (rowStatusCase_) {
+        case 8:
+          result = result && (getResetRow()
+              == other.getResetRow());
+          break;
+        case 9:
+          result = result && (getCommitRow()
+              == other.getCommitRow());
+          break;
+        case 0:
+        default:
+      }
+      return result;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptorForType().hashCode();
+      hash = (37 * hash) + ROW_KEY_FIELD_NUMBER;
+      hash = (53 * hash) + getRowKey().hashCode();
+      if (hasFamilyName()) {
+        hash = (37 * hash) + FAMILY_NAME_FIELD_NUMBER;
+        hash = (53 * hash) + getFamilyName().hashCode();
+      }
+      if (hasQualifier()) {
+        hash = (37 * hash) + QUALIFIER_FIELD_NUMBER;
+        hash = (53 * hash) + getQualifier().hashCode();
+      }
+      hash = (37 * hash) + TIMESTAMP_MICROS_FIELD_NUMBER;
+      hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
+          getTimestampMicros());
+      if (getLabelsCount() > 0) {
+        hash = (37 * hash) + LABELS_FIELD_NUMBER;
+        hash = (53 * hash) + getLabelsList().hashCode();
+      }
+      hash = (37 * hash) + VALUE_FIELD_NUMBER;
+      hash = (53 * hash) + getValue().hashCode();
+      hash = (37 * hash) + VALUE_SIZE_FIELD_NUMBER;
+      hash = (53 * hash) + getValueSize();
+      switch (rowStatusCase_) {
+        case 8:
+          hash = (37 * hash) + RESET_ROW_FIELD_NUMBER;
+          hash = (53 * hash) + com.google.protobuf.Internal.hashBoolean(
+              getResetRow());
+          break;
+        case 9:
+          hash = (37 * hash) + COMMIT_ROW_FIELD_NUMBER;
+          hash = (53 * hash) + com.google.protobuf.Internal.hashBoolean(
+              getCommitRow());
+          break;
+        case 0:
+        default:
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
     public static com.google.bigtable.v2.ReadRowsResponse.CellChunk parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
@@ -830,39 +927,39 @@ public  final class ReadRowsResponse extends
     }
     public static com.google.bigtable.v2.ReadRowsResponse.CellChunk parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
     public static com.google.bigtable.v2.ReadRowsResponse.CellChunk parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
     public static com.google.bigtable.v2.ReadRowsResponse.CellChunk parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
     public static com.google.bigtable.v2.ReadRowsResponse.CellChunk parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
     public static com.google.bigtable.v2.ReadRowsResponse.CellChunk parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
     public static com.google.bigtable.v2.ReadRowsResponse.CellChunk parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
@@ -880,7 +977,7 @@ public  final class ReadRowsResponse extends
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -893,7 +990,7 @@ public  final class ReadRowsResponse extends
      * Protobuf type {@code google.bigtable.v2.ReadRowsResponse.CellChunk}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:google.bigtable.v2.ReadRowsResponse.CellChunk)
         com.google.bigtable.v2.ReadRowsResponse.CellChunkOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -901,7 +998,7 @@ public  final class ReadRowsResponse extends
         return com.google.bigtable.v2.BigtableProto.internal_static_google_bigtable_v2_ReadRowsResponse_CellChunk_descriptor;
       }
 
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return com.google.bigtable.v2.BigtableProto.internal_static_google_bigtable_v2_ReadRowsResponse_CellChunk_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -914,12 +1011,13 @@ public  final class ReadRowsResponse extends
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
       private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
         }
       }
       public Builder clear() {
@@ -1003,6 +1101,32 @@ public  final class ReadRowsResponse extends
         return result;
       }
 
+      public Builder clone() {
+        return (Builder) super.clone();
+      }
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          Object value) {
+        return (Builder) super.setField(field, value);
+      }
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return (Builder) super.clearField(field);
+      }
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return (Builder) super.clearOneof(oneof);
+      }
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, Object value) {
+        return (Builder) super.setRepeatedField(field, index, value);
+      }
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          Object value) {
+        return (Builder) super.addRepeatedField(field, value);
+      }
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof com.google.bigtable.v2.ReadRowsResponse.CellChunk) {
           return mergeFrom((com.google.bigtable.v2.ReadRowsResponse.CellChunk)other);
@@ -1148,7 +1272,7 @@ public  final class ReadRowsResponse extends
       }
 
       private com.google.protobuf.StringValue familyName_ = null;
-      private com.google.protobuf.SingleFieldBuilder<
+      private com.google.protobuf.SingleFieldBuilderV3<
           com.google.protobuf.StringValue, com.google.protobuf.StringValue.Builder, com.google.protobuf.StringValueOrBuilder> familyNameBuilder_;
       /**
        * <pre>
@@ -1331,11 +1455,11 @@ public  final class ReadRowsResponse extends
        *
        * <code>optional .google.protobuf.StringValue family_name = 2;</code>
        */
-      private com.google.protobuf.SingleFieldBuilder<
+      private com.google.protobuf.SingleFieldBuilderV3<
           com.google.protobuf.StringValue, com.google.protobuf.StringValue.Builder, com.google.protobuf.StringValueOrBuilder> 
           getFamilyNameFieldBuilder() {
         if (familyNameBuilder_ == null) {
-          familyNameBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+          familyNameBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
               com.google.protobuf.StringValue, com.google.protobuf.StringValue.Builder, com.google.protobuf.StringValueOrBuilder>(
                   getFamilyName(),
                   getParentForChildren(),
@@ -1346,7 +1470,7 @@ public  final class ReadRowsResponse extends
       }
 
       private com.google.protobuf.BytesValue qualifier_ = null;
-      private com.google.protobuf.SingleFieldBuilder<
+      private com.google.protobuf.SingleFieldBuilderV3<
           com.google.protobuf.BytesValue, com.google.protobuf.BytesValue.Builder, com.google.protobuf.BytesValueOrBuilder> qualifierBuilder_;
       /**
        * <pre>
@@ -1520,11 +1644,11 @@ public  final class ReadRowsResponse extends
        *
        * <code>optional .google.protobuf.BytesValue qualifier = 3;</code>
        */
-      private com.google.protobuf.SingleFieldBuilder<
+      private com.google.protobuf.SingleFieldBuilderV3<
           com.google.protobuf.BytesValue, com.google.protobuf.BytesValue.Builder, com.google.protobuf.BytesValueOrBuilder> 
           getQualifierFieldBuilder() {
         if (qualifierBuilder_ == null) {
-          qualifierBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+          qualifierBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
               com.google.protobuf.BytesValue, com.google.protobuf.BytesValue.Builder, com.google.protobuf.BytesValueOrBuilder>(
                   getQualifier(),
                   getParentForChildren(),
@@ -2072,6 +2196,42 @@ public  final class ReadRowsResponse extends
   }
 
   private static final long serialVersionUID = 0L;
+  @java.lang.Override
+  public boolean equals(final java.lang.Object obj) {
+    if (obj == this) {
+     return true;
+    }
+    if (!(obj instanceof com.google.bigtable.v2.ReadRowsResponse)) {
+      return super.equals(obj);
+    }
+    com.google.bigtable.v2.ReadRowsResponse other = (com.google.bigtable.v2.ReadRowsResponse) obj;
+
+    boolean result = true;
+    result = result && getChunksList()
+        .equals(other.getChunksList());
+    result = result && getLastScannedRowKey()
+        .equals(other.getLastScannedRowKey());
+    return result;
+  }
+
+  @java.lang.Override
+  public int hashCode() {
+    if (memoizedHashCode != 0) {
+      return memoizedHashCode;
+    }
+    int hash = 41;
+    hash = (19 * hash) + getDescriptorForType().hashCode();
+    if (getChunksCount() > 0) {
+      hash = (37 * hash) + CHUNKS_FIELD_NUMBER;
+      hash = (53 * hash) + getChunksList().hashCode();
+    }
+    hash = (37 * hash) + LAST_SCANNED_ROW_KEY_FIELD_NUMBER;
+    hash = (53 * hash) + getLastScannedRowKey().hashCode();
+    hash = (29 * hash) + unknownFields.hashCode();
+    memoizedHashCode = hash;
+    return hash;
+  }
+
   public static com.google.bigtable.v2.ReadRowsResponse parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -2095,39 +2255,39 @@ public  final class ReadRowsResponse extends
   }
   public static com.google.bigtable.v2.ReadRowsResponse parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.ReadRowsResponse parseFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.v2.ReadRowsResponse parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.ReadRowsResponse parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.v2.ReadRowsResponse parseFrom(
       com.google.protobuf.CodedInputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.ReadRowsResponse parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
@@ -2145,7 +2305,7 @@ public  final class ReadRowsResponse extends
 
   @java.lang.Override
   protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
@@ -2157,7 +2317,7 @@ public  final class ReadRowsResponse extends
    * Protobuf type {@code google.bigtable.v2.ReadRowsResponse}
    */
   public static final class Builder extends
-      com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
       // @@protoc_insertion_point(builder_implements:google.bigtable.v2.ReadRowsResponse)
       com.google.bigtable.v2.ReadRowsResponseOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
@@ -2165,7 +2325,7 @@ public  final class ReadRowsResponse extends
       return com.google.bigtable.v2.BigtableProto.internal_static_google_bigtable_v2_ReadRowsResponse_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.bigtable.v2.BigtableProto.internal_static_google_bigtable_v2_ReadRowsResponse_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -2178,12 +2338,13 @@ public  final class ReadRowsResponse extends
     }
 
     private Builder(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
         getChunksFieldBuilder();
       }
     }
@@ -2236,6 +2397,32 @@ public  final class ReadRowsResponse extends
       return result;
     }
 
+    public Builder clone() {
+      return (Builder) super.clone();
+    }
+    public Builder setField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.setField(field, value);
+    }
+    public Builder clearField(
+        com.google.protobuf.Descriptors.FieldDescriptor field) {
+      return (Builder) super.clearField(field);
+    }
+    public Builder clearOneof(
+        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      return (Builder) super.clearOneof(oneof);
+    }
+    public Builder setRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        int index, Object value) {
+      return (Builder) super.setRepeatedField(field, index, value);
+    }
+    public Builder addRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.addRepeatedField(field, value);
+    }
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.bigtable.v2.ReadRowsResponse) {
         return mergeFrom((com.google.bigtable.v2.ReadRowsResponse)other);
@@ -2266,7 +2453,7 @@ public  final class ReadRowsResponse extends
             chunks_ = other.chunks_;
             bitField0_ = (bitField0_ & ~0x00000001);
             chunksBuilder_ = 
-              com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+              com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
                  getChunksFieldBuilder() : null;
           } else {
             chunksBuilder_.addAllMessages(other.chunks_);
@@ -2312,7 +2499,7 @@ public  final class ReadRowsResponse extends
        }
     }
 
-    private com.google.protobuf.RepeatedFieldBuilder<
+    private com.google.protobuf.RepeatedFieldBuilderV3<
         com.google.bigtable.v2.ReadRowsResponse.CellChunk, com.google.bigtable.v2.ReadRowsResponse.CellChunk.Builder, com.google.bigtable.v2.ReadRowsResponse.CellChunkOrBuilder> chunksBuilder_;
 
     /**
@@ -2528,11 +2715,11 @@ public  final class ReadRowsResponse extends
          getChunksBuilderList() {
       return getChunksFieldBuilder().getBuilderList();
     }
-    private com.google.protobuf.RepeatedFieldBuilder<
+    private com.google.protobuf.RepeatedFieldBuilderV3<
         com.google.bigtable.v2.ReadRowsResponse.CellChunk, com.google.bigtable.v2.ReadRowsResponse.CellChunk.Builder, com.google.bigtable.v2.ReadRowsResponse.CellChunkOrBuilder> 
         getChunksFieldBuilder() {
       if (chunksBuilder_ == null) {
-        chunksBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
+        chunksBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
             com.google.bigtable.v2.ReadRowsResponse.CellChunk, com.google.bigtable.v2.ReadRowsResponse.CellChunk.Builder, com.google.bigtable.v2.ReadRowsResponse.CellChunkOrBuilder>(
                 chunks_,
                 ((bitField0_ & 0x00000001) == 0x00000001),

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/Row.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/Row.java
@@ -12,11 +12,11 @@ package com.google.bigtable.v2;
  * Protobuf type {@code google.bigtable.v2.Row}
  */
 public  final class Row extends
-    com.google.protobuf.GeneratedMessage implements
+    com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:google.bigtable.v2.Row)
     RowOrBuilder {
   // Use Row.newBuilder() to construct.
-  private Row(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+  private Row(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private Row() {
@@ -59,7 +59,8 @@ public  final class Row extends
               families_ = new java.util.ArrayList<com.google.bigtable.v2.Family>();
               mutable_bitField0_ |= 0x00000002;
             }
-            families_.add(input.readMessage(com.google.bigtable.v2.Family.parser(), extensionRegistry));
+            families_.add(
+                input.readMessage(com.google.bigtable.v2.Family.parser(), extensionRegistry));
             break;
           }
         }
@@ -81,7 +82,7 @@ public  final class Row extends
     return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_Row_descriptor;
   }
 
-  protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_Row_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
@@ -202,6 +203,42 @@ public  final class Row extends
   }
 
   private static final long serialVersionUID = 0L;
+  @java.lang.Override
+  public boolean equals(final java.lang.Object obj) {
+    if (obj == this) {
+     return true;
+    }
+    if (!(obj instanceof com.google.bigtable.v2.Row)) {
+      return super.equals(obj);
+    }
+    com.google.bigtable.v2.Row other = (com.google.bigtable.v2.Row) obj;
+
+    boolean result = true;
+    result = result && getKey()
+        .equals(other.getKey());
+    result = result && getFamiliesList()
+        .equals(other.getFamiliesList());
+    return result;
+  }
+
+  @java.lang.Override
+  public int hashCode() {
+    if (memoizedHashCode != 0) {
+      return memoizedHashCode;
+    }
+    int hash = 41;
+    hash = (19 * hash) + getDescriptorForType().hashCode();
+    hash = (37 * hash) + KEY_FIELD_NUMBER;
+    hash = (53 * hash) + getKey().hashCode();
+    if (getFamiliesCount() > 0) {
+      hash = (37 * hash) + FAMILIES_FIELD_NUMBER;
+      hash = (53 * hash) + getFamiliesList().hashCode();
+    }
+    hash = (29 * hash) + unknownFields.hashCode();
+    memoizedHashCode = hash;
+    return hash;
+  }
+
   public static com.google.bigtable.v2.Row parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -225,39 +262,39 @@ public  final class Row extends
   }
   public static com.google.bigtable.v2.Row parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.Row parseFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.v2.Row parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.Row parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.v2.Row parseFrom(
       com.google.protobuf.CodedInputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.Row parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
@@ -275,7 +312,7 @@ public  final class Row extends
 
   @java.lang.Override
   protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
@@ -288,7 +325,7 @@ public  final class Row extends
    * Protobuf type {@code google.bigtable.v2.Row}
    */
   public static final class Builder extends
-      com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
       // @@protoc_insertion_point(builder_implements:google.bigtable.v2.Row)
       com.google.bigtable.v2.RowOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
@@ -296,7 +333,7 @@ public  final class Row extends
       return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_Row_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_Row_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -309,12 +346,13 @@ public  final class Row extends
     }
 
     private Builder(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
         getFamiliesFieldBuilder();
       }
     }
@@ -367,6 +405,32 @@ public  final class Row extends
       return result;
     }
 
+    public Builder clone() {
+      return (Builder) super.clone();
+    }
+    public Builder setField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.setField(field, value);
+    }
+    public Builder clearField(
+        com.google.protobuf.Descriptors.FieldDescriptor field) {
+      return (Builder) super.clearField(field);
+    }
+    public Builder clearOneof(
+        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      return (Builder) super.clearOneof(oneof);
+    }
+    public Builder setRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        int index, Object value) {
+      return (Builder) super.setRepeatedField(field, index, value);
+    }
+    public Builder addRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.addRepeatedField(field, value);
+    }
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.bigtable.v2.Row) {
         return mergeFrom((com.google.bigtable.v2.Row)other);
@@ -400,7 +464,7 @@ public  final class Row extends
             families_ = other.families_;
             bitField0_ = (bitField0_ & ~0x00000002);
             familiesBuilder_ = 
-              com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+              com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
                  getFamiliesFieldBuilder() : null;
           } else {
             familiesBuilder_.addAllMessages(other.families_);
@@ -490,7 +554,7 @@ public  final class Row extends
        }
     }
 
-    private com.google.protobuf.RepeatedFieldBuilder<
+    private com.google.protobuf.RepeatedFieldBuilderV3<
         com.google.bigtable.v2.Family, com.google.bigtable.v2.Family.Builder, com.google.bigtable.v2.FamilyOrBuilder> familiesBuilder_;
 
     /**
@@ -796,11 +860,11 @@ public  final class Row extends
          getFamiliesBuilderList() {
       return getFamiliesFieldBuilder().getBuilderList();
     }
-    private com.google.protobuf.RepeatedFieldBuilder<
+    private com.google.protobuf.RepeatedFieldBuilderV3<
         com.google.bigtable.v2.Family, com.google.bigtable.v2.Family.Builder, com.google.bigtable.v2.FamilyOrBuilder> 
         getFamiliesFieldBuilder() {
       if (familiesBuilder_ == null) {
-        familiesBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
+        familiesBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
             com.google.bigtable.v2.Family, com.google.bigtable.v2.Family.Builder, com.google.bigtable.v2.FamilyOrBuilder>(
                 families_,
                 ((bitField0_ & 0x00000002) == 0x00000002),

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/RowFilter.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/RowFilter.java
@@ -38,11 +38,11 @@ package com.google.bigtable.v2;
  * Protobuf type {@code google.bigtable.v2.RowFilter}
  */
 public  final class RowFilter extends
-    com.google.protobuf.GeneratedMessage implements
+    com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:google.bigtable.v2.RowFilter)
     RowFilterOrBuilder {
   // Use RowFilter.newBuilder() to construct.
-  private RowFilter(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+  private RowFilter(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private RowFilter() {
@@ -240,7 +240,7 @@ public  final class RowFilter extends
     return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_RowFilter_descriptor;
   }
 
-  protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_RowFilter_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
@@ -313,11 +313,11 @@ public  final class RowFilter extends
    * Protobuf type {@code google.bigtable.v2.RowFilter.Chain}
    */
   public  static final class Chain extends
-      com.google.protobuf.GeneratedMessage implements
+      com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:google.bigtable.v2.RowFilter.Chain)
       ChainOrBuilder {
     // Use Chain.newBuilder() to construct.
-    private Chain(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+    private Chain(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
     }
     private Chain() {
@@ -354,7 +354,8 @@ public  final class RowFilter extends
                 filters_ = new java.util.ArrayList<com.google.bigtable.v2.RowFilter>();
                 mutable_bitField0_ |= 0x00000001;
               }
-              filters_.add(input.readMessage(com.google.bigtable.v2.RowFilter.parser(), extensionRegistry));
+              filters_.add(
+                  input.readMessage(com.google.bigtable.v2.RowFilter.parser(), extensionRegistry));
               break;
             }
           }
@@ -376,7 +377,7 @@ public  final class RowFilter extends
       return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_RowFilter_Chain_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_RowFilter_Chain_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -479,6 +480,38 @@ public  final class RowFilter extends
     }
 
     private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.google.bigtable.v2.RowFilter.Chain)) {
+        return super.equals(obj);
+      }
+      com.google.bigtable.v2.RowFilter.Chain other = (com.google.bigtable.v2.RowFilter.Chain) obj;
+
+      boolean result = true;
+      result = result && getFiltersList()
+          .equals(other.getFiltersList());
+      return result;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptorForType().hashCode();
+      if (getFiltersCount() > 0) {
+        hash = (37 * hash) + FILTERS_FIELD_NUMBER;
+        hash = (53 * hash) + getFiltersList().hashCode();
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
     public static com.google.bigtable.v2.RowFilter.Chain parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
@@ -502,39 +535,39 @@ public  final class RowFilter extends
     }
     public static com.google.bigtable.v2.RowFilter.Chain parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
     public static com.google.bigtable.v2.RowFilter.Chain parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
     public static com.google.bigtable.v2.RowFilter.Chain parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
     public static com.google.bigtable.v2.RowFilter.Chain parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
     public static com.google.bigtable.v2.RowFilter.Chain parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
     public static com.google.bigtable.v2.RowFilter.Chain parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
@@ -552,7 +585,7 @@ public  final class RowFilter extends
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -564,7 +597,7 @@ public  final class RowFilter extends
      * Protobuf type {@code google.bigtable.v2.RowFilter.Chain}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:google.bigtable.v2.RowFilter.Chain)
         com.google.bigtable.v2.RowFilter.ChainOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -572,7 +605,7 @@ public  final class RowFilter extends
         return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_RowFilter_Chain_descriptor;
       }
 
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_RowFilter_Chain_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -585,12 +618,13 @@ public  final class RowFilter extends
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
       private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
           getFiltersFieldBuilder();
         }
       }
@@ -638,6 +672,32 @@ public  final class RowFilter extends
         return result;
       }
 
+      public Builder clone() {
+        return (Builder) super.clone();
+      }
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          Object value) {
+        return (Builder) super.setField(field, value);
+      }
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return (Builder) super.clearField(field);
+      }
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return (Builder) super.clearOneof(oneof);
+      }
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, Object value) {
+        return (Builder) super.setRepeatedField(field, index, value);
+      }
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          Object value) {
+        return (Builder) super.addRepeatedField(field, value);
+      }
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof com.google.bigtable.v2.RowFilter.Chain) {
           return mergeFrom((com.google.bigtable.v2.RowFilter.Chain)other);
@@ -668,7 +728,7 @@ public  final class RowFilter extends
               filters_ = other.filters_;
               bitField0_ = (bitField0_ & ~0x00000001);
               filtersBuilder_ = 
-                com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+                com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
                    getFiltersFieldBuilder() : null;
             } else {
               filtersBuilder_.addAllMessages(other.filters_);
@@ -711,7 +771,7 @@ public  final class RowFilter extends
          }
       }
 
-      private com.google.protobuf.RepeatedFieldBuilder<
+      private com.google.protobuf.RepeatedFieldBuilderV3<
           com.google.bigtable.v2.RowFilter, com.google.bigtable.v2.RowFilter.Builder, com.google.bigtable.v2.RowFilterOrBuilder> filtersBuilder_;
 
       /**
@@ -1035,11 +1095,11 @@ public  final class RowFilter extends
            getFiltersBuilderList() {
         return getFiltersFieldBuilder().getBuilderList();
       }
-      private com.google.protobuf.RepeatedFieldBuilder<
+      private com.google.protobuf.RepeatedFieldBuilderV3<
           com.google.bigtable.v2.RowFilter, com.google.bigtable.v2.RowFilter.Builder, com.google.bigtable.v2.RowFilterOrBuilder> 
           getFiltersFieldBuilder() {
         if (filtersBuilder_ == null) {
-          filtersBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
+          filtersBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
               com.google.bigtable.v2.RowFilter, com.google.bigtable.v2.RowFilter.Builder, com.google.bigtable.v2.RowFilterOrBuilder>(
                   filters_,
                   ((bitField0_ & 0x00000001) == 0x00000001),
@@ -1265,11 +1325,11 @@ public  final class RowFilter extends
    * Protobuf type {@code google.bigtable.v2.RowFilter.Interleave}
    */
   public  static final class Interleave extends
-      com.google.protobuf.GeneratedMessage implements
+      com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:google.bigtable.v2.RowFilter.Interleave)
       InterleaveOrBuilder {
     // Use Interleave.newBuilder() to construct.
-    private Interleave(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+    private Interleave(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
     }
     private Interleave() {
@@ -1306,7 +1366,8 @@ public  final class RowFilter extends
                 filters_ = new java.util.ArrayList<com.google.bigtable.v2.RowFilter>();
                 mutable_bitField0_ |= 0x00000001;
               }
-              filters_.add(input.readMessage(com.google.bigtable.v2.RowFilter.parser(), extensionRegistry));
+              filters_.add(
+                  input.readMessage(com.google.bigtable.v2.RowFilter.parser(), extensionRegistry));
               break;
             }
           }
@@ -1328,7 +1389,7 @@ public  final class RowFilter extends
       return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_RowFilter_Interleave_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_RowFilter_Interleave_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -1531,6 +1592,38 @@ public  final class RowFilter extends
     }
 
     private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.google.bigtable.v2.RowFilter.Interleave)) {
+        return super.equals(obj);
+      }
+      com.google.bigtable.v2.RowFilter.Interleave other = (com.google.bigtable.v2.RowFilter.Interleave) obj;
+
+      boolean result = true;
+      result = result && getFiltersList()
+          .equals(other.getFiltersList());
+      return result;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptorForType().hashCode();
+      if (getFiltersCount() > 0) {
+        hash = (37 * hash) + FILTERS_FIELD_NUMBER;
+        hash = (53 * hash) + getFiltersList().hashCode();
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
     public static com.google.bigtable.v2.RowFilter.Interleave parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
@@ -1554,39 +1647,39 @@ public  final class RowFilter extends
     }
     public static com.google.bigtable.v2.RowFilter.Interleave parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
     public static com.google.bigtable.v2.RowFilter.Interleave parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
     public static com.google.bigtable.v2.RowFilter.Interleave parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
     public static com.google.bigtable.v2.RowFilter.Interleave parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
     public static com.google.bigtable.v2.RowFilter.Interleave parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
     public static com.google.bigtable.v2.RowFilter.Interleave parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
@@ -1604,7 +1697,7 @@ public  final class RowFilter extends
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -1617,7 +1710,7 @@ public  final class RowFilter extends
      * Protobuf type {@code google.bigtable.v2.RowFilter.Interleave}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:google.bigtable.v2.RowFilter.Interleave)
         com.google.bigtable.v2.RowFilter.InterleaveOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -1625,7 +1718,7 @@ public  final class RowFilter extends
         return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_RowFilter_Interleave_descriptor;
       }
 
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_RowFilter_Interleave_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -1638,12 +1731,13 @@ public  final class RowFilter extends
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
       private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
           getFiltersFieldBuilder();
         }
       }
@@ -1691,6 +1785,32 @@ public  final class RowFilter extends
         return result;
       }
 
+      public Builder clone() {
+        return (Builder) super.clone();
+      }
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          Object value) {
+        return (Builder) super.setField(field, value);
+      }
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return (Builder) super.clearField(field);
+      }
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return (Builder) super.clearOneof(oneof);
+      }
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, Object value) {
+        return (Builder) super.setRepeatedField(field, index, value);
+      }
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          Object value) {
+        return (Builder) super.addRepeatedField(field, value);
+      }
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof com.google.bigtable.v2.RowFilter.Interleave) {
           return mergeFrom((com.google.bigtable.v2.RowFilter.Interleave)other);
@@ -1721,7 +1841,7 @@ public  final class RowFilter extends
               filters_ = other.filters_;
               bitField0_ = (bitField0_ & ~0x00000001);
               filtersBuilder_ = 
-                com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+                com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
                    getFiltersFieldBuilder() : null;
             } else {
               filtersBuilder_.addAllMessages(other.filters_);
@@ -1764,7 +1884,7 @@ public  final class RowFilter extends
          }
       }
 
-      private com.google.protobuf.RepeatedFieldBuilder<
+      private com.google.protobuf.RepeatedFieldBuilderV3<
           com.google.bigtable.v2.RowFilter, com.google.bigtable.v2.RowFilter.Builder, com.google.bigtable.v2.RowFilterOrBuilder> filtersBuilder_;
 
       /**
@@ -2448,11 +2568,11 @@ public  final class RowFilter extends
            getFiltersBuilderList() {
         return getFiltersFieldBuilder().getBuilderList();
       }
-      private com.google.protobuf.RepeatedFieldBuilder<
+      private com.google.protobuf.RepeatedFieldBuilderV3<
           com.google.bigtable.v2.RowFilter, com.google.bigtable.v2.RowFilter.Builder, com.google.bigtable.v2.RowFilterOrBuilder> 
           getFiltersFieldBuilder() {
         if (filtersBuilder_ == null) {
-          filtersBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
+          filtersBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
               com.google.bigtable.v2.RowFilter, com.google.bigtable.v2.RowFilter.Builder, com.google.bigtable.v2.RowFilterOrBuilder>(
                   filters_,
                   ((bitField0_ & 0x00000001) == 0x00000001),
@@ -2615,11 +2735,11 @@ public  final class RowFilter extends
    * Protobuf type {@code google.bigtable.v2.RowFilter.Condition}
    */
   public  static final class Condition extends
-      com.google.protobuf.GeneratedMessage implements
+      com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:google.bigtable.v2.RowFilter.Condition)
       ConditionOrBuilder {
     // Use Condition.newBuilder() to construct.
-    private Condition(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+    private Condition(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
     }
     private Condition() {
@@ -2705,7 +2825,7 @@ public  final class RowFilter extends
       return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_RowFilter_Condition_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_RowFilter_Condition_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -2868,6 +2988,59 @@ public  final class RowFilter extends
     }
 
     private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.google.bigtable.v2.RowFilter.Condition)) {
+        return super.equals(obj);
+      }
+      com.google.bigtable.v2.RowFilter.Condition other = (com.google.bigtable.v2.RowFilter.Condition) obj;
+
+      boolean result = true;
+      result = result && (hasPredicateFilter() == other.hasPredicateFilter());
+      if (hasPredicateFilter()) {
+        result = result && getPredicateFilter()
+            .equals(other.getPredicateFilter());
+      }
+      result = result && (hasTrueFilter() == other.hasTrueFilter());
+      if (hasTrueFilter()) {
+        result = result && getTrueFilter()
+            .equals(other.getTrueFilter());
+      }
+      result = result && (hasFalseFilter() == other.hasFalseFilter());
+      if (hasFalseFilter()) {
+        result = result && getFalseFilter()
+            .equals(other.getFalseFilter());
+      }
+      return result;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptorForType().hashCode();
+      if (hasPredicateFilter()) {
+        hash = (37 * hash) + PREDICATE_FILTER_FIELD_NUMBER;
+        hash = (53 * hash) + getPredicateFilter().hashCode();
+      }
+      if (hasTrueFilter()) {
+        hash = (37 * hash) + TRUE_FILTER_FIELD_NUMBER;
+        hash = (53 * hash) + getTrueFilter().hashCode();
+      }
+      if (hasFalseFilter()) {
+        hash = (37 * hash) + FALSE_FILTER_FIELD_NUMBER;
+        hash = (53 * hash) + getFalseFilter().hashCode();
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
     public static com.google.bigtable.v2.RowFilter.Condition parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
@@ -2891,39 +3064,39 @@ public  final class RowFilter extends
     }
     public static com.google.bigtable.v2.RowFilter.Condition parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
     public static com.google.bigtable.v2.RowFilter.Condition parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
     public static com.google.bigtable.v2.RowFilter.Condition parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
     public static com.google.bigtable.v2.RowFilter.Condition parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
     public static com.google.bigtable.v2.RowFilter.Condition parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
     public static com.google.bigtable.v2.RowFilter.Condition parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
@@ -2941,7 +3114,7 @@ public  final class RowFilter extends
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -2958,7 +3131,7 @@ public  final class RowFilter extends
      * Protobuf type {@code google.bigtable.v2.RowFilter.Condition}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:google.bigtable.v2.RowFilter.Condition)
         com.google.bigtable.v2.RowFilter.ConditionOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -2966,7 +3139,7 @@ public  final class RowFilter extends
         return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_RowFilter_Condition_descriptor;
       }
 
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_RowFilter_Condition_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -2979,12 +3152,13 @@ public  final class RowFilter extends
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
       private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
         }
       }
       public Builder clear() {
@@ -3048,6 +3222,32 @@ public  final class RowFilter extends
         return result;
       }
 
+      public Builder clone() {
+        return (Builder) super.clone();
+      }
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          Object value) {
+        return (Builder) super.setField(field, value);
+      }
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return (Builder) super.clearField(field);
+      }
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return (Builder) super.clearOneof(oneof);
+      }
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, Object value) {
+        return (Builder) super.setRepeatedField(field, index, value);
+      }
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          Object value) {
+        return (Builder) super.addRepeatedField(field, value);
+      }
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof com.google.bigtable.v2.RowFilter.Condition) {
           return mergeFrom((com.google.bigtable.v2.RowFilter.Condition)other);
@@ -3095,7 +3295,7 @@ public  final class RowFilter extends
       }
 
       private com.google.bigtable.v2.RowFilter predicateFilter_ = null;
-      private com.google.protobuf.SingleFieldBuilder<
+      private com.google.protobuf.SingleFieldBuilderV3<
           com.google.bigtable.v2.RowFilter, com.google.bigtable.v2.RowFilter.Builder, com.google.bigtable.v2.RowFilterOrBuilder> predicateFilterBuilder_;
       /**
        * <pre>
@@ -3242,11 +3442,11 @@ public  final class RowFilter extends
        *
        * <code>optional .google.bigtable.v2.RowFilter predicate_filter = 1;</code>
        */
-      private com.google.protobuf.SingleFieldBuilder<
+      private com.google.protobuf.SingleFieldBuilderV3<
           com.google.bigtable.v2.RowFilter, com.google.bigtable.v2.RowFilter.Builder, com.google.bigtable.v2.RowFilterOrBuilder> 
           getPredicateFilterFieldBuilder() {
         if (predicateFilterBuilder_ == null) {
-          predicateFilterBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+          predicateFilterBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
               com.google.bigtable.v2.RowFilter, com.google.bigtable.v2.RowFilter.Builder, com.google.bigtable.v2.RowFilterOrBuilder>(
                   getPredicateFilter(),
                   getParentForChildren(),
@@ -3257,7 +3457,7 @@ public  final class RowFilter extends
       }
 
       private com.google.bigtable.v2.RowFilter trueFilter_ = null;
-      private com.google.protobuf.SingleFieldBuilder<
+      private com.google.protobuf.SingleFieldBuilderV3<
           com.google.bigtable.v2.RowFilter, com.google.bigtable.v2.RowFilter.Builder, com.google.bigtable.v2.RowFilterOrBuilder> trueFilterBuilder_;
       /**
        * <pre>
@@ -3404,11 +3604,11 @@ public  final class RowFilter extends
        *
        * <code>optional .google.bigtable.v2.RowFilter true_filter = 2;</code>
        */
-      private com.google.protobuf.SingleFieldBuilder<
+      private com.google.protobuf.SingleFieldBuilderV3<
           com.google.bigtable.v2.RowFilter, com.google.bigtable.v2.RowFilter.Builder, com.google.bigtable.v2.RowFilterOrBuilder> 
           getTrueFilterFieldBuilder() {
         if (trueFilterBuilder_ == null) {
-          trueFilterBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+          trueFilterBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
               com.google.bigtable.v2.RowFilter, com.google.bigtable.v2.RowFilter.Builder, com.google.bigtable.v2.RowFilterOrBuilder>(
                   getTrueFilter(),
                   getParentForChildren(),
@@ -3419,7 +3619,7 @@ public  final class RowFilter extends
       }
 
       private com.google.bigtable.v2.RowFilter falseFilter_ = null;
-      private com.google.protobuf.SingleFieldBuilder<
+      private com.google.protobuf.SingleFieldBuilderV3<
           com.google.bigtable.v2.RowFilter, com.google.bigtable.v2.RowFilter.Builder, com.google.bigtable.v2.RowFilterOrBuilder> falseFilterBuilder_;
       /**
        * <pre>
@@ -3575,11 +3775,11 @@ public  final class RowFilter extends
        *
        * <code>optional .google.bigtable.v2.RowFilter false_filter = 3;</code>
        */
-      private com.google.protobuf.SingleFieldBuilder<
+      private com.google.protobuf.SingleFieldBuilderV3<
           com.google.bigtable.v2.RowFilter, com.google.bigtable.v2.RowFilter.Builder, com.google.bigtable.v2.RowFilterOrBuilder> 
           getFalseFilterFieldBuilder() {
         if (falseFilterBuilder_ == null) {
-          falseFilterBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+          falseFilterBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
               com.google.bigtable.v2.RowFilter, com.google.bigtable.v2.RowFilter.Builder, com.google.bigtable.v2.RowFilterOrBuilder>(
                   getFalseFilter(),
                   getParentForChildren(),
@@ -4286,7 +4486,7 @@ public  final class RowFilter extends
           4, (com.google.protobuf.ByteString)((com.google.protobuf.ByteString) filter_));
     }
     if (filterCase_ == 5) {
-      com.google.protobuf.GeneratedMessage.writeString(output, 5, filter_);
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 5, filter_);
     }
     if (filterCase_ == 6) {
       output.writeBytes(
@@ -4338,7 +4538,7 @@ public  final class RowFilter extends
           18, (boolean)((java.lang.Boolean) filter_));
     }
     if (filterCase_ == 19) {
-      com.google.protobuf.GeneratedMessage.writeString(output, 19, filter_);
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 19, filter_);
     }
   }
 
@@ -4365,7 +4565,7 @@ public  final class RowFilter extends
             4, (com.google.protobuf.ByteString)((com.google.protobuf.ByteString) filter_));
     }
     if (filterCase_ == 5) {
-      size += com.google.protobuf.GeneratedMessage.computeStringSize(5, filter_);
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(5, filter_);
     }
     if (filterCase_ == 6) {
       size += com.google.protobuf.CodedOutputStream
@@ -4430,13 +4630,209 @@ public  final class RowFilter extends
             18, (boolean)((java.lang.Boolean) filter_));
     }
     if (filterCase_ == 19) {
-      size += com.google.protobuf.GeneratedMessage.computeStringSize(19, filter_);
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(19, filter_);
     }
     memoizedSize = size;
     return size;
   }
 
   private static final long serialVersionUID = 0L;
+  @java.lang.Override
+  public boolean equals(final java.lang.Object obj) {
+    if (obj == this) {
+     return true;
+    }
+    if (!(obj instanceof com.google.bigtable.v2.RowFilter)) {
+      return super.equals(obj);
+    }
+    com.google.bigtable.v2.RowFilter other = (com.google.bigtable.v2.RowFilter) obj;
+
+    boolean result = true;
+    result = result && getFilterCase().equals(
+        other.getFilterCase());
+    if (!result) return false;
+    switch (filterCase_) {
+      case 1:
+        result = result && getChain()
+            .equals(other.getChain());
+        break;
+      case 2:
+        result = result && getInterleave()
+            .equals(other.getInterleave());
+        break;
+      case 3:
+        result = result && getCondition()
+            .equals(other.getCondition());
+        break;
+      case 16:
+        result = result && (getSink()
+            == other.getSink());
+        break;
+      case 17:
+        result = result && (getPassAllFilter()
+            == other.getPassAllFilter());
+        break;
+      case 18:
+        result = result && (getBlockAllFilter()
+            == other.getBlockAllFilter());
+        break;
+      case 4:
+        result = result && getRowKeyRegexFilter()
+            .equals(other.getRowKeyRegexFilter());
+        break;
+      case 14:
+        result = result && (
+            java.lang.Double.doubleToLongBits(getRowSampleFilter())
+            == java.lang.Double.doubleToLongBits(
+                other.getRowSampleFilter()));
+        break;
+      case 5:
+        result = result && getFamilyNameRegexFilter()
+            .equals(other.getFamilyNameRegexFilter());
+        break;
+      case 6:
+        result = result && getColumnQualifierRegexFilter()
+            .equals(other.getColumnQualifierRegexFilter());
+        break;
+      case 7:
+        result = result && getColumnRangeFilter()
+            .equals(other.getColumnRangeFilter());
+        break;
+      case 8:
+        result = result && getTimestampRangeFilter()
+            .equals(other.getTimestampRangeFilter());
+        break;
+      case 9:
+        result = result && getValueRegexFilter()
+            .equals(other.getValueRegexFilter());
+        break;
+      case 15:
+        result = result && getValueRangeFilter()
+            .equals(other.getValueRangeFilter());
+        break;
+      case 10:
+        result = result && (getCellsPerRowOffsetFilter()
+            == other.getCellsPerRowOffsetFilter());
+        break;
+      case 11:
+        result = result && (getCellsPerRowLimitFilter()
+            == other.getCellsPerRowLimitFilter());
+        break;
+      case 12:
+        result = result && (getCellsPerColumnLimitFilter()
+            == other.getCellsPerColumnLimitFilter());
+        break;
+      case 13:
+        result = result && (getStripValueTransformer()
+            == other.getStripValueTransformer());
+        break;
+      case 19:
+        result = result && getApplyLabelTransformer()
+            .equals(other.getApplyLabelTransformer());
+        break;
+      case 0:
+      default:
+    }
+    return result;
+  }
+
+  @java.lang.Override
+  public int hashCode() {
+    if (memoizedHashCode != 0) {
+      return memoizedHashCode;
+    }
+    int hash = 41;
+    hash = (19 * hash) + getDescriptorForType().hashCode();
+    switch (filterCase_) {
+      case 1:
+        hash = (37 * hash) + CHAIN_FIELD_NUMBER;
+        hash = (53 * hash) + getChain().hashCode();
+        break;
+      case 2:
+        hash = (37 * hash) + INTERLEAVE_FIELD_NUMBER;
+        hash = (53 * hash) + getInterleave().hashCode();
+        break;
+      case 3:
+        hash = (37 * hash) + CONDITION_FIELD_NUMBER;
+        hash = (53 * hash) + getCondition().hashCode();
+        break;
+      case 16:
+        hash = (37 * hash) + SINK_FIELD_NUMBER;
+        hash = (53 * hash) + com.google.protobuf.Internal.hashBoolean(
+            getSink());
+        break;
+      case 17:
+        hash = (37 * hash) + PASS_ALL_FILTER_FIELD_NUMBER;
+        hash = (53 * hash) + com.google.protobuf.Internal.hashBoolean(
+            getPassAllFilter());
+        break;
+      case 18:
+        hash = (37 * hash) + BLOCK_ALL_FILTER_FIELD_NUMBER;
+        hash = (53 * hash) + com.google.protobuf.Internal.hashBoolean(
+            getBlockAllFilter());
+        break;
+      case 4:
+        hash = (37 * hash) + ROW_KEY_REGEX_FILTER_FIELD_NUMBER;
+        hash = (53 * hash) + getRowKeyRegexFilter().hashCode();
+        break;
+      case 14:
+        hash = (37 * hash) + ROW_SAMPLE_FILTER_FIELD_NUMBER;
+        hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
+            java.lang.Double.doubleToLongBits(getRowSampleFilter()));
+        break;
+      case 5:
+        hash = (37 * hash) + FAMILY_NAME_REGEX_FILTER_FIELD_NUMBER;
+        hash = (53 * hash) + getFamilyNameRegexFilter().hashCode();
+        break;
+      case 6:
+        hash = (37 * hash) + COLUMN_QUALIFIER_REGEX_FILTER_FIELD_NUMBER;
+        hash = (53 * hash) + getColumnQualifierRegexFilter().hashCode();
+        break;
+      case 7:
+        hash = (37 * hash) + COLUMN_RANGE_FILTER_FIELD_NUMBER;
+        hash = (53 * hash) + getColumnRangeFilter().hashCode();
+        break;
+      case 8:
+        hash = (37 * hash) + TIMESTAMP_RANGE_FILTER_FIELD_NUMBER;
+        hash = (53 * hash) + getTimestampRangeFilter().hashCode();
+        break;
+      case 9:
+        hash = (37 * hash) + VALUE_REGEX_FILTER_FIELD_NUMBER;
+        hash = (53 * hash) + getValueRegexFilter().hashCode();
+        break;
+      case 15:
+        hash = (37 * hash) + VALUE_RANGE_FILTER_FIELD_NUMBER;
+        hash = (53 * hash) + getValueRangeFilter().hashCode();
+        break;
+      case 10:
+        hash = (37 * hash) + CELLS_PER_ROW_OFFSET_FILTER_FIELD_NUMBER;
+        hash = (53 * hash) + getCellsPerRowOffsetFilter();
+        break;
+      case 11:
+        hash = (37 * hash) + CELLS_PER_ROW_LIMIT_FILTER_FIELD_NUMBER;
+        hash = (53 * hash) + getCellsPerRowLimitFilter();
+        break;
+      case 12:
+        hash = (37 * hash) + CELLS_PER_COLUMN_LIMIT_FILTER_FIELD_NUMBER;
+        hash = (53 * hash) + getCellsPerColumnLimitFilter();
+        break;
+      case 13:
+        hash = (37 * hash) + STRIP_VALUE_TRANSFORMER_FIELD_NUMBER;
+        hash = (53 * hash) + com.google.protobuf.Internal.hashBoolean(
+            getStripValueTransformer());
+        break;
+      case 19:
+        hash = (37 * hash) + APPLY_LABEL_TRANSFORMER_FIELD_NUMBER;
+        hash = (53 * hash) + getApplyLabelTransformer().hashCode();
+        break;
+      case 0:
+      default:
+    }
+    hash = (29 * hash) + unknownFields.hashCode();
+    memoizedHashCode = hash;
+    return hash;
+  }
+
   public static com.google.bigtable.v2.RowFilter parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -4460,39 +4856,39 @@ public  final class RowFilter extends
   }
   public static com.google.bigtable.v2.RowFilter parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.RowFilter parseFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.v2.RowFilter parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.RowFilter parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.v2.RowFilter parseFrom(
       com.google.protobuf.CodedInputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.RowFilter parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
@@ -4510,7 +4906,7 @@ public  final class RowFilter extends
 
   @java.lang.Override
   protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
@@ -4549,7 +4945,7 @@ public  final class RowFilter extends
    * Protobuf type {@code google.bigtable.v2.RowFilter}
    */
   public static final class Builder extends
-      com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
       // @@protoc_insertion_point(builder_implements:google.bigtable.v2.RowFilter)
       com.google.bigtable.v2.RowFilterOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
@@ -4557,7 +4953,7 @@ public  final class RowFilter extends
       return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_RowFilter_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_RowFilter_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -4570,12 +4966,13 @@ public  final class RowFilter extends
     }
 
     private Builder(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
       }
     }
     public Builder clear() {
@@ -4690,6 +5087,32 @@ public  final class RowFilter extends
       return result;
     }
 
+    public Builder clone() {
+      return (Builder) super.clone();
+    }
+    public Builder setField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.setField(field, value);
+    }
+    public Builder clearField(
+        com.google.protobuf.Descriptors.FieldDescriptor field) {
+      return (Builder) super.clearField(field);
+    }
+    public Builder clearOneof(
+        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      return (Builder) super.clearOneof(oneof);
+    }
+    public Builder setRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        int index, Object value) {
+      return (Builder) super.setRepeatedField(field, index, value);
+    }
+    public Builder addRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.addRepeatedField(field, value);
+    }
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.bigtable.v2.RowFilter) {
         return mergeFrom((com.google.bigtable.v2.RowFilter)other);
@@ -4827,7 +5250,7 @@ public  final class RowFilter extends
     }
 
 
-    private com.google.protobuf.SingleFieldBuilder<
+    private com.google.protobuf.SingleFieldBuilderV3<
         com.google.bigtable.v2.RowFilter.Chain, com.google.bigtable.v2.RowFilter.Chain.Builder, com.google.bigtable.v2.RowFilter.ChainOrBuilder> chainBuilder_;
     /**
      * <pre>
@@ -4978,14 +5401,14 @@ public  final class RowFilter extends
      *
      * <code>optional .google.bigtable.v2.RowFilter.Chain chain = 1;</code>
      */
-    private com.google.protobuf.SingleFieldBuilder<
+    private com.google.protobuf.SingleFieldBuilderV3<
         com.google.bigtable.v2.RowFilter.Chain, com.google.bigtable.v2.RowFilter.Chain.Builder, com.google.bigtable.v2.RowFilter.ChainOrBuilder> 
         getChainFieldBuilder() {
       if (chainBuilder_ == null) {
         if (!(filterCase_ == 1)) {
           filter_ = com.google.bigtable.v2.RowFilter.Chain.getDefaultInstance();
         }
-        chainBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+        chainBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
             com.google.bigtable.v2.RowFilter.Chain, com.google.bigtable.v2.RowFilter.Chain.Builder, com.google.bigtable.v2.RowFilter.ChainOrBuilder>(
                 (com.google.bigtable.v2.RowFilter.Chain) filter_,
                 getParentForChildren(),
@@ -4997,7 +5420,7 @@ public  final class RowFilter extends
       return chainBuilder_;
     }
 
-    private com.google.protobuf.SingleFieldBuilder<
+    private com.google.protobuf.SingleFieldBuilderV3<
         com.google.bigtable.v2.RowFilter.Interleave, com.google.bigtable.v2.RowFilter.Interleave.Builder, com.google.bigtable.v2.RowFilter.InterleaveOrBuilder> interleaveBuilder_;
     /**
      * <pre>
@@ -5148,14 +5571,14 @@ public  final class RowFilter extends
      *
      * <code>optional .google.bigtable.v2.RowFilter.Interleave interleave = 2;</code>
      */
-    private com.google.protobuf.SingleFieldBuilder<
+    private com.google.protobuf.SingleFieldBuilderV3<
         com.google.bigtable.v2.RowFilter.Interleave, com.google.bigtable.v2.RowFilter.Interleave.Builder, com.google.bigtable.v2.RowFilter.InterleaveOrBuilder> 
         getInterleaveFieldBuilder() {
       if (interleaveBuilder_ == null) {
         if (!(filterCase_ == 2)) {
           filter_ = com.google.bigtable.v2.RowFilter.Interleave.getDefaultInstance();
         }
-        interleaveBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+        interleaveBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
             com.google.bigtable.v2.RowFilter.Interleave, com.google.bigtable.v2.RowFilter.Interleave.Builder, com.google.bigtable.v2.RowFilter.InterleaveOrBuilder>(
                 (com.google.bigtable.v2.RowFilter.Interleave) filter_,
                 getParentForChildren(),
@@ -5167,7 +5590,7 @@ public  final class RowFilter extends
       return interleaveBuilder_;
     }
 
-    private com.google.protobuf.SingleFieldBuilder<
+    private com.google.protobuf.SingleFieldBuilderV3<
         com.google.bigtable.v2.RowFilter.Condition, com.google.bigtable.v2.RowFilter.Condition.Builder, com.google.bigtable.v2.RowFilter.ConditionOrBuilder> conditionBuilder_;
     /**
      * <pre>
@@ -5318,14 +5741,14 @@ public  final class RowFilter extends
      *
      * <code>optional .google.bigtable.v2.RowFilter.Condition condition = 3;</code>
      */
-    private com.google.protobuf.SingleFieldBuilder<
+    private com.google.protobuf.SingleFieldBuilderV3<
         com.google.bigtable.v2.RowFilter.Condition, com.google.bigtable.v2.RowFilter.Condition.Builder, com.google.bigtable.v2.RowFilter.ConditionOrBuilder> 
         getConditionFieldBuilder() {
       if (conditionBuilder_ == null) {
         if (!(filterCase_ == 3)) {
           filter_ = com.google.bigtable.v2.RowFilter.Condition.getDefaultInstance();
         }
-        conditionBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+        conditionBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
             com.google.bigtable.v2.RowFilter.Condition, com.google.bigtable.v2.RowFilter.Condition.Builder, com.google.bigtable.v2.RowFilter.ConditionOrBuilder>(
                 (com.google.bigtable.v2.RowFilter.Condition) filter_,
                 getParentForChildren(),
@@ -5921,7 +6344,7 @@ public  final class RowFilter extends
       return this;
     }
 
-    private com.google.protobuf.SingleFieldBuilder<
+    private com.google.protobuf.SingleFieldBuilderV3<
         com.google.bigtable.v2.ColumnRange, com.google.bigtable.v2.ColumnRange.Builder, com.google.bigtable.v2.ColumnRangeOrBuilder> columnRangeFilterBuilder_;
     /**
      * <pre>
@@ -6064,14 +6487,14 @@ public  final class RowFilter extends
      *
      * <code>optional .google.bigtable.v2.ColumnRange column_range_filter = 7;</code>
      */
-    private com.google.protobuf.SingleFieldBuilder<
+    private com.google.protobuf.SingleFieldBuilderV3<
         com.google.bigtable.v2.ColumnRange, com.google.bigtable.v2.ColumnRange.Builder, com.google.bigtable.v2.ColumnRangeOrBuilder> 
         getColumnRangeFilterFieldBuilder() {
       if (columnRangeFilterBuilder_ == null) {
         if (!(filterCase_ == 7)) {
           filter_ = com.google.bigtable.v2.ColumnRange.getDefaultInstance();
         }
-        columnRangeFilterBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+        columnRangeFilterBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
             com.google.bigtable.v2.ColumnRange, com.google.bigtable.v2.ColumnRange.Builder, com.google.bigtable.v2.ColumnRangeOrBuilder>(
                 (com.google.bigtable.v2.ColumnRange) filter_,
                 getParentForChildren(),
@@ -6083,7 +6506,7 @@ public  final class RowFilter extends
       return columnRangeFilterBuilder_;
     }
 
-    private com.google.protobuf.SingleFieldBuilder<
+    private com.google.protobuf.SingleFieldBuilderV3<
         com.google.bigtable.v2.TimestampRange, com.google.bigtable.v2.TimestampRange.Builder, com.google.bigtable.v2.TimestampRangeOrBuilder> timestampRangeFilterBuilder_;
     /**
      * <pre>
@@ -6226,14 +6649,14 @@ public  final class RowFilter extends
      *
      * <code>optional .google.bigtable.v2.TimestampRange timestamp_range_filter = 8;</code>
      */
-    private com.google.protobuf.SingleFieldBuilder<
+    private com.google.protobuf.SingleFieldBuilderV3<
         com.google.bigtable.v2.TimestampRange, com.google.bigtable.v2.TimestampRange.Builder, com.google.bigtable.v2.TimestampRangeOrBuilder> 
         getTimestampRangeFilterFieldBuilder() {
       if (timestampRangeFilterBuilder_ == null) {
         if (!(filterCase_ == 8)) {
           filter_ = com.google.bigtable.v2.TimestampRange.getDefaultInstance();
         }
-        timestampRangeFilterBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+        timestampRangeFilterBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
             com.google.bigtable.v2.TimestampRange, com.google.bigtable.v2.TimestampRange.Builder, com.google.bigtable.v2.TimestampRangeOrBuilder>(
                 (com.google.bigtable.v2.TimestampRange) filter_,
                 getParentForChildren(),
@@ -6302,7 +6725,7 @@ public  final class RowFilter extends
       return this;
     }
 
-    private com.google.protobuf.SingleFieldBuilder<
+    private com.google.protobuf.SingleFieldBuilderV3<
         com.google.bigtable.v2.ValueRange, com.google.bigtable.v2.ValueRange.Builder, com.google.bigtable.v2.ValueRangeOrBuilder> valueRangeFilterBuilder_;
     /**
      * <pre>
@@ -6445,14 +6868,14 @@ public  final class RowFilter extends
      *
      * <code>optional .google.bigtable.v2.ValueRange value_range_filter = 15;</code>
      */
-    private com.google.protobuf.SingleFieldBuilder<
+    private com.google.protobuf.SingleFieldBuilderV3<
         com.google.bigtable.v2.ValueRange, com.google.bigtable.v2.ValueRange.Builder, com.google.bigtable.v2.ValueRangeOrBuilder> 
         getValueRangeFilterFieldBuilder() {
       if (valueRangeFilterBuilder_ == null) {
         if (!(filterCase_ == 15)) {
           filter_ = com.google.bigtable.v2.ValueRange.getDefaultInstance();
         }
-        valueRangeFilterBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+        valueRangeFilterBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
             com.google.bigtable.v2.ValueRange, com.google.bigtable.v2.ValueRange.Builder, com.google.bigtable.v2.ValueRangeOrBuilder>(
                 (com.google.bigtable.v2.ValueRange) filter_,
                 getParentForChildren(),

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/RowRange.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/RowRange.java
@@ -11,11 +11,11 @@ package com.google.bigtable.v2;
  * Protobuf type {@code google.bigtable.v2.RowRange}
  */
 public  final class RowRange extends
-    com.google.protobuf.GeneratedMessage implements
+    com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:google.bigtable.v2.RowRange)
     RowRangeOrBuilder {
   // Use RowRange.newBuilder() to construct.
-  private RowRange(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+  private RowRange(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private RowRange() {
@@ -82,7 +82,7 @@ public  final class RowRange extends
     return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_RowRange_descriptor;
   }
 
-  protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_RowRange_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
@@ -285,6 +285,86 @@ public  final class RowRange extends
   }
 
   private static final long serialVersionUID = 0L;
+  @java.lang.Override
+  public boolean equals(final java.lang.Object obj) {
+    if (obj == this) {
+     return true;
+    }
+    if (!(obj instanceof com.google.bigtable.v2.RowRange)) {
+      return super.equals(obj);
+    }
+    com.google.bigtable.v2.RowRange other = (com.google.bigtable.v2.RowRange) obj;
+
+    boolean result = true;
+    result = result && getStartKeyCase().equals(
+        other.getStartKeyCase());
+    if (!result) return false;
+    switch (startKeyCase_) {
+      case 1:
+        result = result && getStartKeyClosed()
+            .equals(other.getStartKeyClosed());
+        break;
+      case 2:
+        result = result && getStartKeyOpen()
+            .equals(other.getStartKeyOpen());
+        break;
+      case 0:
+      default:
+    }
+    result = result && getEndKeyCase().equals(
+        other.getEndKeyCase());
+    if (!result) return false;
+    switch (endKeyCase_) {
+      case 3:
+        result = result && getEndKeyOpen()
+            .equals(other.getEndKeyOpen());
+        break;
+      case 4:
+        result = result && getEndKeyClosed()
+            .equals(other.getEndKeyClosed());
+        break;
+      case 0:
+      default:
+    }
+    return result;
+  }
+
+  @java.lang.Override
+  public int hashCode() {
+    if (memoizedHashCode != 0) {
+      return memoizedHashCode;
+    }
+    int hash = 41;
+    hash = (19 * hash) + getDescriptorForType().hashCode();
+    switch (startKeyCase_) {
+      case 1:
+        hash = (37 * hash) + START_KEY_CLOSED_FIELD_NUMBER;
+        hash = (53 * hash) + getStartKeyClosed().hashCode();
+        break;
+      case 2:
+        hash = (37 * hash) + START_KEY_OPEN_FIELD_NUMBER;
+        hash = (53 * hash) + getStartKeyOpen().hashCode();
+        break;
+      case 0:
+      default:
+    }
+    switch (endKeyCase_) {
+      case 3:
+        hash = (37 * hash) + END_KEY_OPEN_FIELD_NUMBER;
+        hash = (53 * hash) + getEndKeyOpen().hashCode();
+        break;
+      case 4:
+        hash = (37 * hash) + END_KEY_CLOSED_FIELD_NUMBER;
+        hash = (53 * hash) + getEndKeyClosed().hashCode();
+        break;
+      case 0:
+      default:
+    }
+    hash = (29 * hash) + unknownFields.hashCode();
+    memoizedHashCode = hash;
+    return hash;
+  }
+
   public static com.google.bigtable.v2.RowRange parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -308,39 +388,39 @@ public  final class RowRange extends
   }
   public static com.google.bigtable.v2.RowRange parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.RowRange parseFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.v2.RowRange parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.RowRange parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.v2.RowRange parseFrom(
       com.google.protobuf.CodedInputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.RowRange parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
@@ -358,7 +438,7 @@ public  final class RowRange extends
 
   @java.lang.Override
   protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
@@ -370,7 +450,7 @@ public  final class RowRange extends
    * Protobuf type {@code google.bigtable.v2.RowRange}
    */
   public static final class Builder extends
-      com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
       // @@protoc_insertion_point(builder_implements:google.bigtable.v2.RowRange)
       com.google.bigtable.v2.RowRangeOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
@@ -378,7 +458,7 @@ public  final class RowRange extends
       return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_RowRange_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_RowRange_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -391,12 +471,13 @@ public  final class RowRange extends
     }
 
     private Builder(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
       }
     }
     public Builder clear() {
@@ -445,6 +526,32 @@ public  final class RowRange extends
       return result;
     }
 
+    public Builder clone() {
+      return (Builder) super.clone();
+    }
+    public Builder setField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.setField(field, value);
+    }
+    public Builder clearField(
+        com.google.protobuf.Descriptors.FieldDescriptor field) {
+      return (Builder) super.clearField(field);
+    }
+    public Builder clearOneof(
+        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      return (Builder) super.clearOneof(oneof);
+    }
+    public Builder setRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        int index, Object value) {
+      return (Builder) super.setRepeatedField(field, index, value);
+    }
+    public Builder addRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.addRepeatedField(field, value);
+    }
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.bigtable.v2.RowRange) {
         return mergeFrom((com.google.bigtable.v2.RowRange)other);

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/RowSet.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/RowSet.java
@@ -11,11 +11,11 @@ package com.google.bigtable.v2;
  * Protobuf type {@code google.bigtable.v2.RowSet}
  */
 public  final class RowSet extends
-    com.google.protobuf.GeneratedMessage implements
+    com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:google.bigtable.v2.RowSet)
     RowSetOrBuilder {
   // Use RowSet.newBuilder() to construct.
-  private RowSet(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+  private RowSet(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private RowSet() {
@@ -61,7 +61,8 @@ public  final class RowSet extends
               rowRanges_ = new java.util.ArrayList<com.google.bigtable.v2.RowRange>();
               mutable_bitField0_ |= 0x00000002;
             }
-            rowRanges_.add(input.readMessage(com.google.bigtable.v2.RowRange.parser(), extensionRegistry));
+            rowRanges_.add(
+                input.readMessage(com.google.bigtable.v2.RowRange.parser(), extensionRegistry));
             break;
           }
         }
@@ -86,7 +87,7 @@ public  final class RowSet extends
     return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_RowSet_descriptor;
   }
 
-  protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_RowSet_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
@@ -225,6 +226,44 @@ public  final class RowSet extends
   }
 
   private static final long serialVersionUID = 0L;
+  @java.lang.Override
+  public boolean equals(final java.lang.Object obj) {
+    if (obj == this) {
+     return true;
+    }
+    if (!(obj instanceof com.google.bigtable.v2.RowSet)) {
+      return super.equals(obj);
+    }
+    com.google.bigtable.v2.RowSet other = (com.google.bigtable.v2.RowSet) obj;
+
+    boolean result = true;
+    result = result && getRowKeysList()
+        .equals(other.getRowKeysList());
+    result = result && getRowRangesList()
+        .equals(other.getRowRangesList());
+    return result;
+  }
+
+  @java.lang.Override
+  public int hashCode() {
+    if (memoizedHashCode != 0) {
+      return memoizedHashCode;
+    }
+    int hash = 41;
+    hash = (19 * hash) + getDescriptorForType().hashCode();
+    if (getRowKeysCount() > 0) {
+      hash = (37 * hash) + ROW_KEYS_FIELD_NUMBER;
+      hash = (53 * hash) + getRowKeysList().hashCode();
+    }
+    if (getRowRangesCount() > 0) {
+      hash = (37 * hash) + ROW_RANGES_FIELD_NUMBER;
+      hash = (53 * hash) + getRowRangesList().hashCode();
+    }
+    hash = (29 * hash) + unknownFields.hashCode();
+    memoizedHashCode = hash;
+    return hash;
+  }
+
   public static com.google.bigtable.v2.RowSet parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -248,39 +287,39 @@ public  final class RowSet extends
   }
   public static com.google.bigtable.v2.RowSet parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.RowSet parseFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.v2.RowSet parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.RowSet parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.v2.RowSet parseFrom(
       com.google.protobuf.CodedInputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.RowSet parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
@@ -298,7 +337,7 @@ public  final class RowSet extends
 
   @java.lang.Override
   protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
@@ -310,7 +349,7 @@ public  final class RowSet extends
    * Protobuf type {@code google.bigtable.v2.RowSet}
    */
   public static final class Builder extends
-      com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
       // @@protoc_insertion_point(builder_implements:google.bigtable.v2.RowSet)
       com.google.bigtable.v2.RowSetOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
@@ -318,7 +357,7 @@ public  final class RowSet extends
       return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_RowSet_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_RowSet_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -331,12 +370,13 @@ public  final class RowSet extends
     }
 
     private Builder(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
         getRowRangesFieldBuilder();
       }
     }
@@ -391,6 +431,32 @@ public  final class RowSet extends
       return result;
     }
 
+    public Builder clone() {
+      return (Builder) super.clone();
+    }
+    public Builder setField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.setField(field, value);
+    }
+    public Builder clearField(
+        com.google.protobuf.Descriptors.FieldDescriptor field) {
+      return (Builder) super.clearField(field);
+    }
+    public Builder clearOneof(
+        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      return (Builder) super.clearOneof(oneof);
+    }
+    public Builder setRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        int index, Object value) {
+      return (Builder) super.setRepeatedField(field, index, value);
+    }
+    public Builder addRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.addRepeatedField(field, value);
+    }
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.bigtable.v2.RowSet) {
         return mergeFrom((com.google.bigtable.v2.RowSet)other);
@@ -431,7 +497,7 @@ public  final class RowSet extends
             rowRanges_ = other.rowRanges_;
             bitField0_ = (bitField0_ & ~0x00000002);
             rowRangesBuilder_ = 
-              com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+              com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
                  getRowRangesFieldBuilder() : null;
           } else {
             rowRangesBuilder_.addAllMessages(other.rowRanges_);
@@ -574,7 +640,7 @@ public  final class RowSet extends
        }
     }
 
-    private com.google.protobuf.RepeatedFieldBuilder<
+    private com.google.protobuf.RepeatedFieldBuilderV3<
         com.google.bigtable.v2.RowRange, com.google.bigtable.v2.RowRange.Builder, com.google.bigtable.v2.RowRangeOrBuilder> rowRangesBuilder_;
 
     /**
@@ -862,11 +928,11 @@ public  final class RowSet extends
          getRowRangesBuilderList() {
       return getRowRangesFieldBuilder().getBuilderList();
     }
-    private com.google.protobuf.RepeatedFieldBuilder<
+    private com.google.protobuf.RepeatedFieldBuilderV3<
         com.google.bigtable.v2.RowRange, com.google.bigtable.v2.RowRange.Builder, com.google.bigtable.v2.RowRangeOrBuilder> 
         getRowRangesFieldBuilder() {
       if (rowRangesBuilder_ == null) {
-        rowRangesBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
+        rowRangesBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
             com.google.bigtable.v2.RowRange, com.google.bigtable.v2.RowRange.Builder, com.google.bigtable.v2.RowRangeOrBuilder>(
                 rowRanges_,
                 ((bitField0_ & 0x00000002) == 0x00000002),

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/SampleRowKeysRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/SampleRowKeysRequest.java
@@ -11,11 +11,11 @@ package com.google.bigtable.v2;
  * Protobuf type {@code google.bigtable.v2.SampleRowKeysRequest}
  */
 public  final class SampleRowKeysRequest extends
-    com.google.protobuf.GeneratedMessage implements
+    com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:google.bigtable.v2.SampleRowKeysRequest)
     SampleRowKeysRequestOrBuilder {
   // Use SampleRowKeysRequest.newBuilder() to construct.
-  private SampleRowKeysRequest(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+  private SampleRowKeysRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private SampleRowKeysRequest() {
@@ -69,7 +69,7 @@ public  final class SampleRowKeysRequest extends
     return com.google.bigtable.v2.BigtableProto.internal_static_google_bigtable_v2_SampleRowKeysRequest_descriptor;
   }
 
-  protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.google.bigtable.v2.BigtableProto.internal_static_google_bigtable_v2_SampleRowKeysRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
@@ -135,7 +135,7 @@ public  final class SampleRowKeysRequest extends
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
     if (!getTableNameBytes().isEmpty()) {
-      com.google.protobuf.GeneratedMessage.writeString(output, 1, tableName_);
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 1, tableName_);
     }
   }
 
@@ -145,13 +145,43 @@ public  final class SampleRowKeysRequest extends
 
     size = 0;
     if (!getTableNameBytes().isEmpty()) {
-      size += com.google.protobuf.GeneratedMessage.computeStringSize(1, tableName_);
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, tableName_);
     }
     memoizedSize = size;
     return size;
   }
 
   private static final long serialVersionUID = 0L;
+  @java.lang.Override
+  public boolean equals(final java.lang.Object obj) {
+    if (obj == this) {
+     return true;
+    }
+    if (!(obj instanceof com.google.bigtable.v2.SampleRowKeysRequest)) {
+      return super.equals(obj);
+    }
+    com.google.bigtable.v2.SampleRowKeysRequest other = (com.google.bigtable.v2.SampleRowKeysRequest) obj;
+
+    boolean result = true;
+    result = result && getTableName()
+        .equals(other.getTableName());
+    return result;
+  }
+
+  @java.lang.Override
+  public int hashCode() {
+    if (memoizedHashCode != 0) {
+      return memoizedHashCode;
+    }
+    int hash = 41;
+    hash = (19 * hash) + getDescriptorForType().hashCode();
+    hash = (37 * hash) + TABLE_NAME_FIELD_NUMBER;
+    hash = (53 * hash) + getTableName().hashCode();
+    hash = (29 * hash) + unknownFields.hashCode();
+    memoizedHashCode = hash;
+    return hash;
+  }
+
   public static com.google.bigtable.v2.SampleRowKeysRequest parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -175,39 +205,39 @@ public  final class SampleRowKeysRequest extends
   }
   public static com.google.bigtable.v2.SampleRowKeysRequest parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.SampleRowKeysRequest parseFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.v2.SampleRowKeysRequest parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.SampleRowKeysRequest parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.v2.SampleRowKeysRequest parseFrom(
       com.google.protobuf.CodedInputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.SampleRowKeysRequest parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
@@ -225,7 +255,7 @@ public  final class SampleRowKeysRequest extends
 
   @java.lang.Override
   protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
@@ -237,7 +267,7 @@ public  final class SampleRowKeysRequest extends
    * Protobuf type {@code google.bigtable.v2.SampleRowKeysRequest}
    */
   public static final class Builder extends
-      com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
       // @@protoc_insertion_point(builder_implements:google.bigtable.v2.SampleRowKeysRequest)
       com.google.bigtable.v2.SampleRowKeysRequestOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
@@ -245,7 +275,7 @@ public  final class SampleRowKeysRequest extends
       return com.google.bigtable.v2.BigtableProto.internal_static_google_bigtable_v2_SampleRowKeysRequest_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.bigtable.v2.BigtableProto.internal_static_google_bigtable_v2_SampleRowKeysRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -258,12 +288,13 @@ public  final class SampleRowKeysRequest extends
     }
 
     private Builder(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
       }
     }
     public Builder clear() {
@@ -297,6 +328,32 @@ public  final class SampleRowKeysRequest extends
       return result;
     }
 
+    public Builder clone() {
+      return (Builder) super.clone();
+    }
+    public Builder setField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.setField(field, value);
+    }
+    public Builder clearField(
+        com.google.protobuf.Descriptors.FieldDescriptor field) {
+      return (Builder) super.clearField(field);
+    }
+    public Builder clearOneof(
+        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      return (Builder) super.clearOneof(oneof);
+    }
+    public Builder setRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        int index, Object value) {
+      return (Builder) super.setRepeatedField(field, index, value);
+    }
+    public Builder addRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.addRepeatedField(field, value);
+    }
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.bigtable.v2.SampleRowKeysRequest) {
         return mergeFrom((com.google.bigtable.v2.SampleRowKeysRequest)other);

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/SampleRowKeysResponse.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/SampleRowKeysResponse.java
@@ -11,11 +11,11 @@ package com.google.bigtable.v2;
  * Protobuf type {@code google.bigtable.v2.SampleRowKeysResponse}
  */
 public  final class SampleRowKeysResponse extends
-    com.google.protobuf.GeneratedMessage implements
+    com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:google.bigtable.v2.SampleRowKeysResponse)
     SampleRowKeysResponseOrBuilder {
   // Use SampleRowKeysResponse.newBuilder() to construct.
-  private SampleRowKeysResponse(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+  private SampleRowKeysResponse(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private SampleRowKeysResponse() {
@@ -74,7 +74,7 @@ public  final class SampleRowKeysResponse extends
     return com.google.bigtable.v2.BigtableProto.internal_static_google_bigtable_v2_SampleRowKeysResponse_descriptor;
   }
 
-  protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.google.bigtable.v2.BigtableProto.internal_static_google_bigtable_v2_SampleRowKeysResponse_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
@@ -154,6 +154,41 @@ public  final class SampleRowKeysResponse extends
   }
 
   private static final long serialVersionUID = 0L;
+  @java.lang.Override
+  public boolean equals(final java.lang.Object obj) {
+    if (obj == this) {
+     return true;
+    }
+    if (!(obj instanceof com.google.bigtable.v2.SampleRowKeysResponse)) {
+      return super.equals(obj);
+    }
+    com.google.bigtable.v2.SampleRowKeysResponse other = (com.google.bigtable.v2.SampleRowKeysResponse) obj;
+
+    boolean result = true;
+    result = result && getRowKey()
+        .equals(other.getRowKey());
+    result = result && (getOffsetBytes()
+        == other.getOffsetBytes());
+    return result;
+  }
+
+  @java.lang.Override
+  public int hashCode() {
+    if (memoizedHashCode != 0) {
+      return memoizedHashCode;
+    }
+    int hash = 41;
+    hash = (19 * hash) + getDescriptorForType().hashCode();
+    hash = (37 * hash) + ROW_KEY_FIELD_NUMBER;
+    hash = (53 * hash) + getRowKey().hashCode();
+    hash = (37 * hash) + OFFSET_BYTES_FIELD_NUMBER;
+    hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
+        getOffsetBytes());
+    hash = (29 * hash) + unknownFields.hashCode();
+    memoizedHashCode = hash;
+    return hash;
+  }
+
   public static com.google.bigtable.v2.SampleRowKeysResponse parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -177,39 +212,39 @@ public  final class SampleRowKeysResponse extends
   }
   public static com.google.bigtable.v2.SampleRowKeysResponse parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.SampleRowKeysResponse parseFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.v2.SampleRowKeysResponse parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.SampleRowKeysResponse parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.v2.SampleRowKeysResponse parseFrom(
       com.google.protobuf.CodedInputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.SampleRowKeysResponse parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
@@ -227,7 +262,7 @@ public  final class SampleRowKeysResponse extends
 
   @java.lang.Override
   protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
@@ -239,7 +274,7 @@ public  final class SampleRowKeysResponse extends
    * Protobuf type {@code google.bigtable.v2.SampleRowKeysResponse}
    */
   public static final class Builder extends
-      com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
       // @@protoc_insertion_point(builder_implements:google.bigtable.v2.SampleRowKeysResponse)
       com.google.bigtable.v2.SampleRowKeysResponseOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
@@ -247,7 +282,7 @@ public  final class SampleRowKeysResponse extends
       return com.google.bigtable.v2.BigtableProto.internal_static_google_bigtable_v2_SampleRowKeysResponse_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.bigtable.v2.BigtableProto.internal_static_google_bigtable_v2_SampleRowKeysResponse_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -260,12 +295,13 @@ public  final class SampleRowKeysResponse extends
     }
 
     private Builder(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
       }
     }
     public Builder clear() {
@@ -302,6 +338,32 @@ public  final class SampleRowKeysResponse extends
       return result;
     }
 
+    public Builder clone() {
+      return (Builder) super.clone();
+    }
+    public Builder setField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.setField(field, value);
+    }
+    public Builder clearField(
+        com.google.protobuf.Descriptors.FieldDescriptor field) {
+      return (Builder) super.clearField(field);
+    }
+    public Builder clearOneof(
+        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      return (Builder) super.clearOneof(oneof);
+    }
+    public Builder setRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        int index, Object value) {
+      return (Builder) super.setRepeatedField(field, index, value);
+    }
+    public Builder addRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.addRepeatedField(field, value);
+    }
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.bigtable.v2.SampleRowKeysResponse) {
         return mergeFrom((com.google.bigtable.v2.SampleRowKeysResponse)other);

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/TimestampRange.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/TimestampRange.java
@@ -11,11 +11,11 @@ package com.google.bigtable.v2;
  * Protobuf type {@code google.bigtable.v2.TimestampRange}
  */
 public  final class TimestampRange extends
-    com.google.protobuf.GeneratedMessage implements
+    com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:google.bigtable.v2.TimestampRange)
     TimestampRangeOrBuilder {
   // Use TimestampRange.newBuilder() to construct.
-  private TimestampRange(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+  private TimestampRange(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private TimestampRange() {
@@ -74,7 +74,7 @@ public  final class TimestampRange extends
     return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_TimestampRange_descriptor;
   }
 
-  protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_TimestampRange_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
@@ -145,6 +145,42 @@ public  final class TimestampRange extends
   }
 
   private static final long serialVersionUID = 0L;
+  @java.lang.Override
+  public boolean equals(final java.lang.Object obj) {
+    if (obj == this) {
+     return true;
+    }
+    if (!(obj instanceof com.google.bigtable.v2.TimestampRange)) {
+      return super.equals(obj);
+    }
+    com.google.bigtable.v2.TimestampRange other = (com.google.bigtable.v2.TimestampRange) obj;
+
+    boolean result = true;
+    result = result && (getStartTimestampMicros()
+        == other.getStartTimestampMicros());
+    result = result && (getEndTimestampMicros()
+        == other.getEndTimestampMicros());
+    return result;
+  }
+
+  @java.lang.Override
+  public int hashCode() {
+    if (memoizedHashCode != 0) {
+      return memoizedHashCode;
+    }
+    int hash = 41;
+    hash = (19 * hash) + getDescriptorForType().hashCode();
+    hash = (37 * hash) + START_TIMESTAMP_MICROS_FIELD_NUMBER;
+    hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
+        getStartTimestampMicros());
+    hash = (37 * hash) + END_TIMESTAMP_MICROS_FIELD_NUMBER;
+    hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
+        getEndTimestampMicros());
+    hash = (29 * hash) + unknownFields.hashCode();
+    memoizedHashCode = hash;
+    return hash;
+  }
+
   public static com.google.bigtable.v2.TimestampRange parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -168,39 +204,39 @@ public  final class TimestampRange extends
   }
   public static com.google.bigtable.v2.TimestampRange parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.TimestampRange parseFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.v2.TimestampRange parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.TimestampRange parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.v2.TimestampRange parseFrom(
       com.google.protobuf.CodedInputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.TimestampRange parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
@@ -218,7 +254,7 @@ public  final class TimestampRange extends
 
   @java.lang.Override
   protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
@@ -230,7 +266,7 @@ public  final class TimestampRange extends
    * Protobuf type {@code google.bigtable.v2.TimestampRange}
    */
   public static final class Builder extends
-      com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
       // @@protoc_insertion_point(builder_implements:google.bigtable.v2.TimestampRange)
       com.google.bigtable.v2.TimestampRangeOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
@@ -238,7 +274,7 @@ public  final class TimestampRange extends
       return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_TimestampRange_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_TimestampRange_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -251,12 +287,13 @@ public  final class TimestampRange extends
     }
 
     private Builder(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
       }
     }
     public Builder clear() {
@@ -293,6 +330,32 @@ public  final class TimestampRange extends
       return result;
     }
 
+    public Builder clone() {
+      return (Builder) super.clone();
+    }
+    public Builder setField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.setField(field, value);
+    }
+    public Builder clearField(
+        com.google.protobuf.Descriptors.FieldDescriptor field) {
+      return (Builder) super.clearField(field);
+    }
+    public Builder clearOneof(
+        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      return (Builder) super.clearOneof(oneof);
+    }
+    public Builder setRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        int index, Object value) {
+      return (Builder) super.setRepeatedField(field, index, value);
+    }
+    public Builder addRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.addRepeatedField(field, value);
+    }
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.bigtable.v2.TimestampRange) {
         return mergeFrom((com.google.bigtable.v2.TimestampRange)other);

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/ValueRange.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/bigtable/v2/ValueRange.java
@@ -11,11 +11,11 @@ package com.google.bigtable.v2;
  * Protobuf type {@code google.bigtable.v2.ValueRange}
  */
 public  final class ValueRange extends
-    com.google.protobuf.GeneratedMessage implements
+    com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:google.bigtable.v2.ValueRange)
     ValueRangeOrBuilder {
   // Use ValueRange.newBuilder() to construct.
-  private ValueRange(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+  private ValueRange(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private ValueRange() {
@@ -82,7 +82,7 @@ public  final class ValueRange extends
     return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_ValueRange_descriptor;
   }
 
-  protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_ValueRange_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
@@ -285,6 +285,86 @@ public  final class ValueRange extends
   }
 
   private static final long serialVersionUID = 0L;
+  @java.lang.Override
+  public boolean equals(final java.lang.Object obj) {
+    if (obj == this) {
+     return true;
+    }
+    if (!(obj instanceof com.google.bigtable.v2.ValueRange)) {
+      return super.equals(obj);
+    }
+    com.google.bigtable.v2.ValueRange other = (com.google.bigtable.v2.ValueRange) obj;
+
+    boolean result = true;
+    result = result && getStartValueCase().equals(
+        other.getStartValueCase());
+    if (!result) return false;
+    switch (startValueCase_) {
+      case 1:
+        result = result && getStartValueClosed()
+            .equals(other.getStartValueClosed());
+        break;
+      case 2:
+        result = result && getStartValueOpen()
+            .equals(other.getStartValueOpen());
+        break;
+      case 0:
+      default:
+    }
+    result = result && getEndValueCase().equals(
+        other.getEndValueCase());
+    if (!result) return false;
+    switch (endValueCase_) {
+      case 3:
+        result = result && getEndValueClosed()
+            .equals(other.getEndValueClosed());
+        break;
+      case 4:
+        result = result && getEndValueOpen()
+            .equals(other.getEndValueOpen());
+        break;
+      case 0:
+      default:
+    }
+    return result;
+  }
+
+  @java.lang.Override
+  public int hashCode() {
+    if (memoizedHashCode != 0) {
+      return memoizedHashCode;
+    }
+    int hash = 41;
+    hash = (19 * hash) + getDescriptorForType().hashCode();
+    switch (startValueCase_) {
+      case 1:
+        hash = (37 * hash) + START_VALUE_CLOSED_FIELD_NUMBER;
+        hash = (53 * hash) + getStartValueClosed().hashCode();
+        break;
+      case 2:
+        hash = (37 * hash) + START_VALUE_OPEN_FIELD_NUMBER;
+        hash = (53 * hash) + getStartValueOpen().hashCode();
+        break;
+      case 0:
+      default:
+    }
+    switch (endValueCase_) {
+      case 3:
+        hash = (37 * hash) + END_VALUE_CLOSED_FIELD_NUMBER;
+        hash = (53 * hash) + getEndValueClosed().hashCode();
+        break;
+      case 4:
+        hash = (37 * hash) + END_VALUE_OPEN_FIELD_NUMBER;
+        hash = (53 * hash) + getEndValueOpen().hashCode();
+        break;
+      case 0:
+      default:
+    }
+    hash = (29 * hash) + unknownFields.hashCode();
+    memoizedHashCode = hash;
+    return hash;
+  }
+
   public static com.google.bigtable.v2.ValueRange parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -308,39 +388,39 @@ public  final class ValueRange extends
   }
   public static com.google.bigtable.v2.ValueRange parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.ValueRange parseFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.v2.ValueRange parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.ValueRange parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.bigtable.v2.ValueRange parseFrom(
       com.google.protobuf.CodedInputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.bigtable.v2.ValueRange parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
@@ -358,7 +438,7 @@ public  final class ValueRange extends
 
   @java.lang.Override
   protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
@@ -370,7 +450,7 @@ public  final class ValueRange extends
    * Protobuf type {@code google.bigtable.v2.ValueRange}
    */
   public static final class Builder extends
-      com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
       // @@protoc_insertion_point(builder_implements:google.bigtable.v2.ValueRange)
       com.google.bigtable.v2.ValueRangeOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
@@ -378,7 +458,7 @@ public  final class ValueRange extends
       return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_ValueRange_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.bigtable.v2.DataProto.internal_static_google_bigtable_v2_ValueRange_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -391,12 +471,13 @@ public  final class ValueRange extends
     }
 
     private Builder(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
       }
     }
     public Builder clear() {
@@ -445,6 +526,32 @@ public  final class ValueRange extends
       return result;
     }
 
+    public Builder clone() {
+      return (Builder) super.clone();
+    }
+    public Builder setField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.setField(field, value);
+    }
+    public Builder clearField(
+        com.google.protobuf.Descriptors.FieldDescriptor field) {
+      return (Builder) super.clearField(field);
+    }
+    public Builder clearOneof(
+        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      return (Builder) super.clearOneof(oneof);
+    }
+    public Builder setRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        int index, Object value) {
+      return (Builder) super.setRepeatedField(field, index, value);
+    }
+    public Builder addRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.addRepeatedField(field, value);
+    }
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.bigtable.v2.ValueRange) {
         return mergeFrom((com.google.bigtable.v2.ValueRange)other);

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/longrunning/CancelOperationRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/longrunning/CancelOperationRequest.java
@@ -11,11 +11,11 @@ package com.google.longrunning;
  * Protobuf type {@code google.longrunning.CancelOperationRequest}
  */
 public  final class CancelOperationRequest extends
-    com.google.protobuf.GeneratedMessage implements
+    com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:google.longrunning.CancelOperationRequest)
     CancelOperationRequestOrBuilder {
   // Use CancelOperationRequest.newBuilder() to construct.
-  private CancelOperationRequest(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+  private CancelOperationRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private CancelOperationRequest() {
@@ -69,7 +69,7 @@ public  final class CancelOperationRequest extends
     return com.google.longrunning.OperationsProto.internal_static_google_longrunning_CancelOperationRequest_descriptor;
   }
 
-  protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.google.longrunning.OperationsProto.internal_static_google_longrunning_CancelOperationRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
@@ -131,7 +131,7 @@ public  final class CancelOperationRequest extends
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
     if (!getNameBytes().isEmpty()) {
-      com.google.protobuf.GeneratedMessage.writeString(output, 1, name_);
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 1, name_);
     }
   }
 
@@ -141,13 +141,43 @@ public  final class CancelOperationRequest extends
 
     size = 0;
     if (!getNameBytes().isEmpty()) {
-      size += com.google.protobuf.GeneratedMessage.computeStringSize(1, name_);
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, name_);
     }
     memoizedSize = size;
     return size;
   }
 
   private static final long serialVersionUID = 0L;
+  @java.lang.Override
+  public boolean equals(final java.lang.Object obj) {
+    if (obj == this) {
+     return true;
+    }
+    if (!(obj instanceof com.google.longrunning.CancelOperationRequest)) {
+      return super.equals(obj);
+    }
+    com.google.longrunning.CancelOperationRequest other = (com.google.longrunning.CancelOperationRequest) obj;
+
+    boolean result = true;
+    result = result && getName()
+        .equals(other.getName());
+    return result;
+  }
+
+  @java.lang.Override
+  public int hashCode() {
+    if (memoizedHashCode != 0) {
+      return memoizedHashCode;
+    }
+    int hash = 41;
+    hash = (19 * hash) + getDescriptorForType().hashCode();
+    hash = (37 * hash) + NAME_FIELD_NUMBER;
+    hash = (53 * hash) + getName().hashCode();
+    hash = (29 * hash) + unknownFields.hashCode();
+    memoizedHashCode = hash;
+    return hash;
+  }
+
   public static com.google.longrunning.CancelOperationRequest parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -171,39 +201,39 @@ public  final class CancelOperationRequest extends
   }
   public static com.google.longrunning.CancelOperationRequest parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.longrunning.CancelOperationRequest parseFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.longrunning.CancelOperationRequest parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
   public static com.google.longrunning.CancelOperationRequest parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.longrunning.CancelOperationRequest parseFrom(
       com.google.protobuf.CodedInputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.longrunning.CancelOperationRequest parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
@@ -221,7 +251,7 @@ public  final class CancelOperationRequest extends
 
   @java.lang.Override
   protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
@@ -233,7 +263,7 @@ public  final class CancelOperationRequest extends
    * Protobuf type {@code google.longrunning.CancelOperationRequest}
    */
   public static final class Builder extends
-      com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
       // @@protoc_insertion_point(builder_implements:google.longrunning.CancelOperationRequest)
       com.google.longrunning.CancelOperationRequestOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
@@ -241,7 +271,7 @@ public  final class CancelOperationRequest extends
       return com.google.longrunning.OperationsProto.internal_static_google_longrunning_CancelOperationRequest_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.longrunning.OperationsProto.internal_static_google_longrunning_CancelOperationRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -254,12 +284,13 @@ public  final class CancelOperationRequest extends
     }
 
     private Builder(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
       }
     }
     public Builder clear() {
@@ -293,6 +324,32 @@ public  final class CancelOperationRequest extends
       return result;
     }
 
+    public Builder clone() {
+      return (Builder) super.clone();
+    }
+    public Builder setField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.setField(field, value);
+    }
+    public Builder clearField(
+        com.google.protobuf.Descriptors.FieldDescriptor field) {
+      return (Builder) super.clearField(field);
+    }
+    public Builder clearOneof(
+        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      return (Builder) super.clearOneof(oneof);
+    }
+    public Builder setRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        int index, Object value) {
+      return (Builder) super.setRepeatedField(field, index, value);
+    }
+    public Builder addRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.addRepeatedField(field, value);
+    }
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.longrunning.CancelOperationRequest) {
         return mergeFrom((com.google.longrunning.CancelOperationRequest)other);

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/longrunning/DeleteOperationRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/longrunning/DeleteOperationRequest.java
@@ -11,11 +11,11 @@ package com.google.longrunning;
  * Protobuf type {@code google.longrunning.DeleteOperationRequest}
  */
 public  final class DeleteOperationRequest extends
-    com.google.protobuf.GeneratedMessage implements
+    com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:google.longrunning.DeleteOperationRequest)
     DeleteOperationRequestOrBuilder {
   // Use DeleteOperationRequest.newBuilder() to construct.
-  private DeleteOperationRequest(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+  private DeleteOperationRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private DeleteOperationRequest() {
@@ -69,7 +69,7 @@ public  final class DeleteOperationRequest extends
     return com.google.longrunning.OperationsProto.internal_static_google_longrunning_DeleteOperationRequest_descriptor;
   }
 
-  protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.google.longrunning.OperationsProto.internal_static_google_longrunning_DeleteOperationRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
@@ -131,7 +131,7 @@ public  final class DeleteOperationRequest extends
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
     if (!getNameBytes().isEmpty()) {
-      com.google.protobuf.GeneratedMessage.writeString(output, 1, name_);
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 1, name_);
     }
   }
 
@@ -141,13 +141,43 @@ public  final class DeleteOperationRequest extends
 
     size = 0;
     if (!getNameBytes().isEmpty()) {
-      size += com.google.protobuf.GeneratedMessage.computeStringSize(1, name_);
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, name_);
     }
     memoizedSize = size;
     return size;
   }
 
   private static final long serialVersionUID = 0L;
+  @java.lang.Override
+  public boolean equals(final java.lang.Object obj) {
+    if (obj == this) {
+     return true;
+    }
+    if (!(obj instanceof com.google.longrunning.DeleteOperationRequest)) {
+      return super.equals(obj);
+    }
+    com.google.longrunning.DeleteOperationRequest other = (com.google.longrunning.DeleteOperationRequest) obj;
+
+    boolean result = true;
+    result = result && getName()
+        .equals(other.getName());
+    return result;
+  }
+
+  @java.lang.Override
+  public int hashCode() {
+    if (memoizedHashCode != 0) {
+      return memoizedHashCode;
+    }
+    int hash = 41;
+    hash = (19 * hash) + getDescriptorForType().hashCode();
+    hash = (37 * hash) + NAME_FIELD_NUMBER;
+    hash = (53 * hash) + getName().hashCode();
+    hash = (29 * hash) + unknownFields.hashCode();
+    memoizedHashCode = hash;
+    return hash;
+  }
+
   public static com.google.longrunning.DeleteOperationRequest parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -171,39 +201,39 @@ public  final class DeleteOperationRequest extends
   }
   public static com.google.longrunning.DeleteOperationRequest parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.longrunning.DeleteOperationRequest parseFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.longrunning.DeleteOperationRequest parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
   public static com.google.longrunning.DeleteOperationRequest parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.longrunning.DeleteOperationRequest parseFrom(
       com.google.protobuf.CodedInputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.longrunning.DeleteOperationRequest parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
@@ -221,7 +251,7 @@ public  final class DeleteOperationRequest extends
 
   @java.lang.Override
   protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
@@ -233,7 +263,7 @@ public  final class DeleteOperationRequest extends
    * Protobuf type {@code google.longrunning.DeleteOperationRequest}
    */
   public static final class Builder extends
-      com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
       // @@protoc_insertion_point(builder_implements:google.longrunning.DeleteOperationRequest)
       com.google.longrunning.DeleteOperationRequestOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
@@ -241,7 +271,7 @@ public  final class DeleteOperationRequest extends
       return com.google.longrunning.OperationsProto.internal_static_google_longrunning_DeleteOperationRequest_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.longrunning.OperationsProto.internal_static_google_longrunning_DeleteOperationRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -254,12 +284,13 @@ public  final class DeleteOperationRequest extends
     }
 
     private Builder(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
       }
     }
     public Builder clear() {
@@ -293,6 +324,32 @@ public  final class DeleteOperationRequest extends
       return result;
     }
 
+    public Builder clone() {
+      return (Builder) super.clone();
+    }
+    public Builder setField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.setField(field, value);
+    }
+    public Builder clearField(
+        com.google.protobuf.Descriptors.FieldDescriptor field) {
+      return (Builder) super.clearField(field);
+    }
+    public Builder clearOneof(
+        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      return (Builder) super.clearOneof(oneof);
+    }
+    public Builder setRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        int index, Object value) {
+      return (Builder) super.setRepeatedField(field, index, value);
+    }
+    public Builder addRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.addRepeatedField(field, value);
+    }
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.longrunning.DeleteOperationRequest) {
         return mergeFrom((com.google.longrunning.DeleteOperationRequest)other);

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/longrunning/GetOperationRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/longrunning/GetOperationRequest.java
@@ -11,11 +11,11 @@ package com.google.longrunning;
  * Protobuf type {@code google.longrunning.GetOperationRequest}
  */
 public  final class GetOperationRequest extends
-    com.google.protobuf.GeneratedMessage implements
+    com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:google.longrunning.GetOperationRequest)
     GetOperationRequestOrBuilder {
   // Use GetOperationRequest.newBuilder() to construct.
-  private GetOperationRequest(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+  private GetOperationRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private GetOperationRequest() {
@@ -69,7 +69,7 @@ public  final class GetOperationRequest extends
     return com.google.longrunning.OperationsProto.internal_static_google_longrunning_GetOperationRequest_descriptor;
   }
 
-  protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.google.longrunning.OperationsProto.internal_static_google_longrunning_GetOperationRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
@@ -131,7 +131,7 @@ public  final class GetOperationRequest extends
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
     if (!getNameBytes().isEmpty()) {
-      com.google.protobuf.GeneratedMessage.writeString(output, 1, name_);
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 1, name_);
     }
   }
 
@@ -141,13 +141,43 @@ public  final class GetOperationRequest extends
 
     size = 0;
     if (!getNameBytes().isEmpty()) {
-      size += com.google.protobuf.GeneratedMessage.computeStringSize(1, name_);
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, name_);
     }
     memoizedSize = size;
     return size;
   }
 
   private static final long serialVersionUID = 0L;
+  @java.lang.Override
+  public boolean equals(final java.lang.Object obj) {
+    if (obj == this) {
+     return true;
+    }
+    if (!(obj instanceof com.google.longrunning.GetOperationRequest)) {
+      return super.equals(obj);
+    }
+    com.google.longrunning.GetOperationRequest other = (com.google.longrunning.GetOperationRequest) obj;
+
+    boolean result = true;
+    result = result && getName()
+        .equals(other.getName());
+    return result;
+  }
+
+  @java.lang.Override
+  public int hashCode() {
+    if (memoizedHashCode != 0) {
+      return memoizedHashCode;
+    }
+    int hash = 41;
+    hash = (19 * hash) + getDescriptorForType().hashCode();
+    hash = (37 * hash) + NAME_FIELD_NUMBER;
+    hash = (53 * hash) + getName().hashCode();
+    hash = (29 * hash) + unknownFields.hashCode();
+    memoizedHashCode = hash;
+    return hash;
+  }
+
   public static com.google.longrunning.GetOperationRequest parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -171,39 +201,39 @@ public  final class GetOperationRequest extends
   }
   public static com.google.longrunning.GetOperationRequest parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.longrunning.GetOperationRequest parseFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.longrunning.GetOperationRequest parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
   public static com.google.longrunning.GetOperationRequest parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.longrunning.GetOperationRequest parseFrom(
       com.google.protobuf.CodedInputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.longrunning.GetOperationRequest parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
@@ -221,7 +251,7 @@ public  final class GetOperationRequest extends
 
   @java.lang.Override
   protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
@@ -233,7 +263,7 @@ public  final class GetOperationRequest extends
    * Protobuf type {@code google.longrunning.GetOperationRequest}
    */
   public static final class Builder extends
-      com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
       // @@protoc_insertion_point(builder_implements:google.longrunning.GetOperationRequest)
       com.google.longrunning.GetOperationRequestOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
@@ -241,7 +271,7 @@ public  final class GetOperationRequest extends
       return com.google.longrunning.OperationsProto.internal_static_google_longrunning_GetOperationRequest_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.longrunning.OperationsProto.internal_static_google_longrunning_GetOperationRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -254,12 +284,13 @@ public  final class GetOperationRequest extends
     }
 
     private Builder(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
       }
     }
     public Builder clear() {
@@ -293,6 +324,32 @@ public  final class GetOperationRequest extends
       return result;
     }
 
+    public Builder clone() {
+      return (Builder) super.clone();
+    }
+    public Builder setField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.setField(field, value);
+    }
+    public Builder clearField(
+        com.google.protobuf.Descriptors.FieldDescriptor field) {
+      return (Builder) super.clearField(field);
+    }
+    public Builder clearOneof(
+        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      return (Builder) super.clearOneof(oneof);
+    }
+    public Builder setRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        int index, Object value) {
+      return (Builder) super.setRepeatedField(field, index, value);
+    }
+    public Builder addRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.addRepeatedField(field, value);
+    }
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.longrunning.GetOperationRequest) {
         return mergeFrom((com.google.longrunning.GetOperationRequest)other);

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/longrunning/ListOperationsRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/longrunning/ListOperationsRequest.java
@@ -11,11 +11,11 @@ package com.google.longrunning;
  * Protobuf type {@code google.longrunning.ListOperationsRequest}
  */
 public  final class ListOperationsRequest extends
-    com.google.protobuf.GeneratedMessage implements
+    com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:google.longrunning.ListOperationsRequest)
     ListOperationsRequestOrBuilder {
   // Use ListOperationsRequest.newBuilder() to construct.
-  private ListOperationsRequest(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+  private ListOperationsRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private ListOperationsRequest() {
@@ -89,7 +89,7 @@ public  final class ListOperationsRequest extends
     return com.google.longrunning.OperationsProto.internal_static_google_longrunning_ListOperationsRequest_descriptor;
   }
 
-  protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.google.longrunning.OperationsProto.internal_static_google_longrunning_ListOperationsRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
@@ -248,16 +248,16 @@ public  final class ListOperationsRequest extends
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
     if (!getFilterBytes().isEmpty()) {
-      com.google.protobuf.GeneratedMessage.writeString(output, 1, filter_);
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 1, filter_);
     }
     if (pageSize_ != 0) {
       output.writeInt32(2, pageSize_);
     }
     if (!getPageTokenBytes().isEmpty()) {
-      com.google.protobuf.GeneratedMessage.writeString(output, 3, pageToken_);
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 3, pageToken_);
     }
     if (!getNameBytes().isEmpty()) {
-      com.google.protobuf.GeneratedMessage.writeString(output, 4, name_);
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 4, name_);
     }
   }
 
@@ -267,23 +267,65 @@ public  final class ListOperationsRequest extends
 
     size = 0;
     if (!getFilterBytes().isEmpty()) {
-      size += com.google.protobuf.GeneratedMessage.computeStringSize(1, filter_);
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, filter_);
     }
     if (pageSize_ != 0) {
       size += com.google.protobuf.CodedOutputStream
         .computeInt32Size(2, pageSize_);
     }
     if (!getPageTokenBytes().isEmpty()) {
-      size += com.google.protobuf.GeneratedMessage.computeStringSize(3, pageToken_);
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, pageToken_);
     }
     if (!getNameBytes().isEmpty()) {
-      size += com.google.protobuf.GeneratedMessage.computeStringSize(4, name_);
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(4, name_);
     }
     memoizedSize = size;
     return size;
   }
 
   private static final long serialVersionUID = 0L;
+  @java.lang.Override
+  public boolean equals(final java.lang.Object obj) {
+    if (obj == this) {
+     return true;
+    }
+    if (!(obj instanceof com.google.longrunning.ListOperationsRequest)) {
+      return super.equals(obj);
+    }
+    com.google.longrunning.ListOperationsRequest other = (com.google.longrunning.ListOperationsRequest) obj;
+
+    boolean result = true;
+    result = result && getName()
+        .equals(other.getName());
+    result = result && getFilter()
+        .equals(other.getFilter());
+    result = result && (getPageSize()
+        == other.getPageSize());
+    result = result && getPageToken()
+        .equals(other.getPageToken());
+    return result;
+  }
+
+  @java.lang.Override
+  public int hashCode() {
+    if (memoizedHashCode != 0) {
+      return memoizedHashCode;
+    }
+    int hash = 41;
+    hash = (19 * hash) + getDescriptorForType().hashCode();
+    hash = (37 * hash) + NAME_FIELD_NUMBER;
+    hash = (53 * hash) + getName().hashCode();
+    hash = (37 * hash) + FILTER_FIELD_NUMBER;
+    hash = (53 * hash) + getFilter().hashCode();
+    hash = (37 * hash) + PAGE_SIZE_FIELD_NUMBER;
+    hash = (53 * hash) + getPageSize();
+    hash = (37 * hash) + PAGE_TOKEN_FIELD_NUMBER;
+    hash = (53 * hash) + getPageToken().hashCode();
+    hash = (29 * hash) + unknownFields.hashCode();
+    memoizedHashCode = hash;
+    return hash;
+  }
+
   public static com.google.longrunning.ListOperationsRequest parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -307,39 +349,39 @@ public  final class ListOperationsRequest extends
   }
   public static com.google.longrunning.ListOperationsRequest parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.longrunning.ListOperationsRequest parseFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.longrunning.ListOperationsRequest parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
   public static com.google.longrunning.ListOperationsRequest parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.longrunning.ListOperationsRequest parseFrom(
       com.google.protobuf.CodedInputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.longrunning.ListOperationsRequest parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
@@ -357,7 +399,7 @@ public  final class ListOperationsRequest extends
 
   @java.lang.Override
   protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
@@ -369,7 +411,7 @@ public  final class ListOperationsRequest extends
    * Protobuf type {@code google.longrunning.ListOperationsRequest}
    */
   public static final class Builder extends
-      com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
       // @@protoc_insertion_point(builder_implements:google.longrunning.ListOperationsRequest)
       com.google.longrunning.ListOperationsRequestOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
@@ -377,7 +419,7 @@ public  final class ListOperationsRequest extends
       return com.google.longrunning.OperationsProto.internal_static_google_longrunning_ListOperationsRequest_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.longrunning.OperationsProto.internal_static_google_longrunning_ListOperationsRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -390,12 +432,13 @@ public  final class ListOperationsRequest extends
     }
 
     private Builder(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
       }
     }
     public Builder clear() {
@@ -438,6 +481,32 @@ public  final class ListOperationsRequest extends
       return result;
     }
 
+    public Builder clone() {
+      return (Builder) super.clone();
+    }
+    public Builder setField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.setField(field, value);
+    }
+    public Builder clearField(
+        com.google.protobuf.Descriptors.FieldDescriptor field) {
+      return (Builder) super.clearField(field);
+    }
+    public Builder clearOneof(
+        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      return (Builder) super.clearOneof(oneof);
+    }
+    public Builder setRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        int index, Object value) {
+      return (Builder) super.setRepeatedField(field, index, value);
+    }
+    public Builder addRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.addRepeatedField(field, value);
+    }
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.longrunning.ListOperationsRequest) {
         return mergeFrom((com.google.longrunning.ListOperationsRequest)other);

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/longrunning/ListOperationsResponse.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/longrunning/ListOperationsResponse.java
@@ -11,11 +11,11 @@ package com.google.longrunning;
  * Protobuf type {@code google.longrunning.ListOperationsResponse}
  */
 public  final class ListOperationsResponse extends
-    com.google.protobuf.GeneratedMessage implements
+    com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:google.longrunning.ListOperationsResponse)
     ListOperationsResponseOrBuilder {
   // Use ListOperationsResponse.newBuilder() to construct.
-  private ListOperationsResponse(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+  private ListOperationsResponse(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private ListOperationsResponse() {
@@ -53,7 +53,8 @@ public  final class ListOperationsResponse extends
               operations_ = new java.util.ArrayList<com.google.longrunning.Operation>();
               mutable_bitField0_ |= 0x00000001;
             }
-            operations_.add(input.readMessage(com.google.longrunning.Operation.parser(), extensionRegistry));
+            operations_.add(
+                input.readMessage(com.google.longrunning.Operation.parser(), extensionRegistry));
             break;
           }
           case 18: {
@@ -81,7 +82,7 @@ public  final class ListOperationsResponse extends
     return com.google.longrunning.OperationsProto.internal_static_google_longrunning_ListOperationsResponse_descriptor;
   }
 
-  protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.google.longrunning.OperationsProto.internal_static_google_longrunning_ListOperationsResponse_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
@@ -202,7 +203,7 @@ public  final class ListOperationsResponse extends
       output.writeMessage(1, operations_.get(i));
     }
     if (!getNextPageTokenBytes().isEmpty()) {
-      com.google.protobuf.GeneratedMessage.writeString(output, 2, nextPageToken_);
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 2, nextPageToken_);
     }
   }
 
@@ -216,13 +217,49 @@ public  final class ListOperationsResponse extends
         .computeMessageSize(1, operations_.get(i));
     }
     if (!getNextPageTokenBytes().isEmpty()) {
-      size += com.google.protobuf.GeneratedMessage.computeStringSize(2, nextPageToken_);
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, nextPageToken_);
     }
     memoizedSize = size;
     return size;
   }
 
   private static final long serialVersionUID = 0L;
+  @java.lang.Override
+  public boolean equals(final java.lang.Object obj) {
+    if (obj == this) {
+     return true;
+    }
+    if (!(obj instanceof com.google.longrunning.ListOperationsResponse)) {
+      return super.equals(obj);
+    }
+    com.google.longrunning.ListOperationsResponse other = (com.google.longrunning.ListOperationsResponse) obj;
+
+    boolean result = true;
+    result = result && getOperationsList()
+        .equals(other.getOperationsList());
+    result = result && getNextPageToken()
+        .equals(other.getNextPageToken());
+    return result;
+  }
+
+  @java.lang.Override
+  public int hashCode() {
+    if (memoizedHashCode != 0) {
+      return memoizedHashCode;
+    }
+    int hash = 41;
+    hash = (19 * hash) + getDescriptorForType().hashCode();
+    if (getOperationsCount() > 0) {
+      hash = (37 * hash) + OPERATIONS_FIELD_NUMBER;
+      hash = (53 * hash) + getOperationsList().hashCode();
+    }
+    hash = (37 * hash) + NEXT_PAGE_TOKEN_FIELD_NUMBER;
+    hash = (53 * hash) + getNextPageToken().hashCode();
+    hash = (29 * hash) + unknownFields.hashCode();
+    memoizedHashCode = hash;
+    return hash;
+  }
+
   public static com.google.longrunning.ListOperationsResponse parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -246,39 +283,39 @@ public  final class ListOperationsResponse extends
   }
   public static com.google.longrunning.ListOperationsResponse parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.longrunning.ListOperationsResponse parseFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.longrunning.ListOperationsResponse parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
   public static com.google.longrunning.ListOperationsResponse parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.longrunning.ListOperationsResponse parseFrom(
       com.google.protobuf.CodedInputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.longrunning.ListOperationsResponse parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
@@ -296,7 +333,7 @@ public  final class ListOperationsResponse extends
 
   @java.lang.Override
   protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
@@ -308,7 +345,7 @@ public  final class ListOperationsResponse extends
    * Protobuf type {@code google.longrunning.ListOperationsResponse}
    */
   public static final class Builder extends
-      com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
       // @@protoc_insertion_point(builder_implements:google.longrunning.ListOperationsResponse)
       com.google.longrunning.ListOperationsResponseOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
@@ -316,7 +353,7 @@ public  final class ListOperationsResponse extends
       return com.google.longrunning.OperationsProto.internal_static_google_longrunning_ListOperationsResponse_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.longrunning.OperationsProto.internal_static_google_longrunning_ListOperationsResponse_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -329,12 +366,13 @@ public  final class ListOperationsResponse extends
     }
 
     private Builder(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
         getOperationsFieldBuilder();
       }
     }
@@ -387,6 +425,32 @@ public  final class ListOperationsResponse extends
       return result;
     }
 
+    public Builder clone() {
+      return (Builder) super.clone();
+    }
+    public Builder setField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.setField(field, value);
+    }
+    public Builder clearField(
+        com.google.protobuf.Descriptors.FieldDescriptor field) {
+      return (Builder) super.clearField(field);
+    }
+    public Builder clearOneof(
+        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      return (Builder) super.clearOneof(oneof);
+    }
+    public Builder setRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        int index, Object value) {
+      return (Builder) super.setRepeatedField(field, index, value);
+    }
+    public Builder addRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.addRepeatedField(field, value);
+    }
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.longrunning.ListOperationsResponse) {
         return mergeFrom((com.google.longrunning.ListOperationsResponse)other);
@@ -417,7 +481,7 @@ public  final class ListOperationsResponse extends
             operations_ = other.operations_;
             bitField0_ = (bitField0_ & ~0x00000001);
             operationsBuilder_ = 
-              com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+              com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
                  getOperationsFieldBuilder() : null;
           } else {
             operationsBuilder_.addAllMessages(other.operations_);
@@ -464,7 +528,7 @@ public  final class ListOperationsResponse extends
        }
     }
 
-    private com.google.protobuf.RepeatedFieldBuilder<
+    private com.google.protobuf.RepeatedFieldBuilderV3<
         com.google.longrunning.Operation, com.google.longrunning.Operation.Builder, com.google.longrunning.OperationOrBuilder> operationsBuilder_;
 
     /**
@@ -752,11 +816,11 @@ public  final class ListOperationsResponse extends
          getOperationsBuilderList() {
       return getOperationsFieldBuilder().getBuilderList();
     }
-    private com.google.protobuf.RepeatedFieldBuilder<
+    private com.google.protobuf.RepeatedFieldBuilderV3<
         com.google.longrunning.Operation, com.google.longrunning.Operation.Builder, com.google.longrunning.OperationOrBuilder> 
         getOperationsFieldBuilder() {
       if (operationsBuilder_ == null) {
-        operationsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
+        operationsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
             com.google.longrunning.Operation, com.google.longrunning.Operation.Builder, com.google.longrunning.OperationOrBuilder>(
                 operations_,
                 ((bitField0_ & 0x00000001) == 0x00000001),

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/longrunning/Operation.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/longrunning/Operation.java
@@ -12,11 +12,11 @@ package com.google.longrunning;
  * Protobuf type {@code google.longrunning.Operation}
  */
 public  final class Operation extends
-    com.google.protobuf.GeneratedMessage implements
+    com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:google.longrunning.Operation)
     OperationOrBuilder {
   // Use Operation.newBuilder() to construct.
-  private Operation(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+  private Operation(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private Operation() {
@@ -117,7 +117,7 @@ public  final class Operation extends
     return com.google.longrunning.OperationsProto.internal_static_google_longrunning_Operation_descriptor;
   }
 
-  protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.google.longrunning.OperationsProto.internal_static_google_longrunning_Operation_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
@@ -345,7 +345,7 @@ public  final class Operation extends
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
     if (!getNameBytes().isEmpty()) {
-      com.google.protobuf.GeneratedMessage.writeString(output, 1, name_);
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 1, name_);
     }
     if (metadata_ != null) {
       output.writeMessage(2, getMetadata());
@@ -367,7 +367,7 @@ public  final class Operation extends
 
     size = 0;
     if (!getNameBytes().isEmpty()) {
-      size += com.google.protobuf.GeneratedMessage.computeStringSize(1, name_);
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, name_);
     }
     if (metadata_ != null) {
       size += com.google.protobuf.CodedOutputStream
@@ -390,6 +390,77 @@ public  final class Operation extends
   }
 
   private static final long serialVersionUID = 0L;
+  @java.lang.Override
+  public boolean equals(final java.lang.Object obj) {
+    if (obj == this) {
+     return true;
+    }
+    if (!(obj instanceof com.google.longrunning.Operation)) {
+      return super.equals(obj);
+    }
+    com.google.longrunning.Operation other = (com.google.longrunning.Operation) obj;
+
+    boolean result = true;
+    result = result && getName()
+        .equals(other.getName());
+    result = result && (hasMetadata() == other.hasMetadata());
+    if (hasMetadata()) {
+      result = result && getMetadata()
+          .equals(other.getMetadata());
+    }
+    result = result && (getDone()
+        == other.getDone());
+    result = result && getResultCase().equals(
+        other.getResultCase());
+    if (!result) return false;
+    switch (resultCase_) {
+      case 4:
+        result = result && getError()
+            .equals(other.getError());
+        break;
+      case 5:
+        result = result && getResponse()
+            .equals(other.getResponse());
+        break;
+      case 0:
+      default:
+    }
+    return result;
+  }
+
+  @java.lang.Override
+  public int hashCode() {
+    if (memoizedHashCode != 0) {
+      return memoizedHashCode;
+    }
+    int hash = 41;
+    hash = (19 * hash) + getDescriptorForType().hashCode();
+    hash = (37 * hash) + NAME_FIELD_NUMBER;
+    hash = (53 * hash) + getName().hashCode();
+    if (hasMetadata()) {
+      hash = (37 * hash) + METADATA_FIELD_NUMBER;
+      hash = (53 * hash) + getMetadata().hashCode();
+    }
+    hash = (37 * hash) + DONE_FIELD_NUMBER;
+    hash = (53 * hash) + com.google.protobuf.Internal.hashBoolean(
+        getDone());
+    switch (resultCase_) {
+      case 4:
+        hash = (37 * hash) + ERROR_FIELD_NUMBER;
+        hash = (53 * hash) + getError().hashCode();
+        break;
+      case 5:
+        hash = (37 * hash) + RESPONSE_FIELD_NUMBER;
+        hash = (53 * hash) + getResponse().hashCode();
+        break;
+      case 0:
+      default:
+    }
+    hash = (29 * hash) + unknownFields.hashCode();
+    memoizedHashCode = hash;
+    return hash;
+  }
+
   public static com.google.longrunning.Operation parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -413,39 +484,39 @@ public  final class Operation extends
   }
   public static com.google.longrunning.Operation parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.longrunning.Operation parseFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.longrunning.Operation parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
   public static com.google.longrunning.Operation parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.longrunning.Operation parseFrom(
       com.google.protobuf.CodedInputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.longrunning.Operation parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
@@ -463,7 +534,7 @@ public  final class Operation extends
 
   @java.lang.Override
   protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
@@ -476,7 +547,7 @@ public  final class Operation extends
    * Protobuf type {@code google.longrunning.Operation}
    */
   public static final class Builder extends
-      com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
       // @@protoc_insertion_point(builder_implements:google.longrunning.Operation)
       com.google.longrunning.OperationOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
@@ -484,7 +555,7 @@ public  final class Operation extends
       return com.google.longrunning.OperationsProto.internal_static_google_longrunning_Operation_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.longrunning.OperationsProto.internal_static_google_longrunning_Operation_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -497,12 +568,13 @@ public  final class Operation extends
     }
 
     private Builder(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
       }
     }
     public Builder clear() {
@@ -567,6 +639,32 @@ public  final class Operation extends
       return result;
     }
 
+    public Builder clone() {
+      return (Builder) super.clone();
+    }
+    public Builder setField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.setField(field, value);
+    }
+    public Builder clearField(
+        com.google.protobuf.Descriptors.FieldDescriptor field) {
+      return (Builder) super.clearField(field);
+    }
+    public Builder clearOneof(
+        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      return (Builder) super.clearOneof(oneof);
+    }
+    public Builder setRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        int index, Object value) {
+      return (Builder) super.setRepeatedField(field, index, value);
+    }
+    public Builder addRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.addRepeatedField(field, value);
+    }
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.longrunning.Operation) {
         return mergeFrom((com.google.longrunning.Operation)other);
@@ -737,7 +835,7 @@ public  final class Operation extends
     }
 
     private com.google.protobuf.Any metadata_ = null;
-    private com.google.protobuf.SingleFieldBuilder<
+    private com.google.protobuf.SingleFieldBuilderV3<
         com.google.protobuf.Any, com.google.protobuf.Any.Builder, com.google.protobuf.AnyOrBuilder> metadataBuilder_;
     /**
      * <pre>
@@ -902,11 +1000,11 @@ public  final class Operation extends
      *
      * <code>optional .google.protobuf.Any metadata = 2;</code>
      */
-    private com.google.protobuf.SingleFieldBuilder<
+    private com.google.protobuf.SingleFieldBuilderV3<
         com.google.protobuf.Any, com.google.protobuf.Any.Builder, com.google.protobuf.AnyOrBuilder> 
         getMetadataFieldBuilder() {
       if (metadataBuilder_ == null) {
-        metadataBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+        metadataBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
             com.google.protobuf.Any, com.google.protobuf.Any.Builder, com.google.protobuf.AnyOrBuilder>(
                 getMetadata(),
                 getParentForChildren(),
@@ -957,7 +1055,7 @@ public  final class Operation extends
       return this;
     }
 
-    private com.google.protobuf.SingleFieldBuilder<
+    private com.google.protobuf.SingleFieldBuilderV3<
         com.google.rpc.Status, com.google.rpc.Status.Builder, com.google.rpc.StatusOrBuilder> errorBuilder_;
     /**
      * <pre>
@@ -1100,14 +1198,14 @@ public  final class Operation extends
      *
      * <code>optional .google.rpc.Status error = 4;</code>
      */
-    private com.google.protobuf.SingleFieldBuilder<
+    private com.google.protobuf.SingleFieldBuilderV3<
         com.google.rpc.Status, com.google.rpc.Status.Builder, com.google.rpc.StatusOrBuilder> 
         getErrorFieldBuilder() {
       if (errorBuilder_ == null) {
         if (!(resultCase_ == 4)) {
           result_ = com.google.rpc.Status.getDefaultInstance();
         }
-        errorBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+        errorBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
             com.google.rpc.Status, com.google.rpc.Status.Builder, com.google.rpc.StatusOrBuilder>(
                 (com.google.rpc.Status) result_,
                 getParentForChildren(),
@@ -1119,7 +1217,7 @@ public  final class Operation extends
       return errorBuilder_;
     }
 
-    private com.google.protobuf.SingleFieldBuilder<
+    private com.google.protobuf.SingleFieldBuilderV3<
         com.google.protobuf.Any, com.google.protobuf.Any.Builder, com.google.protobuf.AnyOrBuilder> responseBuilder_;
     /**
      * <pre>
@@ -1318,14 +1416,14 @@ public  final class Operation extends
      *
      * <code>optional .google.protobuf.Any response = 5;</code>
      */
-    private com.google.protobuf.SingleFieldBuilder<
+    private com.google.protobuf.SingleFieldBuilderV3<
         com.google.protobuf.Any, com.google.protobuf.Any.Builder, com.google.protobuf.AnyOrBuilder> 
         getResponseFieldBuilder() {
       if (responseBuilder_ == null) {
         if (!(resultCase_ == 5)) {
           result_ = com.google.protobuf.Any.getDefaultInstance();
         }
-        responseBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+        responseBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
             com.google.protobuf.Any, com.google.protobuf.Any.Builder, com.google.protobuf.AnyOrBuilder>(
                 (com.google.protobuf.Any) result_,
                 getParentForChildren(),

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/longrunning/OperationsProto.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/longrunning/OperationsProto.java
@@ -6,37 +6,43 @@ package com.google.longrunning;
 public final class OperationsProto {
   private OperationsProto() {}
   public static void registerAllExtensions(
+      com.google.protobuf.ExtensionRegistryLite registry) {
+  }
+
+  public static void registerAllExtensions(
       com.google.protobuf.ExtensionRegistry registry) {
+    registerAllExtensions(
+        (com.google.protobuf.ExtensionRegistryLite) registry);
   }
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_longrunning_Operation_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_longrunning_Operation_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_longrunning_GetOperationRequest_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_longrunning_GetOperationRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_longrunning_ListOperationsRequest_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_longrunning_ListOperationsRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_longrunning_ListOperationsResponse_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_longrunning_ListOperationsResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_longrunning_CancelOperationRequest_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_longrunning_CancelOperationRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_longrunning_DeleteOperationRequest_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_longrunning_DeleteOperationRequest_fieldAccessorTable;
 
   public static com.google.protobuf.Descriptors.FileDescriptor
@@ -98,37 +104,37 @@ public final class OperationsProto {
     internal_static_google_longrunning_Operation_descriptor =
       getDescriptor().getMessageTypes().get(0);
     internal_static_google_longrunning_Operation_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_longrunning_Operation_descriptor,
         new java.lang.String[] { "Name", "Metadata", "Done", "Error", "Response", "Result", });
     internal_static_google_longrunning_GetOperationRequest_descriptor =
       getDescriptor().getMessageTypes().get(1);
     internal_static_google_longrunning_GetOperationRequest_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_longrunning_GetOperationRequest_descriptor,
         new java.lang.String[] { "Name", });
     internal_static_google_longrunning_ListOperationsRequest_descriptor =
       getDescriptor().getMessageTypes().get(2);
     internal_static_google_longrunning_ListOperationsRequest_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_longrunning_ListOperationsRequest_descriptor,
         new java.lang.String[] { "Name", "Filter", "PageSize", "PageToken", });
     internal_static_google_longrunning_ListOperationsResponse_descriptor =
       getDescriptor().getMessageTypes().get(3);
     internal_static_google_longrunning_ListOperationsResponse_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_longrunning_ListOperationsResponse_descriptor,
         new java.lang.String[] { "Operations", "NextPageToken", });
     internal_static_google_longrunning_CancelOperationRequest_descriptor =
       getDescriptor().getMessageTypes().get(4);
     internal_static_google_longrunning_CancelOperationRequest_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_longrunning_CancelOperationRequest_descriptor,
         new java.lang.String[] { "Name", });
     internal_static_google_longrunning_DeleteOperationRequest_descriptor =
       getDescriptor().getMessageTypes().get(5);
     internal_static_google_longrunning_DeleteOperationRequest_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_longrunning_DeleteOperationRequest_descriptor,
         new java.lang.String[] { "Name", });
     com.google.protobuf.ExtensionRegistry registry =

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/rpc/BadRequest.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/rpc/BadRequest.java
@@ -12,11 +12,11 @@ package com.google.rpc;
  * Protobuf type {@code google.rpc.BadRequest}
  */
 public  final class BadRequest extends
-    com.google.protobuf.GeneratedMessage implements
+    com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:google.rpc.BadRequest)
     BadRequestOrBuilder {
   // Use BadRequest.newBuilder() to construct.
-  private BadRequest(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+  private BadRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private BadRequest() {
@@ -53,7 +53,8 @@ public  final class BadRequest extends
               fieldViolations_ = new java.util.ArrayList<com.google.rpc.BadRequest.FieldViolation>();
               mutable_bitField0_ |= 0x00000001;
             }
-            fieldViolations_.add(input.readMessage(com.google.rpc.BadRequest.FieldViolation.parser(), extensionRegistry));
+            fieldViolations_.add(
+                input.readMessage(com.google.rpc.BadRequest.FieldViolation.parser(), extensionRegistry));
             break;
           }
         }
@@ -75,7 +76,7 @@ public  final class BadRequest extends
     return com.google.rpc.ErrorDetailsProto.internal_static_google_rpc_BadRequest_descriptor;
   }
 
-  protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.google.rpc.ErrorDetailsProto.internal_static_google_rpc_BadRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
@@ -134,11 +135,11 @@ public  final class BadRequest extends
    * Protobuf type {@code google.rpc.BadRequest.FieldViolation}
    */
   public  static final class FieldViolation extends
-      com.google.protobuf.GeneratedMessage implements
+      com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:google.rpc.BadRequest.FieldViolation)
       FieldViolationOrBuilder {
     // Use FieldViolation.newBuilder() to construct.
-    private FieldViolation(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+    private FieldViolation(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
     }
     private FieldViolation() {
@@ -199,7 +200,7 @@ public  final class BadRequest extends
       return com.google.rpc.ErrorDetailsProto.internal_static_google_rpc_BadRequest_FieldViolation_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.rpc.ErrorDetailsProto.internal_static_google_rpc_BadRequest_FieldViolation_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -307,10 +308,10 @@ public  final class BadRequest extends
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (!getFieldBytes().isEmpty()) {
-        com.google.protobuf.GeneratedMessage.writeString(output, 1, field_);
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, field_);
       }
       if (!getDescriptionBytes().isEmpty()) {
-        com.google.protobuf.GeneratedMessage.writeString(output, 2, description_);
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 2, description_);
       }
     }
 
@@ -320,16 +321,50 @@ public  final class BadRequest extends
 
       size = 0;
       if (!getFieldBytes().isEmpty()) {
-        size += com.google.protobuf.GeneratedMessage.computeStringSize(1, field_);
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, field_);
       }
       if (!getDescriptionBytes().isEmpty()) {
-        size += com.google.protobuf.GeneratedMessage.computeStringSize(2, description_);
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, description_);
       }
       memoizedSize = size;
       return size;
     }
 
     private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.google.rpc.BadRequest.FieldViolation)) {
+        return super.equals(obj);
+      }
+      com.google.rpc.BadRequest.FieldViolation other = (com.google.rpc.BadRequest.FieldViolation) obj;
+
+      boolean result = true;
+      result = result && getField()
+          .equals(other.getField());
+      result = result && getDescription()
+          .equals(other.getDescription());
+      return result;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptorForType().hashCode();
+      hash = (37 * hash) + FIELD_FIELD_NUMBER;
+      hash = (53 * hash) + getField().hashCode();
+      hash = (37 * hash) + DESCRIPTION_FIELD_NUMBER;
+      hash = (53 * hash) + getDescription().hashCode();
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
     public static com.google.rpc.BadRequest.FieldViolation parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
@@ -353,39 +388,39 @@ public  final class BadRequest extends
     }
     public static com.google.rpc.BadRequest.FieldViolation parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
     public static com.google.rpc.BadRequest.FieldViolation parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
     public static com.google.rpc.BadRequest.FieldViolation parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
     public static com.google.rpc.BadRequest.FieldViolation parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
     public static com.google.rpc.BadRequest.FieldViolation parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
     public static com.google.rpc.BadRequest.FieldViolation parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
@@ -403,7 +438,7 @@ public  final class BadRequest extends
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -415,7 +450,7 @@ public  final class BadRequest extends
      * Protobuf type {@code google.rpc.BadRequest.FieldViolation}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:google.rpc.BadRequest.FieldViolation)
         com.google.rpc.BadRequest.FieldViolationOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -423,7 +458,7 @@ public  final class BadRequest extends
         return com.google.rpc.ErrorDetailsProto.internal_static_google_rpc_BadRequest_FieldViolation_descriptor;
       }
 
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return com.google.rpc.ErrorDetailsProto.internal_static_google_rpc_BadRequest_FieldViolation_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -436,12 +471,13 @@ public  final class BadRequest extends
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
       private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
         }
       }
       public Builder clear() {
@@ -478,6 +514,32 @@ public  final class BadRequest extends
         return result;
       }
 
+      public Builder clone() {
+        return (Builder) super.clone();
+      }
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          Object value) {
+        return (Builder) super.setField(field, value);
+      }
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return (Builder) super.clearField(field);
+      }
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return (Builder) super.clearOneof(oneof);
+      }
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, Object value) {
+        return (Builder) super.setRepeatedField(field, index, value);
+      }
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          Object value) {
+        return (Builder) super.addRepeatedField(field, value);
+      }
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof com.google.rpc.BadRequest.FieldViolation) {
           return mergeFrom((com.google.rpc.BadRequest.FieldViolation)other);
@@ -845,6 +907,38 @@ public  final class BadRequest extends
   }
 
   private static final long serialVersionUID = 0L;
+  @java.lang.Override
+  public boolean equals(final java.lang.Object obj) {
+    if (obj == this) {
+     return true;
+    }
+    if (!(obj instanceof com.google.rpc.BadRequest)) {
+      return super.equals(obj);
+    }
+    com.google.rpc.BadRequest other = (com.google.rpc.BadRequest) obj;
+
+    boolean result = true;
+    result = result && getFieldViolationsList()
+        .equals(other.getFieldViolationsList());
+    return result;
+  }
+
+  @java.lang.Override
+  public int hashCode() {
+    if (memoizedHashCode != 0) {
+      return memoizedHashCode;
+    }
+    int hash = 41;
+    hash = (19 * hash) + getDescriptorForType().hashCode();
+    if (getFieldViolationsCount() > 0) {
+      hash = (37 * hash) + FIELD_VIOLATIONS_FIELD_NUMBER;
+      hash = (53 * hash) + getFieldViolationsList().hashCode();
+    }
+    hash = (29 * hash) + unknownFields.hashCode();
+    memoizedHashCode = hash;
+    return hash;
+  }
+
   public static com.google.rpc.BadRequest parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -868,39 +962,39 @@ public  final class BadRequest extends
   }
   public static com.google.rpc.BadRequest parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.rpc.BadRequest parseFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.rpc.BadRequest parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
   public static com.google.rpc.BadRequest parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.rpc.BadRequest parseFrom(
       com.google.protobuf.CodedInputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.rpc.BadRequest parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
@@ -918,7 +1012,7 @@ public  final class BadRequest extends
 
   @java.lang.Override
   protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
@@ -931,7 +1025,7 @@ public  final class BadRequest extends
    * Protobuf type {@code google.rpc.BadRequest}
    */
   public static final class Builder extends
-      com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
       // @@protoc_insertion_point(builder_implements:google.rpc.BadRequest)
       com.google.rpc.BadRequestOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
@@ -939,7 +1033,7 @@ public  final class BadRequest extends
       return com.google.rpc.ErrorDetailsProto.internal_static_google_rpc_BadRequest_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.rpc.ErrorDetailsProto.internal_static_google_rpc_BadRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -952,12 +1046,13 @@ public  final class BadRequest extends
     }
 
     private Builder(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
         getFieldViolationsFieldBuilder();
       }
     }
@@ -1005,6 +1100,32 @@ public  final class BadRequest extends
       return result;
     }
 
+    public Builder clone() {
+      return (Builder) super.clone();
+    }
+    public Builder setField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.setField(field, value);
+    }
+    public Builder clearField(
+        com.google.protobuf.Descriptors.FieldDescriptor field) {
+      return (Builder) super.clearField(field);
+    }
+    public Builder clearOneof(
+        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      return (Builder) super.clearOneof(oneof);
+    }
+    public Builder setRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        int index, Object value) {
+      return (Builder) super.setRepeatedField(field, index, value);
+    }
+    public Builder addRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.addRepeatedField(field, value);
+    }
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.rpc.BadRequest) {
         return mergeFrom((com.google.rpc.BadRequest)other);
@@ -1035,7 +1156,7 @@ public  final class BadRequest extends
             fieldViolations_ = other.fieldViolations_;
             bitField0_ = (bitField0_ & ~0x00000001);
             fieldViolationsBuilder_ = 
-              com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+              com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
                  getFieldViolationsFieldBuilder() : null;
           } else {
             fieldViolationsBuilder_.addAllMessages(other.fieldViolations_);
@@ -1078,7 +1199,7 @@ public  final class BadRequest extends
        }
     }
 
-    private com.google.protobuf.RepeatedFieldBuilder<
+    private com.google.protobuf.RepeatedFieldBuilderV3<
         com.google.rpc.BadRequest.FieldViolation, com.google.rpc.BadRequest.FieldViolation.Builder, com.google.rpc.BadRequest.FieldViolationOrBuilder> fieldViolationsBuilder_;
 
     /**
@@ -1366,11 +1487,11 @@ public  final class BadRequest extends
          getFieldViolationsBuilderList() {
       return getFieldViolationsFieldBuilder().getBuilderList();
     }
-    private com.google.protobuf.RepeatedFieldBuilder<
+    private com.google.protobuf.RepeatedFieldBuilderV3<
         com.google.rpc.BadRequest.FieldViolation, com.google.rpc.BadRequest.FieldViolation.Builder, com.google.rpc.BadRequest.FieldViolationOrBuilder> 
         getFieldViolationsFieldBuilder() {
       if (fieldViolationsBuilder_ == null) {
-        fieldViolationsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
+        fieldViolationsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
             com.google.rpc.BadRequest.FieldViolation, com.google.rpc.BadRequest.FieldViolation.Builder, com.google.rpc.BadRequest.FieldViolationOrBuilder>(
                 fieldViolations_,
                 ((bitField0_ & 0x00000001) == 0x00000001),

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/rpc/CodeProto.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/rpc/CodeProto.java
@@ -6,7 +6,13 @@ package com.google.rpc;
 public final class CodeProto {
   private CodeProto() {}
   public static void registerAllExtensions(
+      com.google.protobuf.ExtensionRegistryLite registry) {
+  }
+
+  public static void registerAllExtensions(
       com.google.protobuf.ExtensionRegistry registry) {
+    registerAllExtensions(
+        (com.google.protobuf.ExtensionRegistryLite) registry);
   }
 
   public static com.google.protobuf.Descriptors.FileDescriptor

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/rpc/DebugInfo.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/rpc/DebugInfo.java
@@ -11,11 +11,11 @@ package com.google.rpc;
  * Protobuf type {@code google.rpc.DebugInfo}
  */
 public  final class DebugInfo extends
-    com.google.protobuf.GeneratedMessage implements
+    com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:google.rpc.DebugInfo)
     DebugInfoOrBuilder {
   // Use DebugInfo.newBuilder() to construct.
-  private DebugInfo(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+  private DebugInfo(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private DebugInfo() {
@@ -82,7 +82,7 @@ public  final class DebugInfo extends
     return com.google.rpc.ErrorDetailsProto.internal_static_google_rpc_DebugInfo_descriptor;
   }
 
-  protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.google.rpc.ErrorDetailsProto.internal_static_google_rpc_DebugInfo_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
@@ -190,10 +190,10 @@ public  final class DebugInfo extends
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
     for (int i = 0; i < stackEntries_.size(); i++) {
-      com.google.protobuf.GeneratedMessage.writeString(output, 1, stackEntries_.getRaw(i));
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 1, stackEntries_.getRaw(i));
     }
     if (!getDetailBytes().isEmpty()) {
-      com.google.protobuf.GeneratedMessage.writeString(output, 2, detail_);
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 2, detail_);
     }
   }
 
@@ -211,13 +211,49 @@ public  final class DebugInfo extends
       size += 1 * getStackEntriesList().size();
     }
     if (!getDetailBytes().isEmpty()) {
-      size += com.google.protobuf.GeneratedMessage.computeStringSize(2, detail_);
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, detail_);
     }
     memoizedSize = size;
     return size;
   }
 
   private static final long serialVersionUID = 0L;
+  @java.lang.Override
+  public boolean equals(final java.lang.Object obj) {
+    if (obj == this) {
+     return true;
+    }
+    if (!(obj instanceof com.google.rpc.DebugInfo)) {
+      return super.equals(obj);
+    }
+    com.google.rpc.DebugInfo other = (com.google.rpc.DebugInfo) obj;
+
+    boolean result = true;
+    result = result && getStackEntriesList()
+        .equals(other.getStackEntriesList());
+    result = result && getDetail()
+        .equals(other.getDetail());
+    return result;
+  }
+
+  @java.lang.Override
+  public int hashCode() {
+    if (memoizedHashCode != 0) {
+      return memoizedHashCode;
+    }
+    int hash = 41;
+    hash = (19 * hash) + getDescriptorForType().hashCode();
+    if (getStackEntriesCount() > 0) {
+      hash = (37 * hash) + STACK_ENTRIES_FIELD_NUMBER;
+      hash = (53 * hash) + getStackEntriesList().hashCode();
+    }
+    hash = (37 * hash) + DETAIL_FIELD_NUMBER;
+    hash = (53 * hash) + getDetail().hashCode();
+    hash = (29 * hash) + unknownFields.hashCode();
+    memoizedHashCode = hash;
+    return hash;
+  }
+
   public static com.google.rpc.DebugInfo parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -241,39 +277,39 @@ public  final class DebugInfo extends
   }
   public static com.google.rpc.DebugInfo parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.rpc.DebugInfo parseFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.rpc.DebugInfo parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
   public static com.google.rpc.DebugInfo parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.rpc.DebugInfo parseFrom(
       com.google.protobuf.CodedInputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.rpc.DebugInfo parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
@@ -291,7 +327,7 @@ public  final class DebugInfo extends
 
   @java.lang.Override
   protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
@@ -303,7 +339,7 @@ public  final class DebugInfo extends
    * Protobuf type {@code google.rpc.DebugInfo}
    */
   public static final class Builder extends
-      com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
       // @@protoc_insertion_point(builder_implements:google.rpc.DebugInfo)
       com.google.rpc.DebugInfoOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
@@ -311,7 +347,7 @@ public  final class DebugInfo extends
       return com.google.rpc.ErrorDetailsProto.internal_static_google_rpc_DebugInfo_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.rpc.ErrorDetailsProto.internal_static_google_rpc_DebugInfo_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -324,12 +360,13 @@ public  final class DebugInfo extends
     }
 
     private Builder(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
       }
     }
     public Builder clear() {
@@ -373,6 +410,32 @@ public  final class DebugInfo extends
       return result;
     }
 
+    public Builder clone() {
+      return (Builder) super.clone();
+    }
+    public Builder setField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.setField(field, value);
+    }
+    public Builder clearField(
+        com.google.protobuf.Descriptors.FieldDescriptor field) {
+      return (Builder) super.clearField(field);
+    }
+    public Builder clearOneof(
+        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      return (Builder) super.clearOneof(oneof);
+    }
+    public Builder setRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        int index, Object value) {
+      return (Builder) super.setRepeatedField(field, index, value);
+    }
+    public Builder addRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.addRepeatedField(field, value);
+    }
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.rpc.DebugInfo) {
         return mergeFrom((com.google.rpc.DebugInfo)other);

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/rpc/DebugInfoOrBuilder.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/rpc/DebugInfoOrBuilder.java
@@ -14,7 +14,7 @@ public interface DebugInfoOrBuilder extends
    *
    * <code>repeated string stack_entries = 1;</code>
    */
-  com.google.protobuf.ProtocolStringList
+  java.util.List<java.lang.String>
       getStackEntriesList();
   /**
    * <pre>

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/rpc/ErrorDetailsProto.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/rpc/ErrorDetailsProto.java
@@ -6,57 +6,63 @@ package com.google.rpc;
 public final class ErrorDetailsProto {
   private ErrorDetailsProto() {}
   public static void registerAllExtensions(
+      com.google.protobuf.ExtensionRegistryLite registry) {
+  }
+
+  public static void registerAllExtensions(
       com.google.protobuf.ExtensionRegistry registry) {
+    registerAllExtensions(
+        (com.google.protobuf.ExtensionRegistryLite) registry);
   }
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_rpc_RetryInfo_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_rpc_RetryInfo_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_rpc_DebugInfo_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_rpc_DebugInfo_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_rpc_QuotaFailure_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_rpc_QuotaFailure_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_rpc_QuotaFailure_Violation_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_rpc_QuotaFailure_Violation_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_rpc_BadRequest_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_rpc_BadRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_rpc_BadRequest_FieldViolation_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_rpc_BadRequest_FieldViolation_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_rpc_RequestInfo_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_rpc_RequestInfo_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_rpc_ResourceInfo_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_rpc_ResourceInfo_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_rpc_Help_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_rpc_Help_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_rpc_Help_Link_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_rpc_Help_Link_fieldAccessorTable;
 
   public static com.google.protobuf.Descriptors.FileDescriptor
@@ -103,61 +109,61 @@ public final class ErrorDetailsProto {
     internal_static_google_rpc_RetryInfo_descriptor =
       getDescriptor().getMessageTypes().get(0);
     internal_static_google_rpc_RetryInfo_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_rpc_RetryInfo_descriptor,
         new java.lang.String[] { "RetryDelay", });
     internal_static_google_rpc_DebugInfo_descriptor =
       getDescriptor().getMessageTypes().get(1);
     internal_static_google_rpc_DebugInfo_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_rpc_DebugInfo_descriptor,
         new java.lang.String[] { "StackEntries", "Detail", });
     internal_static_google_rpc_QuotaFailure_descriptor =
       getDescriptor().getMessageTypes().get(2);
     internal_static_google_rpc_QuotaFailure_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_rpc_QuotaFailure_descriptor,
         new java.lang.String[] { "Violations", });
     internal_static_google_rpc_QuotaFailure_Violation_descriptor =
       internal_static_google_rpc_QuotaFailure_descriptor.getNestedTypes().get(0);
     internal_static_google_rpc_QuotaFailure_Violation_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_rpc_QuotaFailure_Violation_descriptor,
         new java.lang.String[] { "Subject", "Description", });
     internal_static_google_rpc_BadRequest_descriptor =
       getDescriptor().getMessageTypes().get(3);
     internal_static_google_rpc_BadRequest_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_rpc_BadRequest_descriptor,
         new java.lang.String[] { "FieldViolations", });
     internal_static_google_rpc_BadRequest_FieldViolation_descriptor =
       internal_static_google_rpc_BadRequest_descriptor.getNestedTypes().get(0);
     internal_static_google_rpc_BadRequest_FieldViolation_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_rpc_BadRequest_FieldViolation_descriptor,
         new java.lang.String[] { "Field", "Description", });
     internal_static_google_rpc_RequestInfo_descriptor =
       getDescriptor().getMessageTypes().get(4);
     internal_static_google_rpc_RequestInfo_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_rpc_RequestInfo_descriptor,
         new java.lang.String[] { "RequestId", "ServingData", });
     internal_static_google_rpc_ResourceInfo_descriptor =
       getDescriptor().getMessageTypes().get(5);
     internal_static_google_rpc_ResourceInfo_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_rpc_ResourceInfo_descriptor,
         new java.lang.String[] { "ResourceType", "ResourceName", "Owner", "Description", });
     internal_static_google_rpc_Help_descriptor =
       getDescriptor().getMessageTypes().get(6);
     internal_static_google_rpc_Help_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_rpc_Help_descriptor,
         new java.lang.String[] { "Links", });
     internal_static_google_rpc_Help_Link_descriptor =
       internal_static_google_rpc_Help_descriptor.getNestedTypes().get(0);
     internal_static_google_rpc_Help_Link_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_rpc_Help_Link_descriptor,
         new java.lang.String[] { "Description", "Url", });
     com.google.protobuf.DurationProto.getDescriptor();

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/rpc/Help.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/rpc/Help.java
@@ -14,11 +14,11 @@ package com.google.rpc;
  * Protobuf type {@code google.rpc.Help}
  */
 public  final class Help extends
-    com.google.protobuf.GeneratedMessage implements
+    com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:google.rpc.Help)
     HelpOrBuilder {
   // Use Help.newBuilder() to construct.
-  private Help(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+  private Help(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private Help() {
@@ -55,7 +55,8 @@ public  final class Help extends
               links_ = new java.util.ArrayList<com.google.rpc.Help.Link>();
               mutable_bitField0_ |= 0x00000001;
             }
-            links_.add(input.readMessage(com.google.rpc.Help.Link.parser(), extensionRegistry));
+            links_.add(
+                input.readMessage(com.google.rpc.Help.Link.parser(), extensionRegistry));
             break;
           }
         }
@@ -77,7 +78,7 @@ public  final class Help extends
     return com.google.rpc.ErrorDetailsProto.internal_static_google_rpc_Help_descriptor;
   }
 
-  protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.google.rpc.ErrorDetailsProto.internal_static_google_rpc_Help_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
@@ -132,11 +133,11 @@ public  final class Help extends
    * Protobuf type {@code google.rpc.Help.Link}
    */
   public  static final class Link extends
-      com.google.protobuf.GeneratedMessage implements
+      com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:google.rpc.Help.Link)
       LinkOrBuilder {
     // Use Link.newBuilder() to construct.
-    private Link(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+    private Link(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
     }
     private Link() {
@@ -197,7 +198,7 @@ public  final class Help extends
       return com.google.rpc.ErrorDetailsProto.internal_static_google_rpc_Help_Link_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.rpc.ErrorDetailsProto.internal_static_google_rpc_Help_Link_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -301,10 +302,10 @@ public  final class Help extends
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (!getDescriptionBytes().isEmpty()) {
-        com.google.protobuf.GeneratedMessage.writeString(output, 1, description_);
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, description_);
       }
       if (!getUrlBytes().isEmpty()) {
-        com.google.protobuf.GeneratedMessage.writeString(output, 2, url_);
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 2, url_);
       }
     }
 
@@ -314,16 +315,50 @@ public  final class Help extends
 
       size = 0;
       if (!getDescriptionBytes().isEmpty()) {
-        size += com.google.protobuf.GeneratedMessage.computeStringSize(1, description_);
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, description_);
       }
       if (!getUrlBytes().isEmpty()) {
-        size += com.google.protobuf.GeneratedMessage.computeStringSize(2, url_);
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, url_);
       }
       memoizedSize = size;
       return size;
     }
 
     private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.google.rpc.Help.Link)) {
+        return super.equals(obj);
+      }
+      com.google.rpc.Help.Link other = (com.google.rpc.Help.Link) obj;
+
+      boolean result = true;
+      result = result && getDescription()
+          .equals(other.getDescription());
+      result = result && getUrl()
+          .equals(other.getUrl());
+      return result;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptorForType().hashCode();
+      hash = (37 * hash) + DESCRIPTION_FIELD_NUMBER;
+      hash = (53 * hash) + getDescription().hashCode();
+      hash = (37 * hash) + URL_FIELD_NUMBER;
+      hash = (53 * hash) + getUrl().hashCode();
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
     public static com.google.rpc.Help.Link parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
@@ -347,39 +382,39 @@ public  final class Help extends
     }
     public static com.google.rpc.Help.Link parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
     public static com.google.rpc.Help.Link parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
     public static com.google.rpc.Help.Link parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
     public static com.google.rpc.Help.Link parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
     public static com.google.rpc.Help.Link parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
     public static com.google.rpc.Help.Link parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
@@ -397,7 +432,7 @@ public  final class Help extends
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -409,7 +444,7 @@ public  final class Help extends
      * Protobuf type {@code google.rpc.Help.Link}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:google.rpc.Help.Link)
         com.google.rpc.Help.LinkOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -417,7 +452,7 @@ public  final class Help extends
         return com.google.rpc.ErrorDetailsProto.internal_static_google_rpc_Help_Link_descriptor;
       }
 
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return com.google.rpc.ErrorDetailsProto.internal_static_google_rpc_Help_Link_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -430,12 +465,13 @@ public  final class Help extends
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
       private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
         }
       }
       public Builder clear() {
@@ -472,6 +508,32 @@ public  final class Help extends
         return result;
       }
 
+      public Builder clone() {
+        return (Builder) super.clone();
+      }
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          Object value) {
+        return (Builder) super.setField(field, value);
+      }
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return (Builder) super.clearField(field);
+      }
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return (Builder) super.clearOneof(oneof);
+      }
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, Object value) {
+        return (Builder) super.setRepeatedField(field, index, value);
+      }
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          Object value) {
+        return (Builder) super.addRepeatedField(field, value);
+      }
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof com.google.rpc.Help.Link) {
           return mergeFrom((com.google.rpc.Help.Link)other);
@@ -829,6 +891,38 @@ public  final class Help extends
   }
 
   private static final long serialVersionUID = 0L;
+  @java.lang.Override
+  public boolean equals(final java.lang.Object obj) {
+    if (obj == this) {
+     return true;
+    }
+    if (!(obj instanceof com.google.rpc.Help)) {
+      return super.equals(obj);
+    }
+    com.google.rpc.Help other = (com.google.rpc.Help) obj;
+
+    boolean result = true;
+    result = result && getLinksList()
+        .equals(other.getLinksList());
+    return result;
+  }
+
+  @java.lang.Override
+  public int hashCode() {
+    if (memoizedHashCode != 0) {
+      return memoizedHashCode;
+    }
+    int hash = 41;
+    hash = (19 * hash) + getDescriptorForType().hashCode();
+    if (getLinksCount() > 0) {
+      hash = (37 * hash) + LINKS_FIELD_NUMBER;
+      hash = (53 * hash) + getLinksList().hashCode();
+    }
+    hash = (29 * hash) + unknownFields.hashCode();
+    memoizedHashCode = hash;
+    return hash;
+  }
+
   public static com.google.rpc.Help parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -852,39 +946,39 @@ public  final class Help extends
   }
   public static com.google.rpc.Help parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.rpc.Help parseFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.rpc.Help parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
   public static com.google.rpc.Help parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.rpc.Help parseFrom(
       com.google.protobuf.CodedInputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.rpc.Help parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
@@ -902,7 +996,7 @@ public  final class Help extends
 
   @java.lang.Override
   protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
@@ -917,7 +1011,7 @@ public  final class Help extends
    * Protobuf type {@code google.rpc.Help}
    */
   public static final class Builder extends
-      com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
       // @@protoc_insertion_point(builder_implements:google.rpc.Help)
       com.google.rpc.HelpOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
@@ -925,7 +1019,7 @@ public  final class Help extends
       return com.google.rpc.ErrorDetailsProto.internal_static_google_rpc_Help_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.rpc.ErrorDetailsProto.internal_static_google_rpc_Help_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -938,12 +1032,13 @@ public  final class Help extends
     }
 
     private Builder(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
         getLinksFieldBuilder();
       }
     }
@@ -991,6 +1086,32 @@ public  final class Help extends
       return result;
     }
 
+    public Builder clone() {
+      return (Builder) super.clone();
+    }
+    public Builder setField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.setField(field, value);
+    }
+    public Builder clearField(
+        com.google.protobuf.Descriptors.FieldDescriptor field) {
+      return (Builder) super.clearField(field);
+    }
+    public Builder clearOneof(
+        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      return (Builder) super.clearOneof(oneof);
+    }
+    public Builder setRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        int index, Object value) {
+      return (Builder) super.setRepeatedField(field, index, value);
+    }
+    public Builder addRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.addRepeatedField(field, value);
+    }
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.rpc.Help) {
         return mergeFrom((com.google.rpc.Help)other);
@@ -1021,7 +1142,7 @@ public  final class Help extends
             links_ = other.links_;
             bitField0_ = (bitField0_ & ~0x00000001);
             linksBuilder_ = 
-              com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+              com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
                  getLinksFieldBuilder() : null;
           } else {
             linksBuilder_.addAllMessages(other.links_);
@@ -1064,7 +1185,7 @@ public  final class Help extends
        }
     }
 
-    private com.google.protobuf.RepeatedFieldBuilder<
+    private com.google.protobuf.RepeatedFieldBuilderV3<
         com.google.rpc.Help.Link, com.google.rpc.Help.Link.Builder, com.google.rpc.Help.LinkOrBuilder> linksBuilder_;
 
     /**
@@ -1352,11 +1473,11 @@ public  final class Help extends
          getLinksBuilderList() {
       return getLinksFieldBuilder().getBuilderList();
     }
-    private com.google.protobuf.RepeatedFieldBuilder<
+    private com.google.protobuf.RepeatedFieldBuilderV3<
         com.google.rpc.Help.Link, com.google.rpc.Help.Link.Builder, com.google.rpc.Help.LinkOrBuilder> 
         getLinksFieldBuilder() {
       if (linksBuilder_ == null) {
-        linksBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
+        linksBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
             com.google.rpc.Help.Link, com.google.rpc.Help.Link.Builder, com.google.rpc.Help.LinkOrBuilder>(
                 links_,
                 ((bitField0_ & 0x00000001) == 0x00000001),

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/rpc/QuotaFailure.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/rpc/QuotaFailure.java
@@ -19,11 +19,11 @@ package com.google.rpc;
  * Protobuf type {@code google.rpc.QuotaFailure}
  */
 public  final class QuotaFailure extends
-    com.google.protobuf.GeneratedMessage implements
+    com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:google.rpc.QuotaFailure)
     QuotaFailureOrBuilder {
   // Use QuotaFailure.newBuilder() to construct.
-  private QuotaFailure(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+  private QuotaFailure(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private QuotaFailure() {
@@ -60,7 +60,8 @@ public  final class QuotaFailure extends
               violations_ = new java.util.ArrayList<com.google.rpc.QuotaFailure.Violation>();
               mutable_bitField0_ |= 0x00000001;
             }
-            violations_.add(input.readMessage(com.google.rpc.QuotaFailure.Violation.parser(), extensionRegistry));
+            violations_.add(
+                input.readMessage(com.google.rpc.QuotaFailure.Violation.parser(), extensionRegistry));
             break;
           }
         }
@@ -82,7 +83,7 @@ public  final class QuotaFailure extends
     return com.google.rpc.ErrorDetailsProto.internal_static_google_rpc_QuotaFailure_descriptor;
   }
 
-  protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.google.rpc.ErrorDetailsProto.internal_static_google_rpc_QuotaFailure_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
@@ -152,11 +153,11 @@ public  final class QuotaFailure extends
    * Protobuf type {@code google.rpc.QuotaFailure.Violation}
    */
   public  static final class Violation extends
-      com.google.protobuf.GeneratedMessage implements
+      com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:google.rpc.QuotaFailure.Violation)
       ViolationOrBuilder {
     // Use Violation.newBuilder() to construct.
-    private Violation(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+    private Violation(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
     }
     private Violation() {
@@ -217,7 +218,7 @@ public  final class QuotaFailure extends
       return com.google.rpc.ErrorDetailsProto.internal_static_google_rpc_QuotaFailure_Violation_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.rpc.ErrorDetailsProto.internal_static_google_rpc_QuotaFailure_Violation_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -335,10 +336,10 @@ public  final class QuotaFailure extends
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (!getSubjectBytes().isEmpty()) {
-        com.google.protobuf.GeneratedMessage.writeString(output, 1, subject_);
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, subject_);
       }
       if (!getDescriptionBytes().isEmpty()) {
-        com.google.protobuf.GeneratedMessage.writeString(output, 2, description_);
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 2, description_);
       }
     }
 
@@ -348,16 +349,50 @@ public  final class QuotaFailure extends
 
       size = 0;
       if (!getSubjectBytes().isEmpty()) {
-        size += com.google.protobuf.GeneratedMessage.computeStringSize(1, subject_);
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, subject_);
       }
       if (!getDescriptionBytes().isEmpty()) {
-        size += com.google.protobuf.GeneratedMessage.computeStringSize(2, description_);
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, description_);
       }
       memoizedSize = size;
       return size;
     }
 
     private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.google.rpc.QuotaFailure.Violation)) {
+        return super.equals(obj);
+      }
+      com.google.rpc.QuotaFailure.Violation other = (com.google.rpc.QuotaFailure.Violation) obj;
+
+      boolean result = true;
+      result = result && getSubject()
+          .equals(other.getSubject());
+      result = result && getDescription()
+          .equals(other.getDescription());
+      return result;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptorForType().hashCode();
+      hash = (37 * hash) + SUBJECT_FIELD_NUMBER;
+      hash = (53 * hash) + getSubject().hashCode();
+      hash = (37 * hash) + DESCRIPTION_FIELD_NUMBER;
+      hash = (53 * hash) + getDescription().hashCode();
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
     public static com.google.rpc.QuotaFailure.Violation parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
@@ -381,39 +416,39 @@ public  final class QuotaFailure extends
     }
     public static com.google.rpc.QuotaFailure.Violation parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
     public static com.google.rpc.QuotaFailure.Violation parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
     public static com.google.rpc.QuotaFailure.Violation parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
     public static com.google.rpc.QuotaFailure.Violation parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
     public static com.google.rpc.QuotaFailure.Violation parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
     public static com.google.rpc.QuotaFailure.Violation parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessage
+      return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
@@ -431,7 +466,7 @@ public  final class QuotaFailure extends
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -444,7 +479,7 @@ public  final class QuotaFailure extends
      * Protobuf type {@code google.rpc.QuotaFailure.Violation}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:google.rpc.QuotaFailure.Violation)
         com.google.rpc.QuotaFailure.ViolationOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -452,7 +487,7 @@ public  final class QuotaFailure extends
         return com.google.rpc.ErrorDetailsProto.internal_static_google_rpc_QuotaFailure_Violation_descriptor;
       }
 
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return com.google.rpc.ErrorDetailsProto.internal_static_google_rpc_QuotaFailure_Violation_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -465,12 +500,13 @@ public  final class QuotaFailure extends
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
       private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
         }
       }
       public Builder clear() {
@@ -507,6 +543,32 @@ public  final class QuotaFailure extends
         return result;
       }
 
+      public Builder clone() {
+        return (Builder) super.clone();
+      }
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          Object value) {
+        return (Builder) super.setField(field, value);
+      }
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return (Builder) super.clearField(field);
+      }
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return (Builder) super.clearOneof(oneof);
+      }
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, Object value) {
+        return (Builder) super.setRepeatedField(field, index, value);
+      }
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          Object value) {
+        return (Builder) super.addRepeatedField(field, value);
+      }
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof com.google.rpc.QuotaFailure.Violation) {
           return mergeFrom((com.google.rpc.QuotaFailure.Violation)other);
@@ -899,6 +961,38 @@ public  final class QuotaFailure extends
   }
 
   private static final long serialVersionUID = 0L;
+  @java.lang.Override
+  public boolean equals(final java.lang.Object obj) {
+    if (obj == this) {
+     return true;
+    }
+    if (!(obj instanceof com.google.rpc.QuotaFailure)) {
+      return super.equals(obj);
+    }
+    com.google.rpc.QuotaFailure other = (com.google.rpc.QuotaFailure) obj;
+
+    boolean result = true;
+    result = result && getViolationsList()
+        .equals(other.getViolationsList());
+    return result;
+  }
+
+  @java.lang.Override
+  public int hashCode() {
+    if (memoizedHashCode != 0) {
+      return memoizedHashCode;
+    }
+    int hash = 41;
+    hash = (19 * hash) + getDescriptorForType().hashCode();
+    if (getViolationsCount() > 0) {
+      hash = (37 * hash) + VIOLATIONS_FIELD_NUMBER;
+      hash = (53 * hash) + getViolationsList().hashCode();
+    }
+    hash = (29 * hash) + unknownFields.hashCode();
+    memoizedHashCode = hash;
+    return hash;
+  }
+
   public static com.google.rpc.QuotaFailure parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -922,39 +1016,39 @@ public  final class QuotaFailure extends
   }
   public static com.google.rpc.QuotaFailure parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.rpc.QuotaFailure parseFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.rpc.QuotaFailure parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
   public static com.google.rpc.QuotaFailure parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.rpc.QuotaFailure parseFrom(
       com.google.protobuf.CodedInputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.rpc.QuotaFailure parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
@@ -972,7 +1066,7 @@ public  final class QuotaFailure extends
 
   @java.lang.Override
   protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
@@ -992,7 +1086,7 @@ public  final class QuotaFailure extends
    * Protobuf type {@code google.rpc.QuotaFailure}
    */
   public static final class Builder extends
-      com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
       // @@protoc_insertion_point(builder_implements:google.rpc.QuotaFailure)
       com.google.rpc.QuotaFailureOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
@@ -1000,7 +1094,7 @@ public  final class QuotaFailure extends
       return com.google.rpc.ErrorDetailsProto.internal_static_google_rpc_QuotaFailure_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.rpc.ErrorDetailsProto.internal_static_google_rpc_QuotaFailure_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -1013,12 +1107,13 @@ public  final class QuotaFailure extends
     }
 
     private Builder(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
         getViolationsFieldBuilder();
       }
     }
@@ -1066,6 +1161,32 @@ public  final class QuotaFailure extends
       return result;
     }
 
+    public Builder clone() {
+      return (Builder) super.clone();
+    }
+    public Builder setField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.setField(field, value);
+    }
+    public Builder clearField(
+        com.google.protobuf.Descriptors.FieldDescriptor field) {
+      return (Builder) super.clearField(field);
+    }
+    public Builder clearOneof(
+        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      return (Builder) super.clearOneof(oneof);
+    }
+    public Builder setRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        int index, Object value) {
+      return (Builder) super.setRepeatedField(field, index, value);
+    }
+    public Builder addRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.addRepeatedField(field, value);
+    }
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.rpc.QuotaFailure) {
         return mergeFrom((com.google.rpc.QuotaFailure)other);
@@ -1096,7 +1217,7 @@ public  final class QuotaFailure extends
             violations_ = other.violations_;
             bitField0_ = (bitField0_ & ~0x00000001);
             violationsBuilder_ = 
-              com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+              com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
                  getViolationsFieldBuilder() : null;
           } else {
             violationsBuilder_.addAllMessages(other.violations_);
@@ -1139,7 +1260,7 @@ public  final class QuotaFailure extends
        }
     }
 
-    private com.google.protobuf.RepeatedFieldBuilder<
+    private com.google.protobuf.RepeatedFieldBuilderV3<
         com.google.rpc.QuotaFailure.Violation, com.google.rpc.QuotaFailure.Violation.Builder, com.google.rpc.QuotaFailure.ViolationOrBuilder> violationsBuilder_;
 
     /**
@@ -1427,11 +1548,11 @@ public  final class QuotaFailure extends
          getViolationsBuilderList() {
       return getViolationsFieldBuilder().getBuilderList();
     }
-    private com.google.protobuf.RepeatedFieldBuilder<
+    private com.google.protobuf.RepeatedFieldBuilderV3<
         com.google.rpc.QuotaFailure.Violation, com.google.rpc.QuotaFailure.Violation.Builder, com.google.rpc.QuotaFailure.ViolationOrBuilder> 
         getViolationsFieldBuilder() {
       if (violationsBuilder_ == null) {
-        violationsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
+        violationsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
             com.google.rpc.QuotaFailure.Violation, com.google.rpc.QuotaFailure.Violation.Builder, com.google.rpc.QuotaFailure.ViolationOrBuilder>(
                 violations_,
                 ((bitField0_ & 0x00000001) == 0x00000001),

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/rpc/RequestInfo.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/rpc/RequestInfo.java
@@ -12,11 +12,11 @@ package com.google.rpc;
  * Protobuf type {@code google.rpc.RequestInfo}
  */
 public  final class RequestInfo extends
-    com.google.protobuf.GeneratedMessage implements
+    com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:google.rpc.RequestInfo)
     RequestInfoOrBuilder {
   // Use RequestInfo.newBuilder() to construct.
-  private RequestInfo(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+  private RequestInfo(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private RequestInfo() {
@@ -77,7 +77,7 @@ public  final class RequestInfo extends
     return com.google.rpc.ErrorDetailsProto.internal_static_google_rpc_RequestInfo_descriptor;
   }
 
-  protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.google.rpc.ErrorDetailsProto.internal_static_google_rpc_RequestInfo_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
@@ -185,10 +185,10 @@ public  final class RequestInfo extends
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
     if (!getRequestIdBytes().isEmpty()) {
-      com.google.protobuf.GeneratedMessage.writeString(output, 1, requestId_);
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 1, requestId_);
     }
     if (!getServingDataBytes().isEmpty()) {
-      com.google.protobuf.GeneratedMessage.writeString(output, 2, servingData_);
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 2, servingData_);
     }
   }
 
@@ -198,16 +198,50 @@ public  final class RequestInfo extends
 
     size = 0;
     if (!getRequestIdBytes().isEmpty()) {
-      size += com.google.protobuf.GeneratedMessage.computeStringSize(1, requestId_);
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, requestId_);
     }
     if (!getServingDataBytes().isEmpty()) {
-      size += com.google.protobuf.GeneratedMessage.computeStringSize(2, servingData_);
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, servingData_);
     }
     memoizedSize = size;
     return size;
   }
 
   private static final long serialVersionUID = 0L;
+  @java.lang.Override
+  public boolean equals(final java.lang.Object obj) {
+    if (obj == this) {
+     return true;
+    }
+    if (!(obj instanceof com.google.rpc.RequestInfo)) {
+      return super.equals(obj);
+    }
+    com.google.rpc.RequestInfo other = (com.google.rpc.RequestInfo) obj;
+
+    boolean result = true;
+    result = result && getRequestId()
+        .equals(other.getRequestId());
+    result = result && getServingData()
+        .equals(other.getServingData());
+    return result;
+  }
+
+  @java.lang.Override
+  public int hashCode() {
+    if (memoizedHashCode != 0) {
+      return memoizedHashCode;
+    }
+    int hash = 41;
+    hash = (19 * hash) + getDescriptorForType().hashCode();
+    hash = (37 * hash) + REQUEST_ID_FIELD_NUMBER;
+    hash = (53 * hash) + getRequestId().hashCode();
+    hash = (37 * hash) + SERVING_DATA_FIELD_NUMBER;
+    hash = (53 * hash) + getServingData().hashCode();
+    hash = (29 * hash) + unknownFields.hashCode();
+    memoizedHashCode = hash;
+    return hash;
+  }
+
   public static com.google.rpc.RequestInfo parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -231,39 +265,39 @@ public  final class RequestInfo extends
   }
   public static com.google.rpc.RequestInfo parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.rpc.RequestInfo parseFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.rpc.RequestInfo parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
   public static com.google.rpc.RequestInfo parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.rpc.RequestInfo parseFrom(
       com.google.protobuf.CodedInputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.rpc.RequestInfo parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
@@ -281,7 +315,7 @@ public  final class RequestInfo extends
 
   @java.lang.Override
   protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
@@ -294,7 +328,7 @@ public  final class RequestInfo extends
    * Protobuf type {@code google.rpc.RequestInfo}
    */
   public static final class Builder extends
-      com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
       // @@protoc_insertion_point(builder_implements:google.rpc.RequestInfo)
       com.google.rpc.RequestInfoOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
@@ -302,7 +336,7 @@ public  final class RequestInfo extends
       return com.google.rpc.ErrorDetailsProto.internal_static_google_rpc_RequestInfo_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.rpc.ErrorDetailsProto.internal_static_google_rpc_RequestInfo_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -315,12 +349,13 @@ public  final class RequestInfo extends
     }
 
     private Builder(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
       }
     }
     public Builder clear() {
@@ -357,6 +392,32 @@ public  final class RequestInfo extends
       return result;
     }
 
+    public Builder clone() {
+      return (Builder) super.clone();
+    }
+    public Builder setField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.setField(field, value);
+    }
+    public Builder clearField(
+        com.google.protobuf.Descriptors.FieldDescriptor field) {
+      return (Builder) super.clearField(field);
+    }
+    public Builder clearOneof(
+        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      return (Builder) super.clearOneof(oneof);
+    }
+    public Builder setRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        int index, Object value) {
+      return (Builder) super.setRepeatedField(field, index, value);
+    }
+    public Builder addRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.addRepeatedField(field, value);
+    }
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.rpc.RequestInfo) {
         return mergeFrom((com.google.rpc.RequestInfo)other);

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/rpc/ResourceInfo.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/rpc/ResourceInfo.java
@@ -11,11 +11,11 @@ package com.google.rpc;
  * Protobuf type {@code google.rpc.ResourceInfo}
  */
 public  final class ResourceInfo extends
-    com.google.protobuf.GeneratedMessage implements
+    com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:google.rpc.ResourceInfo)
     ResourceInfoOrBuilder {
   // Use ResourceInfo.newBuilder() to construct.
-  private ResourceInfo(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+  private ResourceInfo(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private ResourceInfo() {
@@ -90,7 +90,7 @@ public  final class ResourceInfo extends
     return com.google.rpc.ErrorDetailsProto.internal_static_google_rpc_ResourceInfo_descriptor;
   }
 
-  protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.google.rpc.ErrorDetailsProto.internal_static_google_rpc_ResourceInfo_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
@@ -294,16 +294,16 @@ public  final class ResourceInfo extends
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
     if (!getResourceTypeBytes().isEmpty()) {
-      com.google.protobuf.GeneratedMessage.writeString(output, 1, resourceType_);
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 1, resourceType_);
     }
     if (!getResourceNameBytes().isEmpty()) {
-      com.google.protobuf.GeneratedMessage.writeString(output, 2, resourceName_);
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 2, resourceName_);
     }
     if (!getOwnerBytes().isEmpty()) {
-      com.google.protobuf.GeneratedMessage.writeString(output, 3, owner_);
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 3, owner_);
     }
     if (!getDescriptionBytes().isEmpty()) {
-      com.google.protobuf.GeneratedMessage.writeString(output, 4, description_);
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 4, description_);
     }
   }
 
@@ -313,22 +313,64 @@ public  final class ResourceInfo extends
 
     size = 0;
     if (!getResourceTypeBytes().isEmpty()) {
-      size += com.google.protobuf.GeneratedMessage.computeStringSize(1, resourceType_);
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, resourceType_);
     }
     if (!getResourceNameBytes().isEmpty()) {
-      size += com.google.protobuf.GeneratedMessage.computeStringSize(2, resourceName_);
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, resourceName_);
     }
     if (!getOwnerBytes().isEmpty()) {
-      size += com.google.protobuf.GeneratedMessage.computeStringSize(3, owner_);
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, owner_);
     }
     if (!getDescriptionBytes().isEmpty()) {
-      size += com.google.protobuf.GeneratedMessage.computeStringSize(4, description_);
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(4, description_);
     }
     memoizedSize = size;
     return size;
   }
 
   private static final long serialVersionUID = 0L;
+  @java.lang.Override
+  public boolean equals(final java.lang.Object obj) {
+    if (obj == this) {
+     return true;
+    }
+    if (!(obj instanceof com.google.rpc.ResourceInfo)) {
+      return super.equals(obj);
+    }
+    com.google.rpc.ResourceInfo other = (com.google.rpc.ResourceInfo) obj;
+
+    boolean result = true;
+    result = result && getResourceType()
+        .equals(other.getResourceType());
+    result = result && getResourceName()
+        .equals(other.getResourceName());
+    result = result && getOwner()
+        .equals(other.getOwner());
+    result = result && getDescription()
+        .equals(other.getDescription());
+    return result;
+  }
+
+  @java.lang.Override
+  public int hashCode() {
+    if (memoizedHashCode != 0) {
+      return memoizedHashCode;
+    }
+    int hash = 41;
+    hash = (19 * hash) + getDescriptorForType().hashCode();
+    hash = (37 * hash) + RESOURCE_TYPE_FIELD_NUMBER;
+    hash = (53 * hash) + getResourceType().hashCode();
+    hash = (37 * hash) + RESOURCE_NAME_FIELD_NUMBER;
+    hash = (53 * hash) + getResourceName().hashCode();
+    hash = (37 * hash) + OWNER_FIELD_NUMBER;
+    hash = (53 * hash) + getOwner().hashCode();
+    hash = (37 * hash) + DESCRIPTION_FIELD_NUMBER;
+    hash = (53 * hash) + getDescription().hashCode();
+    hash = (29 * hash) + unknownFields.hashCode();
+    memoizedHashCode = hash;
+    return hash;
+  }
+
   public static com.google.rpc.ResourceInfo parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -352,39 +394,39 @@ public  final class ResourceInfo extends
   }
   public static com.google.rpc.ResourceInfo parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.rpc.ResourceInfo parseFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.rpc.ResourceInfo parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
   public static com.google.rpc.ResourceInfo parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.rpc.ResourceInfo parseFrom(
       com.google.protobuf.CodedInputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.rpc.ResourceInfo parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
@@ -402,7 +444,7 @@ public  final class ResourceInfo extends
 
   @java.lang.Override
   protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
@@ -414,7 +456,7 @@ public  final class ResourceInfo extends
    * Protobuf type {@code google.rpc.ResourceInfo}
    */
   public static final class Builder extends
-      com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
       // @@protoc_insertion_point(builder_implements:google.rpc.ResourceInfo)
       com.google.rpc.ResourceInfoOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
@@ -422,7 +464,7 @@ public  final class ResourceInfo extends
       return com.google.rpc.ErrorDetailsProto.internal_static_google_rpc_ResourceInfo_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.rpc.ErrorDetailsProto.internal_static_google_rpc_ResourceInfo_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -435,12 +477,13 @@ public  final class ResourceInfo extends
     }
 
     private Builder(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
       }
     }
     public Builder clear() {
@@ -483,6 +526,32 @@ public  final class ResourceInfo extends
       return result;
     }
 
+    public Builder clone() {
+      return (Builder) super.clone();
+    }
+    public Builder setField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.setField(field, value);
+    }
+    public Builder clearField(
+        com.google.protobuf.Descriptors.FieldDescriptor field) {
+      return (Builder) super.clearField(field);
+    }
+    public Builder clearOneof(
+        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      return (Builder) super.clearOneof(oneof);
+    }
+    public Builder setRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        int index, Object value) {
+      return (Builder) super.setRepeatedField(field, index, value);
+    }
+    public Builder addRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.addRepeatedField(field, value);
+    }
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.rpc.ResourceInfo) {
         return mergeFrom((com.google.rpc.ResourceInfo)other);

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/rpc/RetryInfo.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/rpc/RetryInfo.java
@@ -21,11 +21,11 @@ package com.google.rpc;
  * Protobuf type {@code google.rpc.RetryInfo}
  */
 public  final class RetryInfo extends
-    com.google.protobuf.GeneratedMessage implements
+    com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:google.rpc.RetryInfo)
     RetryInfoOrBuilder {
   // Use RetryInfo.newBuilder() to construct.
-  private RetryInfo(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+  private RetryInfo(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private RetryInfo() {
@@ -85,7 +85,7 @@ public  final class RetryInfo extends
     return com.google.rpc.ErrorDetailsProto.internal_static_google_rpc_RetryInfo_descriptor;
   }
 
-  protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.google.rpc.ErrorDetailsProto.internal_static_google_rpc_RetryInfo_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
@@ -156,6 +156,41 @@ public  final class RetryInfo extends
   }
 
   private static final long serialVersionUID = 0L;
+  @java.lang.Override
+  public boolean equals(final java.lang.Object obj) {
+    if (obj == this) {
+     return true;
+    }
+    if (!(obj instanceof com.google.rpc.RetryInfo)) {
+      return super.equals(obj);
+    }
+    com.google.rpc.RetryInfo other = (com.google.rpc.RetryInfo) obj;
+
+    boolean result = true;
+    result = result && (hasRetryDelay() == other.hasRetryDelay());
+    if (hasRetryDelay()) {
+      result = result && getRetryDelay()
+          .equals(other.getRetryDelay());
+    }
+    return result;
+  }
+
+  @java.lang.Override
+  public int hashCode() {
+    if (memoizedHashCode != 0) {
+      return memoizedHashCode;
+    }
+    int hash = 41;
+    hash = (19 * hash) + getDescriptorForType().hashCode();
+    if (hasRetryDelay()) {
+      hash = (37 * hash) + RETRY_DELAY_FIELD_NUMBER;
+      hash = (53 * hash) + getRetryDelay().hashCode();
+    }
+    hash = (29 * hash) + unknownFields.hashCode();
+    memoizedHashCode = hash;
+    return hash;
+  }
+
   public static com.google.rpc.RetryInfo parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -179,39 +214,39 @@ public  final class RetryInfo extends
   }
   public static com.google.rpc.RetryInfo parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.rpc.RetryInfo parseFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.rpc.RetryInfo parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
   public static com.google.rpc.RetryInfo parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.rpc.RetryInfo parseFrom(
       com.google.protobuf.CodedInputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.rpc.RetryInfo parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
@@ -229,7 +264,7 @@ public  final class RetryInfo extends
 
   @java.lang.Override
   protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
@@ -251,7 +286,7 @@ public  final class RetryInfo extends
    * Protobuf type {@code google.rpc.RetryInfo}
    */
   public static final class Builder extends
-      com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
       // @@protoc_insertion_point(builder_implements:google.rpc.RetryInfo)
       com.google.rpc.RetryInfoOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
@@ -259,7 +294,7 @@ public  final class RetryInfo extends
       return com.google.rpc.ErrorDetailsProto.internal_static_google_rpc_RetryInfo_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.rpc.ErrorDetailsProto.internal_static_google_rpc_RetryInfo_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -272,12 +307,13 @@ public  final class RetryInfo extends
     }
 
     private Builder(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
       }
     }
     public Builder clear() {
@@ -319,6 +355,32 @@ public  final class RetryInfo extends
       return result;
     }
 
+    public Builder clone() {
+      return (Builder) super.clone();
+    }
+    public Builder setField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.setField(field, value);
+    }
+    public Builder clearField(
+        com.google.protobuf.Descriptors.FieldDescriptor field) {
+      return (Builder) super.clearField(field);
+    }
+    public Builder clearOneof(
+        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      return (Builder) super.clearOneof(oneof);
+    }
+    public Builder setRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        int index, Object value) {
+      return (Builder) super.setRepeatedField(field, index, value);
+    }
+    public Builder addRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.addRepeatedField(field, value);
+    }
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.rpc.RetryInfo) {
         return mergeFrom((com.google.rpc.RetryInfo)other);
@@ -360,7 +422,7 @@ public  final class RetryInfo extends
     }
 
     private com.google.protobuf.Duration retryDelay_ = null;
-    private com.google.protobuf.SingleFieldBuilder<
+    private com.google.protobuf.SingleFieldBuilderV3<
         com.google.protobuf.Duration, com.google.protobuf.Duration.Builder, com.google.protobuf.DurationOrBuilder> retryDelayBuilder_;
     /**
      * <pre>
@@ -498,11 +560,11 @@ public  final class RetryInfo extends
      *
      * <code>optional .google.protobuf.Duration retry_delay = 1;</code>
      */
-    private com.google.protobuf.SingleFieldBuilder<
+    private com.google.protobuf.SingleFieldBuilderV3<
         com.google.protobuf.Duration, com.google.protobuf.Duration.Builder, com.google.protobuf.DurationOrBuilder> 
         getRetryDelayFieldBuilder() {
       if (retryDelayBuilder_ == null) {
-        retryDelayBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+        retryDelayBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
             com.google.protobuf.Duration, com.google.protobuf.Duration.Builder, com.google.protobuf.DurationOrBuilder>(
                 getRetryDelay(),
                 getParentForChildren(),

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/rpc/Status.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/rpc/Status.java
@@ -49,11 +49,11 @@ package com.google.rpc;
  * Protobuf type {@code google.rpc.Status}
  */
 public  final class Status extends
-    com.google.protobuf.GeneratedMessage implements
+    com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:google.rpc.Status)
     StatusOrBuilder {
   // Use Status.newBuilder() to construct.
-  private Status(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+  private Status(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private Status() {
@@ -103,7 +103,8 @@ public  final class Status extends
               details_ = new java.util.ArrayList<com.google.protobuf.Any>();
               mutable_bitField0_ |= 0x00000004;
             }
-            details_.add(input.readMessage(com.google.protobuf.Any.parser(), extensionRegistry));
+            details_.add(
+                input.readMessage(com.google.protobuf.Any.parser(), extensionRegistry));
             break;
           }
         }
@@ -125,7 +126,7 @@ public  final class Status extends
     return com.google.rpc.StatusProto.internal_static_google_rpc_Status_descriptor;
   }
 
-  protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.google.rpc.StatusProto.internal_static_google_rpc_Status_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
@@ -268,7 +269,7 @@ public  final class Status extends
       output.writeInt32(1, code_);
     }
     if (!getMessageBytes().isEmpty()) {
-      com.google.protobuf.GeneratedMessage.writeString(output, 2, message_);
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 2, message_);
     }
     for (int i = 0; i < details_.size(); i++) {
       output.writeMessage(3, details_.get(i));
@@ -285,7 +286,7 @@ public  final class Status extends
         .computeInt32Size(1, code_);
     }
     if (!getMessageBytes().isEmpty()) {
-      size += com.google.protobuf.GeneratedMessage.computeStringSize(2, message_);
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, message_);
     }
     for (int i = 0; i < details_.size(); i++) {
       size += com.google.protobuf.CodedOutputStream
@@ -296,6 +297,46 @@ public  final class Status extends
   }
 
   private static final long serialVersionUID = 0L;
+  @java.lang.Override
+  public boolean equals(final java.lang.Object obj) {
+    if (obj == this) {
+     return true;
+    }
+    if (!(obj instanceof com.google.rpc.Status)) {
+      return super.equals(obj);
+    }
+    com.google.rpc.Status other = (com.google.rpc.Status) obj;
+
+    boolean result = true;
+    result = result && (getCode()
+        == other.getCode());
+    result = result && getMessage()
+        .equals(other.getMessage());
+    result = result && getDetailsList()
+        .equals(other.getDetailsList());
+    return result;
+  }
+
+  @java.lang.Override
+  public int hashCode() {
+    if (memoizedHashCode != 0) {
+      return memoizedHashCode;
+    }
+    int hash = 41;
+    hash = (19 * hash) + getDescriptorForType().hashCode();
+    hash = (37 * hash) + CODE_FIELD_NUMBER;
+    hash = (53 * hash) + getCode();
+    hash = (37 * hash) + MESSAGE_FIELD_NUMBER;
+    hash = (53 * hash) + getMessage().hashCode();
+    if (getDetailsCount() > 0) {
+      hash = (37 * hash) + DETAILS_FIELD_NUMBER;
+      hash = (53 * hash) + getDetailsList().hashCode();
+    }
+    hash = (29 * hash) + unknownFields.hashCode();
+    memoizedHashCode = hash;
+    return hash;
+  }
+
   public static com.google.rpc.Status parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -319,39 +360,39 @@ public  final class Status extends
   }
   public static com.google.rpc.Status parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.rpc.Status parseFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.rpc.Status parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
   public static com.google.rpc.Status parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.rpc.Status parseFrom(
       com.google.protobuf.CodedInputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.rpc.Status parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
@@ -369,7 +410,7 @@ public  final class Status extends
 
   @java.lang.Override
   protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
@@ -419,7 +460,7 @@ public  final class Status extends
    * Protobuf type {@code google.rpc.Status}
    */
   public static final class Builder extends
-      com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
       // @@protoc_insertion_point(builder_implements:google.rpc.Status)
       com.google.rpc.StatusOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
@@ -427,7 +468,7 @@ public  final class Status extends
       return com.google.rpc.StatusProto.internal_static_google_rpc_Status_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.rpc.StatusProto.internal_static_google_rpc_Status_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -440,12 +481,13 @@ public  final class Status extends
     }
 
     private Builder(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
         getDetailsFieldBuilder();
       }
     }
@@ -501,6 +543,32 @@ public  final class Status extends
       return result;
     }
 
+    public Builder clone() {
+      return (Builder) super.clone();
+    }
+    public Builder setField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.setField(field, value);
+    }
+    public Builder clearField(
+        com.google.protobuf.Descriptors.FieldDescriptor field) {
+      return (Builder) super.clearField(field);
+    }
+    public Builder clearOneof(
+        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      return (Builder) super.clearOneof(oneof);
+    }
+    public Builder setRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        int index, Object value) {
+      return (Builder) super.setRepeatedField(field, index, value);
+    }
+    public Builder addRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.addRepeatedField(field, value);
+    }
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.rpc.Status) {
         return mergeFrom((com.google.rpc.Status)other);
@@ -538,7 +606,7 @@ public  final class Status extends
             details_ = other.details_;
             bitField0_ = (bitField0_ & ~0x00000004);
             detailsBuilder_ = 
-              com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+              com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
                  getDetailsFieldBuilder() : null;
           } else {
             detailsBuilder_.addAllMessages(other.details_);
@@ -718,7 +786,7 @@ public  final class Status extends
        }
     }
 
-    private com.google.protobuf.RepeatedFieldBuilder<
+    private com.google.protobuf.RepeatedFieldBuilderV3<
         com.google.protobuf.Any, com.google.protobuf.Any.Builder, com.google.protobuf.AnyOrBuilder> detailsBuilder_;
 
     /**
@@ -1024,11 +1092,11 @@ public  final class Status extends
          getDetailsBuilderList() {
       return getDetailsFieldBuilder().getBuilderList();
     }
-    private com.google.protobuf.RepeatedFieldBuilder<
+    private com.google.protobuf.RepeatedFieldBuilderV3<
         com.google.protobuf.Any, com.google.protobuf.Any.Builder, com.google.protobuf.AnyOrBuilder> 
         getDetailsFieldBuilder() {
       if (detailsBuilder_ == null) {
-        detailsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
+        detailsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
             com.google.protobuf.Any, com.google.protobuf.Any.Builder, com.google.protobuf.AnyOrBuilder>(
                 details_,
                 ((bitField0_ & 0x00000004) == 0x00000004),

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/rpc/StatusProto.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/rpc/StatusProto.java
@@ -6,12 +6,18 @@ package com.google.rpc;
 public final class StatusProto {
   private StatusProto() {}
   public static void registerAllExtensions(
+      com.google.protobuf.ExtensionRegistryLite registry) {
+  }
+
+  public static void registerAllExtensions(
       com.google.protobuf.ExtensionRegistry registry) {
+    registerAllExtensions(
+        (com.google.protobuf.ExtensionRegistryLite) registry);
   }
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_rpc_Status_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_rpc_Status_fieldAccessorTable;
 
   public static com.google.protobuf.Descriptors.FileDescriptor
@@ -44,7 +50,7 @@ public final class StatusProto {
     internal_static_google_rpc_Status_descriptor =
       getDescriptor().getMessageTypes().get(0);
     internal_static_google_rpc_Status_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_rpc_Status_descriptor,
         new java.lang.String[] { "Code", "Message", "Details", });
     com.google.protobuf.AnyProto.getDescriptor();

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/type/Color.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/type/Color.java
@@ -109,11 +109,11 @@ package com.google.type;
  * Protobuf type {@code google.type.Color}
  */
 public  final class Color extends
-    com.google.protobuf.GeneratedMessage implements
+    com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:google.type.Color)
     ColorOrBuilder {
   // Use Color.newBuilder() to construct.
-  private Color(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+  private Color(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private Color() {
@@ -191,7 +191,7 @@ public  final class Color extends
     return com.google.type.ColorProto.internal_static_google_type_Color_descriptor;
   }
 
-  protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.google.type.ColorProto.internal_static_google_type_Color_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
@@ -346,6 +346,62 @@ public  final class Color extends
   }
 
   private static final long serialVersionUID = 0L;
+  @java.lang.Override
+  public boolean equals(final java.lang.Object obj) {
+    if (obj == this) {
+     return true;
+    }
+    if (!(obj instanceof com.google.type.Color)) {
+      return super.equals(obj);
+    }
+    com.google.type.Color other = (com.google.type.Color) obj;
+
+    boolean result = true;
+    result = result && (
+        java.lang.Float.floatToIntBits(getRed())
+        == java.lang.Float.floatToIntBits(
+            other.getRed()));
+    result = result && (
+        java.lang.Float.floatToIntBits(getGreen())
+        == java.lang.Float.floatToIntBits(
+            other.getGreen()));
+    result = result && (
+        java.lang.Float.floatToIntBits(getBlue())
+        == java.lang.Float.floatToIntBits(
+            other.getBlue()));
+    result = result && (hasAlpha() == other.hasAlpha());
+    if (hasAlpha()) {
+      result = result && getAlpha()
+          .equals(other.getAlpha());
+    }
+    return result;
+  }
+
+  @java.lang.Override
+  public int hashCode() {
+    if (memoizedHashCode != 0) {
+      return memoizedHashCode;
+    }
+    int hash = 41;
+    hash = (19 * hash) + getDescriptorForType().hashCode();
+    hash = (37 * hash) + RED_FIELD_NUMBER;
+    hash = (53 * hash) + java.lang.Float.floatToIntBits(
+        getRed());
+    hash = (37 * hash) + GREEN_FIELD_NUMBER;
+    hash = (53 * hash) + java.lang.Float.floatToIntBits(
+        getGreen());
+    hash = (37 * hash) + BLUE_FIELD_NUMBER;
+    hash = (53 * hash) + java.lang.Float.floatToIntBits(
+        getBlue());
+    if (hasAlpha()) {
+      hash = (37 * hash) + ALPHA_FIELD_NUMBER;
+      hash = (53 * hash) + getAlpha().hashCode();
+    }
+    hash = (29 * hash) + unknownFields.hashCode();
+    memoizedHashCode = hash;
+    return hash;
+  }
+
   public static com.google.type.Color parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -369,39 +425,39 @@ public  final class Color extends
   }
   public static com.google.type.Color parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.type.Color parseFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.type.Color parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
   public static com.google.type.Color parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.type.Color parseFrom(
       com.google.protobuf.CodedInputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.type.Color parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
@@ -419,7 +475,7 @@ public  final class Color extends
 
   @java.lang.Override
   protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
@@ -529,7 +585,7 @@ public  final class Color extends
    * Protobuf type {@code google.type.Color}
    */
   public static final class Builder extends
-      com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
       // @@protoc_insertion_point(builder_implements:google.type.Color)
       com.google.type.ColorOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
@@ -537,7 +593,7 @@ public  final class Color extends
       return com.google.type.ColorProto.internal_static_google_type_Color_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.type.ColorProto.internal_static_google_type_Color_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -550,12 +606,13 @@ public  final class Color extends
     }
 
     private Builder(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
       }
     }
     public Builder clear() {
@@ -606,6 +663,32 @@ public  final class Color extends
       return result;
     }
 
+    public Builder clone() {
+      return (Builder) super.clone();
+    }
+    public Builder setField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.setField(field, value);
+    }
+    public Builder clearField(
+        com.google.protobuf.Descriptors.FieldDescriptor field) {
+      return (Builder) super.clearField(field);
+    }
+    public Builder clearOneof(
+        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      return (Builder) super.clearOneof(oneof);
+    }
+    public Builder setRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        int index, Object value) {
+      return (Builder) super.setRepeatedField(field, index, value);
+    }
+    public Builder addRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.addRepeatedField(field, value);
+    }
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.type.Color) {
         return mergeFrom((com.google.type.Color)other);
@@ -770,7 +853,7 @@ public  final class Color extends
     }
 
     private com.google.protobuf.FloatValue alpha_ = null;
-    private com.google.protobuf.SingleFieldBuilder<
+    private com.google.protobuf.SingleFieldBuilderV3<
         com.google.protobuf.FloatValue, com.google.protobuf.FloatValue.Builder, com.google.protobuf.FloatValueOrBuilder> alphaBuilder_;
     /**
      * <pre>
@@ -980,11 +1063,11 @@ public  final class Color extends
      *
      * <code>optional .google.protobuf.FloatValue alpha = 4;</code>
      */
-    private com.google.protobuf.SingleFieldBuilder<
+    private com.google.protobuf.SingleFieldBuilderV3<
         com.google.protobuf.FloatValue, com.google.protobuf.FloatValue.Builder, com.google.protobuf.FloatValueOrBuilder> 
         getAlphaFieldBuilder() {
       if (alphaBuilder_ == null) {
-        alphaBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+        alphaBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
             com.google.protobuf.FloatValue, com.google.protobuf.FloatValue.Builder, com.google.protobuf.FloatValueOrBuilder>(
                 getAlpha(),
                 getParentForChildren(),

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/type/ColorProto.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/type/ColorProto.java
@@ -6,12 +6,18 @@ package com.google.type;
 public final class ColorProto {
   private ColorProto() {}
   public static void registerAllExtensions(
+      com.google.protobuf.ExtensionRegistryLite registry) {
+  }
+
+  public static void registerAllExtensions(
       com.google.protobuf.ExtensionRegistry registry) {
+    registerAllExtensions(
+        (com.google.protobuf.ExtensionRegistryLite) registry);
   }
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_type_Color_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_type_Color_fieldAccessorTable;
 
   public static com.google.protobuf.Descriptors.FileDescriptor
@@ -45,7 +51,7 @@ public final class ColorProto {
     internal_static_google_type_Color_descriptor =
       getDescriptor().getMessageTypes().get(0);
     internal_static_google_type_Color_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_type_Color_descriptor,
         new java.lang.String[] { "Red", "Green", "Blue", "Alpha", });
     com.google.protobuf.WrappersProto.getDescriptor();

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/type/Date.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/type/Date.java
@@ -17,11 +17,11 @@ package com.google.type;
  * Protobuf type {@code google.type.Date}
  */
 public  final class Date extends
-    com.google.protobuf.GeneratedMessage implements
+    com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:google.type.Date)
     DateOrBuilder {
   // Use Date.newBuilder() to construct.
-  private Date(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+  private Date(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private Date() {
@@ -86,7 +86,7 @@ public  final class Date extends
     return com.google.type.DateProto.internal_static_google_type_Date_descriptor;
   }
 
-  protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.google.type.DateProto.internal_static_google_type_Date_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
@@ -240,39 +240,39 @@ public  final class Date extends
   }
   public static com.google.type.Date parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.type.Date parseFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.type.Date parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
   public static com.google.type.Date parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.type.Date parseFrom(
       com.google.protobuf.CodedInputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.type.Date parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
@@ -290,7 +290,7 @@ public  final class Date extends
 
   @java.lang.Override
   protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
@@ -308,7 +308,7 @@ public  final class Date extends
    * Protobuf type {@code google.type.Date}
    */
   public static final class Builder extends
-      com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
       // @@protoc_insertion_point(builder_implements:google.type.Date)
       com.google.type.DateOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
@@ -316,7 +316,7 @@ public  final class Date extends
       return com.google.type.DateProto.internal_static_google_type_Date_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.type.DateProto.internal_static_google_type_Date_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -329,12 +329,13 @@ public  final class Date extends
     }
 
     private Builder(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
       }
     }
     public Builder clear() {
@@ -374,6 +375,32 @@ public  final class Date extends
       return result;
     }
 
+    public Builder clone() {
+      return (Builder) super.clone();
+    }
+    public Builder setField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.setField(field, value);
+    }
+    public Builder clearField(
+        com.google.protobuf.Descriptors.FieldDescriptor field) {
+      return (Builder) super.clearField(field);
+    }
+    public Builder clearOneof(
+        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      return (Builder) super.clearOneof(oneof);
+    }
+    public Builder setRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        int index, Object value) {
+      return (Builder) super.setRepeatedField(field, index, value);
+    }
+    public Builder addRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.addRepeatedField(field, value);
+    }
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.type.Date) {
         return mergeFrom((com.google.type.Date)other);

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/type/DateProto.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/type/DateProto.java
@@ -6,12 +6,18 @@ package com.google.type;
 public final class DateProto {
   private DateProto() {}
   public static void registerAllExtensions(
+      com.google.protobuf.ExtensionRegistryLite registry) {
+  }
+
+  public static void registerAllExtensions(
       com.google.protobuf.ExtensionRegistry registry) {
+    registerAllExtensions(
+        (com.google.protobuf.ExtensionRegistryLite) registry);
   }
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_type_Date_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_type_Date_fieldAccessorTable;
 
   public static com.google.protobuf.Descriptors.FileDescriptor
@@ -42,7 +48,7 @@ public final class DateProto {
     internal_static_google_type_Date_descriptor =
       getDescriptor().getMessageTypes().get(0);
     internal_static_google_type_Date_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_type_Date_descriptor,
         new java.lang.String[] { "Year", "Month", "Day", });
   }

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/type/DayOfWeekProto.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/type/DayOfWeekProto.java
@@ -6,7 +6,13 @@ package com.google.type;
 public final class DayOfWeekProto {
   private DayOfWeekProto() {}
   public static void registerAllExtensions(
+      com.google.protobuf.ExtensionRegistryLite registry) {
+  }
+
+  public static void registerAllExtensions(
       com.google.protobuf.ExtensionRegistry registry) {
+    registerAllExtensions(
+        (com.google.protobuf.ExtensionRegistryLite) registry);
   }
 
   public static com.google.protobuf.Descriptors.FileDescriptor

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/type/TimeOfDay.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/type/TimeOfDay.java
@@ -13,11 +13,11 @@ package com.google.type;
  * Protobuf type {@code google.type.TimeOfDay}
  */
 public  final class TimeOfDay extends
-    com.google.protobuf.GeneratedMessage implements
+    com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:google.type.TimeOfDay)
     TimeOfDayOrBuilder {
   // Use TimeOfDay.newBuilder() to construct.
-  private TimeOfDay(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+  private TimeOfDay(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
   private TimeOfDay() {
@@ -88,7 +88,7 @@ public  final class TimeOfDay extends
     return com.google.type.TimeOfDayProto.internal_static_google_type_TimeOfDay_descriptor;
   }
 
-  protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
     return com.google.type.TimeOfDayProto.internal_static_google_type_TimeOfDay_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
@@ -266,39 +266,39 @@ public  final class TimeOfDay extends
   }
   public static com.google.type.TimeOfDay parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.type.TimeOfDay parseFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.type.TimeOfDay parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
   public static com.google.type.TimeOfDay parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
   }
   public static com.google.type.TimeOfDay parseFrom(
       com.google.protobuf.CodedInputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
   public static com.google.type.TimeOfDay parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessage
+    return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
 
@@ -316,7 +316,7 @@ public  final class TimeOfDay extends
 
   @java.lang.Override
   protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
@@ -330,7 +330,7 @@ public  final class TimeOfDay extends
    * Protobuf type {@code google.type.TimeOfDay}
    */
   public static final class Builder extends
-      com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
       // @@protoc_insertion_point(builder_implements:google.type.TimeOfDay)
       com.google.type.TimeOfDayOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
@@ -338,7 +338,7 @@ public  final class TimeOfDay extends
       return com.google.type.TimeOfDayProto.internal_static_google_type_TimeOfDay_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.type.TimeOfDayProto.internal_static_google_type_TimeOfDay_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -351,12 +351,13 @@ public  final class TimeOfDay extends
     }
 
     private Builder(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
       }
     }
     public Builder clear() {
@@ -399,6 +400,32 @@ public  final class TimeOfDay extends
       return result;
     }
 
+    public Builder clone() {
+      return (Builder) super.clone();
+    }
+    public Builder setField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.setField(field, value);
+    }
+    public Builder clearField(
+        com.google.protobuf.Descriptors.FieldDescriptor field) {
+      return (Builder) super.clearField(field);
+    }
+    public Builder clearOneof(
+        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      return (Builder) super.clearOneof(oneof);
+    }
+    public Builder setRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        int index, Object value) {
+      return (Builder) super.setRepeatedField(field, index, value);
+    }
+    public Builder addRepeatedField(
+        com.google.protobuf.Descriptors.FieldDescriptor field,
+        Object value) {
+      return (Builder) super.addRepeatedField(field, value);
+    }
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.type.TimeOfDay) {
         return mergeFrom((com.google.type.TimeOfDay)other);

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/type/TimeOfDayProto.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/protos/com/google/type/TimeOfDayProto.java
@@ -6,12 +6,18 @@ package com.google.type;
 public final class TimeOfDayProto {
   private TimeOfDayProto() {}
   public static void registerAllExtensions(
+      com.google.protobuf.ExtensionRegistryLite registry) {
+  }
+
+  public static void registerAllExtensions(
       com.google.protobuf.ExtensionRegistry registry) {
+    registerAllExtensions(
+        (com.google.protobuf.ExtensionRegistryLite) registry);
   }
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_type_TimeOfDay_descriptor;
   static final 
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_type_TimeOfDay_fieldAccessorTable;
 
   public static com.google.protobuf.Descriptors.FileDescriptor
@@ -43,7 +49,7 @@ public final class TimeOfDayProto {
     internal_static_google_type_TimeOfDay_descriptor =
       getDescriptor().getMessageTypes().get(0);
     internal_static_google_type_TimeOfDay_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_type_TimeOfDay_descriptor,
         new java.lang.String[] { "Hours", "Minutes", "Seconds", "Nanos", });
   }

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/services/com/google/bigtable/admin/v2/BigtableInstanceAdminGrpc.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/services/com/google/bigtable/admin/v2/BigtableInstanceAdminGrpc.java
@@ -23,7 +23,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedStreamingCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.0.0-pre1)",
+    value = "by gRPC proto compiler (version 1.0.0-pre2)",
     comments = "Source: google/bigtable/admin/v2/bigtable_instance_admin.proto")
 public class BigtableInstanceAdminGrpc {
 

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/services/com/google/bigtable/admin/v2/BigtableTableAdminGrpc.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/services/com/google/bigtable/admin/v2/BigtableTableAdminGrpc.java
@@ -23,7 +23,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedStreamingCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.0.0-pre1)",
+    value = "by gRPC proto compiler (version 1.0.0-pre2)",
     comments = "Source: google/bigtable/admin/v2/bigtable_table_admin.proto")
 public class BigtableTableAdminGrpc {
 

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/services/com/google/bigtable/v2/BigtableGrpc.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/services/com/google/bigtable/v2/BigtableGrpc.java
@@ -21,7 +21,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedStreamingCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.0.0-pre1)",
+    value = "by gRPC proto compiler (version 1.0.0-pre2)",
     comments = "Source: google/bigtable/v2/bigtable.proto")
 public class BigtableGrpc {
 

--- a/bigtable-client-core-parent/bigtable-protos/src/generated/java/services/com/google/longrunning/OperationsGrpc.java
+++ b/bigtable-client-core-parent/bigtable-protos/src/generated/java/services/com/google/longrunning/OperationsGrpc.java
@@ -29,7 +29,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedStreamingCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.0.0-pre1)",
+    value = "by gRPC proto compiler (version 1.0.0-pre2)",
     comments = "Source: google/longrunning/operations.proto")
 public class OperationsGrpc {
 

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BatchExecutor.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BatchExecutor.java
@@ -51,7 +51,7 @@ import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
-import com.google.protobuf.GeneratedMessage;
+import com.google.protobuf.GeneratedMessageV3;
 
 /**
  * Class to help BigtableTable with batch operations on an BigtableClient.
@@ -85,7 +85,7 @@ public class BatchExecutor {
    * A callback for ListenableFutures issued as a result of an RPC
    * @param <T> The type of message the hbase callback requires.
    */
-  static class RpcResultFutureCallback<T> implements FutureCallback<GeneratedMessage> {
+  static class RpcResultFutureCallback<T> implements FutureCallback<GeneratedMessageV3> {
     private final Row row;
     private final Batch.Callback<T> callback;
 
@@ -109,7 +109,7 @@ public class BatchExecutor {
 
     @SuppressWarnings("unchecked")
     @Override
-    public final void onSuccess(GeneratedMessage message) {
+    public final void onSuccess(GeneratedMessageV3 message) {
       try {
         Result result = Result.EMPTY_RESULT;
         if (message instanceof com.google.bigtable.v2.Row) {
@@ -154,7 +154,7 @@ public class BatchExecutor {
       this.bulkMutation = session.createBulkMutation(tableName, asyncExecutor);
     }
 
-    public ListenableFuture<? extends GeneratedMessage> mutateRowAsync(MutateRowRequest request)
+    public ListenableFuture<? extends GeneratedMessageV3> mutateRowAsync(MutateRowRequest request)
         throws InterruptedException {
       if (!options.getBulkOptions().useBulkApi()) {
         return asyncExecutor.mutateRowAsync(request);
@@ -163,7 +163,7 @@ public class BatchExecutor {
       }
     }
 
-    public ListenableFuture<? extends GeneratedMessage> readRowsAsync(ReadRowsRequest request)
+    public ListenableFuture<? extends GeneratedMessageV3> readRowsAsync(ReadRowsRequest request)
         throws InterruptedException {
       if (!options.getBulkOptions().useBulkApi()) {
         return Futures.transform(asyncExecutor.readRowsAsync(request), ROWS_TO_ROW_CONVERTER);
@@ -222,7 +222,7 @@ public class BatchExecutor {
     return resultFuture;
   }
 
-  private ListenableFuture<? extends GeneratedMessage>
+  private ListenableFuture<? extends GeneratedMessageV3>
       issueAsyncRequest(BulkOperation bulkOperation, Row row) {
     try {
       if (row instanceof Get) {

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutator.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutator.java
@@ -51,7 +51,7 @@ import com.google.cloud.bigtable.hbase.adapters.HBaseRequestAdapter;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.google.protobuf.GeneratedMessage;
+import com.google.protobuf.GeneratedMessageV3;
 
 /**
  * Bigtable's {@link org.apache.hadoop.hbase.client.BufferedMutator} implementation.
@@ -331,7 +331,7 @@ public class BigtableBufferedMutator implements BufferedMutator {
    * @param future a {@link com.google.common.util.concurrent.ListenableFuture} object.
    * @param mutation a {@link org.apache.hadoop.hbase.client.Mutation} object.
    */
-  protected void addExceptionCallback(ListenableFuture<? extends GeneratedMessage> future,
+  protected void addExceptionCallback(ListenableFuture<? extends GeneratedMessageV3> future,
       Mutation mutation) {
     Futures.addCallback(future, new ExceptionCallback(mutation));
   }
@@ -353,7 +353,7 @@ public class BigtableBufferedMutator implements BufferedMutator {
     }
   }
 
-  private ListenableFuture<? extends GeneratedMessage> issueRequestDetails(Mutation mutation,
+  private ListenableFuture<? extends GeneratedMessageV3> issueRequestDetails(Mutation mutation,
       long operationId) {
     try {
       if (mutation == null) {
@@ -419,7 +419,7 @@ public class BigtableBufferedMutator implements BufferedMutator {
     }
   }
 
-  private class ExceptionCallback implements FutureCallback<GeneratedMessage> {
+  private class ExceptionCallback implements FutureCallback<GeneratedMessageV3> {
     private final Row mutation;
 
     public ExceptionCallback(Row mutation) {
@@ -432,7 +432,7 @@ public class BigtableBufferedMutator implements BufferedMutator {
     }
 
     @Override
-    public void onSuccess(GeneratedMessage ignored) {
+    public void onSuccess(GeneratedMessageV3 ignored) {
     }
   }
 

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/OperationAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/OperationAdapter.java
@@ -15,7 +15,7 @@
  */
 package com.google.cloud.bigtable.hbase.adapters;
 
-import com.google.protobuf.GeneratedMessage.Builder;
+import com.google.protobuf.GeneratedMessageV3;
 
 import org.apache.hadoop.hbase.client.Operation;
 
@@ -27,7 +27,7 @@ import org.apache.hadoop.hbase.client.Operation;
  * @author sduskis
  * @version $Id: $Id
  */
-public interface OperationAdapter<T extends Operation, U extends Builder<?>> {
+public interface OperationAdapter<T extends Operation, U extends GeneratedMessageV3.Builder<?>> {
 
   /**
    * Adapt a single HBase Operation to a single Bigtable generated message.

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/ResponseAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/ResponseAdapter.java
@@ -15,7 +15,7 @@
  */
 package com.google.cloud.bigtable.hbase.adapters;
 
-import com.google.protobuf.GeneratedMessage;
+import com.google.protobuf.GeneratedMessageV3;
 
 import org.apache.hadoop.hbase.client.Result;
 
@@ -27,7 +27,7 @@ import org.apache.hadoop.hbase.client.Result;
  * @author sduskis
  * @version $Id: $Id
  */
-public interface ResponseAdapter<T extends GeneratedMessage, U extends Result> {
+public interface ResponseAdapter<T extends GeneratedMessageV3, U extends Result> {
 
   /**
    * Transform an Bigtable server response to an HBase Result instance.

--- a/pom.xml
+++ b/pom.xml
@@ -57,11 +57,11 @@ limitations under the License.
         <compat.module>hbase-hadoop2-compat</compat.module>
         <junit.version>4.12</junit.version>
         <mockito.version>1.10.19</mockito.version>
-        <protobuff-java.version>3.0.0-beta-3</protobuff-java.version>
-        <grpc.version>1.0.0-pre1</grpc.version>
+        <grpc.version>1.0.0-pre2</grpc.version>
+        <netty.version>4.1.4.Final</netty.version>
+        <protobuff-java.version>3.0.0</protobuff-java.version>
         <google.api.client.version>1.22.0</google.api.client.version>
         <google.http.client.version>1.22.0</google.http.client.version>
-        <netty.version>4.1.3.Final</netty.version>
         <guava.version>19.0</guava.version>
         <google.auth.library.version>0.4.0</google.auth.library.version>
         <dropwizard.metrics.version>3.1.2</dropwizard.metrics.version>


### PR DESCRIPTION
new:
        grpc.version: 1.0.0-pre2
        netty.version: 4.1.4.Final
        protobuff-java.version: 3.0.0

old:
        grpc.version: 1.0.0-pre1
        netty.version: 4.1.3.Final
        protobuff-java.version: 3.0.0-beta-3

There was manual code changes to replace GeneratedMessage with GeneratedMessageV3.