### PR TITLE
Fix minor javadoc fallout

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ReadRowsRequestRetryHandler.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ReadRowsRequestRetryHandler.java
@@ -95,7 +95,6 @@ public class ReadRowsRequestRetryHandler {
     this.logger = logger;
   }
 
-  /** {@inheritDoc} */
   public void update(Row result) throws IOException {
     if (result != null) {
       updateLastFoundKey(result.getKey());


### PR DESCRIPTION
Looks like some refactoring broke this, error is you can't use
@inheritdoc if the class isn't subclassing anything.