### PR TITLE
Fixing javadoc issue with ByteStrings.

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/protobuf/BigtableZeroCopyByteStringUtil.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/protobuf/BigtableZeroCopyByteStringUtil.java
@@ -37,9 +37,7 @@ public final class BigtableZeroCopyByteStringUtil {
   /**
    * Extracts the byte array from the given {@link com.google.protobuf.ByteString} without copy.
    *
-   * @param buf A buffer from which to extract the array. This buffer must be an instance of a
-   *          {@code LiteralByteString} in order to be efficient. {@link com.google.protobuf.ByteString#toByteArray()}
-   *          will be called for all other implementations, including subclasses.
+   * @param buf A buffer from which to extract the array.
    * @return an array of byte.
    */
   public static byte[] zeroCopyGetBytes(final ByteString buf) {

--- a/bigtable-dataflow-parent/bigtable-dataflow-import/src/test/java/com/google/protobuf/HBaseZeroCopyByteString.java
+++ b/bigtable-dataflow-parent/bigtable-dataflow-import/src/test/java/com/google/protobuf/HBaseZeroCopyByteString.java
@@ -56,8 +56,7 @@ public final class HBaseZeroCopyByteString  {
 
   /**
    * Extracts the byte array from the given {@link ByteString} without copy.
-   * @param buf A buffer from which to extract the array.  This buffer must be
-   * actually an instance of a {@code LiteralByteString}.
+   * @param buf A buffer from which to extract the array.
    * @return byte[] representation
    */
   public static byte[] zeroCopyGetBytes(final ByteString buf) {


### PR DESCRIPTION
There were some protobuf upgrades that removed a class that was referenced in javadoc.  Removing the reference.