### PR TITLE
Refactoring BigtableAsyncRpc

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AbstractRetryingRpcListener.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AbstractRetryingRpcListener.java
@@ -194,15 +194,17 @@ public abstract class AbstractRetryingRpcListener<RequestT, ResponseT, ResultT>
   /**
    * {@inheritDoc}
    *
-   * Calls {@link BigtableAsyncRpc#call} with this as the listener so that
-   * retries happen correctly.
+   * <p>Calls {@link BigtableAsyncRpc#newCall(CallOptions)} and {@link
+   * BigtableAsyncRpc#start(ClientCall, Object, io.grpc.ClientCall.Listener, Metadata)} with this as
+   * the listener so that retries happen correctly.
    */
   @Override
   public void run() {
     this.rpcTimerContext = this.rpc.getRpcMetrics().timeRpc();
     Metadata metadata = new Metadata();
     metadata.merge(originalMetadata);
-    this.call = rpc.call(getRetryRequest(), this, callOptions, metadata);
+    this.call = rpc.newCall(callOptions);
+    rpc.start(this.call, getRetryRequest(), this, metadata);
   }
 
   protected RequestT getRetryRequest() {

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BigtableAsyncRpc.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BigtableAsyncRpc.java
@@ -84,14 +84,24 @@ public interface BigtableAsyncRpc<REQUEST, RESPONSE> {
   /**
    * Creates a {@link io.grpc.ClientCall}.
    *
-   * @param request The request to send.
-   * @param listener A listener which handles responses.
    * @param callOptions A set of gRPC options to use on this call.
-   * @param metadata A set of predefined headers to use.
    * @return A ClientCall that represents a new request.
    */
-  ClientCall<REQUEST, RESPONSE> call(REQUEST request, ClientCall.Listener<RESPONSE> listener,
-      CallOptions callOptions, Metadata metadata);
+  ClientCall<REQUEST, RESPONSE> newCall(CallOptions callOptions);
+
+  /**
+   * Creates a {@link io.grpc.ClientCall}.
+   *
+   * @param call The ClientCall to use. See {@link BigtableAsyncRpc#newCall(CallOptions)}
+   * @param request The request to send.
+   * @param listener A listener which handles responses.
+   * @param metadata A set of predefined headers to use.
+   */
+  void start(
+      ClientCall<REQUEST, RESPONSE> call,
+      REQUEST request,
+      ClientCall.Listener<RESPONSE> listener,
+      Metadata metadata);
 
   /**
    * Can this request be retried?


### PR DESCRIPTION
The goal here is to move the read rows functionality into the same
listener model that all of the other RPCs use.  That will help with
metrics gathering and the "observer" read rows functionality described
in #703.