### PR TITLE
Fixing hbase/Dataflow shading.

### DIFF
--- a/bigtable-dataflow-parent/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/CloudBigtableConfiguration.java
+++ b/bigtable-dataflow-parent/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/CloudBigtableConfiguration.java
@@ -25,7 +25,7 @@ import java.util.Map.Entry;
 import org.apache.hadoop.conf.Configuration;
 
 import com.google.bigtable.repackaged.com.google.cloud.config.BigtableOptions;
-import com.google.cloud.bigtable.hbase.BigtableOptionsFactory;
+import com.google.bigtable.repackaged.com.google.cloud.hbase.BigtableOptionsFactory;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 

--- a/bigtable-dataflow-parent/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/CloudBigtableConnectionPool.java
+++ b/bigtable-dataflow-parent/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/CloudBigtableConnectionPool.java
@@ -15,18 +15,16 @@
  */
 package com.google.cloud.bigtable.dataflow;
 
+import com.google.bigtable.repackaged.com.google.cloud.hbase.BigtableOptionsFactory;
+import com.google.bigtable.repackaged.com.google.cloud.hbase1_0.BigtableConnection;
+import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.client.Connection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.cloud.bigtable.hbase.BigtableOptionsFactory;
-import com.google.cloud.bigtable.hbase1_0.BigtableConnection;
-import com.google.common.annotations.VisibleForTesting;
 
 /**
  * Pubsub and other windowed sources can have a large quantity of bundles in short amounts of time.

--- a/bigtable-dataflow-parent/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/CloudBigtableIO.java
+++ b/bigtable-dataflow-parent/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/CloudBigtableIO.java
@@ -53,6 +53,7 @@ import com.google.bigtable.repackaged.com.google.cloud.grpc.BigtableDataClient;
 import com.google.bigtable.repackaged.com.google.cloud.grpc.BigtableSession;
 import com.google.bigtable.repackaged.com.google.cloud.grpc.BigtableTableName;
 import com.google.bigtable.repackaged.com.google.cloud.grpc.scanner.ResultScanner;
+import com.google.bigtable.repackaged.com.google.cloud.hbase.BigtableOptionsFactory;
 import com.google.bigtable.repackaged.com.google.cloud.hbase.adapters.Adapters;
 import com.google.bigtable.repackaged.com.google.com.google.bigtable.v2.ReadRowsRequest;
 import com.google.bigtable.repackaged.com.google.com.google.bigtable.v2.Row;
@@ -63,7 +64,6 @@ import com.google.bigtable.repackaged.com.google.protobuf.BigtableZeroCopyByteSt
 import com.google.cloud.bigtable.dataflow.coders.HBaseMutationCoder;
 import com.google.cloud.bigtable.dataflow.coders.HBaseResultArrayCoder;
 import com.google.cloud.bigtable.dataflow.coders.HBaseResultCoder;
-import com.google.cloud.bigtable.hbase.BigtableOptionsFactory;
 import com.google.cloud.dataflow.sdk.Pipeline;
 import com.google.cloud.dataflow.sdk.coders.AtomicCoder;
 import com.google.cloud.dataflow.sdk.coders.Coder;
@@ -121,8 +121,7 @@ import com.google.protobuf.ByteString;
  *   Read.from(CloudBigtableIO.read(
  *      new CloudBigtableScanConfiguration.Builder()
  *          .withProjectId("project-id")
- *          .withZoneId("zone-id")
- *          .withClusterId("cluster-id")
+ *          .withInstanceId("instance-id")
  *          .withTableId("table-id")
  *          .build())));
  * }
@@ -143,8 +142,7 @@ import com.google.protobuf.ByteString;
  *   CloudBigtableIO.writeToTable(
  *      new CloudBigtableScanConfiguration.Builder()
  *          .withProjectId("project-id")
- *          .withZoneId("zone-id")
- *          .withClusterId("cluster-id")
+ *          .withInstanceId("instance-id")
  *          .withTableId("table-id")
  *          .build()));
  * }

--- a/bigtable-dataflow-parent/bigtable-hbase-dataflow/src/test/java/com/google/cloud/bigtable/dataflow/CloudBigtableConfigurationTest.java
+++ b/bigtable-dataflow-parent/bigtable-hbase-dataflow/src/test/java/com/google/cloud/bigtable/dataflow/CloudBigtableConfigurationTest.java
@@ -18,7 +18,6 @@ package com.google.cloud.bigtable.dataflow;
 
 import static org.junit.Assert.assertEquals;
 
-import java.io.IOException;
 import java.util.Collections;
 
 import org.junit.Assert;
@@ -41,7 +40,7 @@ public class CloudBigtableConfigurationTest {
   private static final String INSTANCE = "instance";
 
   @Test
-  public void testHBaseConfig() throws IOException {
+  public void testHBaseConfig() {
     CloudBigtableConfiguration underTest =
         new CloudBigtableConfiguration(PROJECT, INSTANCE,
             Collections.<String, String> emptyMap());

--- a/bigtable-dataflow-parent/bigtable-hbase-dataflow/src/test/java/com/google/cloud/bigtable/dataflow/CloudBigtableIOIntegrationTest.java
+++ b/bigtable-dataflow-parent/bigtable-hbase-dataflow/src/test/java/com/google/cloud/bigtable/dataflow/CloudBigtableIOIntegrationTest.java
@@ -16,6 +16,7 @@ import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Admin;
 import org.apache.hadoop.hbase.client.BufferedMutator;
+import org.apache.hadoop.hbase.client.Connection;
 import org.apache.hadoop.hbase.client.Mutation;
 import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.Result;
@@ -31,9 +32,9 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import com.google.bigtable.repackaged.com.google.cloud.config.Logger;
+import com.google.bigtable.repackaged.com.google.cloud.hbase1_0.BigtableConnection;
 import com.google.bigtable.repackaged.com.google.com.google.bigtable.v2.SampleRowKeysResponse;
 import com.google.cloud.bigtable.dataflow.CloudBigtableIO.Source;
-import com.google.cloud.bigtable.hbase1_0.BigtableConnection;
 import com.google.cloud.dataflow.sdk.io.BoundedSource;
 import com.google.cloud.dataflow.sdk.io.BoundedSource.BoundedReader;
 import com.google.cloud.dataflow.sdk.transforms.DoFn;
@@ -67,7 +68,7 @@ public class CloudBigtableIOIntegrationTest {
     return tableName;
   }
 
-  private static BigtableConnection connection;
+  private static Connection connection;
   private static CloudBigtableConfiguration config;
 
   @BeforeClass

--- a/bigtable-dataflow-parent/bigtable-hbase-dataflow/src/test/java/com/google/cloud/bigtable/dataflow/CloudBigtableTableConfigurationTest.java
+++ b/bigtable-dataflow-parent/bigtable-hbase-dataflow/src/test/java/com/google/cloud/bigtable/dataflow/CloudBigtableTableConfigurationTest.java
@@ -18,8 +18,6 @@ package com.google.cloud.bigtable.dataflow;
 
 import static org.junit.Assert.assertEquals;
 
-import java.io.IOException;
-
 import org.apache.hadoop.conf.Configuration;
 import org.junit.Assert;
 import org.junit.Test;
@@ -49,7 +47,7 @@ public class CloudBigtableTableConfigurationTest {
   }
 
   @Test
-  public void testHBaseConfig() throws IOException {
+  public void testHBaseConfig() {
     CloudBigtableTableConfiguration underTest = buildConfiguration();
 
     Configuration config = underTest.toHBaseConfig();

--- a/bigtable-dataflow-parent/bigtable-hbase-dataflow/src/test/java/com/google/cloud/bigtable/dataflow/coders/CoderTestUtil.java
+++ b/bigtable-dataflow-parent/bigtable-hbase-dataflow/src/test/java/com/google/cloud/bigtable/dataflow/coders/CoderTestUtil.java
@@ -22,7 +22,7 @@ import java.io.IOException;
 import com.google.cloud.dataflow.sdk.coders.AtomicCoder;
 
 /**
- * Simple tool to help with testing {@link BigtableConverter}s.
+ * Simple tool to help with testing {@link AtomicCoder}s.
  */
 public class CoderTestUtil {
 

--- a/bigtable-dataflow-parent/bigtable-hbase-shaded-for-dataflow/pom.xml
+++ b/bigtable-dataflow-parent/bigtable-hbase-shaded-for-dataflow/pom.xml
@@ -83,9 +83,7 @@ limitations under the License.
                                     <pattern>com.google.cloud.bigtable</pattern>
                                     <shadedPattern>com.google.bigtable.repackaged.com.google.cloud</shadedPattern>
                                     <excludes>
-                                        <exclude>com.google.cloud.bigtable.hbase1_0.BigtableConnection*</exclude>
                                         <exclude>com.google.cloud.bigtable.dataflow.*</exclude>
-                                        <exclude>com.google.cloud.bigtable.hbase.*</exclude>
                                     </excludes>
                                 </relocation>
                                 <relocation>


### PR DESCRIPTION
A user who has bigtable-hbase-1.* in the classpath should be able to use bigtable-hbase-dataflow.  Currently, as see in #958, the shading we added so that BigtableIO and CloudBigtableIO can coexist doesn't quite work for bigtable-hbase.