### PR TITLE
Adding pom.xml exclusions for shaded artifacts.

### DIFF
--- a/bigtable-dataflow-parent/bigtable-dataflow-import/pom.xml
+++ b/bigtable-dataflow-parent/bigtable-dataflow-import/pom.xml
@@ -39,6 +39,12 @@ limitations under the License.
             <groupId>com.google.cloud.bigtable</groupId>
             <artifactId>bigtable-hbase-dataflow</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.cloud.bigtable</groupId>
+                    <artifactId>bigtable-hbase-shaded-for-dataflow</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <!-- Keeping guava dependency here so that third party code using this package

--- a/bigtable-dataflow-parent/bigtable-hbase-dataflow/pom.xml
+++ b/bigtable-dataflow-parent/bigtable-hbase-dataflow/pom.xml
@@ -37,6 +37,12 @@ limitations under the License.
             <groupId>com.google.cloud.bigtable</groupId>
             <artifactId>bigtable-hbase-shaded-for-dataflow</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.cloud.bigtable</groupId>
+                    <artifactId>bigtable-hbase-1.0</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/bigtable-dataflow-parent/bigtable-hbase-shaded-for-dataflow/pom.xml
+++ b/bigtable-dataflow-parent/bigtable-hbase-shaded-for-dataflow/pom.xml
@@ -32,6 +32,12 @@ limitations under the License.
             <groupId>com.google.cloud.bigtable</groupId>
             <artifactId>bigtable-hbase-1.0</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>${project.groupId}</groupId>
+                    <artifactId>bigtable-hbase-shaded</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/bigtable-hbase-parent/bigtable-hbase-1.0/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-1.0/pom.xml
@@ -39,6 +39,12 @@ limitations under the License.
             <groupId>${project.groupId}</groupId>
             <artifactId>bigtable-hbase-shaded</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>${project.groupId}</groupId>
+                    <artifactId>bigtable-hbase</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.hbase</groupId>

--- a/bigtable-hbase-parent/bigtable-hbase-1.1/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-1.1/pom.xml
@@ -39,6 +39,12 @@ limitations under the License.
             <groupId>${project.groupId}</groupId>
             <artifactId>bigtable-hbase-shaded</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>${project.groupId}</groupId>
+                    <artifactId>bigtable-hbase</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.hbase</groupId>

--- a/bigtable-hbase-parent/bigtable-hbase-1.2/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-1.2/pom.xml
@@ -39,6 +39,12 @@ limitations under the License.
             <groupId>${project.groupId}</groupId>
             <artifactId>bigtable-hbase-shaded</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>${project.groupId}</groupId>
+                    <artifactId>bigtable-hbase</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.hbase</groupId>

--- a/bigtable-hbase-parent/bigtable-hbase-mapreduce/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-mapreduce/pom.xml
@@ -65,6 +65,12 @@ limitations under the License.
             <groupId>com.google.cloud.bigtable</groupId>
             <artifactId>bigtable-hbase-1.1</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>${project.groupId}</groupId>
+                    <artifactId>bigtable-hbase-shaded</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>


### PR DESCRIPTION
This helps the eclipse plugin understand what dependencies not to include for shaded projects.