### PR TITLE
SLF4J reporter should work with other Dropwizard reporters.

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/metrics/BigtableClientMetrics.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/metrics/BigtableClientMetrics.java
@@ -123,7 +123,18 @@ public final class BigtableClientMetrics {
   static {
     Logger logger = LoggerFactory.getLogger(BigtableClientMetrics.class);
     if (logger.isDebugEnabled()) {
-      setMetricRegistry(DropwizardMetricRegistry.createSlf4jReporter(logger, 1, TimeUnit.MINUTES));
+      if (registry == MetricRegistry.NULL_METRICS_REGISTRY) {
+        DropwizardMetricRegistry dropwizardRegistry = new DropwizardMetricRegistry();
+        registry = dropwizardRegistry;
+        DropwizardMetricRegistry.createSlf4jReporter(dropwizardRegistry, logger, 1, TimeUnit.MINUTES);
+      } else if (registry instanceof DropwizardMetricRegistry) {
+        DropwizardMetricRegistry dropwizardRegistry = (DropwizardMetricRegistry) registry;
+        DropwizardMetricRegistry.createSlf4jReporter(dropwizardRegistry, logger, 1, TimeUnit.MINUTES);
+      } else {
+        logger.info(
+          "Could not set up logging since the metrics registry is not a DropwizardMetricRegistry; it is a %s w.",
+          registry.getClass().getName());
+      }
     }
   }
 

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/metrics/DropwizardMetricRegistry.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/metrics/DropwizardMetricRegistry.java
@@ -20,17 +20,15 @@ public class DropwizardMetricRegistry implements MetricRegistry {
    * Creates a {@link DropwizardMetricRegistry} with an {@link Slf4jReporter}.  Only non-zero metrics
    * will be logged to the {@link Slf4jReporter}.
    * 
+   * @param registry The registry on which to add the reporter.
    * @param logger The {@link Logger} to report to
    * @param period the amount of time between polls
    * @param unit   the unit for {@code period}
    *
    * @return the {@link DropwizardMetricRegistry}
    */
-  public static DropwizardMetricRegistry createSlf4jReporter(
-      Logger logger, long period, TimeUnit unit) {
-    // This adds a simple mechanism of enabling statistics via slf4j configuration.
-    // More complex configuration is available programmatically.
-    DropwizardMetricRegistry registry = new DropwizardMetricRegistry();
+  public static void createSlf4jReporter(DropwizardMetricRegistry registry, Logger logger,
+      long period, TimeUnit unit) {
     MetricFilter nonZeroMatcher =
         new MetricFilter() {
           @Override
@@ -42,15 +40,13 @@ public class DropwizardMetricRegistry implements MetricRegistry {
             return true;
           }
         };
-    final Slf4jReporter reporter =
-        Slf4jReporter.forRegistry(registry.getRegistry())
-            .outputTo(logger)
-            .convertRatesTo(TimeUnit.SECONDS)
-            .convertDurationsTo(TimeUnit.MILLISECONDS)
-            .filter(nonZeroMatcher)
-            .build();
-    reporter.start(period, unit);
-    return registry;
+    Slf4jReporter.forRegistry(registry.getRegistry())
+        .outputTo(logger)
+        .convertRatesTo(TimeUnit.SECONDS)
+        .convertDurationsTo(TimeUnit.MILLISECONDS)
+        .filter(nonZeroMatcher)
+        .build()
+        .start(period, unit);
   }
 
   /**


### PR DESCRIPTION
Currently, our performance tests creates a different DropwizardMetricsRegistry instance.  This change allows the SLF4J Reporter to use the same instance as the one created by the performance tests.