### PR TITLE
Remove attach-javadocs from package target

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -638,15 +638,6 @@ limitations under the License.
                         <excludePackageNames>com.google.cloud.bigtable.dataflow:com.google.cloud.bigtable.dataflowimport:com.google.clooud</excludePackageNames>
                         <detectLinks />
                     </configuration>
-                    <executions>
-                        <execution>
-                            <id>attach-javadocs</id>
-                            <goals>
-                                <goal>aggregate-jar</goal>
-                            </goals>
-                            <phase>package</phase>
-                        </execution>
-                    </executions>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
Causing problems for the release process, so let's disable it for now.