### PR TITLE
Try jar instead of aggregate-jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -638,6 +638,15 @@ limitations under the License.
                         <excludePackageNames>com.google.cloud.bigtable.dataflow:com.google.cloud.bigtable.dataflowimport:com.google.clooud</excludePackageNames>
                         <detectLinks />
                     </configuration>
+                    <executions>
+                        <execution>
+                            <id>attach-javadocs</id>
+                            <goals>
+                                <goal>jar</goal>
+                            </goals>
+                            <phase>package</phase>
+                        </execution>
+                    </executions>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
Removing the javadoc step entirely causes other problems, so let's try
what we were doing for 0.9.1 (jar instead of aggregate-jar).