### PR TITLE
Restore excluded package names in javadoc default-cli

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -630,12 +630,6 @@ limitations under the License.
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <version>2.10.4</version>
                     <configuration>
-                        <!--
-                        javadoc excluded packages:
-                            com.google.cloud.bigtable.dataflow{import,}     (Breaks with javadoc:aggregate, handled separately)
-                            com.google.clooud.*                             (Ignore, a hack/workaround for separate maven issue)
-                        -->
-                        <excludePackageNames>com.google.clooud</excludePackageNames>
                         <detectLinks />
                     </configuration>
                     <executions>
@@ -645,6 +639,24 @@ limitations under the License.
                                 <goal>jar</goal>
                             </goals>
                             <phase>package</phase>
+                            <configuration>
+                                <!--
+                                javadoc excluded packages:
+                                    com.google.clooud.*                             (Ignore, a hack/workaround for separate maven issue)
+                                -->
+                                <excludePackageNames>com.google.clooud</excludePackageNames>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <id>default-cli</id>
+                            <configuration>
+                                <!--
+                                javadoc excluded packages:
+                                    com.google.cloud.bigtable.dataflow{import,}     (Breaks with javadoc:aggregate, handled separately)
+                                    com.google.clooud.*                             (Ignore, a hack/workaround for separate maven issue)
+                                -->
+                                <excludePackageNames>com.google.cloud.bigtable.dataflow:com.google.cloud.bigtable.dataflowimport:com.google.clooud</excludePackageNames>
+                            </configuration>
                         </execution>
                     </executions>
                 </plugin>


### PR DESCRIPTION
Removing the exclusions for dataflow breaks the javadoc:aggregate target, which we
still want to keep working when it is invoked directly.

With this change, we add the additional dataflow exclusions for the
javadoc plugin under the default-cli execution id (used when the plugin
is invoked directly), but leave them out in the attach-javadocs
execution (used as part of the package phase / release process).