### PR TITLE
Use null credentials with bigtable emulator

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableOptions.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableOptions.java
@@ -203,6 +203,7 @@ public class BigtableOptions implements Serializable {
             " environment variable: " + emulatorHost);
       }
       setUsePlaintextNegotiation(true);
+      setCredentialOptions(CredentialOptions.nullCredential());
       setDataHost(hostPort[0]);
       setTableAdminHost(hostPort[0]);
       setInstanceAdminHost(hostPort[0]);

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/config/TestBigtableOptions.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/config/TestBigtableOptions.java
@@ -102,6 +102,7 @@ public class TestBigtableOptions {
     Assert.assertEquals("localhost", options.getInstanceAdminHost());
     Assert.assertEquals("localhost", options.getTableAdminHost());
     Assert.assertTrue(options.usePlaintextNegotiation());
+    Assert.assertEquals(CredentialOptions.nullCredential(), options.getCredentialOptions());
 
     setTestEnv(oldEnv);
     options = new BigtableOptions.Builder()
@@ -112,6 +113,7 @@ public class TestBigtableOptions {
     Assert.assertEquals(BigtableOptions.BIGTABLE_INSTANCE_ADMIN_HOST_DEFAULT, options.getInstanceAdminHost());
     Assert.assertEquals(BigtableOptions.BIGTABLE_TABLE_ADMIN_HOST_DEFAULT, options.getTableAdminHost());
     Assert.assertFalse(options.usePlaintextNegotiation());
+    Assert.assertEquals(CredentialOptions.defaultCredentials(), options.getCredentialOptions());
   }
 
   /**


### PR DESCRIPTION
When using the bigtable emulator, you should not need to define credentials since the emulator does not require them. Currently in a completely new terminal instance when running the emulator the following exception is thrown:
```
Caused by: java.io.IOException: The Application Default Credentials are not available.
They are available if running in Google Compute Engine. Otherwise, the environment variable GOOGLE_APPLICATION_CREDENTIALS must be defined pointing to a file defining the credentials. See https://developers.google.com/accounts/docs/application-default-credentials for more information
```

This should allow somebody to experiment on top of the emulator without having to worry about credentials.