### PR TITLE
Spell out Google Compute Engine, and update some links

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableOptions.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableOptions.java
@@ -88,8 +88,8 @@ public class BigtableOptions implements Serializable {
     private RetryOptions retryOptions = new RetryOptions.Builder().build();
     private CallOptionsConfig callOptionsConfig = new CallOptionsConfig.Builder().build();
     // CredentialOptions.defaultCredentials() gets credentials from well known locations, such as
-    // the GCE metdata service or gcloud configuration in other environments. A user can also
-    // override the default behavior with P12 or JSon configuration.
+    // the Google Compute Engine metadata service or gcloud configuration in other environments. A
+    // user can also override the default behavior with P12 or JSON configuration.
     private CredentialOptions credentialOptions = CredentialOptions.defaultCredentials();
 
     public Builder() {

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/CredentialFactory.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/CredentialFactory.java
@@ -4,9 +4,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -136,8 +136,9 @@ public class CredentialFactory {
 
   /**
    * Initializes OAuth2 credential using preconfigured ServiceAccount settings on the local
-   * GCE VM. See: <a href="https://developers.google.com/compute/docs/authentication"
-   * >Authenticating from Google Compute Engine</a>.
+   * Google Compute Engine VM. See:
+   * <a href="https://cloud.google.com/compute/docs/access/create-enable-service-accounts-for-instances"
+   * >Creating and Enabling Service Accounts for Instances</a>.
    *
    * @return a {@link com.google.auth.Credentials} object.
    * @throws java.io.IOException if any.
@@ -150,8 +151,8 @@ public class CredentialFactory {
 
   /**
    * Initializes OAuth2 credential from a private keyfile, as described in
-   * <a href="https://code.google.com/p/google-api-java-client/wiki/OAuth2#Service_Accounts"
-   * > OAuth2 Service Accounts</a>.
+   * <a href="https://developers.google.com/api-client-library/java/google-api-java-client/oauth2#service_accounts"
+   * >Service accounts</a>.
    *
    * @param serviceAccountEmail Email address of the service account associated with the keyfile.
    * @param privateKeyFile Full local path to private keyfile.
@@ -168,8 +169,8 @@ public class CredentialFactory {
 
   /**
    * Initializes OAuth2 credential from a private keyfile, as described in
-   * <a href="https://code.google.com/p/google-api-java-client/wiki/OAuth2#Service_Accounts"
-   * > OAuth2 Service Accounts</a>.
+   * <a href="https://developers.google.com/api-client-library/java/google-api-java-client/oauth2#service_accounts"
+   * >Service accounts</a>.
    *
    * @param serviceAccountEmail Email address of the service account associated with the keyfile.
    * @param privateKeyFile Full local path to private keyfile.
@@ -195,7 +196,7 @@ public class CredentialFactory {
    * in. If a service account is to be used with JSON file, set the environment variable with name
    * "GOOGLE_APPLICATION_CREDENTIALS" to the JSON file path. For more details on application default
    * credentials:
-   * <a href="https://developers.google.com/accounts/docs/application-default-credentials" >
+   * <a href="https://developers.google.com/identity/protocols/application-default-credentials" >
    * Application Default Credentials</a>.
    *
    * @return a {@link com.google.auth.Credentials} object.

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/CredentialOptions.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/CredentialOptions.java
@@ -28,14 +28,15 @@ import com.google.auth.Credentials;
  * </p>
  * <ol>
  * <li>DefaultCredentials - Initializes OAuth2 credential using preconfigured ServiceAccount
- * settings on the local GCE VM or GOOGLE_APPLICATION_CREDENTIALS environment variable or gcloud configured security. See: <a
- * href="https://developers.google.com/compute/docs/authentication">Authenticating from Google
- * Compute Engine</a> and <a
- * href="https://developers.google.com/accounts/docs/application-default-credentials" > Application
- * Default Credentials</a>.</li>
+ * settings on the local Google Compute Engine instance or GOOGLE_APPLICATION_CREDENTIALS
+ * environment variable or gcloud configured security. See: <a
+ * href="https://cloud.google.com/compute/docs/access/create-enable-service-accounts-for-instances"
+ * >Creating and Enabling Service Accounts for Instances</a> and <a
+ * href="https://developers.google.com/identity/protocols/application-default-credentials"
+ * >Application Default Credentials</a>.</li>
  * <li>P12 - Initializes OAuth2 credential from a private keyfile, as described in <a
- * href="https://code.google.com/p/google-api-java-client/wiki/OAuth2#Service_Accounts" > OAuth2
- * Service Accounts</a>.</li>
+ * href="https://developers.google.com/api-client-library/java/google-api-java-client/oauth2#service_accounts"
+ * >Service accounts</a>.</li>
  * <li>UserSupplied - User supplies a fully formed Credentials.
  * <li>None - used for unit testing</li>
  * </ol>
@@ -90,9 +91,10 @@ public class CredentialOptions implements Serializable {
    * gcloud/application_default_credentials.json file in the (User)/APPDATA/ directory on Windows or
    * ~/.config/ directory on other OSs .
    * </p>
-   * Initializes OAuth2 credential using preconfigured ServiceAccount settings on the local GCE VM.
-   * See: <a href="https://developers.google.com/compute/docs/authentication">Authenticating from
-   * Google Compute Engine</a>.
+   * Initializes OAuth2 credential using preconfigured ServiceAccount settings on the local Google
+   * Compute Engine VM. See:
+   * <a href="https://cloud.google.com/compute/docs/access/create-enable-service-accounts-for-instances"
+   * >Creating and Enabling Service Accounts for Instances</a>.
    *
    * @return a {@link com.google.cloud.bigtable.config.CredentialOptions} object.
    */
@@ -102,8 +104,8 @@ public class CredentialOptions implements Serializable {
 
   /**
    * Initializes OAuth2 credential from a private keyfile, as described in <a
-   * href="https://code.google.com/p/google-api-java-client/wiki/OAuth2#Service_Accounts" > OAuth2
-   * Service Accounts</a>
+   * href="https://developers.google.com/api-client-library/java/google-api-java-client/oauth2#service_accounts"
+   * >Service accounts</a>.
    *
    * @param serviceAccount a {@link java.lang.String} object.
    * @param keyFile a {@link java.lang.String} object.

--- a/bigtable-dataflow-parent/bigtable-dataflow-import/src/main/java/com/google/cloud/bigtable/dataflowimport/HadoopFileSource.java
+++ b/bigtable-dataflow-parent/bigtable-dataflow-import/src/main/java/com/google/cloud/bigtable/dataflowimport/HadoopFileSource.java
@@ -181,9 +181,10 @@ public class HadoopFileSource<K, V> extends BoundedSource<KV<K, V>> {
    * <p>If a dataflow job using files on Google Cloud Storage is launched off the cloud
    * (e.g., from user's desktop), dataflow causes the source to access the files UNNECESSARILY
    * from the local host, which is bound to fail because gcs-connector is already configured to
-   * use GCE VM's authenticaton mechanism, which won't work for access from off the cloud. The
-   * resulting warnings are very confusing because it happens right before dataflow task-staging,
-   * which may take a long time. To the user the program may appear to have failed fatally.
+   * use the Google Compute Engine instance's authentication mechanism, which won't work for access
+   * from off the cloud. The resulting warnings are very confusing because it happens right before
+   * dataflow task-staging, which may take a long time. To the user the program may appear to have
+   * failed fatally.
    *
    * <p>When {@code isRemoteFile} is {@code true}, this class would not try to access
    * google cloud storage from off the cloud, sidestepping the problem. When the program is staged


### PR DESCRIPTION
This PR makes the following changes to the Javadoc comments:

+ Spells out "Google Compute Engine" rather than using the unapproved acronym "GCE."
+ Refers to Compute Engine "instances" rather than "VMs."
+ Updates outdated links.
+ Fixes typos.