### PR TITLE
Adding dynamic rebalancing to the CloudBigtableIO.Reader.

### DIFF
--- a/bigtable-dataflow-parent/bigtable-hbase-dataflow/pom.xml
+++ b/bigtable-dataflow-parent/bigtable-hbase-dataflow/pom.xml
@@ -31,7 +31,7 @@ limitations under the License.
         <dependency>
             <groupId>com.google.cloud.dataflow</groupId>
             <artifactId>google-cloud-dataflow-java-sdk-all</artifactId>
-            <version>1.6.1</version>
+            <version>1.7.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.cloud.bigtable</groupId>

--- a/bigtable-dataflow-parent/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/ByteStringUtil.java
+++ b/bigtable-dataflow-parent/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/ByteStringUtil.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.dataflow;
+
+import com.google.bigtable.repackaged.com.google.protobuf.BigtableZeroCopyByteStringUtil;
+import com.google.bigtable.repackaged.com.google.protobuf.ByteString;
+import com.google.cloud.dataflow.sdk.io.range.ByteKey;
+
+/**
+ * Converts between shaded and unshaded versions of ByteStrings
+ * @author sduskis
+ *
+ */
+public class ByteStringUtil {
+
+  public static ByteKey toByteKey(ByteString byteString) {
+    return ByteKey.of(toUnshaded(byteString));
+  }
+
+  public static com.google.protobuf.ByteString toUnshaded(ByteString byteString) {
+    byte[] bytes = getBytes(byteString);
+    try {
+      return com.google.protobuf.BigtableZeroCopyByteStringUtil.wrap(bytes);
+    } catch (Throwable e) {
+      // There are some nasty Errors that can be thrown here.
+      return com.google.protobuf.ByteString.copyFrom(bytes);
+    }
+  }
+
+  private static byte[] getBytes(ByteString key) {
+    try {
+      return BigtableZeroCopyByteStringUtil.zeroCopyGetBytes(key);
+    } catch(Exception e) {
+      return key.toByteArray();
+    }
+  }
+
+}

--- a/bigtable-dataflow-parent/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/CloudBigtableScanConfiguration.java
+++ b/bigtable-dataflow-parent/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/CloudBigtableScanConfiguration.java
@@ -27,6 +27,7 @@ import com.google.bigtable.repackaged.com.google.com.google.bigtable.v2.RowRange
 import com.google.bigtable.repackaged.com.google.com.google.bigtable.v2.RowSet;
 import com.google.bigtable.repackaged.com.google.protobuf.BigtableZeroCopyByteStringUtil;
 import com.google.bigtable.repackaged.com.google.protobuf.ByteString;
+import com.google.cloud.dataflow.sdk.io.range.ByteKeyRange;
 
 import java.util.Map;
 import java.util.Objects;
@@ -268,5 +269,16 @@ public class CloudBigtableScanConfiguration extends CloudBigtableTableConfigurat
   public void copyConfig(Builder builder) {
     super.copyConfig(builder);
     builder.withRequest(request);
+  }
+
+  /**
+   * Creates a {@link ByteKeyRange} representing the start and stop keys for this instance.
+   *
+   * @return A {@link ByteKeyRange}.
+   */
+  public ByteKeyRange toByteKeyRange() {
+    return ByteKeyRange.of(
+      ByteStringUtil.toByteKey(getStartRowByteString()),
+      ByteStringUtil.toByteKey(getStopRowByteString()));
   }
 }

--- a/bigtable-dataflow-parent/bigtable-hbase-dataflow/src/test/java/com/google/cloud/bigtable/dataflow/CloudBigtableIOReaderTest.java
+++ b/bigtable-dataflow-parent/bigtable-hbase-dataflow/src/test/java/com/google/cloud/bigtable/dataflow/CloudBigtableIOReaderTest.java
@@ -33,7 +33,6 @@ import com.google.bigtable.repackaged.com.google.com.google.bigtable.v2.ReadRows
 import com.google.bigtable.repackaged.com.google.com.google.bigtable.v2.Row;
 import com.google.bigtable.repackaged.com.google.protobuf.ByteString;
 import com.google.cloud.bigtable.dataflow.CloudBigtableScanConfiguration.Builder;
-import com.google.cloud.dataflow.sdk.io.BoundedSource;
 import com.google.cloud.dataflow.sdk.io.range.ByteKey;
 import com.google.cloud.dataflow.sdk.io.range.ByteKeyRange;
 import com.google.cloud.dataflow.sdk.io.range.ByteKeyRangeTracker;
@@ -123,7 +122,7 @@ public class CloudBigtableIOReaderTest {
   private void testTrackerAtKey(CloudBigtableIO.Reader<Result> underTest, ByteKeyRangeTracker tracker,
       final String key, final int count) throws IOException {
     setRowKey(key);
-    tracker.tryReturnRecordAt(false, ByteKey.copyFrom(key.getBytes()));
+    tracker.tryReturnRecordAt(true, ByteKey.copyFrom(key.getBytes()));
     Assert.assertTrue(underTest.start());
     Assert.assertEquals(count, underTest.getRowsReadCount());
     Assert.assertEquals(tracker.getFractionConsumed(),

--- a/bigtable-dataflow-parent/bigtable-hbase-dataflow/src/test/java/com/google/cloud/bigtable/dataflow/CloudBigtableIOReaderTest.java
+++ b/bigtable-dataflow-parent/bigtable-hbase-dataflow/src/test/java/com/google/cloud/bigtable/dataflow/CloudBigtableIOReaderTest.java
@@ -29,8 +29,14 @@ import org.mockito.MockitoAnnotations;
 
 import com.google.bigtable.repackaged.com.google.cloud.grpc.BigtableSession;
 import com.google.bigtable.repackaged.com.google.cloud.grpc.scanner.ResultScanner;
+import com.google.bigtable.repackaged.com.google.com.google.bigtable.v2.ReadRowsRequest;
 import com.google.bigtable.repackaged.com.google.com.google.bigtable.v2.Row;
 import com.google.bigtable.repackaged.com.google.protobuf.ByteString;
+import com.google.cloud.bigtable.dataflow.CloudBigtableScanConfiguration.Builder;
+import com.google.cloud.dataflow.sdk.io.BoundedSource;
+import com.google.cloud.dataflow.sdk.io.range.ByteKey;
+import com.google.cloud.dataflow.sdk.io.range.ByteKeyRange;
+import com.google.cloud.dataflow.sdk.io.range.ByteKeyRangeTracker;
 
 /**
  * Tests for {@link CloudBigtableIO.Reader}.
@@ -51,24 +57,20 @@ public class CloudBigtableIOReaderTest {
   @Before
   public void setup(){
     MockitoAnnotations.initMocks(this);
-    CloudBigtableScanConfiguration config = new CloudBigtableScanConfiguration.Builder()
-        .withProjectId("test").withInstanceId("test").withTableId("test").build();
-    when(mockSource.getConfiguration()).thenReturn(config);
+  }
+
+  private Builder createDefaultConfig() {
+    return new CloudBigtableScanConfiguration.Builder().withProjectId("test").withInstanceId("test")
+        .withTableId("test").withRequest(ReadRowsRequest.getDefaultInstance())
+        .withKeys(new byte[0], new byte[0]);
   }
 
   @Test
   public void testBasic() throws IOException {
-    CloudBigtableIO.Reader<Result> underTest =
-        new CloudBigtableIO.Reader<Result>(mockSource, CloudBigtableIO.RESULT_ADVANCER) {
-          @Override
-          void initializeScanner() throws IOException {
-            setSession(mockSession);
-            setScanner(mockScanner);
-          }
-        };
 
-    ByteString key = ByteString.copyFrom(Bytes.toBytes("a"));
-    when(mockScanner.next()).thenReturn(Row.newBuilder().setKey(key).build());
+    CloudBigtableIO.Reader<Result> underTest = initializeReader(createDefaultConfig().build());
+
+    setRowKey("a");
     Assert.assertTrue(underTest.start());
     Assert.assertEquals(1, underTest.getRowsReadCount());
 
@@ -77,5 +79,54 @@ public class CloudBigtableIOReaderTest {
     Assert.assertEquals(1, underTest.getRowsReadCount());
 
     underTest.close();
+  }
+
+  private void setRowKey(String rowKey) throws IOException {
+    ByteString rowKeyByteString = ByteString.copyFrom(Bytes.toBytes(rowKey));
+    Row row = Row.newBuilder().setKey(rowKeyByteString).build();
+    when(mockScanner.next()).thenReturn(row);
+  }
+
+  private CloudBigtableIO.Reader<Result> initializeReader(CloudBigtableScanConfiguration config) {
+    when(mockSource.getConfiguration()).thenReturn(config);
+    return new CloudBigtableIO.Reader<Result>(mockSource, CloudBigtableIO.RESULT_ADVANCER) {
+      @Override
+      void initializeScanner() throws IOException {
+        setSession(mockSession);
+        setScanner(mockScanner);
+      }
+    };
+  }
+
+  @Test
+  public void testPercent() throws IOException{
+    byte[] start = "aa".getBytes();
+    byte[] end = "zz".getBytes();
+    CloudBigtableScanConfiguration config = createDefaultConfig().withKeys(start, end).build();
+    CloudBigtableIO.Reader<Result> underTest = initializeReader(config);
+    ByteKeyRangeTracker tracker =
+        ByteKeyRangeTracker.of(ByteKeyRange.of(ByteKey.copyFrom(start), ByteKey.copyFrom(end)));
+
+    testTrackerAtKey(underTest, tracker, "bb", 1);
+    testTrackerAtKey(underTest, tracker, "qq", 2);
+
+    double splitAtFraction =
+        (1 - tracker.getFractionConsumed()) * .5 + tracker.getFractionConsumed();
+    ByteKey newSplitEnd = config.toByteKeyRange().interpolateKey(splitAtFraction);
+
+    underTest.splitAtFraction(splitAtFraction);
+    tracker.trySplitAtPosition(newSplitEnd);
+
+    Assert.assertEquals(tracker.getFractionConsumed(), underTest.getFractionConsumed(), 0.0001d);
+  }
+
+  private void testTrackerAtKey(CloudBigtableIO.Reader<Result> underTest, ByteKeyRangeTracker tracker,
+      final String key, final int count) throws IOException {
+    setRowKey(key);
+    tracker.tryReturnRecordAt(false, ByteKey.copyFrom(key.getBytes()));
+    Assert.assertTrue(underTest.start());
+    Assert.assertEquals(count, underTest.getRowsReadCount());
+    Assert.assertEquals(tracker.getFractionConsumed(),
+      underTest.getFractionConsumed().doubleValue(), .001d);
   }
 }


### PR DESCRIPTION
This replaces #997 which has some merge conflicts.  This also has some unit testing.

Dynamic rebalancing (aka liquid sharding) is Dataflow's ability to split long running, straggler Read jobs into 2 jobs. That allows Dataflow to reduce overall execution time by moving parts of a job that are on busy machines to idle machines.