### PR TITLE
Remove cancel

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataGrpcClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataGrpcClient.java
@@ -20,7 +20,6 @@ import io.grpc.CallOptions;
 import io.grpc.ClientCall;
 import io.grpc.Metadata;
 import io.grpc.Status;
-import io.grpc.stub.StreamObserver;
 
 import java.io.IOException;
 import java.util.List;
@@ -404,41 +403,34 @@ public class BigtableDataGrpcClient implements BigtableDataClient {
   }
 
   private ResultScanner<Row> streamRows(ReadRowsRequest request) {
-    Timer.Context timerContext = readRowsAsync.getRpcMetrics().timeRpc();
+    final Timer.Context timerContext = readRowsAsync.getRpcMetrics().timeRpc();
 
     expandPoolIfNecessary(this.bigtableOptions.getChannelCount());
 
     // TODO: This should use getCallOptions(ReqT request, BigtableAsyncRpc<ReqT, ?> rpc) for Gets.
-    CallOptions callOptions = CallOptions.DEFAULT;
-    ClientCall<ReadRowsRequest, ReadRowsResponse> readRowsCall = readRowsAsync.newCall(callOptions);
+    final ClientCall<ReadRowsRequest, ReadRowsResponse> readRowsCall =
+        readRowsAsync.newCall(CallOptions.DEFAULT);
 
-    ResponseQueueReader reader =
-        new ResponseQueueReader(
-            retryOptions.getReadPartialRowTimeoutMillis(), retryOptions.getStreamingBufferSize());
+    ResponseQueueReader reader = new ResponseQueueReader(
+        retryOptions.getReadPartialRowTimeoutMillis(), retryOptions.getStreamingBufferSize());
 
-    StreamObserver<ReadRowsResponse> rowMerger = new RowMerger(reader);
-    ClientCall.Listener<ReadRowsResponse> listener =
-        new StreamObserverAdapter<>(readRowsCall, rowMerger);
+    final StreamObserverAdapter<ReadRowsResponse> listener =
+        new StreamObserverAdapter<>(readRowsCall, new RowMerger(reader));
 
     readRowsAsync.start(readRowsCall, request, listener, createMetadata(request.getTableName()));
-
-    CancellationToken cancellationToken = createCancellationToken(readRowsCall, timerContext);
-    return new StreamingBigtableResultScanner(reader, cancellationToken);
-  }
-
-  private CancellationToken createCancellationToken(
-      final ClientCall<ReadRowsRequest, ReadRowsResponse> readRowsCall,
-      final Timer.Context timerContext) {
     // If the scanner is closed before we're done streaming, we want to cancel the RPC.
     CancellationToken cancellationToken = new CancellationToken();
     cancellationToken.addListener(new Runnable() {
       @Override
       public void run() {
-        timerContext.close();
+        if (!listener.hasStatusBeenRecieved()) {
+          timerContext.close();
+        }
         readRowsCall.cancel("User requested cancelation.", null);
       }
     }, MoreExecutors.directExecutor());
-    return cancellationToken;
+
+    return new StreamingBigtableResultScanner(reader, cancellationToken);
   }
 
   private void expandPoolIfNecessary(int channelCount) {

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AbstractRetryingRpcListener.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AbstractRetryingRpcListener.java
@@ -151,14 +151,6 @@ public abstract class AbstractRetryingRpcListener<RequestT, ResponseT, ResultT>
     // Perform Retry
     LOG.info("Retrying failed call. Failure #%d, got: %s", status.getCause(), failedCount, status);
 
-    // TODO: This is probably not needed.  Consider removing the cancel here.
-    if (this.call != null) {
-      call.cancel(
-          String.format(
-              "Request being retried. Previous call failed with status %s.",
-              status.getCode().name()),
-          null);
-    }
     call = null;
 
     rpc.getRpcMetrics().markRetry();

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/StreamObserverAdapter.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/StreamObserverAdapter.java
@@ -31,6 +31,7 @@ public class StreamObserverAdapter<T> extends ClientCall.Listener<T> {
 
   private final ClientCall<?, T> call;
   private final StreamObserver<T> observer;
+  private boolean statusRecieved = false;
 
   /**
    * <p>Constructor for StreamObserverAdapter.</p>
@@ -53,10 +54,18 @@ public class StreamObserverAdapter<T> extends ClientCall.Listener<T> {
   /** {@inheritDoc} */
   @Override
   public void onClose(Status status, Metadata trailers) {
+    this.statusRecieved = true;
     if (status.isOk()) {
       observer.onCompleted();
     } else {
       observer.onError(status.asRuntimeException());
     }
+  }
+
+  /**
+   * @return true if {@link #onClose(Status, Metadata)} was called.
+   */
+  public boolean hasStatusBeenRecieved() {
+    return statusRecieved;
   }
 }


### PR DESCRIPTION
We call cancel gratuitously.  If we already get a response status, it means the client call is complete.  There is no need to call cancel again.  It's unclear if this is causing any problems, although there's a possibility that there's a performance hit for doing another round trip.