### PR TITLE
Adding a bigtable-legacy-compatibility project

### DIFF
--- a/bigtable-client-core-parent/bigtable-legacy-compatibility/pom.xml
+++ b/bigtable-client-core-parent/bigtable-legacy-compatibility/pom.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright 2015 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.google.cloud.bigtable</groupId>
+        <artifactId>bigtable-client-core-parent</artifactId>
+        <version>0.9.3-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>bigtable-legacy-compatibility</artifactId>
+    <packaging>jar</packaging>
+    <name>${project.groupId}:${project.artifactId}</name>
+    <description>
+       This project implements converters for v1 protobuf objects into v2 protobuf objects, and vice versa.  This package is intended for use for Dataflow, and should probably not be used by other users without a discussion on https://groups.google.com/forum/#!forum/google-cloud-bigtable-discuss first.
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>bigtable-protos</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>bigtable-legacy-protos</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.4.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>
+

--- a/bigtable-client-core-parent/bigtable-legacy-compatibility/src/main/java/com/google/cloud/bigtable/legacy/coverter/BigtableLegacyProtobufConverter.java
+++ b/bigtable-client-core-parent/bigtable-legacy-compatibility/src/main/java/com/google/cloud/bigtable/legacy/coverter/BigtableLegacyProtobufConverter.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.legacy.coverter;
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.InvalidProtocolBufferException;
+
+/**
+ * Converts protobuf objects between V1 and V2 instances, primarily for the sake of Dataflow. It
+ * converts:
+ * <ol>
+ *   <li> V1 {@link com.google.bigtable.v1.Mutation} to V2 {@link com.google.bigtable.v2.Mutation}</li>
+ *   <li> V2 {@link com.google.bigtable.v2.Row} to V1 {@link com.google.bigtable.v1.Row}</li>
+ *   <li> V1 {@link com.google.bigtable.v1.RowFilter} to V2 {@link com.google.bigtable.v2.RowFilter} (TODO)</li>
+ * </ol>
+ * @author sduskis
+ */
+public class BigtableLegacyProtobufConverter {
+
+  /**
+   * Convert between v1 {@link com.google.bigtable.v1.Mutation} and v2 {@link com.google.bigtable.v2.Mutation}.
+   * The conversion is pretty straight forward. The v1 and v2 Mutation objects have the same
+   * structure, just different packages. Call {@link com.google.bigtable.v1.Mutation#toByteString()}
+   * for v1, and {@link com.google.bigtable.v2.Mutation#parseFrom(ByteString)} for v2.
+   *
+   * @param v1Mutation the {@link com.google.bigtable.v1.Mutation} to convert.
+   * @return @{link com.google.bigtable.v2.Mutation} of equivalent content to the v1Mutation
+   * @throws InvalidProtocolBufferException
+   */
+  public static com.google.bigtable.v2.Mutation convert(com.google.bigtable.v1.Mutation v1Mutation)
+      throws InvalidProtocolBufferException {
+    return com.google.bigtable.v2.Mutation.parseFrom(v1Mutation.toByteString());
+  }
+
+  /**
+   * Convert between v2 {@link com.google.bigtable.v2.Row} and v1 {@link com.google.bigtable.v1.Row}.
+   * The conversion is pretty straight forward. The v1 and v2 Mutation objects have the same
+   * structure, just different packages. Call {@link com.google.bigtable.v2.Row#toByteString()}
+   * for v2, and {@link com.google.bigtable.v1.Row#parseFrom(ByteString)} for v1.
+   *
+   * @param v2Row the {@link com.google.bigtable.v2.Row} to convert.
+   * @return @{link com.google.bigtable.v1.Row} of equivalent content to the v2Row.
+   * @throws InvalidProtocolBufferException
+   */
+  public static com.google.bigtable.v1.Row convert(com.google.bigtable.v2.Row v2Row)
+      throws InvalidProtocolBufferException {
+    return com.google.bigtable.v1.Row.parseFrom(v2Row.toByteString());
+  }
+
+  /**
+   * Convert between v1 {@link com.google.bigtable.v1.RowFilter} and v2
+   * {@link com.google.bigtable.v2.RowFilter}. The conversion is a bit more complicated than the Row
+   * and Mutation counterparts, since RowFilter is a more complicaed structure. Please raise a issue
+   * if this is a problem.
+   *
+   * @param v1RowFilter the {@link com.google.bigtable.v1.RowFilter} to convert.
+   * @return @{link com.google.bigtable.v2.RowFilter} of equivalent content to the v1RowFilter
+   * @throws InvalidProtocolBufferException
+   */
+  public static com.google.bigtable.v2.RowFilter
+      convert(com.google.bigtable.v1.RowFilter v1RowFilter) throws InvalidProtocolBufferException {
+    return com.google.bigtable.v2.RowFilter.parseFrom(v1RowFilter.toByteString());
+  }
+}

--- a/bigtable-client-core-parent/bigtable-legacy-compatibility/src/test/java/com/google/cloud/bigtable/legacy/coverter/TestConvert_Mutations.java
+++ b/bigtable-client-core-parent/bigtable-legacy-compatibility/src/test/java/com/google/cloud/bigtable/legacy/coverter/TestConvert_Mutations.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.legacy.coverter;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.google.bigtable.v1.Mutation.DeleteFromRow;
+import com.google.bigtable.v2.Mutation.MutationCase;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.InvalidProtocolBufferException;
+
+/**
+ * Tests {@link BigtableLegacyProtobufConverter} for various types of {@link com.google.bigtable.v1.Mutation} scenarios.
+ * @author sduskis
+ *
+ */
+public class TestConvert_Mutations {
+
+  @Test
+  public void testDefaultMutation() throws InvalidProtocolBufferException {
+    BigtableLegacyProtobufConverter.convert(com.google.bigtable.v1.Mutation.getDefaultInstance());
+  }
+
+  @Test
+  public void testSetCell() throws InvalidProtocolBufferException {
+    com.google.bigtable.v1.Mutation.SetCell v1SetCell =
+        com.google.bigtable.v1.Mutation.SetCell.newBuilder().setFamilyName("Family")
+            .setColumnQualifier(ByteString.copyFrom("Qualifier".getBytes()))
+            .setTimestampMicros(100000000)
+            .setValue(ByteString.copyFrom("Some Random Value".getBytes())).build();
+
+    com.google.bigtable.v2.Mutation.SetCell v2SetCell = BigtableLegacyProtobufConverter
+        .convert(com.google.bigtable.v1.Mutation.newBuilder().setSetCell(v1SetCell).build())
+        .getSetCell();
+
+    Assert.assertEquals(v1SetCell.getFamilyName(), v2SetCell.getFamilyName());
+    Assert.assertEquals(v1SetCell.getColumnQualifier(), v2SetCell.getColumnQualifier());
+    Assert.assertEquals(v1SetCell.getTimestampMicros(), v2SetCell.getTimestampMicros());
+    Assert.assertEquals(v1SetCell.getTimestampMicros(), v2SetCell.getTimestampMicros());
+    Assert.assertEquals(v1SetCell.getValue(), v2SetCell.getValue());
+  }
+
+  @Test
+  public void testDeleteFromRow() throws InvalidProtocolBufferException {
+    com.google.bigtable.v2.Mutation mutation = BigtableLegacyProtobufConverter.convert(com.google.bigtable.v1.Mutation
+        .newBuilder().setDeleteFromRow(DeleteFromRow.getDefaultInstance()).build());
+    Assert.assertEquals(MutationCase.DELETE_FROM_ROW, mutation.getMutationCase());
+  }
+
+  public void testDeleteFromColumn() throws InvalidProtocolBufferException {
+    com.google.bigtable.v1.Mutation.DeleteFromColumn v1DeleteFromColumn =
+        com.google.bigtable.v1.Mutation.DeleteFromColumn.newBuilder().setFamilyName("Family")
+            .setColumnQualifier(ByteString.copyFrom("Qualifier".getBytes())).build();
+
+    com.google.bigtable.v2.Mutation.DeleteFromColumn v2DeleteFromColumn = BigtableLegacyProtobufConverter.convert(
+      com.google.bigtable.v1.Mutation.newBuilder().setDeleteFromColumn(v1DeleteFromColumn).build())
+        .getDeleteFromColumn();
+
+    Assert.assertEquals(v1DeleteFromColumn.getFamilyName(), v2DeleteFromColumn.getFamilyName());
+    Assert.assertEquals(v1DeleteFromColumn.getColumnQualifier(),
+      v2DeleteFromColumn.getColumnQualifier());
+  }
+}

--- a/bigtable-client-core-parent/bigtable-legacy-compatibility/src/test/java/com/google/cloud/bigtable/legacy/coverter/TestConvert_Row.java
+++ b/bigtable-client-core-parent/bigtable-legacy-compatibility/src/test/java/com/google/cloud/bigtable/legacy/coverter/TestConvert_Row.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.legacy.coverter;
+
+import org.junit.Test;
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.InvalidProtocolBufferException;
+
+import org.junit.Assert;
+
+/**
+ * Tests {@link BigtableLegacyProtobufConverter} for various types of {@link com.google.bigtable.v2.Row} scenarios.
+ * @author sduskis
+ *
+ */
+
+public class TestConvert_Row {
+
+  @Test 
+  public void testRow_default() throws InvalidProtocolBufferException {
+    BigtableLegacyProtobufConverter.convert(com.google.bigtable.v2.Row.getDefaultInstance());
+  }
+
+  @Test
+  public void testRow_full() throws InvalidProtocolBufferException {
+    com.google.bigtable.v2.Cell v2Cell = com.google.bigtable.v2.Cell.newBuilder()
+        .setTimestampMicros(1020222)
+        .setValue(ByteString.copyFrom("value".getBytes()))
+        .build();
+    com.google.bigtable.v2.Column v2Column = com.google.bigtable.v2.Column.newBuilder()
+        .setQualifier(ByteString.copyFrom("Qualifier".getBytes()))
+        .addCells(v2Cell)
+        .build();
+    com.google.bigtable.v2.Family v2Family = com.google.bigtable.v2.Family.newBuilder()
+        .setName("family")
+        .addColumns(v2Column)
+        .build();
+    com.google.bigtable.v2.Row v2Row = com.google.bigtable.v2.Row.newBuilder()
+        .setKey(ByteString.copyFrom("key".getBytes()))
+        .addFamilies(v2Family)
+        .build();
+
+    com.google.bigtable.v1.Row v1Row = BigtableLegacyProtobufConverter.convert(v2Row);
+    com.google.bigtable.v1.Family v1Family = v1Row.getFamilies(0);
+    com.google.bigtable.v1.Column v1Column = v1Family.getColumns(0);
+    com.google.bigtable.v1.Cell v1Cell = v1Column.getCells(0);
+
+    Assert.assertEquals(v2Row.getKey(), v1Row.getKey());
+    Assert.assertEquals(v2Family.getName(), v1Family.getName());
+    Assert.assertEquals(v2Column.getQualifier(), v1Column.getQualifier());
+    Assert.assertEquals(v2Cell.getValue(), v1Cell.getValue());
+    Assert.assertEquals(v2Cell.getTimestampMicros(), v1Cell.getTimestampMicros());
+  }
+}

--- a/bigtable-client-core-parent/bigtable-legacy-compatibility/src/test/java/com/google/cloud/bigtable/legacy/coverter/TestConvert_RowFilter.java
+++ b/bigtable-client-core-parent/bigtable-legacy-compatibility/src/test/java/com/google/cloud/bigtable/legacy/coverter/TestConvert_RowFilter.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.legacy.coverter;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.InvalidProtocolBufferException;
+
+/**
+ * Tests {@link BigtableLegacyProtobufConverter} for various types of
+ * {@link com.google.bigtable.vv.RowFilter} scenarios.
+ * @author sduskis
+ */
+
+public class TestConvert_RowFilter {
+
+  @Test
+  public void testRowFilter_default() throws InvalidProtocolBufferException {
+    BigtableLegacyProtobufConverter.convert(com.google.bigtable.v1.RowFilter.getDefaultInstance());
+  }
+
+  @Test
+  public void testRowFilter_ColumnRange() throws InvalidProtocolBufferException {
+    com.google.bigtable.v1.ColumnRange v1ColumnRange = com.google.bigtable.v1.ColumnRange
+        .newBuilder().setStartQualifierInclusive(ByteString.copyFrom("start".getBytes()))
+        .setEndQualifierExclusive(ByteString.copyFrom("end".getBytes())).build();
+    com.google.bigtable.v1.RowFilter v1RowFilter =
+        com.google.bigtable.v1.RowFilter.newBuilder().setColumnRangeFilter(v1ColumnRange).build();
+    com.google.bigtable.v2.RowFilter v2RowFilter =
+        BigtableLegacyProtobufConverter.convert(v1RowFilter);
+
+    com.google.bigtable.v2.ColumnRange v2ColumnRange = v2RowFilter.getColumnRangeFilter();
+
+    Assert.assertEquals(v1ColumnRange.getStartQualifierInclusive(),
+      v2ColumnRange.getStartQualifierClosed());
+  }
+
+  // TODO: MORE TESTS!
+}

--- a/bigtable-client-core-parent/bigtable-legacy-compatibility/src/test/java/com/google/cloud/bigtable/legacy/coverter/TestConvert_RowFilter.java
+++ b/bigtable-client-core-parent/bigtable-legacy-compatibility/src/test/java/com/google/cloud/bigtable/legacy/coverter/TestConvert_RowFilter.java
@@ -17,13 +17,13 @@ package com.google.cloud.bigtable.legacy.coverter;
 
 import org.junit.Assert;
 import org.junit.Test;
-
+import com.google.bigtable.v2.TimestampRangeOrBuilder;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 
 /**
  * Tests {@link BigtableLegacyProtobufConverter} for various types of
- * {@link com.google.bigtable.vv.RowFilter} scenarios.
+ * {@link com.google.bigtable.v1.RowFilter} scenarios.
  * @author sduskis
  */
 
@@ -34,11 +34,20 @@ public class TestConvert_RowFilter {
     BigtableLegacyProtobufConverter.convert(com.google.bigtable.v1.RowFilter.getDefaultInstance());
   }
 
+  /**
+   * The structure of {@link com.google.bigtable.v1.ColumnRange} stayed the same across v1 and v2,
+   * but the names of the elements changed. Test to ensure compatibility with v2's {@link
+   * com.google.bigtable.v2.ColumnRange}.
+   *
+   * @throws InvalidProtocolBufferException
+   */
   @Test
   public void testRowFilter_ColumnRange() throws InvalidProtocolBufferException {
     com.google.bigtable.v1.ColumnRange v1ColumnRange = com.google.bigtable.v1.ColumnRange
-        .newBuilder().setStartQualifierInclusive(ByteString.copyFrom("start".getBytes()))
-        .setEndQualifierExclusive(ByteString.copyFrom("end".getBytes())).build();
+        .newBuilder()
+        .setStartQualifierInclusive(ByteString.copyFrom("start".getBytes()))
+        .setEndQualifierExclusive(ByteString.copyFrom("end".getBytes()))
+        .build();
     com.google.bigtable.v1.RowFilter v1RowFilter =
         com.google.bigtable.v1.RowFilter.newBuilder().setColumnRangeFilter(v1ColumnRange).build();
     com.google.bigtable.v2.RowFilter v2RowFilter =
@@ -48,6 +57,38 @@ public class TestConvert_RowFilter {
 
     Assert.assertEquals(v1ColumnRange.getStartQualifierInclusive(),
       v2ColumnRange.getStartQualifierClosed());
+    Assert.assertEquals(v1ColumnRange.getEndQualifierExclusive(),
+      v2ColumnRange.getEndQualifierOpen());
+  }
+
+  /**
+   * The structure of {@link com.google.bigtable.v1.TimestampRange} stayed the same across v1 and
+   * v2, but the names of the elements changed. Test to ensure compatibility with v2's {@link
+   * com.google.bigtable.v2.TimestampRange}.
+   *
+   * @throws InvalidProtocolBufferException
+   */
+  @Test
+  public void testRowFilter_TimestampRange() throws InvalidProtocolBufferException {
+    com.google.bigtable.v1.TimestampRange v1TimestampRange =
+        com.google.bigtable.v1.TimestampRange.newBuilder()
+            .setStartTimestampMicros(1_000_000)
+            .setEndTimestampMicros(2_000_000)
+            .build();
+    com.google.bigtable.v1.RowFilter v1RowFilter =
+        com.google.bigtable.v1.RowFilter.newBuilder()
+            .setTimestampRangeFilter(v1TimestampRange)
+            .build();
+    com.google.bigtable.v2.RowFilter v2RowFilter =
+        BigtableLegacyProtobufConverter.convert(v1RowFilter);
+
+    com.google.bigtable.v2.TimestampRangeOrBuilder v2TimestampRange =
+        v2RowFilter.getTimestampRangeFilterOrBuilder();
+
+    Assert.assertEquals(v1TimestampRange.getStartTimestampMicros(),
+      v2TimestampRange.getStartTimestampMicros());
+    Assert.assertEquals(v1TimestampRange.getEndTimestampMicros(),
+      v2TimestampRange.getEndTimestampMicros());
   }
 
   // TODO: MORE TESTS!

--- a/bigtable-client-core-parent/pom.xml
+++ b/bigtable-client-core-parent/pom.xml
@@ -34,5 +34,6 @@ limitations under the License.
         <module>bigtable-protos</module>
         <module>bigtable-client-core</module>
         <module>bigtable-legacy-protos</module>
+        <module>bigtable-legacy-compatibility</module>
     </modules>
 </project>


### PR DESCRIPTION
This will be used by Google Cloud Dataflow to convert between v1 and v2 protos.