### PR TITLE
Throw `TableExistsException` 

### DIFF
--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestCreateTable.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestCreateTable.java
@@ -351,7 +351,6 @@ public class TestCreateTable extends AbstractTest {
   }
 
   @Test
-  @Category(KnownGap.class)
   public void testAlreadyExists() throws IOException {
     thrown.expect(TableExistsException.class);
     Admin admin = getConnection().getAdmin();

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableAdmin.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableAdmin.java
@@ -369,11 +369,17 @@ public abstract class AbstractBigtableAdmin implements Admin {
     try {
       bigtableTableAdminClient.createTable(builder.build());
     } catch (Throwable throwable) {
+      if (throwable.getCause() instanceof StatusRuntimeException) {
+        StatusRuntimeException e = (StatusRuntimeException) throwable.getCause();
+        if (e.getStatus() == Status.ALREADY_EXISTS) {
+          throw new TableExistsException(desc.getTableName());
+        }
+      }
+
       throw new IOException(
-          String.format(
-              "Failed to create table '%s'",
-              desc.getTableName().getNameAsString()),
-          throwable);
+              String.format("Failed to create table '%s'",
+                      desc.getTableName().getNameAsString()),
+              throwable);
     }
   }
 


### PR DESCRIPTION
The `TableExistsException` would be really useful when calling `createTable()`. See issue #1019 for a use case. It looks like we can use the `StatusRuntimeException` to distinguish between the table already exists and all other errors. 