### PR TITLE
Utility that to change cluster sizes

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableClusterUtilities.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableClusterUtilities.java
@@ -20,71 +20,161 @@ import com.google.bigtable.admin.v2.Cluster;
 import com.google.bigtable.admin.v2.ListClustersRequest;
 import com.google.bigtable.admin.v2.ListClustersResponse;
 import com.google.cloud.bigtable.config.BigtableOptions;
+import com.google.cloud.bigtable.config.Logger;
 import com.google.cloud.bigtable.grpc.io.ChannelPool;
 import com.google.cloud.bigtable.grpc.io.CredentialInterceptorCache;
 import com.google.cloud.bigtable.grpc.io.HeaderInterceptor;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.longrunning.GetOperationRequest;
+import com.google.longrunning.Operation;
 import io.grpc.ManagedChannel;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
-import java.util.List;
 
 /** Sizes a Cluster to a specific node count. */
-public class BigtableClusterUtilities {
-  public static boolean resizeCluster(
-      BigtableInstanceName instanceName, String clusterId, int newSize)
+public class BigtableClusterUtilities implements AutoCloseable {
+  private static final BigtableOptions DEFAULT_OPTIONS = new BigtableOptions.Builder().build();
+  private static Logger logger = new Logger(BigtableClusterUtilities.class);
+  private final BigtableInstanceName instanceName;
+  private final ChannelPool channelPool;
+  private final BigtableInstanceClient client;
+  private ListClustersResponse clusters;
+
+  public BigtableClusterUtilities(BigtableInstanceName instanceName)
       throws IOException, GeneralSecurityException {
-    final BigtableOptions options =
-        new BigtableOptions.Builder()
-            .setProjectId(instanceName.getProjectId())
-            .setInstanceId(instanceName.getInstanceId())
-            .build();
+    this(instanceName, DEFAULT_OPTIONS);
+  }
+
+  /**
+   * @param options that specify credentials or retry options.
+   * @throws GeneralSecurityException
+   * @throws IOException
+   */
+  public BigtableClusterUtilities(BigtableInstanceName instanceName, final BigtableOptions options)
+      throws IOException, GeneralSecurityException {
+    this.instanceName = instanceName;
     HeaderInterceptor interceptor =
         CredentialInterceptorCache.getInstance()
             .getCredentialsInterceptor(options.getCredentialOptions(), options.getRetryOptions());
-    ManagedChannel channelPool =
+    channelPool =
         new ChannelPool(
             ImmutableList.<HeaderInterceptor>of(interceptor),
             new ChannelPool.ChannelFactory() {
-
               @Override
               public ManagedChannel create() throws IOException {
-                return BigtableSession.createNettyChannel(
-                    BigtableOptions.BIGTABLE_INSTANCE_ADMIN_HOST_DEFAULT, options);
+                return BigtableSession.createNettyChannel(options.getInstanceAdminHost(), options);
               }
             });
-
-    try {
-      BigtableInstanceClient client = new BigtableInstanceGrpcClient(channelPool);
-      ListClustersRequest listRequest =
-          ListClustersRequest.newBuilder().setParent(instanceName.getInstanceName()).build();
-      ListClustersResponse list = client.listCluster(listRequest);
-      Cluster cluster = getCluster(list, clusterId);
-      System.out.println(cluster ); 
-    } finally {
-      channelPool.shutdownNow();
-    }
-    //    BigtableInstanceClient client =
-    return false;
+    client = new BigtableInstanceGrpcClient(channelPool);
   }
 
+  public int getClusterSize(String clusterId){
+    Cluster cluster =
+    Preconditions.checkNotNull(getCluster(clusterId), "Cluster " + clusterId + " was not found");
+    return cluster.getServeNodes();
+  }
 
-  private static Cluster getCluster(ListClustersResponse list, String clusterId) {
-    for (Cluster cluster : list.getClustersList()) {
+  public synchronized ListClustersResponse getClusters() {
+    if (this.clusters == null) {
+      logger.info("Reading clusters."); 
+      this.clusters =
+          client.listCluster(
+              ListClustersRequest.newBuilder().setParent(instanceName.getInstanceName()).build());
+    }
+    return this.clusters;
+  }
+ 
+  public synchronized void setClusterSize(String clusterId, int newSize)
+      throws InterruptedException {
+    Cluster cluster = getCluster(clusterId);
+    updateClusterSize(cluster, newSize);
+  }
+
+  /**
+   * @param clusterId
+   * @param incrementCount a positive or negative number to add to the current node count
+   * @return the new size of the cluster.
+   * @throws InterruptedException
+   */
+  public synchronized int incrementClusterSize(String clusterId, int incrementCount)
+      throws InterruptedException {
+    Cluster cluster = getCluster(clusterId);
+    int newSize = incrementCount + cluster.getServeNodes();
+    updateClusterSize(cluster, newSize);
+    return newSize;
+  }
+
+  private void updateClusterSize(Cluster cluster, int newSize) throws InterruptedException {
+    logger.info("Updating cluster " + cluster.getName() + " to size: " + newSize); 
+    Operation operation =
+        client.updateCluster(
+            Cluster.newBuilder().setName(cluster.getName()).setServeNodes(newSize).build());
+    waitForOperation(operation.getName(), 30);
+    logger.info("Done updating cluster " + cluster.getName() + "."); 
+    this.clusters = null;
+  }
+
+  private void waitForOperation(String operationName,
+      int maxSeconds) throws InterruptedException {
+    GetOperationRequest request = GetOperationRequest.newBuilder().setName(operationName).build();
+    for (int i = 0; i < maxSeconds; i++) {
+      Thread.sleep(1000);
+      Operation response = client.getOperation(request);
+      if (response.getDone()) {
+        switch (response.getResultCase()) {
+          case ERROR:
+            throw new RuntimeException("Cluster could not be created: " + response.getError());
+          case RESPONSE:
+            return;
+          case RESULT_NOT_SET:
+            throw new IllegalStateException(
+                "System returned invalid response for Operation check: " + response);
+        }
+      }
+    }
+    throw new IllegalStateException(String.format(
+      "Waited %d seconds and operation was not complete", maxSeconds));
+  }
+
+  public synchronized int getClusterNodeCount(String clusterId) {
+    return getCluster(clusterId).getServeNodes();
+  }
+
+  public synchronized Cluster getCluster(String clusterId) {
+    for (Cluster cluster : getClusters().getClustersList()) {
       if (cluster.getName().endsWith("/clusters/" + clusterId)){
         return cluster;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Cluster " + clusterId + " was not found");
   }
 
+  @Override
+  public synchronized void close() throws Exception {
+    clusters = null;
+    channelPool.shutdownNow();
+  }
 
   public static void main(String[] args) throws Exception {
     Preconditions.checkArgument(
         args.length == 4,
         "Usage: BigtableClusterUtilities [projectId] [instanceId] [clusterId] [size]");
-    BigtableClusterUtilities.resizeCluster(
-        new BigtableInstanceName(args[0], args[1]), args[2], Integer.valueOf(args[3]));
+    BigtableInstanceName instanceName = new BigtableInstanceName(args[0], args[1]);
+    try (BigtableClusterUtilities util = new BigtableClusterUtilities(instanceName)) {
+      String clusterId = args[2];
+      logger.info(
+          "Size of "
+              + clusterId
+              + " before the resize: "
+              + util.getCluster(clusterId).getServeNodes());
+      Integer newSize = Integer.valueOf(args[3]);
+      util.setClusterSize(clusterId, newSize);
+      logger.info(
+        "Size of "
+            + clusterId
+            + " after the resize: "
+            + util.getCluster(clusterId).getServeNodes());
+    }
   }
 }

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableClusterUtilities.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableClusterUtilities.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.bigtable.grpc;
+
+import com.google.bigtable.admin.v2.Cluster;
+import com.google.bigtable.admin.v2.ListClustersRequest;
+import com.google.bigtable.admin.v2.ListClustersResponse;
+import com.google.cloud.bigtable.config.BigtableOptions;
+import com.google.cloud.bigtable.grpc.io.ChannelPool;
+import com.google.cloud.bigtable.grpc.io.CredentialInterceptorCache;
+import com.google.cloud.bigtable.grpc.io.HeaderInterceptor;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import io.grpc.ManagedChannel;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.List;
+
+/** Sizes a Cluster to a specific node count. */
+public class BigtableClusterUtilities {
+  public static boolean resizeCluster(
+      BigtableInstanceName instanceName, String clusterId, int newSize)
+      throws IOException, GeneralSecurityException {
+    final BigtableOptions options =
+        new BigtableOptions.Builder()
+            .setProjectId(instanceName.getProjectId())
+            .setInstanceId(instanceName.getInstanceId())
+            .build();
+    HeaderInterceptor interceptor =
+        CredentialInterceptorCache.getInstance()
+            .getCredentialsInterceptor(options.getCredentialOptions(), options.getRetryOptions());
+    ManagedChannel channelPool =
+        new ChannelPool(
+            ImmutableList.<HeaderInterceptor>of(interceptor),
+            new ChannelPool.ChannelFactory() {
+
+              @Override
+              public ManagedChannel create() throws IOException {
+                return BigtableSession.createNettyChannel(
+                    BigtableOptions.BIGTABLE_INSTANCE_ADMIN_HOST_DEFAULT, options);
+              }
+            });
+
+    try {
+      BigtableInstanceClient client = new BigtableInstanceGrpcClient(channelPool);
+      ListClustersRequest listRequest =
+          ListClustersRequest.newBuilder().setParent(instanceName.getInstanceName()).build();
+      ListClustersResponse list = client.listCluster(listRequest);
+      Cluster cluster = getCluster(list, clusterId);
+      System.out.println(cluster ); 
+    } finally {
+      channelPool.shutdownNow();
+    }
+    //    BigtableInstanceClient client =
+    return false;
+  }
+
+
+  private static Cluster getCluster(ListClustersResponse list, String clusterId) {
+    for (Cluster cluster : list.getClustersList()) {
+      if (cluster.getName().endsWith("/clusters/" + clusterId)){
+        return cluster;
+      }
+    }
+    return null;
+  }
+
+
+  public static void main(String[] args) throws Exception {
+    Preconditions.checkArgument(
+        args.length == 4,
+        "Usage: BigtableClusterUtilities [projectId] [instanceId] [clusterId] [size]");
+    BigtableClusterUtilities.resizeCluster(
+        new BigtableInstanceName(args[0], args[1]), args[2], Integer.valueOf(args[3]));
+  }
+}

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableInstanceName.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableInstanceName.java
@@ -38,6 +38,9 @@ public class BigtableInstanceName implements Serializable {
 
   private final String instanceName;
 
+  private final String projectId;
+  private final String instanceId;
+
   /**
    * <p>Constructor for BigtableInstanceName.</p>
    *
@@ -48,6 +51,8 @@ public class BigtableInstanceName implements Serializable {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId), "projectId must be supplied");
     Preconditions.checkArgument(!Strings.isNullOrEmpty(instanceId), "instanceId must be supplied");
     this.instanceName = String.format(BIGTABLE_V2_INSTANCE_FMT, projectId, instanceId);
+    this.projectId = projectId;
+    this.instanceId = instanceId;
   }
 
   /**
@@ -77,6 +82,7 @@ public class BigtableInstanceName implements Serializable {
     return tableId;
   }
 
+
   /**
    * <p>toTableNameStr.</p>
    *
@@ -96,4 +102,29 @@ public class BigtableInstanceName implements Serializable {
   public BigtableTableName toTableName(String tableId) {
     return new BigtableTableName(toTableNameStr(tableId));
   }
+
+  /**
+   * Creates a fully qualified cluster within the current instance.
+   * @param clusterId the id of the cluster
+   * @return A fully qualified name for the cluster within the instance.
+   */
+  public String toClusterNameString(String clusterId) {
+    return instanceName + "/clusters/" + clusterId;
+  }
+  
+  /** @return the projectId */
+  public String getProjectId() {
+    return projectId;
+  }
+
+  /** @return the instanceId */
+  public String getInstanceId() {
+    return instanceId;
+  }
+
+  /** @return the fully qualified instanceName */
+  public String getInstanceName() {
+    return instanceName;
+  }
 }
+

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableInstanceName.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableInstanceName.java
@@ -103,15 +103,6 @@ public class BigtableInstanceName implements Serializable {
     return new BigtableTableName(toTableNameStr(tableId));
   }
 
-  /**
-   * Creates a fully qualified cluster within the current instance.
-   * @param clusterId the id of the cluster
-   * @return A fully qualified name for the cluster within the instance.
-   */
-  public String toClusterNameString(String clusterId) {
-    return instanceName + "/clusters/" + clusterId;
-  }
-  
   /** @return the projectId */
   public String getProjectId() {
     return projectId;
@@ -122,7 +113,10 @@ public class BigtableInstanceName implements Serializable {
     return instanceId;
   }
 
-  /** @return the fully qualified instanceName */
+  /**
+   * @return the fully qualified instanceName with the form
+   *         'projects/{projectId}/instances/{instanceId}'.
+   */
   public String getInstanceName() {
     return instanceName;
   }

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
@@ -439,12 +439,36 @@ public class BigtableSession implements Closeable {
   }
 
   /**
+   * createChannelPool.
+   *
+   * @param host a {@link String} object.
+   * @param options a {@link BigtableOptions} object.
+   * @return a {@link ChannelPool} object.
+   * @throws IOException if any.
+   * @throws GeneralSecurityException
+   */
+  public static ChannelPool createChannelPool(final String host, final BigtableOptions options)
+      throws IOException, GeneralSecurityException {
+    HeaderInterceptor interceptor =
+        CredentialInterceptorCache.getInstance()
+            .getCredentialsInterceptor(options.getCredentialOptions(), options.getRetryOptions());
+    return new ChannelPool(
+        ImmutableList.<HeaderInterceptor>of(interceptor),
+        new ChannelPool.ChannelFactory() {
+          @Override
+          public ManagedChannel create() throws IOException {
+            return createNettyChannel(host, options);
+          }
+        });
+  }
+
+  /**
    * <p>createNettyChannel.</p>
    *
-   * @param host a {@link java.lang.String} object.
-   * @param options a {@link com.google.cloud.bigtable.config.BigtableOptions} object.
-   * @return a {@link io.grpc.ManagedChannel} object.
-   * @throws java.io.IOException if any.
+   * @param host a {@link String} object.
+   * @param options a {@link BigtableOptions} object.
+   * @return a {@link ManagedChannel} object.
+   * @throws IOException if any.
    */
   public static ManagedChannel createNettyChannel(String host, BigtableOptions options) throws IOException {
     // TODO Go back to using host names once more extensive testing of the IPv6 issues.

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
@@ -415,10 +415,8 @@ public class BigtableSession implements Closeable {
   }
 
   /**
-   * <p>
-   * Create a new {@link com.google.cloud.bigtable.grpc.io.ChannelPool} of the given size, with auth headers and user agent interceptors.
-   * </p>
-   *
+   * Create a new {@link com.google.cloud.bigtable.grpc.io.ChannelPool}, with auth headers.
+   * 
    * @param hostString a {@link java.lang.String} object.
    * @return a {@link com.google.cloud.bigtable.grpc.io.ChannelPool} object.
    * @throws java.io.IOException if any.
@@ -439,7 +437,7 @@ public class BigtableSession implements Closeable {
   }
 
   /**
-   * createChannelPool.
+   * Create a new {@link com.google.cloud.bigtable.grpc.io.ChannelPool}, with auth headers.
    *
    * @param host a {@link String} object.
    * @param options a {@link BigtableOptions} object.


### PR DESCRIPTION
Users want to be able to increase cluster sizes before a large batch job, and reduce it afterwards.  This PR adds a utility to do that.

There's also a refactor to move creating of a ChannelPool into BigtableSession.