### PR TITLE
Updating BigtableZeroCopyByteStringUtil users to use ByteStringer.

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/RowMerger.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/RowMerger.java
@@ -23,8 +23,8 @@ import com.google.bigtable.v2.ReadRowsResponse;
 import com.google.bigtable.v2.ReadRowsResponse.CellChunk;
 import com.google.bigtable.v2.ReadRowsResponse.CellChunk.RowStatusCase;
 import com.google.bigtable.v2.Row;
+import com.google.cloud.bigtable.util.ByteStringer;
 import com.google.common.base.Preconditions;
-import com.google.protobuf.BigtableZeroCopyByteStringUtil;
 import com.google.protobuf.ByteString;
 
 import io.grpc.stub.StreamObserver;
@@ -364,7 +364,7 @@ public class RowMerger implements StreamObserver<ReadRowsResponse> {
 
     public void completeMultiChunkCell() {
       Preconditions.checkArgument(hasChunkInProgess());
-      ByteString value = BigtableZeroCopyByteStringUtil.wrap(outputStream.toByteArray());
+      ByteString value = ByteStringer.wrap(outputStream.toByteArray());
       addCell(cellBuilderInProgress.setValue(value).build());
       outputStream = null;
       cellBuilderInProgress = null;

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/util/ByteStringer.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/util/ByteStringer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.cloud.bigtable.util;
 
 import com.google.protobuf.ByteString;
@@ -7,7 +22,8 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 /**
- * Wrapper around {@link com.google.protobuf.BigtableZeroCopyByteStringUtil} for cases where it's not available.
+ * Wrapper around {@link com.google.protobuf.BigtableZeroCopyByteStringUtil} for cases where it's
+ * not available.
  *
  * @author sduskis
  * @version $Id: $Id
@@ -43,17 +59,20 @@ public class ByteStringer {
    * @return a {@link com.google.protobuf.ByteString} object.
    */
   public static ByteString wrap(final byte[] array) {
-    return USE_ZEROCOPYBYTESTRING? BigtableZeroCopyByteStringUtil.wrap(array): ByteString.copyFrom(array);
+    return USE_ZEROCOPYBYTESTRING
+        ? BigtableZeroCopyByteStringUtil.wrap(array)
+        : ByteString.copyFrom(array);
   }
 
   /**
-   * <p>extract.</p>
+   * extract.
    *
    * @param buf a {@link com.google.protobuf.ByteString} object.
    * @return an array of byte.
    */
   public static byte[] extract(ByteString buf) {
-    return USE_ZEROCOPYBYTESTRING ? BigtableZeroCopyByteStringUtil.zeroCopyGetBytes(buf) : buf
-        .toByteArray();
+    return USE_ZEROCOPYBYTESTRING
+        ? BigtableZeroCopyByteStringUtil.zeroCopyGetBytes(buf)
+        : buf.toByteArray();
   }
 }

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/protobuf/BigtableZeroCopyByteStringUtil.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/protobuf/BigtableZeroCopyByteStringUtil.java
@@ -46,18 +46,6 @@ public final class BigtableZeroCopyByteStringUtil {
   }
 
   /**
-   * Wraps a subset of a byte array in a {@link com.google.protobuf.ByteString} without copying it.
-   *
-   * @param array an array of byte.
-   * @param offset a int.
-   * @param length a int.
-   * @return a {@link com.google.protobuf.ByteString} object.
-   */
-  public static ByteString wrap(final byte[] array, int offset, int length) {
-    return ByteString.wrap(array, offset, length);
-  }
-
-  /**
    * Extracts the byte array from the given {@link com.google.protobuf.ByteString} without copy.
    *
    * @param buf A buffer from which to extract the array.

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/DeleteAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/DeleteAdapter.java
@@ -21,7 +21,7 @@ import com.google.bigtable.v2.Mutation.DeleteFromColumn;
 import com.google.bigtable.v2.Mutation.DeleteFromRow;
 import com.google.bigtable.v2.TimestampRange;
 import com.google.cloud.bigtable.hbase.BigtableConstants;
-import com.google.protobuf.BigtableZeroCopyByteStringUtil;
+import com.google.cloud.bigtable.util.ByteStringer;
 import com.google.protobuf.ByteString;
 
 import org.apache.hadoop.hbase.Cell;
@@ -210,7 +210,7 @@ public class DeleteAdapter implements OperationAdapter<Delete, MutateRowRequest.
   }
 
   private static byte[] getBytes(ByteString bs) {
-    return BigtableZeroCopyByteStringUtil.zeroCopyGetBytes(bs);
+    return ByteStringer.extract(bs);
   }
 
 }

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/PutAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/PutAdapter.java
@@ -22,7 +22,7 @@ import com.google.bigtable.v2.Mutation.MutationCase;
 import com.google.bigtable.v2.Mutation.SetCell;
 import com.google.cloud.bigtable.hbase.BigtableConstants;
 import com.google.cloud.bigtable.hbase.adapters.read.RowCell;
-import com.google.protobuf.BigtableZeroCopyByteStringUtil;
+import com.google.cloud.bigtable.util.ByteStringer;
 import com.google.protobuf.ByteString;
 
 import org.apache.hadoop.hbase.Cell;
@@ -159,6 +159,6 @@ public class PutAdapter implements OperationAdapter<Put, MutateRowRequest.Builde
   }
 
   private static byte[] getBytes(ByteString bs) {
-    return BigtableZeroCopyByteStringUtil.zeroCopyGetBytes(bs);
+    return ByteStringer.extract(bs);
   }
 }

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/RowAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/RowAdapter.java
@@ -32,7 +32,6 @@ import com.google.bigtable.v2.Row;
 import com.google.cloud.bigtable.hbase.BigtableConstants;
 import com.google.cloud.bigtable.hbase.adapters.ResponseAdapter;
 import com.google.cloud.bigtable.util.ByteStringer;
-import com.google.protobuf.BigtableZeroCopyByteStringUtil;
 
 /**
  * Adapt between a {@link com.google.bigtable.v2.Row} and an hbase client {@link org.apache.hadoop.hbase.client.Result}.
@@ -103,7 +102,7 @@ public class RowAdapter implements ResponseAdapter<Row, Result> {
 
     // Result.getRow() is derived from its cells.  If the cells are empty, the row will be null.
     if (result.getRow() != null) {
-      rowBuilder.setKey(BigtableZeroCopyByteStringUtil.wrap(result.getRow()));
+      rowBuilder.setKey(ByteStringer.wrap(result.getRow()));
     }
 
     Map<byte[], NavigableMap<byte[], NavigableMap<Long, byte[]>>> familyMap = result.getMap();
@@ -121,13 +120,13 @@ public class RowAdapter implements ResponseAdapter<Row, Result> {
         for (Entry<byte[], NavigableMap<Long, byte[]>> columnEntry :
             familyEntry.getValue().entrySet()) {
           Column.Builder columnBuilder = familyBuilder.addColumnsBuilder()
-              .setQualifier(BigtableZeroCopyByteStringUtil.wrap(columnEntry.getKey()));
+              .setQualifier(ByteStringer.wrap(columnEntry.getKey()));
 
           // process the cells in the column
           for (Entry<Long, byte[]> cellData : columnEntry.getValue().entrySet()) {
             columnBuilder.addCellsBuilder()
                 .setTimestampMicros(cellData.getKey().longValue() * TIME_CONVERSION_UNIT)
-                .setValue(BigtableZeroCopyByteStringUtil.wrap(cellData.getValue()));
+                .setValue(ByteStringer.wrap(cellData.getValue()));
           }
         }
       }

--- a/bigtable-hbase-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBatchExecutor.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBatchExecutor.java
@@ -43,9 +43,9 @@ import com.google.cloud.bigtable.grpc.async.BulkRead;
 import com.google.cloud.bigtable.grpc.scanner.ResultScanner;
 import com.google.cloud.bigtable.hbase.adapters.Adapters;
 import com.google.cloud.bigtable.hbase.adapters.HBaseRequestAdapter;
+import com.google.cloud.bigtable.util.ByteStringer;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.google.protobuf.BigtableZeroCopyByteStringUtil;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Empty;
 
@@ -275,7 +275,7 @@ public class TestBatchExecutor {
         if (current == 10) {
           return null;
         }
-        ByteString key = BigtableZeroCopyByteStringUtil.wrap(gets.get(current).getRow());
+        ByteString key = ByteStringer.wrap(gets.get(current).getRow());
         ByteString cellValue = ByteString.copyFrom(randomBytes(8));
         com.google.bigtable.v2.Cell cell = Cell.newBuilder()
             .setTimestampMicros(System.nanoTime() / 1000)


### PR DESCRIPTION
ByteStringer is a safer layer on top of BigtableZeroCopyByteStringUtil.
All references to BigtableZeroCopyByteStringUtil have been removed in
favor of calls to ByteStringer.