### PR TITLE
Some refactoring of BulkMutation.

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BulkMutation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BulkMutation.java
@@ -87,9 +87,10 @@ public class BulkMutation {
   static class RequestManager {
     private final List<SettableFuture<MutateRowResponse>> futures = new ArrayList<>();
     private final MutateRowsRequest.Builder builder;
+    private final Meter addMeter;
+
     private MutateRowsRequest request;
     private long approximateByteSize = 0l;
-    private Meter addMeter;
 
     RequestManager(String tableName, Meter addMeter) {
       this.builder = MutateRowsRequest.newBuilder().setTableName(tableName);
@@ -111,13 +112,7 @@ public class BulkMutation {
   }
 
   @VisibleForTesting
-  static class Batch implements Runnable {
-    private final AsyncExecutor asyncExecutor;
-    private final RetryOptions retryOptions;
-    private final ScheduledExecutorService retryExecutorService;
-    private final int maxRowKeyCount;
-    private final long maxRequestSize;
-
+  class Batch implements Runnable {
     private final Meter mutationMeter =
         BigtableClientMetrics.meter(MetricLevel.Info, "bulk-mutator.mutations.added");
     private final Meter mutationRetryMeter =
@@ -128,19 +123,8 @@ public class BulkMutation {
     private BackOff currentBackoff;
     private int failedCount;
 
-    Batch(
-        String tableName,
-        AsyncExecutor asyncExecutor,
-        RetryOptions retryOptions,
-        ScheduledExecutorService retryExecutorService,
-        int maxRowKeyCount,
-        long maxRequestSize) {
+    private Batch() {
       this.currentRequestManager = new RequestManager(tableName, mutationMeter);
-      this.asyncExecutor = asyncExecutor;
-      this.retryOptions = retryOptions;
-      this.retryExecutorService = retryExecutorService;
-      this.maxRowKeyCount = maxRowKeyCount;
-      this.maxRequestSize = maxRequestSize;
     }
 
     /**
@@ -152,14 +136,13 @@ public class BulkMutation {
      *         returns from the server. See {@link #addCallback(ListenableFuture)} for
      *         more information about how the SettableFuture is set.
      */
-    @VisibleForTesting
-    ListenableFuture<MutateRowResponse> add(MutateRowRequest request) {
+    private ListenableFuture<MutateRowResponse> add(MutateRowRequest request) {
       SettableFuture<MutateRowResponse> future = SettableFuture.create();
       currentRequestManager.add(future, convert(request));
       return future;
     }
 
-    boolean isFull() {
+    private boolean isFull() {
       return getRequestCount() >= maxRowKeyCount
           || currentRequestManager.approximateByteSize >= maxRequestSize;
     }
@@ -169,6 +152,7 @@ public class BulkMutation {
      * {@link BulkMutation#add(MutateRowRequest)} when the provided {@link ListenableFuture} for the
      * {@link MutateRowsResponse} is complete.
      */
+    @VisibleForTesting
     void addCallback(ListenableFuture<List<MutateRowsResponse>> bulkFuture) {
       Futures.addCallback(
           bulkFuture,
@@ -185,7 +169,7 @@ public class BulkMutation {
           });
     }
 
-    synchronized void handleResult(List<MutateRowsResponse> results) {
+    private synchronized void handleResult(List<MutateRowsResponse> results) {
       if (this.currentRequestManager == null) {
         LOG.warn("Got duplicate responses for bulk mutation.");
         return;
@@ -328,7 +312,7 @@ public class BulkMutation {
       }
     }
 
-    protected boolean isRetryable(int codeId) {
+    private boolean isRetryable(int codeId) {
       Code code = io.grpc.Status.fromCodeValue(codeId).getCode();
       return retryOptions.isRetryable(code);
     }
@@ -338,10 +322,9 @@ public class BulkMutation {
       ListenableFuture<List<MutateRowsResponse>> future = null;
       try {
         if (retryId == null) {
-          retryId = Long.valueOf(this.asyncExecutor.getRpcThrottler().registerRetry());
+          retryId = Long.valueOf(asyncExecutor.getRpcThrottler().registerRetry());
         }
-        MutateRowsRequest request = currentRequestManager.build();
-        future = asyncExecutor.mutateRowsAsync(request);
+        future = asyncExecutor.mutateRowsAsync(currentRequestManager.build());
       } catch (InterruptedException e) {
         future = Futures.<List<MutateRowsResponse>> immediateFailedFuture(e);
       } finally {
@@ -364,11 +347,12 @@ public class BulkMutation {
     }
 
     private void setRetryComplete() {
-      this.asyncExecutor.getRpcThrottler().onRetryCompletion(retryId);
+      asyncExecutor.getRpcThrottler().onRetryCompletion(retryId);
+      removeBatch(Batch.this);
     }
 
     @VisibleForTesting
-   int getRequestCount() {
+    int getRequestCount() {
       return currentRequestManager == null ? 0 : currentRequestManager.futures.size();
     }
   }
@@ -384,6 +368,8 @@ public class BulkMutation {
   private final long maxRequestSize;
   private final Meter batchMeter =
       BigtableClientMetrics.meter(MetricLevel.Info, "bulk-mutator.batch.meter");
+
+  private List<Batch> activeBatches = new ArrayList<>();
 
   /**
    * <p>Constructor for BulkMutation.</p>
@@ -423,22 +409,20 @@ public class BulkMutation {
   public synchronized ListenableFuture<MutateRowResponse> add(MutateRowRequest request) {
     if (currentBatch == null) {
       batchMeter.mark();
-      currentBatch =
-          new Batch(
-              tableName,
-              asyncExecutor,
-              retryOptions,
-              retryExecutorService,
-              maxRowKeyCount,
-              maxRequestSize);
+      currentBatch = new Batch();
     }
 
     ListenableFuture<MutateRowResponse> future = currentBatch.add(request);
     if (currentBatch.isFull()) {
+      activeBatches.add(currentBatch);
       currentBatch.run();
       currentBatch = null;
     }
     return future;
+  }
+
+  protected synchronized void removeBatch(Batch batch) {
+    activeBatches.remove(batch);
   }
 
   /**

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestBulkMutation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestBulkMutation.java
@@ -48,6 +48,8 @@ import com.google.bigtable.v2.Mutation;
 import com.google.bigtable.v2.Mutation.SetCell;
 import com.google.cloud.bigtable.config.RetryOptions;
 import com.google.cloud.bigtable.config.RetryOptionsUtil;
+import com.google.cloud.bigtable.grpc.BigtableInstanceName;
+import com.google.cloud.bigtable.grpc.BigtableTableName;
 import com.google.cloud.bigtable.grpc.async.AsyncExecutor;
 import com.google.cloud.bigtable.grpc.async.BulkMutation;
 import com.google.cloud.bigtable.grpc.async.RpcThrottler;
@@ -66,7 +68,8 @@ import io.grpc.StatusRuntimeException;
 @SuppressWarnings({"rawtypes", "unchecked"})
 @RunWith(JUnit4.class)
 public class TestBulkMutation {
-  private final static String TABLE_NAME = "table";
+  private final static BigtableTableName TABLE_NAME =
+      new BigtableInstanceName("project", "instance").toTableName("table");
   private final static ByteString QUALIFIER = ByteString.copyFrom("qual".getBytes());
 
   @Rule
@@ -89,7 +92,7 @@ public class TestBulkMutation {
   RetryOptions retryOptions;
 
   private AtomicLong retryIdGenerator = new AtomicLong();
-  private BulkMutation.Batch underTest;
+  private BulkMutation underTest;
 
   @Before
   public void setup() throws InterruptedException {
@@ -114,18 +117,18 @@ public class TestBulkMutation {
       }
     });
 
-    underTest = new BulkMutation.Batch(TABLE_NAME, asyncExecutor, retryOptions, retryExecutorService,
-      1000, 1000000L);
+    underTest = new BulkMutation(TABLE_NAME, asyncExecutor, retryOptions,
+        retryExecutorService, 1000, 1000000L);
   }
 
   @Test
   public void testAdd() {
     MutateRowRequest mutateRowRequest = createRequest();
-    BulkMutation.RequestManager requestManager = new BulkMutation.RequestManager(TABLE_NAME,
-        BigtableClientMetrics.meter(MetricLevel.Trace, "test.bulk"));
+    BulkMutation.RequestManager requestManager = new BulkMutation.RequestManager(
+        TABLE_NAME.toString(), BigtableClientMetrics.meter(MetricLevel.Trace, "test.bulk"));
     requestManager.add(null, BulkMutation.convert(mutateRowRequest));
     MutateRowsRequest expected = MutateRowsRequest.newBuilder()
-        .setTableName(TABLE_NAME)
+        .setTableName(TABLE_NAME.toString())
         .addEntries(Entry.newBuilder().addMutations(mutateRowRequest.getMutations(0)).build())
         .build();
     Assert.assertEquals(expected, requestManager.build());
@@ -159,7 +162,7 @@ public class TestBulkMutation {
     ListenableFuture<MutateRowResponse> rowFuture = underTest.add(createRequest());
     ListenableFuture<List<MutateRowsResponse>> rowsFuture = SettableFuture.<List<MutateRowsResponse>>create();
     when(nanoClock.nanoTime()).thenReturn(1l);
-    underTest.addCallback(rowsFuture);
+    underTest.currentBatch.addCallback(rowsFuture);
     Assert.assertFalse(rowFuture.isDone());
     setResponse(io.grpc.Status.NOT_FOUND);
 
@@ -197,15 +200,15 @@ public class TestBulkMutation {
     ListenableFuture<MutateRowResponse> rowFuture1 = underTest.add(createRequest());
     ListenableFuture<MutateRowResponse> rowFuture2 = underTest.add(createRequest());
     SettableFuture<List<MutateRowsResponse>> rowsFuture = SettableFuture.<List<MutateRowsResponse>> create();
-    underTest.addCallback(rowsFuture);
+    underTest.currentBatch.addCallback(rowsFuture);
     Assert.assertFalse(rowFuture1.isDone());
     Assert.assertFalse(rowFuture2.isDone());
 
-    Assert.assertEquals(2, underTest.getRequestCount());
+    Assert.assertEquals(2, underTest.currentBatch.getRequestCount());
     // Send only one response - this is poor server behavior.
     setResponse(io.grpc.Status.OK);
     when(nanoClock.nanoTime()).thenReturn(0l);
-    Assert.assertEquals(1, underTest.getRequestCount());
+    Assert.assertEquals(1, underTest.currentBatch.getRequestCount());
 
     // Make sure that the first request completes, but the second does not.
     Assert.assertTrue(rowFuture1.isDone());
@@ -217,7 +220,7 @@ public class TestBulkMutation {
 
     // Make sure that only the second request was sent.
     setResponse(io.grpc.Status.OK);
-    Assert.assertEquals(0, underTest.getRequestCount());
+    Assert.assertEquals(0, underTest.currentBatch.getRequestCount());
     Assert.assertTrue(rowFuture2.isDone());
     verify(rpcThrottler, times(1)).onRetryCompletion(eq(retryIdGenerator.get()));
   }
@@ -268,6 +271,6 @@ public class TestBulkMutation {
         .setIndex(0)
         .getStatusBuilder().setCode(code.getCode().value());
     when(mockFuture.get()).thenReturn(ImmutableList.of(responseBuilder.build()));
-    underTest.run();
+    underTest.currentBatch.run();
   }
 }


### PR DESCRIPTION
- Keeping track of all active batches.  This will enable more elaborate retries in the future for hung batches.
- Making Batch a nested class instead of a static nested class.  Batch needs access to most of BulkMutation's objects anyway.