### PR TITLE
Moving user agent calculation into bigtable-client-core.

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/pom.xml
+++ b/bigtable-client-core-parent/bigtable-client-core/pom.xml
@@ -129,6 +129,13 @@ limitations under the License.
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <!-- enable project.version substitution. -->
+                <filtering>true</filtering>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableVersionInfo.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableVersionInfo.java
@@ -14,7 +14,7 @@ public class BigtableVersionInfo {
   public static final String CORE_UESR_AGENT = "bigtable-" + CLIENT_VERSION +",jdk-" + JDK_VERSION;
 
   /**
-   * Gets user agent from bigtable-hbase.properties. Returns a default dev user agent with current
+   * Gets user agent from bigtable-version.properties. Returns a default dev user agent with current
    * timestamp if not found.
    */
   private static String getVersion() {

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableVersionInfo.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableVersionInfo.java
@@ -32,14 +32,14 @@ public class BigtableVersionInfo {
       properties.load(stream);
       String value = properties.getProperty(versionProperty);
       if (value == null) {
-        LOG.error("$1 not found in $2.", versionProperty, fileName);
+        LOG.error("%s not found in %s.", versionProperty, fileName);
       } else if (value.startsWith("$")){
-        LOG.info("$1 property is not replaced.", versionProperty);
+        LOG.info("%s property is not replaced.", versionProperty);
       } else {
         return value;
       }
     } catch (IOException e) {
-      LOG.error("Error while trying to get user agent name from $1", e, fileName);
+      LOG.error("Error while trying to get user agent name from %s", e, fileName);
     }
     return defaultVersion;
   }

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableVersionInfo.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableVersionInfo.java
@@ -1,0 +1,53 @@
+package com.google.cloud.bigtable.config;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+public class BigtableVersionInfo {
+
+  private static final Logger LOG = new Logger(BigtableVersionInfo.class);
+
+  public static final String CLIENT_VERSION = getVersion();
+  public static final String JDK_VERSION = getJavaVersion();
+
+  public static final String CORE_UESR_AGENT = "bigtable-" + CLIENT_VERSION +",jdk-" + JDK_VERSION;
+
+  /**
+   * Gets user agent from bigtable-hbase.properties. Returns a default dev user agent with current
+   * timestamp if not found.
+   */
+  private static String getVersion() {
+    final String defaultVersion = "dev-" + System.currentTimeMillis();
+    final String fileName = "bigtable-version.properties";
+    final String versionProperty = "bigtable.version";
+    try (InputStream stream =
+        BigtableVersionInfo.class.getResourceAsStream(fileName)) {
+      if (stream == null) {
+        LOG.error("Could not load properties file bigtable-version.properties");
+        return defaultVersion;
+      }
+
+      Properties properties = new Properties();
+      properties.load(stream);
+      String value = properties.getProperty(versionProperty);
+      if (value == null) {
+        LOG.error("$1 not found in $2.", versionProperty, fileName);
+      } else if (value.startsWith("$")){
+        LOG.info("$1 property is not replaced.", versionProperty);
+      } else {
+        return value;
+      }
+    } catch (IOException e) {
+      LOG.error("Error while trying to get user agent name from $1", e, fileName);
+    }
+    return defaultVersion;
+  }
+
+  /**
+   * @return The java specification version; for example, 1.7 or 1.8.
+   */
+  private static String getJavaVersion() {
+    return System.getProperty("java.specification.version");
+  }
+}

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
@@ -36,6 +36,7 @@ import javax.net.ssl.SSLException;
 
 import com.google.api.client.util.Strings;
 import com.google.cloud.bigtable.config.BigtableOptions;
+import com.google.cloud.bigtable.config.BigtableVersionInfo;
 import com.google.cloud.bigtable.config.CredentialFactory;
 import com.google.cloud.bigtable.config.CredentialOptions;
 import com.google.cloud.bigtable.config.Logger;
@@ -514,7 +515,7 @@ public class BigtableSession implements Closeable {
         .eventLoopGroup(sharedPools.getElg())
         .executor(sharedPools.getBatchThreadPool())
         .negotiationType(negotiationType)
-        .userAgent(options.getUserAgent())
+        .userAgent(BigtableVersionInfo.CORE_UESR_AGENT + "," + options.getUserAgent())
         .flowControlWindow(FLOW_CONTROL_WINDOW)
         .build();
   }

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/resources/com/google/cloud/bigtable/config/bigtable-version.properties
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/resources/com/google/cloud/bigtable/config/bigtable-version.properties
@@ -1,0 +1,2 @@
+bigtable.version=${project.version}
+

--- a/bigtable-hbase-parent/bigtable-hbase-1.0/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-1.0/pom.xml
@@ -64,13 +64,6 @@ limitations under the License.
         </dependency>
     </dependencies>
     <build>
-        <resources>
-            <resource>
-                <directory>src/main/resources</directory>
-                <!-- enable project.version substitution. -->
-                <filtering>true</filtering>
-            </resource>
-        </resources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/bigtable-hbase-parent/bigtable-hbase-1.0/src/main/resources/com/google/cloud/bigtable/hbase/bigtable-hbase.properties
+++ b/bigtable-hbase-parent/bigtable-hbase-1.0/src/main/resources/com/google/cloud/bigtable/hbase/bigtable-hbase.properties
@@ -1,1 +1,0 @@
-bigtable.hbase.user_agent=${project.artifactId}-${project.version}

--- a/bigtable-hbase-parent/bigtable-hbase-1.1/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-1.1/pom.xml
@@ -64,13 +64,6 @@ limitations under the License.
         </dependency>
     </dependencies>
     <build>
-        <resources>
-            <resource>
-                <directory>src/main/resources</directory>
-                <!-- enable project.version substitution. -->
-                <filtering>true</filtering>
-            </resource>
-        </resources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/bigtable-hbase-parent/bigtable-hbase-1.1/src/main/resources/com/google/cloud/bigtable/hbase/bigtable-hbase.properties
+++ b/bigtable-hbase-parent/bigtable-hbase-1.1/src/main/resources/com/google/cloud/bigtable/hbase/bigtable-hbase.properties
@@ -1,1 +1,0 @@
-bigtable.hbase.user_agent=${project.artifactId}-${project.version}

--- a/bigtable-hbase-parent/bigtable-hbase-1.2/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-1.2/pom.xml
@@ -64,13 +64,6 @@ limitations under the License.
         </dependency>
     </dependencies>
     <build>
-        <resources>
-            <resource>
-                <directory>src/main/resources</directory>
-                <!-- enable project.version substitution. -->
-                <filtering>true</filtering>
-            </resource>
-        </resources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/bigtable-hbase-parent/bigtable-hbase-1.2/src/main/resources/com/google/cloud/bigtable/hbase/bigtable-hbase.properties
+++ b/bigtable-hbase-parent/bigtable-hbase-1.2/src/main/resources/com/google/cloud/bigtable/hbase/bigtable-hbase.properties
@@ -1,1 +1,0 @@
-bigtable.hbase.user_agent=${project.artifactId}-${project.version}

--- a/bigtable-hbase-parent/bigtable-hbase-mapreduce/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-mapreduce/pom.xml
@@ -82,13 +82,6 @@ limitations under the License.
         </dependency>
     </dependencies>
     <build>
-        <resources>
-            <resource>
-                <directory>src/main/resources</directory>
-                <!-- enable project.version substitution. -->
-                <filtering>true</filtering>
-            </resource>
-        </resources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableConstants.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableConstants.java
@@ -16,13 +16,9 @@
 package com.google.cloud.bigtable.hbase;
 
 
-import com.google.cloud.bigtable.config.Logger;
-import com.google.protobuf.ByteString;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Properties;
 import java.util.concurrent.TimeUnit;
+
+import com.google.protobuf.ByteString;
 
 /**
  * Constants related to Bigtable.
@@ -31,8 +27,6 @@ import java.util.concurrent.TimeUnit;
  * @version $Id: $Id
  */
 public class BigtableConstants {
-
-  private static final Logger LOG = new Logger(BigtableConstants.class);
 
   /**
    * Separator between column family and column name for bigtable, as a single byte.
@@ -59,47 +53,4 @@ public class BigtableConstants {
    * TimeUnit in which Bigtable requires messages to be sent and received.
    */
   public static final TimeUnit BIGTABLE_TIMEUNIT = TimeUnit.MICROSECONDS;
-
-  /**
-   * A User-Agent token to be added to User-Agent request header.
-   */
-  public static final String USER_AGENT = getUserAgent() + "," + getJavaVersion();
-
-  /**
-   * Gets user agent from bigtable-hbase.properties. Returns a default dev user agent with current
-   * timestamp if not found.
-   */
-  private static String getUserAgent() {
-    final String defaultUserAgent = "bigtable-hbase/dev-" + System.currentTimeMillis();
-    try (InputStream stream =
-        BigtableConstants.class.getResourceAsStream("bigtable-hbase.properties")) {
-      if (stream == null) {
-        LOG.error("Could not load properties file bigtable-hbase.properties");
-        return defaultUserAgent;
-      }
-
-      Properties properties = new Properties();
-      properties.load(stream);
-      String value = properties.getProperty("bigtable.hbase.user_agent");
-      if (value == null) {
-        LOG.error("bigtable.hbase.user_agent not found in bigtable-hbase.properties.");
-      } else if (value.startsWith("$")){
-        LOG.info("bigtable.hbase.user_agent property is not replaced.");
-      } else {
-        return value;
-      }
-    } catch (IOException e) {
-      LOG.error(
-          String.format("Error while trying to get user agent name from bigtable-hbase.properties"),
-          e);
-    }
-    return defaultUserAgent;
-  }
-
-  /**
-   * @return The java specification version; for example, 1.7 or 1.8.
-   */
-  private static String getJavaVersion() {
-    return System.getProperty("java.specification.version");
-  }
 }

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableOptionsFactory.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableOptionsFactory.java
@@ -36,6 +36,7 @@ import io.grpc.Status;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.util.VersionInfo;
 
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -291,7 +292,8 @@ public class BigtableOptionsFactory {
         BIGTABLE_DATA_CHANNEL_COUNT_KEY, BigtableOptions.BIGTABLE_DATA_CHANNEL_COUNT_DEFAULT);
     builder.setDataChannelCount(channelCount);
 
-    builder.setUserAgent(BigtableConstants.USER_AGENT);
+    // This information is in addition to bigtable-client-core version, and jdk version.
+    builder.setUserAgent("hbase-" + VersionInfo.getVersion());
   }
 
   private static void setBulkOptions(final Configuration configuration,


### PR DESCRIPTION
We always want to include cloud bigtable client version and jdk version in the user agent.  The BigtableOptions user agent is an additional piece of information rather than a substitute, so treat it that way.