### PR TITLE
Resetting the httpTransport and credentials in the interceptor.

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/CredentialFactory.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/CredentialFactory.java
@@ -97,6 +97,18 @@ public class CredentialFactory {
   }
 
   /**
+   * Removes the cached {@link HttpTransport} created by {@link #getHttpTransport()}. This is useful
+   * in cases where the transport is stale.
+   *
+   * @return true if the httpTransport was set to null;
+   */
+  public static boolean clearHttpTransport() {
+    boolean wasSet = httpTransport != null;
+    httpTransport = null;
+    return wasSet;
+  }
+
+  /**
    * Look up a Credentials object based on a configuration of credentials described in a
    * {@link com.google.cloud.bigtable.config.CredentialOptions}.
    *

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/CredentialInterceptorCache.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/CredentialInterceptorCache.java
@@ -103,8 +103,8 @@ public class CredentialInterceptorCache {
             credentials.getClass().getName()));
 
     RefreshingOAuth2CredentialsInterceptor oauth2Interceptor =
-        new RefreshingOAuth2CredentialsInterceptor(
-            executor, (OAuth2Credentials) credentials, retryOptions);
+        new RefreshingOAuth2CredentialsInterceptor(executor, (OAuth2Credentials) credentials,
+            credentialOptions, retryOptions);
 
     // The RefreshingOAuth2CredentialsInterceptor uses the credentials to get a security token that
     // will live for a short time.  That token is added on all calls by the gRPC interceptor to


### PR DESCRIPTION
If there's an IOException, it could very well be due to the http transport and/or the cached credentials.  In that case, get a new transport and new credentials before getting a new OAuth2 token.