### PR TITLE
Expand channel pool in getStreamFuture

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataGrpcClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataGrpcClient.java
@@ -326,6 +326,7 @@ public class BigtableDataGrpcClient implements BigtableDataClient {
    */
   protected <ReqT, RespT> ListenableFuture<List<RespT>> getStreamingFuture(ReqT request,
       BigtableAsyncRpc<ReqT, RespT> rpc, String tableName) {
+    expandPoolIfNecessary(this.bigtableOptions.getChannelCount());
     return getCompletionFuture(createStreamingListener(request, rpc, tableName));
   }
 


### PR DESCRIPTION
It seems that expandPoolIfNecessary is only called from getUnaryFuture.
The result is that if only bulk mutations are used, the pool doesn't get
expanded and we end up with just one TCP connection which hurts performance.

I'm not sure if this is intended or not. But by changing this we get a great performance boost.