### PR TITLE
Setting the number of connections in ChannelPool's constructor.

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataGrpcClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataGrpcClient.java
@@ -326,7 +326,6 @@ public class BigtableDataGrpcClient implements BigtableDataClient {
    */
   protected <ReqT, RespT> ListenableFuture<List<RespT>> getStreamingFuture(ReqT request,
       BigtableAsyncRpc<ReqT, RespT> rpc, String tableName) {
-    expandPoolIfNecessary(this.bigtableOptions.getChannelCount());
     return getCompletionFuture(createStreamingListener(request, rpc, tableName));
   }
 
@@ -337,7 +336,6 @@ public class BigtableDataGrpcClient implements BigtableDataClient {
 
   private <ReqT, RespT> ListenableFuture<RespT> getUnaryFuture(ReqT request,
       BigtableAsyncRpc<ReqT, RespT> rpc, String tableName) {
-    expandPoolIfNecessary(this.bigtableOptions.getChannelCount());
     return getCompletionFuture(createUnaryListener(request, rpc, tableName));
   }
 
@@ -413,8 +411,6 @@ public class BigtableDataGrpcClient implements BigtableDataClient {
     final Timer.Context timerContext = readRowsAsync.getRpcMetrics().timeRpc();
     final AtomicBoolean wasCanceled = new AtomicBoolean(false);
 
-    expandPoolIfNecessary(this.bigtableOptions.getChannelCount());
-
     CallOptions callOptions = getCallOptions(readRowsAsync.getMethodDescriptor(), request);
     final ClientCall<ReadRowsRequest, ReadRowsResponse> readRowsCall =
         readRowsAsync.newCall(callOptions);
@@ -442,13 +438,5 @@ public class BigtableDataGrpcClient implements BigtableDataClient {
     }, MoreExecutors.directExecutor());
 
     return new StreamingBigtableResultScanner(reader, cancellationToken);
-  }
-
-  private void expandPoolIfNecessary(int channelCount) {
-    try {
-      this.channelPool.ensureChannelCount(channelCount);
-    } catch (IOException e) {
-      LOG.info("Could not expand the channel pool.", e);
-    }
   }
 }

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/io/ChannelPoolPerf.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/io/ChannelPoolPerf.java
@@ -17,6 +17,7 @@ package com.google.cloud.bigtable.grpc.io;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -81,14 +82,14 @@ public class ChannelPoolPerf {
     };
     int threads = 10;
     int concurrent = 400;
-    final ChannelPool cp = new ChannelPool(
-      Collections.<HeaderInterceptor>emptyList(), new ChannelPool.ChannelFactory() {
-        @Override
-        public ManagedChannel create() throws IOException {
-          return channel;
-        }
-      });
-    cp.ensureChannelCount(40);
+    final ChannelPool.ChannelFactory pool = new ChannelPool.ChannelFactory() {
+      @Override
+      public ManagedChannel create() throws IOException {
+        return channel;
+      }
+    };
+    List<HeaderInterceptor> headers = Collections.<HeaderInterceptor> emptyList();
+    final ChannelPool cp = new ChannelPool(headers, pool, 40);
     ExecutorService es = Executors.newFixedThreadPool(threads);
     Callable<Void> runnable = new Callable<Void>() {
       @Override

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/io/ChannelPoolTest.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/io/ChannelPoolTest.java
@@ -100,8 +100,7 @@ public class ChannelPoolTest {
     MockChannelFactory factory = new MockChannelFactory();
     MethodDescriptor descriptor = mock(MethodDescriptor.class);
     MockitoAnnotations.initMocks(this);
-    ChannelPool pool = new ChannelPool(null, factory);
-    pool.ensureChannelCount(2);
+    ChannelPool pool = new ChannelPool(null, factory, 2);
     pool.newCall(descriptor, CallOptions.DEFAULT);
     verify(factory.channels.get(0), times(1)).newCall(same(descriptor), same(CallOptions.DEFAULT));
     verify(factory.channels.get(1), times(0)).newCall(same(descriptor), same(CallOptions.DEFAULT));
@@ -113,8 +112,7 @@ public class ChannelPoolTest {
   @Test
   public void testEnsureCapcity() throws IOException {
     MockChannelFactory factory = new MockChannelFactory();
-    ChannelPool pool = new ChannelPool(null, factory);
-    pool.ensureChannelCount(4);
+    ChannelPool pool = new ChannelPool(null, factory, 4);
     Assert.assertEquals(4, factory.channels.size());
     Assert.assertEquals(4, pool.size());
   }
@@ -141,7 +139,6 @@ public class ChannelPoolTest {
   public void testAwaitTermination() throws IOException, InterruptedException {
     MockChannelFactory factory = new MockChannelFactory();
     ChannelPool pool = new ChannelPool(null, factory);
-    pool.ensureChannelCount(5);
     for (ManagedChannel managedChannel : factory.channels) {
       when(managedChannel.isTerminated()).thenReturn(false);
     }


### PR DESCRIPTION
ensureChannelCount was flaky.  We should just create the whole pool to begin with.

This will have an impact on the way we do testing, but we should change our tests rather than have a complicated client.