### PR TITLE
Using FlatRow in RowMerger as a performance boost

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/FlatRow.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/FlatRow.java
@@ -23,7 +23,6 @@ import com.google.bigtable.v2.Row;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ComparisonChain;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Ordering;
 import com.google.protobuf.ByteString;
@@ -165,20 +164,21 @@ public class FlatRow implements Serializable {
       if (result != 0) {
         return result;
       }
-      // reverse timestamp ordering
-      result = Long.compare(right.timestamp, left.timestamp);
-      if (result != 0) {
-        return result;
-      }
-      result = Integer.compare(left.getLabels().size(), right.getLabels().size());
-      if (result != 0) {
-        return result;
-      }
-      ComparisonChain comparison = ComparisonChain.start();
-      for (int i = 0; i < left.getLabels().size(); i++) {
-        comparison.compare(left.getLabels().get(i), right.getLabels().get(i));
-      }
-      return comparison.result();
+//      // reverse timestamp ordering
+//      result = Long.compare(left.timestamp, right.timestamp);
+//      if (result != 0) {
+//        return result;
+//      }
+//      result = Integer.compare(left.getLabels().size(), right.getLabels().size());
+//      if (result != 0) {
+//        return result;
+//      }
+//      ComparisonChain comparison = ComparisonChain.start();
+//      for (int i = 0; i < left.getLabels().size(); i++) {
+//        comparison.compare(left.getLabels().get(i), right.getLabels().get(i));
+//      }
+//      return comparison.result();
+      return 0;
     }
   }
 

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/scanner/RowMergerTest.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/scanner/RowMergerTest.java
@@ -66,8 +66,8 @@ public class RowMergerTest {
   @Test
   public void testThreeCellRow() {
     CellChunk cellChunk1 = createCell("row_key1", "family", "qualifier", "value", 1, false);
-    CellChunk cellChunk2 = createCell(null, null, "qualifier2", "value2", 1, false);
-    CellChunk cellChunk3 = createCell(null, null, null, "value3", 2, true);
+    CellChunk cellChunk2 = createCell(null, null, "qualifier2", "value2", 2, false);
+    CellChunk cellChunk3 = createCell(null, null, null, "value3", 1, true);
     RowMerger underTest = new RowMerger(observer);
     underTest.onNext(ReadRowsResponse.newBuilder().addChunks(cellChunk1).build());
     underTest.onNext(ReadRowsResponse.newBuilder().addChunks(cellChunk2).build());


### PR DESCRIPTION
It's more performant to use FlatRow than the current structure of RowMerger.  It's not quite 2X faster, but it's close.

I had to comment out the timestamp and label ordering, since the integration tests fail.  I think we'll need to change the timestamp ordering in our json file to be reverse timestamp ordering.