### PR TITLE
Removing GeneratedMessage from generics.

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AsyncExecutor.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AsyncExecutor.java
@@ -278,8 +278,8 @@ public class AsyncExecutor {
     return call(rpc, request, id);
   }
 
-  private <ResponseT, RequestT extends GeneratedMessage> ListenableFuture<ResponseT>
-      call(AsyncCall<RequestT, ResponseT> rpc, RequestT request, long id) {
+  private <ResponseT, RequestT> ListenableFuture<ResponseT> call(AsyncCall<RequestT, ResponseT> rpc,
+      RequestT request, long id) {
     ListenableFuture<ResponseT> future;
     try {
       future = rpc.call(client, request);

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutator.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutator.java
@@ -51,7 +51,6 @@ import com.google.cloud.bigtable.hbase.adapters.HBaseRequestAdapter;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.google.protobuf.GeneratedMessage;
 
 /**
  * Bigtable's {@link org.apache.hadoop.hbase.client.BufferedMutator} implementation.
@@ -331,7 +330,8 @@ public class BigtableBufferedMutator implements BufferedMutator {
    * @param future a {@link com.google.common.util.concurrent.ListenableFuture} object.
    * @param mutation a {@link org.apache.hadoop.hbase.client.Mutation} object.
    */
-  protected void addExceptionCallback(ListenableFuture<? extends GeneratedMessage> future,
+  @SuppressWarnings("unchecked")
+  protected void addExceptionCallback(ListenableFuture<?> future,
       Mutation mutation) {
     Futures.addCallback(future, new ExceptionCallback(mutation));
   }
@@ -353,8 +353,7 @@ public class BigtableBufferedMutator implements BufferedMutator {
     }
   }
 
-  private ListenableFuture<? extends GeneratedMessage> issueRequestDetails(Mutation mutation,
-      long operationId) {
+  private ListenableFuture<?> issueRequestDetails(Mutation mutation, long operationId) {
     try {
       if (mutation == null) {
         return Futures.immediateFailedFuture(
@@ -419,7 +418,8 @@ public class BigtableBufferedMutator implements BufferedMutator {
     }
   }
 
-  private class ExceptionCallback implements FutureCallback<GeneratedMessage> {
+  @SuppressWarnings("rawtypes")
+  private class ExceptionCallback implements FutureCallback {
     private final Row mutation;
 
     public ExceptionCallback(Row mutation) {
@@ -432,7 +432,7 @@ public class BigtableBufferedMutator implements BufferedMutator {
     }
 
     @Override
-    public void onSuccess(GeneratedMessage ignored) {
+    public void onSuccess(Object ignored) {
     }
   }
 

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/ResponseAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/ResponseAdapter.java
@@ -15,8 +15,6 @@
  */
 package com.google.cloud.bigtable.hbase.adapters;
 
-import com.google.protobuf.GeneratedMessage;
-
 import org.apache.hadoop.hbase.client.Result;
 
 /**
@@ -27,7 +25,7 @@ import org.apache.hadoop.hbase.client.Result;
  * @author sduskis
  * @version $Id: $Id
  */
-public interface ResponseAdapter<T extends GeneratedMessage, U extends Result> {
+public interface ResponseAdapter<T, U extends Result> {
 
   /**
    * Transform an Bigtable server response to an HBase Result instance.


### PR DESCRIPTION
Overly specific generica caused some issues in both #1079 and protobuf 3.0.0 upgrades.  Remove the specificity where possible.