### PR TITLE
Using FlatRow in Dataflow.

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/FlatRowConverter.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/FlatRowConverter.java
@@ -15,11 +15,12 @@
  */
 package com.google.cloud.bigtable.grpc.scanner;
 
+import java.util.Collection;
+
 import com.google.bigtable.v2.Cell;
 import com.google.bigtable.v2.Column;
 import com.google.bigtable.v2.Family;
 import com.google.bigtable.v2.Row;
-import com.google.common.collect.ImmutableList;
 import com.google.protobuf.ByteString;
 
 /**
@@ -33,9 +34,17 @@ public class FlatRowConverter {
     if (row == null) {
       return null;
     }
-    ImmutableList<FlatRow.Cell> cells =
-        FlatRow.CellOrdering.DEFAULT_ORDERING.immutableSortedCopy(row.getCells());
+    return convert(row, FlatRow.CellOrdering.DEFAULT_ORDERING.immutableSortedCopy(row.getCells()));
+  }
 
+  public static Row convertUnorderd(FlatRow row) {
+    if (row == null) {
+      return null;
+    }
+    return convert(row, row.getCells());
+  }
+
+  private static Row convert(FlatRow row, Collection<FlatRow.Cell> cells) {
     Row.Builder rowBuilder = Row.newBuilder().setKey(row.getRowKey());
     String prevFamily = null;
     Family.Builder familyBuilder = null;

--- a/bigtable-dataflow-parent/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/coders/HBaseResultArrayCoder.java
+++ b/bigtable-dataflow-parent/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/coders/HBaseResultArrayCoder.java
@@ -15,8 +15,6 @@
  */
 package com.google.cloud.bigtable.dataflow.coders;
 
-import com.google.bigtable.repackaged.com.google.cloud.hbase.adapters.Adapters;
-import com.google.bigtable.repackaged.com.google.com.google.bigtable.v2.Row;
 import com.google.cloud.dataflow.sdk.coders.AtomicCoder;
 import com.google.cloud.dataflow.sdk.coders.Coder;
 
@@ -47,7 +45,7 @@ public class HBaseResultArrayCoder extends AtomicCoder<Result[]>{
     int resultCount = ois.readInt();
     Result[] results = new Result[resultCount];
     for (int i = 0; i < resultCount; i++) {
-      results[i] = Adapters.ROW_ADAPTER.adaptResponse(Row.parseDelimitedFrom(inputStream));
+      results[i] = HBaseResultCoder.getInstance().decode(ois, context);
     }
     return results;
   }
@@ -59,7 +57,7 @@ public class HBaseResultArrayCoder extends AtomicCoder<Result[]>{
     oos.writeInt(results.length);
     oos.flush();
     for (Result result : results) {
-      Adapters.ROW_ADAPTER.adaptToRow(result).writeDelimitedTo(outputStream);
+      HBaseResultCoder.getInstance().encode(result, oos, context);
     }
   }
 }

--- a/bigtable-dataflow-parent/bigtable-hbase-dataflow/src/test/java/com/google/cloud/bigtable/dataflow/CloudBigtableIOReaderTest.java
+++ b/bigtable-dataflow-parent/bigtable-hbase-dataflow/src/test/java/com/google/cloud/bigtable/dataflow/CloudBigtableIOReaderTest.java
@@ -28,9 +28,9 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import com.google.bigtable.repackaged.com.google.cloud.grpc.BigtableSession;
+import com.google.bigtable.repackaged.com.google.cloud.grpc.scanner.FlatRow;
 import com.google.bigtable.repackaged.com.google.cloud.grpc.scanner.ResultScanner;
 import com.google.bigtable.repackaged.com.google.com.google.bigtable.v2.ReadRowsRequest;
-import com.google.bigtable.repackaged.com.google.com.google.bigtable.v2.Row;
 import com.google.bigtable.repackaged.com.google.protobuf.ByteString;
 import com.google.cloud.bigtable.dataflow.CloudBigtableScanConfiguration.Builder;
 import com.google.cloud.dataflow.sdk.io.range.ByteKey;
@@ -48,7 +48,7 @@ public class CloudBigtableIOReaderTest {
   BigtableSession mockSession;
 
   @Mock
-  ResultScanner<Row> mockScanner;
+  ResultScanner<FlatRow> mockScanner;
 
   @Mock
   CloudBigtableIO.AbstractSource<Result> mockSource;
@@ -82,7 +82,7 @@ public class CloudBigtableIOReaderTest {
 
   private void setRowKey(String rowKey) throws IOException {
     ByteString rowKeyByteString = ByteString.copyFrom(Bytes.toBytes(rowKey));
-    Row row = Row.newBuilder().setKey(rowKeyByteString).build();
+    FlatRow row = FlatRow.newBuilder().withRowKey(rowKeyByteString).build();
     when(mockScanner.next()).thenReturn(row);
   }
 

--- a/bigtable-dataflow-parent/bigtable-hbase-dataflow/src/test/java/com/google/cloud/bigtable/dataflow/coders/HBaseResultArrayCoderTest.java
+++ b/bigtable-dataflow-parent/bigtable-hbase-dataflow/src/test/java/com/google/cloud/bigtable/dataflow/coders/HBaseResultArrayCoderTest.java
@@ -15,8 +15,6 @@
  */
 package com.google.cloud.bigtable.dataflow.coders;
 
-import org.apache.hadoop.hbase.Cell;
-import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.client.Result;
 import org.junit.Assert;
 import org.junit.Test;
@@ -28,7 +26,8 @@ public class HBaseResultArrayCoderTest {
 
   private HBaseResultArrayCoder underTest = new HBaseResultArrayCoder();
 
-  private Result[] original = new Result[]{createResult()};
+  private Result[] original =
+      new Result[] { HBaseResultCoderTest.TEST_RESULT, HBaseResultCoderTest.TEST_RESULT };
 
   @Test
   public void testRoundTrip() throws Exception {
@@ -37,15 +36,9 @@ public class HBaseResultArrayCoderTest {
     Result.compareResults(original[0], copy[0]);
   }
 
-  private Result createResult() {
-    return Result.create(new Cell[] { new KeyValue("key".getBytes(), "family".getBytes(),
-        "qualifier".getBytes(), System.currentTimeMillis(), "value".getBytes()) });
-  }
-
   @Test
   public void ensureDeterministic() throws Exception {
     Assert.assertArrayEquals(CoderTestUtil.encode(underTest, original),
       CoderTestUtil.encode(underTest, original));
   }
 }
-

--- a/bigtable-dataflow-parent/bigtable-hbase-dataflow/src/test/java/com/google/cloud/bigtable/dataflow/coders/HBaseResultCoderTest.java
+++ b/bigtable-dataflow-parent/bigtable-hbase-dataflow/src/test/java/com/google/cloud/bigtable/dataflow/coders/HBaseResultCoderTest.java
@@ -16,10 +16,11 @@
 package com.google.cloud.bigtable.dataflow.coders;
 
 import org.apache.hadoop.hbase.Cell;
-import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.client.Result;
 import org.junit.Assert;
 import org.junit.Test;
+
+import com.google.bigtable.repackaged.com.google.cloud.hbase.adapters.read.RowCell;
 
 /**
  * Tests for {@link HBaseResultCoder}
@@ -28,23 +29,20 @@ public class HBaseResultCoderTest {
 
   private HBaseResultCoder underTest = new HBaseResultCoder();
 
-  private Result original = createResult();
+  public static final Result TEST_RESULT =
+      Result.create(new Cell[] { new RowCell("key".getBytes(), "family".getBytes(),
+          "qualifier".getBytes(), System.currentTimeMillis(), "value".getBytes()) });;
 
   @Test
   public void testRoundTrip() throws Exception {
-    Result copy = CoderTestUtil.encodeAndDecode(underTest, original);
+    Result copy = CoderTestUtil.encodeAndDecode(underTest, TEST_RESULT);
     // This method throws an exception if the values are not equal.
-    Result.compareResults(original, copy);
-  }
-
-  private Result createResult() {
-    return Result.create(new Cell[] { new KeyValue("key".getBytes(), "family".getBytes(),
-        "qualifier".getBytes(), System.currentTimeMillis(), "value".getBytes()) });
+    Result.compareResults(TEST_RESULT, copy);
   }
 
   @Test
   public void ensureDeterministic() throws Exception {
-    Assert.assertArrayEquals(CoderTestUtil.encode(underTest, original),
-      CoderTestUtil.encode(underTest, original));
+    Assert.assertArrayEquals(CoderTestUtil.encode(underTest, TEST_RESULT),
+      CoderTestUtil.encode(underTest, TEST_RESULT));
   }
 }

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/RowCell.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/RowCell.java
@@ -15,7 +15,9 @@
 package com.google.cloud.bigtable.hbase.adapters.read;
 
 import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.CellComparator;
 import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.KeyValue.Type;
 import org.apache.hadoop.hbase.util.Bytes;
 
@@ -197,4 +199,39 @@ public class RowCell implements Cell {
   public byte[] getRow() {
     return Bytes.copy(this.rowArray);
   }
+
+  /**
+   * Needed doing 'contains' on List.  Only compares the key portion, not the value.
+   */
+  @Override
+  public boolean equals(Object other) {
+    if (!(other instanceof Cell)) {
+      return false;
+    }
+    return CellComparator.equals(this, (Cell)other);
+  }
+
+  /**
+   * In line with {@link #equals(Object)}, only uses the key portion, not the value.
+   */
+  @Override
+  public int hashCode() {
+    return CellComparator.hashCodeIgnoreMvcc(this);
+  }
+
+
+  //---------------------------------------------------------------------------
+  //
+  //  String representation
+  //
+  //---------------------------------------------------------------------------
+
+  @Override
+  public String toString() {
+    if (this.rowArray == null || this.rowArray.length == 0) {
+      return "empty";
+    }
+    return KeyValue.keyToString(this.rowArray) + "/vlen=" + getValueLength();
+  }
 }
+


### PR DESCRIPTION
- I had to add equals / toString in RowCell for testing purposes.  The code was copied from the HBase equivalent (more or less).
- I updated the Dataflow Source to use flatRow.
- I updated the Dataflow Result serializer to write FlatRows to the output stream.  When deserializing, I created a new FlatRow -> Result converter that doesn't sort the Cells, since they were previously sorted. 