### PR TITLE
Moving ManyThreadDriver.java to bigtable-hbase-1.2.

### DIFF
--- a/bigtable-dataflow-parent/bigtable-dataflow-import/pom.xml
+++ b/bigtable-dataflow-parent/bigtable-dataflow-import/pom.xml
@@ -83,7 +83,6 @@ limitations under the License.
             <groupId>io.netty</groupId>
             <artifactId>netty-tcnative-boringssl-static</artifactId>
             <scope>test</scope>
-            <classifier>${os.detected.classifier}</classifier>
         </dependency>
     </dependencies>
     <profiles>

--- a/bigtable-dataflow-parent/bigtable-hbase-dataflow/pom.xml
+++ b/bigtable-dataflow-parent/bigtable-hbase-dataflow/pom.xml
@@ -71,7 +71,6 @@ limitations under the License.
        <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-tcnative-boringssl-static</artifactId>
-            <classifier>${os.detected.classifier}</classifier>
         </dependency>
     </dependencies>
     <profiles>

--- a/bigtable-hbase-parent/bigtable-hbase-1.2/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-1.2/pom.xml
@@ -62,6 +62,11 @@ limitations under the License.
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-tcnative-boringssl-static</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/bigtable-hbase-parent/bigtable-hbase-1.2/src/test/java/com/google/cloud/bigtable/hbase/ManyThreadDriver.java
+++ b/bigtable-hbase-parent/bigtable-hbase-1.2/src/test/java/com/google/cloud/bigtable/hbase/ManyThreadDriver.java
@@ -16,13 +16,11 @@
 package com.google.cloud.bigtable.hbase;
 
 import org.apache.commons.lang.RandomStringUtils;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Admin;
 import org.apache.hadoop.hbase.client.Connection;
-import org.apache.hadoop.hbase.client.ConnectionFactory;
 import org.apache.hadoop.hbase.client.Get;
 import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.Table;
@@ -42,13 +40,8 @@ public class ManyThreadDriver {
 
   private static void runTest(String projectId, String instanceId, final String tableName)
       throws Exception {
-    Configuration configuration = new Configuration();
-    configuration.set(
-        "hbase.client.connection.impl", "com.google.cloud.bigtable.hbase1_0.BigtableConnection");
-    configuration.set("google.bigtable.project.id", projectId);
-    configuration.set("google.bigtable.instance.id", instanceId);
     ExecutorService executor = Executors.newFixedThreadPool(numThreads);
-    try (Connection connection = ConnectionFactory.createConnection(configuration)) {
+    try (Connection connection = BigtableConfiguration.connect(projectId, instanceId)) {
       Admin admin = connection.getAdmin();
 
       HTableDescriptor descriptor = new HTableDescriptor(TableName.valueOf(tableName));

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests/pom.xml
@@ -52,7 +52,6 @@ limitations under the License.
                 <dependency>
                     <groupId>io.netty</groupId>
                     <artifactId>netty-tcnative-boringssl-static</artifactId>
-                    <classifier>${os.detected.classifier}</classifier>
                 </dependency>
             </dependencies>
             <build>
@@ -298,7 +297,6 @@ limitations under the License.
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-tcnative-boringssl-static</artifactId>
-            <classifier>${os.detected.classifier}</classifier>
         </dependency>
     </dependencies>
     <build>

--- a/bigtable-hbase-parent/bigtable-hbase/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase/pom.xml
@@ -75,7 +75,6 @@ limitations under the License.
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-tcnative-boringssl-static</artifactId>
-            <classifier>${os.detected.classifier}</classifier>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -546,8 +546,7 @@ limitations under the License.
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-tcnative-boringssl-static</artifactId>
-                <version>1.1.33.Fork18</version>
-                <classifier>${os.detected.classifier}</classifier>
+                <version>1.1.33.Fork19</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>
@@ -573,14 +572,6 @@ limitations under the License.
     </issueManagement>
 
     <build>
-       <extensions>
-            <!-- Use os-maven-plugin to initialize the "os.detected" properties -->
-            <extension>
-                <groupId>kr.motd.maven</groupId>
-                <artifactId>os-maven-plugin</artifactId>
-                <version>1.4.1.Final</version>
-            </extension>
-        </extensions>
         <testResources>
             <testResource>
                 <directory>src/test/resources</directory>


### PR DESCRIPTION
Also updating our tcnative dependency to Fork19, and without specific OS; the uber jar is easier to work with.