### PR TITLE
Refactoring MutationAdapters.

### DIFF
--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/Adapters.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/Adapters.java
@@ -63,10 +63,10 @@ public final class Adapters {
    * <p>createMutationsAdapter.</p>
    *
    * @param putAdapter a {@link com.google.cloud.bigtable.hbase.adapters.PutAdapter} object.
-   * @return a {@link com.google.cloud.bigtable.hbase.adapters.MutationAdapter} object.
+   * @return a {@link com.google.cloud.bigtable.hbase.adapters.HBaseMutationAdapter} object.
    */
-  public static MutationAdapter createMutationsAdapter(PutAdapter putAdapter) {
-    return new MutationAdapter(
+  public static HBaseMutationAdapter createMutationsAdapter(PutAdapter putAdapter) {
+    return new HBaseMutationAdapter(
       DELETE_ADAPTER,
       putAdapter,
       new UnsupportedOperationAdapter<Increment>("increment"),

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/HBaseMutationAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/HBaseMutationAdapter.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.adapters;
+
+import com.google.bigtable.v2.MutateRowRequest;
+
+import org.apache.hadoop.hbase.client.Append;
+import org.apache.hadoop.hbase.client.Delete;
+import org.apache.hadoop.hbase.client.Increment;
+import org.apache.hadoop.hbase.client.Mutation;
+import org.apache.hadoop.hbase.client.Put;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Adapt a generic Mutation to a bigtable operation.
+ *
+ * This class uses instanceof checking to determine an appropriate adaptation to apply.
+ *
+ * @author sduskis
+ * @version $Id: $Id
+ */
+public class HBaseMutationAdapter extends MutationAdapter<Mutation> {
+
+  static class AdapterInstanceMap {
+    private Map<Class<? extends Mutation>, MutationAdapter<?>> unsafeMap = new HashMap<>();
+
+    public <S extends Mutation, U extends MutationAdapter<S>> Class<S> put(Class<S> key,
+        U adapter) {
+      unsafeMap.put(key, adapter);
+      return key;
+    }
+
+    // The only way to add to the unsafeMap is via put which enforces our type constraints at
+    // compile-time. The unchecked cast should be safe.
+    @SuppressWarnings("unchecked")
+    public <S extends Mutation, U extends OperationAdapter<S, MutateRowRequest.Builder>>
+    U get(Class<? extends S> key) {
+      return (U) unsafeMap.get(key);
+    }
+  }
+
+  private final AdapterInstanceMap adapterMap = new AdapterInstanceMap();
+
+  /**
+   * <p>Constructor for MutationAdapter.</p>
+   *
+   * @param deleteAdapter a {@link com.google.cloud.bigtable.hbase.adapters.OperationAdapter} object.
+   * @param putAdapter a {@link com.google.cloud.bigtable.hbase.adapters.OperationAdapter} object.
+   * @param incrementAdapter a {@link com.google.cloud.bigtable.hbase.adapters.OperationAdapter} object.
+   * @param appendAdapter a {@link com.google.cloud.bigtable.hbase.adapters.OperationAdapter} object.
+   */
+  public HBaseMutationAdapter(
+      MutationAdapter<Delete> deleteAdapter,
+      MutationAdapter<Put> putAdapter,
+      MutationAdapter<Increment> incrementAdapter,
+      MutationAdapter<Append> appendAdapter) {
+    adapterMap.put(Delete.class, deleteAdapter);
+    adapterMap.put(Put.class, putAdapter);
+    adapterMap.put(Increment.class, incrementAdapter);
+    adapterMap.put(Append.class, appendAdapter);
+  }
+
+  private MutationAdapter<Mutation> getAdapter(Mutation mutation) {
+    MutationAdapter<Mutation> adapter = adapterMap.get(mutation.getClass());
+    if (adapter == null) {
+      throw new UnsupportedOperationException(
+          String.format(
+              "Cannot adapt mutation of type %s.", mutation.getClass().getCanonicalName()));
+    }
+    return adapter;
+  }
+
+  @Override
+  protected byte[] getRow(Mutation operation) {
+    return getAdapter(operation).getRow(operation);
+  }
+
+  @Override
+  protected List<com.google.bigtable.v2.Mutation> toMutationList(Mutation operation) {
+    return getAdapter(operation).toMutationList(operation);
+  }
+}

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/HBaseRequestAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/HBaseRequestAdapter.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.hbase.client.RowMutations;
 import org.apache.hadoop.hbase.client.Scan;
 
 import com.google.bigtable.v2.MutateRowRequest;
+import com.google.bigtable.v2.MutateRowsRequest;
 import com.google.bigtable.v2.ReadModifyWriteRowRequest;
 import com.google.bigtable.v2.ReadRowsRequest;
 import com.google.cloud.bigtable.config.BigtableOptions;
@@ -43,7 +44,7 @@ public class HBaseRequestAdapter {
 
   public static class MutationAdapters {
     protected final PutAdapter putAdapter;
-    protected final MutationAdapter mutationAdapter;
+    protected final HBaseMutationAdapter mutationAdapter;
     protected final RowMutationsAdapter rowMutationsAdapter;
 
     public MutationAdapters(BigtableOptions options, Configuration config) {
@@ -160,6 +161,16 @@ public class HBaseRequestAdapter {
   /**
    * <p>adapt.</p>
    *
+   * @param put a {@link org.apache.hadoop.hbase.client.Put} object.
+   * @return a {@link com.google.bigtable.v2.MutateRowsRequest.Entry} object.
+   */
+  public MutateRowsRequest.Entry adaptToBulkEntry(Put put) {
+    return mutationAdapters.putAdapter.adaptToBulkEntry(put).build();
+  }
+
+  /**
+   * <p>adapt.</p>
+   *
    * @param mutations a {@link org.apache.hadoop.hbase.client.RowMutations} object.
    * @return a {@link com.google.bigtable.v2.MutateRowRequest} object.
    */
@@ -207,5 +218,4 @@ public class HBaseRequestAdapter {
   protected String getTableNameString() {
     return getBigtableTableName().toString();
   }
-
 }

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/UnsupportedOperationAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/UnsupportedOperationAdapter.java
@@ -15,9 +15,9 @@
  */
 package com.google.cloud.bigtable.hbase.adapters;
 
-import com.google.bigtable.v2.MutateRowRequest;
+import java.util.List;
 
-import org.apache.hadoop.hbase.client.Operation;
+import org.apache.hadoop.hbase.client.Mutation;
 
 /**
  * An adapter that throws an Unsupported exception when its adapt method is invoked.
@@ -25,8 +25,7 @@ import org.apache.hadoop.hbase.client.Operation;
  * @author sduskis
  * @version $Id: $Id
  */
-public class UnsupportedOperationAdapter<T extends Operation>
-    implements OperationAdapter<T, MutateRowRequest.Builder> {
+public class UnsupportedOperationAdapter<T extends Mutation> extends MutationAdapter<T> {
 
   private final String operationDescription;
 
@@ -39,14 +38,15 @@ public class UnsupportedOperationAdapter<T extends Operation>
     this.operationDescription = operationDescription;
   }
 
-  /**
-   * {@inheritDoc}
-   *
-   * Adapt a single HBase Operation to a single Bigtable generated message.
-   */
   @Override
-  public MutateRowRequest.Builder adapt(T operation) {
+  protected byte[] getRow(T operation) {
     throw new UnsupportedOperationException(
-        String.format("The %s operation is unsupported.", operationDescription));
+      String.format("The %s operation is unsupported.", operationDescription));
+  }
+
+  @Override
+  protected List<com.google.bigtable.v2.Mutation> toMutationList(T operation) {
+    throw new UnsupportedOperationException(
+      String.format("The %s operation is unsupported.", operationDescription));
   }
 }


### PR DESCRIPTION
A MutateRowRequest and a MutateRowsRequest.Entry look very similar.  We currently convert between them in BulkMutator.  If we have a way to convert from a Put/Delete/Mutatations directly to a MutateRowsRequest.Entry, we could remove the unnecessary conversion between protobuf objects.

This PR is to add the infrastructure needed to do the conversion.  We'll be adding the direct conversion later.