### PR TITLE
Renaming MutationAdapter to HBaseMutationAdapter.

### DIFF
--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/Adapters.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/Adapters.java
@@ -63,10 +63,10 @@ public final class Adapters {
    * <p>createMutationsAdapter.</p>
    *
    * @param putAdapter a {@link com.google.cloud.bigtable.hbase.adapters.PutAdapter} object.
-   * @return a {@link com.google.cloud.bigtable.hbase.adapters.MutationAdapter} object.
+   * @return a {@link com.google.cloud.bigtable.hbase.adapters.HBaseMutationAdapter} object.
    */
-  public static MutationAdapter createMutationsAdapter(PutAdapter putAdapter) {
-    return new MutationAdapter(
+  public static HBaseMutationAdapter createMutationsAdapter(PutAdapter putAdapter) {
+    return new HBaseMutationAdapter(
       DELETE_ADAPTER,
       putAdapter,
       new UnsupportedOperationAdapter<Increment>("increment"),

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/HBaseMutationAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/HBaseMutationAdapter.java
@@ -34,7 +34,7 @@ import java.util.Map;
  * @author sduskis
  * @version $Id: $Id
  */
-public class MutationAdapter
+public class HBaseMutationAdapter
     implements OperationAdapter<Mutation, MutateRowRequest.Builder> {
 
   static class AdapterInstanceMap {
@@ -66,7 +66,7 @@ public class MutationAdapter
    * @param incrementAdapter a {@link com.google.cloud.bigtable.hbase.adapters.OperationAdapter} object.
    * @param appendAdapter a {@link com.google.cloud.bigtable.hbase.adapters.OperationAdapter} object.
    */
-  public MutationAdapter(
+  public HBaseMutationAdapter(
       OperationAdapter<Delete, MutateRowRequest.Builder> deleteAdapter,
       OperationAdapter<Put, MutateRowRequest.Builder> putAdapter,
       OperationAdapter<Increment, MutateRowRequest.Builder> incrementAdapter,

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/HBaseRequestAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/HBaseRequestAdapter.java
@@ -43,13 +43,13 @@ public class HBaseRequestAdapter {
 
   public static class MutationAdapters {
     protected final PutAdapter putAdapter;
-    protected final MutationAdapter mutationAdapter;
+    protected final HBaseMutationAdapter hbaseMutationAdapter;
     protected final RowMutationsAdapter rowMutationsAdapter;
 
     public MutationAdapters(BigtableOptions options, Configuration config) {
       this.putAdapter = Adapters.createPutAdapter(config, options);
-      this.mutationAdapter = Adapters.createMutationsAdapter(putAdapter);
-      this.rowMutationsAdapter = new RowMutationsAdapter(mutationAdapter);
+      this.hbaseMutationAdapter = Adapters.createMutationsAdapter(putAdapter);
+      this.rowMutationsAdapter = new RowMutationsAdapter(hbaseMutationAdapter);
     }
   }
 
@@ -176,7 +176,7 @@ public class HBaseRequestAdapter {
    * @return a {@link com.google.bigtable.v2.MutateRowRequest} object.
    */
   public MutateRowRequest adapt(org.apache.hadoop.hbase.client.Mutation mutation) {
-    MutateRowRequest.Builder builder = mutationAdapters.mutationAdapter.adapt(mutation);
+    MutateRowRequest.Builder builder = mutationAdapters.hbaseMutationAdapter.adapt(mutation);
     builder.setTableName(getTableNameString());
     return builder.build();
   }

--- a/bigtable-hbase-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/TestHBaseMutationAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/TestHBaseMutationAdapter.java
@@ -35,7 +35,7 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 @RunWith(JUnit4.class)
-public class TestMutationAdapter {
+public class TestHBaseMutationAdapter {
   @Rule
   public ExpectedException expectedException = ExpectedException.none();
   @Mock
@@ -47,7 +47,7 @@ public class TestMutationAdapter {
   @Mock
   private OperationAdapter<Append, MutateRowRequest.Builder> appendAdapter;
 
-  private MutationAdapter adapter;
+  private HBaseMutationAdapter adapter;
   private DataGenerationHelper dataHelper = new DataGenerationHelper();
 
   public static class UnknownMutation extends Mutation {}
@@ -55,7 +55,7 @@ public class TestMutationAdapter {
   @Before
   public void setUp() {
     MockitoAnnotations.initMocks(this);
-    adapter = new MutationAdapter(deleteAdapter, putAdapter, incrementAdapter, appendAdapter);
+    adapter = new HBaseMutationAdapter(deleteAdapter, putAdapter, incrementAdapter, appendAdapter);
   }
 
   @After


### PR DESCRIPTION
I'd like to introduce a new interface for Put/Delete/RowMutations called MutationAdapter. I'm proposing that we rename the current MutationAdapter to HBaseMutation adapter.