### PR TITLE
Updating RowMergerPerf to be more consistent with the current state.

### DIFF
--- a/bigtable-hbase-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/RowMergerPerf.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/RowMergerPerf.java
@@ -1,7 +1,7 @@
 package com.google.cloud.bigtable.hbase;
 
+
 import java.util.Arrays;
-import java.util.List;
 
 import org.apache.commons.lang.RandomStringUtils;
 import org.apache.hadoop.hbase.util.Bytes;
@@ -9,16 +9,15 @@ import org.apache.hadoop.hbase.util.Bytes;
 import com.google.bigtable.v2.ReadRowsResponse;
 import com.google.bigtable.v2.ReadRowsResponse.Builder;
 import com.google.bigtable.v2.ReadRowsResponse.CellChunk;
-import com.google.bigtable.v2.Row;
 import com.google.cloud.bigtable.grpc.scanner.FlatRow;
-import com.google.cloud.bigtable.grpc.scanner.FlatRowConverter;
 import com.google.cloud.bigtable.grpc.scanner.RowMerger;
 import com.google.cloud.bigtable.hbase.adapters.Adapters;
-import com.google.cloud.bigtable.hbase.adapters.read.RowAdapter;
 import com.google.common.base.Preconditions;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.BytesValue;
 import com.google.protobuf.StringValue;
+
+import io.grpc.stub.StreamObserver;
 
 /**
  * Simple microbenchmark for {@link RowMerger}
@@ -26,10 +25,10 @@ import com.google.protobuf.StringValue;
 public class RowMergerPerf {
 
   static final int VALUE_SIZE_IN_BYTES = 10_000_000;
-  static final long CUMULATIVE_CELL_COUNT = 10_000_000l;
+  static final long CUMULATIVE_CELL_COUNT = 30_000_000l;
 
   public static void main(String[] args) {
-    // warm up
+//     warm up
     for (int i = 0; i < 3; i++) {
       rowMergerPerf(createResponses(1), 1);
     }
@@ -40,7 +39,7 @@ public class RowMergerPerf {
     }
   }
 
-  private static List<ReadRowsResponse> createResponses(int cellCount) {
+  private static ReadRowsResponse createResponses(int cellCount) {
     Builder readRowsResponse = ReadRowsResponse.newBuilder();
 
     Preconditions.checkArgument(cellCount > 0, "cellCount has to be > 0.");
@@ -48,66 +47,77 @@ public class RowMergerPerf {
     // It's ok if 100_000 / cellCount rounds down.  This only has to be approximate.
     int size = VALUE_SIZE_IN_BYTES / cellCount;
     Preconditions.checkArgument(size > 0, "size has to be > 0.");
+    final ByteString rowKey = ByteString.copyFrom(Bytes.toBytes("rowkey-0"));
     for (int i = 0; i < cellCount; i++) {
-      CellChunk contentChunk =
+      CellChunk.Builder contentChunk =
           CellChunk.newBuilder()
-              .setRowKey(ByteString.copyFrom(Bytes.toBytes("rowkey-0")))
-              .setFamilyName(StringValue.newBuilder().setValue("Family" + (i / 4)))
+              .setRowKey(i == 0 ? rowKey : ByteString.EMPTY)
               .setQualifier(BytesValue.newBuilder().setValue(ByteString.copyFromUtf8("Qualifier" + (i%4))))
               .setValue(ByteString.copyFrom(RandomStringUtils.randomAlphanumeric(size).getBytes()))
-              .setTimestampMicros(0L)
-              .setCommitRow(i == cellCount - 1)
-              .build();
+              .setTimestampMicros(330020L)
+              .setCommitRow(i == cellCount - 1);
+      if (i % 4 == 0) {
+        contentChunk.setFamilyName(StringValue.newBuilder().setValue("Family" + (i / 4)));
+      }
 
       readRowsResponse.addChunks(contentChunk);
     }
-    return Arrays.asList(readRowsResponse.build());
+    return readRowsResponse.build();
   }
 
-  private static void rowMergerPerf(List<ReadRowsResponse> responses, int cellCount) {
-    RowAdapter adapter = Adapters.ROW_ADAPTER;
-    long rowCount = CUMULATIVE_CELL_COUNT / cellCount;
-    System.out.println("Size: " + responses.get(0).getSerializedSize());
+  final static StreamObserver<FlatRow> EMPTY_OBSERVER = new StreamObserver<FlatRow>() {
+    @Override
+    public void onNext(FlatRow value) {
+    }
+
+    @Override
+    public void onError(Throwable t) {
+      if (t instanceof RuntimeException) {
+        throw (RuntimeException) t;
+      } else {
+        throw new IllegalStateException(t);
+      }
+    }
+
+    @Override
+    public void onCompleted() {
+    }
+  };
+
+  private static void rowMergerPerf(ReadRowsResponse response, int cellCountPerRow) {
+    System.out.println("Size: " + response.getSerializedSize());
+
     {
+      long rowCount = CUMULATIVE_CELL_COUNT / cellCountPerRow;
       long start = System.nanoTime();
       for (int i = 0; i < rowCount; i++) {
-        RowMerger.toRows(responses);
+        new RowMerger(EMPTY_OBSERVER).onNext(response);
       }
-      long time = System.nanoTime() - start;
-      System.out.println(
-          String.format(
-              "RowMerger: %d rows adapted in %d ms.\n"
-                  + "\t%d nanos per row\n"
-                  + "\t%d nanos per cell",
-              rowCount, time / 1000000, time / rowCount, time / CUMULATIVE_CELL_COUNT));
+      print("RowMerger", start, rowCount, cellCountPerRow);
     }
-    final FlatRow flatRow = RowMerger.toRows(responses).get(0);
+
     {
+      // The adapter is slower than the RowMerger, so decrease the number of rows by a factor of 3
+      // so that the test finishes faster. This will be enough of a sample to get an idea about the
+      // adapter's performance
+      long rowCount = CUMULATIVE_CELL_COUNT / cellCountPerRow / 4;
+
+      FlatRow flatRow = RowMerger.toRows(Arrays.asList(response)).get(0);
       long start = System.nanoTime();
       for (int i = 0; i < rowCount; i++) {
-        FlatRowConverter.convert(flatRow);
+        Adapters.FLAT_ROW_ADAPTER.adaptResponse(flatRow);
       }
-      long time = System.nanoTime() - start;
-      System.out.println(
-          String.format(
-              "FlatRowConverter: %d rows converted in %d ms.\n"
-                  + "\t%d nanos per row\n"
-                  + "\t%d nanos per cell",
-              rowCount, time / 1000000, time / rowCount, time / CUMULATIVE_CELL_COUNT));
+      print("AdaptResponse", start, rowCount, cellCountPerRow);
     }
-    {
-      long start = System.nanoTime();
-      Row response = FlatRowConverter.convert(flatRow);
-      for (int i = 0; i < rowCount; i++) {
-        adapter.adaptResponse(response);
-      }
-      long time = System.nanoTime() - start;
-      System.out.println(
-          String.format(
-              "AdaptResponse: %d rows adapted in %d ms.\n"
-                  + "\t%d nanos per row\n"
-                  + "\t%d nanos per cell",
-              rowCount, time / 1000000, time / rowCount, time / CUMULATIVE_CELL_COUNT));
-    }
+  }
+
+  protected static void print(String type, long start, long rowCount, int cellCountPerRow) {
+    long time = System.nanoTime() - start;
+    System.out.println(
+        String.format(
+            "%s: %d rows adapted in %d ms.\n"
+                + "\t%d nanos per row\n"
+                + "\t%d nanos per cell",
+            type, rowCount, time / 1000000, time / rowCount, time / (rowCount * cellCountPerRow)));
   }
 }


### PR DESCRIPTION
RowMergerPerf's ReadRowsResponses don't set row key or family if they are the same as the predecessor.
Using FlatRowAdapter instead of RowAdapter.