### PR TITLE
Adding adapters for HBase Mutations -> MutateRowsRequest.Entry.

### DIFF
--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/Adapters.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/Adapters.java
@@ -69,8 +69,8 @@ public final class Adapters {
     return new HBaseMutationAdapter(
       DELETE_ADAPTER,
       putAdapter,
-      new UnsupportedOperationAdapter<Increment>("increment"),
-      new UnsupportedOperationAdapter<Append>("append"));
+      new UnsupportedMutationAdapter<Increment>("increment"),
+      new UnsupportedMutationAdapter<Append>("append"));
   }
 
   /**

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/DeleteAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/DeleteAdapter.java
@@ -4,9 +4,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,10 +18,10 @@ package com.google.cloud.bigtable.hbase.adapters;
 import com.google.bigtable.v2.MutateRowRequest;
 import com.google.bigtable.v2.Mutation;
 import com.google.bigtable.v2.Mutation.DeleteFromColumn;
+import com.google.bigtable.v2.Mutation.DeleteFromFamily;
 import com.google.bigtable.v2.Mutation.DeleteFromRow;
 import com.google.bigtable.v2.TimestampRange;
 import com.google.cloud.bigtable.hbase.BigtableConstants;
-import com.google.cloud.bigtable.util.ByteStringer;
 import com.google.protobuf.ByteString;
 
 import org.apache.hadoop.hbase.Cell;
@@ -29,6 +29,8 @@ import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.client.Delete;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -38,7 +40,7 @@ import java.util.Map;
  * @author sduskis
  * @version $Id: $Id
  */
-public class DeleteAdapter implements OperationAdapter<Delete, MutateRowRequest.Builder> {
+public class DeleteAdapter extends MutationAdapter<Delete> {
   static boolean isPointDelete(Cell cell) {
     return cell.getTypeByte() == KeyValue.Type.Delete.getCode();
   }
@@ -89,8 +91,7 @@ public class DeleteAdapter implements OperationAdapter<Delete, MutateRowRequest.
     }
   }
 
-  static Mutation.DeleteFromColumn.Builder addDeleteFromColumnMods(MutateRowRequest.Builder result,
-      ByteString familyByteString, Cell cell) {
+  static Mutation.DeleteFromColumn addDeleteFromColumnMods(ByteString familyByteString, Cell cell) {
 
     ByteString cellQualifierByteString = ByteString.copyFrom(
         cell.getQualifierArray(),
@@ -98,9 +99,9 @@ public class DeleteAdapter implements OperationAdapter<Delete, MutateRowRequest.
         cell.getQualifierLength());
 
     Mutation.DeleteFromColumn.Builder deleteBuilder =
-        result.addMutationsBuilder().getDeleteFromColumnBuilder()
-            .setFamilyNameBytes(familyByteString)
-            .setColumnQualifier(cellQualifierByteString);
+        Mutation.DeleteFromColumn.newBuilder()
+          .setFamilyNameBytes(familyByteString)
+          .setColumnQualifier(cellQualifierByteString);
 
     long endTimestamp = BigtableConstants.BIGTABLE_TIMEUNIT.convert(
         cell.getTimestamp() + 1,
@@ -121,19 +122,18 @@ public class DeleteAdapter implements OperationAdapter<Delete, MutateRowRequest.
         deleteBuilder.getTimeRangeBuilder().setEndTimestampMicros(endTimestamp);
       }
     }
-    return deleteBuilder;
+    return deleteBuilder.build();
   }
 
-  /** {@inheritDoc} */
   @Override
-  public MutateRowRequest.Builder adapt(Delete operation) {
-    MutateRowRequest.Builder result = MutateRowRequest.newBuilder()
-        .setRowKey(ByteString.copyFrom(operation.getRow()));
-
+  /** {@inheritDoc} */
+  protected Collection<Mutation> adaptMutations(Delete operation) {
+    List<Mutation> mutations = new ArrayList<>();
     if (operation.getFamilyCellMap().isEmpty()) {
       throwIfUnsupportedDeleteRow(operation);
 
-      result.addMutationsBuilder().setDeleteFromRow(DeleteFromRow.getDefaultInstance());
+      mutations
+          .add(Mutation.newBuilder().setDeleteFromRow(DeleteFromRow.getDefaultInstance()).build());
     } else {
       for (Map.Entry<byte[], List<Cell>> entry : operation.getFamilyCellMap().entrySet()) {
 
@@ -144,12 +144,16 @@ public class DeleteAdapter implements OperationAdapter<Delete, MutateRowRequest.
             if (isPointDelete(cell)) {
               throwIfUnsupportedPointDelete(cell);
             }
-            addDeleteFromColumnMods(result, familyByteString, cell);
+            mutations.add(Mutation.newBuilder()
+              .setDeleteFromColumn(addDeleteFromColumnMods(familyByteString, cell))
+              .build());
           } else if (isFamilyDelete(cell)) {
             throwIfUnsupportedDeleteFamily(cell);
 
-            result.addMutationsBuilder().getDeleteFromFamilyBuilder()
-                .setFamilyNameBytes(familyByteString);
+            mutations.add(Mutation.newBuilder()
+              .setDeleteFromFamily(DeleteFromFamily.newBuilder()
+                  .setFamilyNameBytes(familyByteString).build())
+              .build());
           } else if (isFamilyVersionDelete(cell)) {
             throwOnUnsupportedDeleteFamilyVersion(cell);
           } else {
@@ -158,7 +162,7 @@ public class DeleteAdapter implements OperationAdapter<Delete, MutateRowRequest.
         }
       }
     }
-    return result;
+    return mutations;
   }
 
 
@@ -208,9 +212,4 @@ public class DeleteAdapter implements OperationAdapter<Delete, MutateRowRequest.
     }
     return delete;
   }
-
-  private static byte[] getBytes(ByteString bs) {
-    return ByteStringer.extract(bs);
-  }
-
 }

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/MutationAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/MutationAdapter.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.adapters;
+
+import java.util.Collection;
+
+import org.apache.hadoop.hbase.client.Mutation;
+
+import com.google.bigtable.v2.MutateRowRequest;
+import com.google.bigtable.v2.MutateRowsRequest;
+import com.google.cloud.bigtable.util.ByteStringer;
+import com.google.protobuf.ByteString;
+
+/**
+ * Adapt an HBase {@link Mutation} Operation into a Bigtable {@link MutateRowRequest.Builder} or
+ * {@link MutateRowsRequest.Entry}.
+ * @author sduskis
+ * @version $Id: $Id
+ */
+
+public abstract class MutationAdapter<T extends Mutation>
+    implements OperationAdapter<T, MutateRowRequest.Builder> {
+
+  protected static byte[] getBytes(ByteString bs) {
+    return ByteStringer.extract(bs);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public final MutateRowRequest.Builder adapt(T operation) {
+    return MutateRowRequest.newBuilder()
+        .setRowKey(ByteString.copyFrom(operation.getRow()))
+        .addAllMutations(adaptMutations(operation));
+  }
+
+  public final MutateRowsRequest.Entry toEntry(T operation) {
+    return MutateRowsRequest.Entry.newBuilder()
+        .setRowKey(ByteString.copyFrom(operation.getRow()))
+        .addAllMutations(adaptMutations(operation)).build();
+  }
+
+  /**
+   * Converts an HBase {@link Mutation} which represents a set of changes to a single row from an
+   * HBase perspective to a collection of Cloud Bigtable {@link com.google.bigtable.v2.Mutation}
+   * which represent the set of changes. The name "Mutation" represents a more granular change in
+   * Bigtable than an HBase "Mutation"; An HBase {@link Cell} is akin to a Cloud Bigtable
+   * {@link com.google.bigtable.v2.Mutation}. A CloudBigtable {@link MutateRowRequest} or
+   * {@link MutateRowsRequest.Entry} is akin to an HBase {@link Mutation}.
+   *
+   * @param operation The HBase {@link Mutation} to convert
+   * @return a {@link Collection} of Cloud Bigtable {@link}
+   */
+  protected abstract Collection<com.google.bigtable.v2.Mutation> adaptMutations(T operation);
+}

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/RowMutationsAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/RowMutationsAdapter.java
@@ -31,16 +31,14 @@ import org.apache.hadoop.hbase.client.RowMutations;
  */
 public class RowMutationsAdapter {
 
-  protected final OperationAdapter<Mutation,
-      MutateRowRequest.Builder> mutationAdapter;
+  protected final MutationAdapter<Mutation> mutationAdapter;
 
   /**
    * <p>Constructor for RowMutationsAdapter.</p>
    *
    * @param mutationAdapter a {@link com.google.cloud.bigtable.hbase.adapters.OperationAdapter} object.
    */
-  public RowMutationsAdapter(
-      OperationAdapter<Mutation, MutateRowRequest.Builder> mutationAdapter) {
+  public RowMutationsAdapter(MutationAdapter<Mutation> mutationAdapter) {
     this.mutationAdapter = mutationAdapter;
   }
 
@@ -56,8 +54,7 @@ public class RowMutationsAdapter {
     result.setRowKey(ByteString.copyFrom(mutations.getRow()));
 
     for (Mutation mutation : mutations.getMutations()) {
-      MutateRowRequest.Builder bigtableBuilder = mutationAdapter.adapt(mutation);
-      result.addAllMutations(bigtableBuilder.getMutationsList());
+      result.addAllMutations(mutationAdapter.adaptMutations(mutation));
     }
 
     return result;

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/UnsupportedMutationAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/UnsupportedMutationAdapter.java
@@ -15,9 +15,9 @@
  */
 package com.google.cloud.bigtable.hbase.adapters;
 
-import com.google.bigtable.v2.MutateRowRequest;
+import java.util.Collection;
 
-import org.apache.hadoop.hbase.client.Operation;
+import org.apache.hadoop.hbase.client.Mutation;
 
 /**
  * An adapter that throws an Unsupported exception when its adapt method is invoked.
@@ -25,8 +25,7 @@ import org.apache.hadoop.hbase.client.Operation;
  * @author sduskis
  * @version $Id: $Id
  */
-public class UnsupportedOperationAdapter<T extends Operation>
-    implements OperationAdapter<T, MutateRowRequest.Builder> {
+public class UnsupportedMutationAdapter<T extends Mutation> extends MutationAdapter<T> {
 
   private final String operationDescription;
 
@@ -35,7 +34,7 @@ public class UnsupportedOperationAdapter<T extends Operation>
    *
    * @param operationDescription a {@link java.lang.String} object.
    */
-  public UnsupportedOperationAdapter(String operationDescription) {
+  public UnsupportedMutationAdapter(String operationDescription) {
     this.operationDescription = operationDescription;
   }
 
@@ -45,8 +44,8 @@ public class UnsupportedOperationAdapter<T extends Operation>
    * Adapt a single HBase Operation to a single Bigtable generated message.
    */
   @Override
-  public MutateRowRequest.Builder adapt(T operation) {
+  protected Collection<com.google.bigtable.v2.Mutation> adaptMutations(T operation) {
     throw new UnsupportedOperationException(
-        String.format("The %s operation is unsupported.", operationDescription));
-  }
+      String.format("The %s operation is unsupported.", operationDescription));
+}
 }

--- a/bigtable-hbase-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/TestHBaseMutationAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/TestHBaseMutationAdapter.java
@@ -15,8 +15,10 @@
  */
 package com.google.cloud.bigtable.hbase.adapters;
 
-import com.google.bigtable.v2.MutateRowRequest;
 import com.google.cloud.bigtable.hbase.DataGenerationHelper;
+
+import java.util.Collections;
+import java.util.List;
 
 import org.apache.hadoop.hbase.client.Append;
 import org.apache.hadoop.hbase.client.Delete;
@@ -39,18 +41,21 @@ public class TestHBaseMutationAdapter {
   @Rule
   public ExpectedException expectedException = ExpectedException.none();
   @Mock
-  private OperationAdapter<Delete, MutateRowRequest.Builder> deleteAdapter;
+  private MutationAdapter<Delete> deleteAdapter;
   @Mock
-  private OperationAdapter<Put, MutateRowRequest.Builder> putAdapter;
+  private MutationAdapter<Put> putAdapter;
   @Mock
-  private OperationAdapter<Increment, MutateRowRequest.Builder> incrementAdapter;
+  private MutationAdapter<Increment> incrementAdapter;
   @Mock
-  private OperationAdapter<Append, MutateRowRequest.Builder> appendAdapter;
+  private MutationAdapter<Append> appendAdapter;
 
   private HBaseMutationAdapter adapter;
   private DataGenerationHelper dataHelper = new DataGenerationHelper();
 
   public static class UnknownMutation extends Mutation {}
+
+  private static final List<com.google.bigtable.v2.Mutation> EMPTY_MUTATIONS =
+      Collections.emptyList();
 
   @Before
   public void setUp() {
@@ -70,44 +75,37 @@ public class TestHBaseMutationAdapter {
   @Test
   public void testPutIsAdapted() {
     Put put = new Put(dataHelper.randomData("rk1"));
-    Mockito.when(putAdapter.adapt(put))
-        .thenReturn(MutateRowRequest.newBuilder());
+    Mockito.when(putAdapter.adaptMutations(put)).thenReturn(EMPTY_MUTATIONS);
+    adapter.adaptMutations(put);
 
-    adapter.adapt(put);
-
-    Mockito.verify(putAdapter, Mockito.times(1)).adapt(Mockito.any(Put.class));
+    Mockito.verify(putAdapter, Mockito.times(1)).adaptMutations(Mockito.any(Put.class));
   }
 
   @Test
   public void testDeleteIsAdapted() {
     Delete delete = new Delete(dataHelper.randomData("rk1"));
-    Mockito.when(deleteAdapter.adapt(delete))
-        .thenReturn(MutateRowRequest.newBuilder());
+    Mockito.when(deleteAdapter.adaptMutations(delete)).thenReturn(EMPTY_MUTATIONS);
+    adapter.adaptMutations(delete);
 
-    adapter.adapt(delete);
-
-    Mockito.verify(deleteAdapter, Mockito.times(1)).adapt(Mockito.any(Delete.class));
+    Mockito.verify(deleteAdapter, Mockito.times(1)).adaptMutations(Mockito.any(Delete.class));
   }
 
   @Test
   public void testAppendIsAdapted() {
     Append append = new Append(dataHelper.randomData("rk1"));
-    Mockito.when(appendAdapter.adapt(append))
-        .thenReturn(MutateRowRequest.newBuilder());
+    Mockito.when(appendAdapter.adaptMutations(append)).thenReturn(EMPTY_MUTATIONS);
+    adapter.adaptMutations(append);
 
-    adapter.adapt(append);
-
-    Mockito.verify(appendAdapter, Mockito.times(1)).adapt(Mockito.any(Append.class));
+    Mockito.verify(appendAdapter, Mockito.times(1)).adaptMutations(Mockito.any(Append.class));
   }
 
   @Test
   public void testIncrementIsAdapted() {
     Increment increment = new Increment(dataHelper.randomData("rk1"));
-    Mockito.when(incrementAdapter.adapt(increment))
-        .thenReturn(MutateRowRequest.newBuilder());
-    adapter.adapt(increment);
+    Mockito.when(incrementAdapter.adaptMutations(increment)).thenReturn(EMPTY_MUTATIONS);
+    adapter.adaptMutations(increment);
 
-    Mockito.verify(incrementAdapter, Mockito.times(1)).adapt(Mockito.any(Increment.class));
+    Mockito.verify(incrementAdapter, Mockito.times(1)).adaptMutations(Mockito.any(Increment.class));
   }
 
   @Test
@@ -118,6 +116,6 @@ public class TestHBaseMutationAdapter {
     expectedException.expectMessage("Cannot adapt mutation of type");
     expectedException.expectMessage("UnknownMutation");
 
-    adapter.adapt(unknownMutation);
+    adapter.adaptMutations(unknownMutation);
   }
 }

--- a/bigtable-hbase-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/TestRowMutationsAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/TestRowMutationsAdapter.java
@@ -17,12 +17,13 @@ package com.google.cloud.bigtable.hbase.adapters;
 
 
 import com.google.bigtable.v2.MutateRowRequest;
+import com.google.bigtable.v2.Mutation;
+import com.google.bigtable.v2.Mutation.SetCell;
 import com.google.cloud.bigtable.hbase.DataGenerationHelper;
-import com.google.cloud.bigtable.hbase.adapters.OperationAdapter;
 import com.google.cloud.bigtable.hbase.adapters.RowMutationsAdapter;
 import com.google.protobuf.ByteString;
 
-import org.apache.hadoop.hbase.client.Mutation;
+//import org.apache.hadoop.hbase.client.Mutation;
 import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.RowMutations;
 import org.junit.Assert;
@@ -36,12 +37,14 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 
 @RunWith(JUnit4.class)
 public class TestRowMutationsAdapter {
 
   @Mock
-  private OperationAdapter<Mutation, MutateRowRequest.Builder> mutationAdapter;
+  private MutationAdapter<org.apache.hadoop.hbase.client.Mutation> mutationAdapter;
 
   private RowMutationsAdapter adapter;
   private DataGenerationHelper dataHelper = new DataGenerationHelper();
@@ -82,21 +85,23 @@ public class TestRowMutationsAdapter {
             .addColumn(family2, qualifier2, value2));
 
     // When mockAdapter is asked to adapt the above mutations, we'll return these responses:
-    MutateRowRequest.Builder response1 = MutateRowRequest.newBuilder();
-    response1.addMutationsBuilder()
-        .getSetCellBuilder()
+    List<Mutation> response1 = Arrays.asList(Mutation.newBuilder()
+        .setSetCell(SetCell.newBuilder()
             .setColumnQualifier(ByteString.copyFrom(qualifier1))
             .setFamilyNameBytes(ByteString.copyFrom(family1))
-            .setValue(ByteString.copyFrom(value1));
+            .setValue(ByteString.copyFrom(value1)))
+        .build());
 
-    MutateRowRequest.Builder response2 = MutateRowRequest.newBuilder();
-    response2.addMutationsBuilder()
-        .getSetCellBuilder()
+    List<Mutation> response2 = Arrays.asList(Mutation.newBuilder()
+      .setSetCell(SetCell.newBuilder()
             .setColumnQualifier(ByteString.copyFrom(qualifier2))
             .setFamilyNameBytes(ByteString.copyFrom(family2))
-            .setValue(ByteString.copyFrom(value2));
+            .setValue(ByteString.copyFrom(value2)))
+      .build());
 
-    Mockito.when(mutationAdapter.adapt(Matchers.any(Mutation.class)))
+    Mockito
+        .when(mutationAdapter
+            .adaptMutations(Matchers.any(org.apache.hadoop.hbase.client.Mutation.class)))
         .thenReturn(response1)
         .thenReturn(response2);
 

--- a/bigtable-hbase-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/TestUnsupportedOperationAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/TestUnsupportedOperationAdapter.java
@@ -31,8 +31,8 @@ public class TestUnsupportedOperationAdapter {
 
   @Test
   public void testUnsupportedOperationExceptionIsThrownOnUse() {
-    UnsupportedOperationAdapter<Append> unsupportedOperationAdapter =
-        new UnsupportedOperationAdapter<Append>("append");
+    UnsupportedMutationAdapter<Append> unsupportedOperationAdapter =
+        new UnsupportedMutationAdapter<Append>("append");
 
     expectedException.expect(UnsupportedOperationException.class);
     expectedException.expectMessage("operation is unsupported");


### PR DESCRIPTION
BigtableBufferedMutor and BatchExecutor should convert from a Put/Delete directly to a MutateRowsRequest.Entry rather than first converting to a MutateRowRequest and then to a MutateRowsRequest.Entry. This PR adds the ability to convert to a MutateRowsRequest.Entry. A future PR will use the new ability from BufferedMutator and BatchExecutor.