### PR TITLE
PutAdapter's clock is now package private.

### DIFF
--- a/bigtable-dataflow-parent/bigtable-hbase-dataflow/src/test/java/com/google/bigtable/repackaged/com/google/cloud/hbase/adapters/PutAdapterUtil.java
+++ b/bigtable-dataflow-parent/bigtable-hbase-dataflow/src/test/java/com/google/bigtable/repackaged/com/google/cloud/hbase/adapters/PutAdapterUtil.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.bigtable.repackaged.com.google.cloud.hbase.adapters;
+
+import com.google.bigtable.repackaged.com.google.api.client.util.Clock;
+import com.google.cloud.bigtable.dataflow.coders.HBaseMutationCoderTest;
+
+/**
+ * The {@link PutAdapter}'s {@link Clock} is package private. This utility in the same package
+ * allows {@link HBaseMutationCoderTest} set the package private clock for testing purposes.
+ */
+public final class PutAdapterUtil {
+
+  /**
+   * Sets a package private clock variable on the {@link PutAdapter} instance.
+   *
+   * @param putAdapter The {@link PutAdapter} on which to set the {@link Clock}.
+   * @param clock The {@link Clock} to set in the {@link PutAdapter}.
+   */
+  public static void setClock(PutAdapter putAdapter, Clock clock){
+    putAdapter.clock = clock;
+  }
+
+  private PutAdapterUtil(){}
+}

--- a/bigtable-dataflow-parent/bigtable-hbase-dataflow/src/test/java/com/google/cloud/bigtable/dataflow/coders/HBaseMutationCoderTest.java
+++ b/bigtable-dataflow-parent/bigtable-hbase-dataflow/src/test/java/com/google/cloud/bigtable/dataflow/coders/HBaseMutationCoderTest.java
@@ -18,6 +18,8 @@ package com.google.cloud.bigtable.dataflow.coders;
 import static org.apache.hadoop.hbase.util.Bytes.toBytes;
 
 import com.google.bigtable.repackaged.com.google.api.client.util.Clock;
+import com.google.bigtable.repackaged.com.google.cloud.hbase.adapters.PutAdapterUtil;
+import com.google.cloud.dataflow.sdk.util.MutationDetector;
 import com.google.cloud.dataflow.sdk.util.MutationDetectors;
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicLong;
@@ -41,41 +43,47 @@ public class HBaseMutationCoderTest {
     underTest = new HBaseMutationCoder();
     time = new AtomicLong(System.currentTimeMillis());
 
-    HBaseMutationCoder.PUT_ADAPTER.clock = new Clock(){
+    PutAdapterUtil.setClock(HBaseMutationCoder.PUT_ADAPTER, new Clock(){
       @Override
       public long currentTimeMillis() {
         return time.get();
       }
-    };
+    });
   }
 
   @After
   public void tearDown() {
-    HBaseMutationCoder.PUT_ADAPTER.clock = Clock.SYSTEM;
+    PutAdapterUtil.setClock(HBaseMutationCoder.PUT_ADAPTER, Clock.SYSTEM);
   }
 
   @Test
   public void testPut() throws IOException {
     Put original =
         new Put(toBytes("key")).addColumn(toBytes("family"), toBytes("column"), toBytes("value"));
+    MutationDetector mutationDetector = MutationDetectors.forValueWithCoder(original, underTest);
     for (int i = 0; i < 5; i++) {
       Assert.assertEquals(
           0, original.compareTo(CoderTestUtil.encodeAndDecode(underTest, original)));
       time.set(time.get() + 10_000);
       Assert.assertEquals(
           0, original.compareTo(CoderTestUtil.encodeAndDecode(underTest, original)));
-      MutationDetectors.forValueWithCoder(original, underTest).verifyUnmodified();
+
+      // Make sure that the clock change didn't modify the serialized value.
+      mutationDetector.verifyUnmodified();
     }
   }
 
   @Test
   public void testDelete() throws IOException {
     Delete original = new Delete(toBytes("key"));
+    MutationDetector mutationDetector = MutationDetectors.forValueWithCoder(original, underTest);
     for (int i = 0; i < 5; i++) {
       Assert.assertEquals(
           0, original.compareTo(CoderTestUtil.encodeAndDecode(underTest, original)));
       time.set(time.get() + 10_000);
-      MutationDetectors.forValueWithCoder(original, underTest).verifyUnmodified();
+
+      // Make sure that the clock change didn't modify the serialized value.
+      mutationDetector.verifyUnmodified();
     }
   }
 }

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/PutAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/PutAdapter.java
@@ -23,6 +23,7 @@ import com.google.bigtable.v2.Mutation.MutationCase;
 import com.google.bigtable.v2.Mutation.SetCell;
 import com.google.cloud.bigtable.hbase.BigtableConstants;
 import com.google.cloud.bigtable.hbase.adapters.read.RowCell;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.ByteString;
 
 import org.apache.hadoop.hbase.Cell;
@@ -44,7 +45,9 @@ import java.util.Map.Entry;
 public class PutAdapter extends MutationAdapter<Put> {
   private final int maxKeyValueSize;
   private final boolean setClientTimestamp;
-  public Clock clock = Clock.SYSTEM;
+
+  @VisibleForTesting
+  Clock clock = Clock.SYSTEM;
 
   /**
    * <p>Constructor for PutAdapter.</p>


### PR DESCRIPTION
I think that the tests in HBaseMutationCoderTest which used the Clock was slightly off.  I now create a MutationDetector mutationDetector before the time changes.