### PR TITLE
Performance increase for scanning.

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/FlatRow.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/FlatRow.java
@@ -29,7 +29,7 @@ import com.google.protobuf.ByteString;
 
 /**
  * <p>
- * This class stores represents a single row. It's a flattened version of the adata of aa
+ * This class stores represents a single row. It's a flattened version of the data of a
  * {@link Row}
  * </p>
  * @author tyagihas
@@ -128,16 +128,17 @@ public class FlatRow implements Serializable {
         return false;
       }
       Cell other = (Cell) obj;
-      return hasEqualKeys(other) &&
+      return equalFamilyQualifierAndTimestamp(other) &&
           Objects.equal(value, other.value) &&
           Objects.equal(labels, other.labels);
     }
 
     /**
      * @param other
-     * @return true if the family, qualifier and timestamps are the same
+     * @return true if the family, qualifier and timestamps are the same in this Cell as it is in
+     *         the other Cell.
      */
-    public boolean hasEqualKeys(Cell other) {
+    public boolean equalFamilyQualifierAndTimestamp(Cell other) {
       return other != null &&
           Objects.equal(family, other.family) &&
           Objects.equal(qualifier, other.qualifier) &&

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/FlatRow.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/FlatRow.java
@@ -128,11 +128,20 @@ public class FlatRow implements Serializable {
         return false;
       }
       Cell other = (Cell) obj;
-      return Objects.equal(family, other.family) &&
-          Objects.equal(qualifier, other.qualifier) &&
-          timestamp == other.timestamp &&
+      return hasEqualKeys(other) &&
           Objects.equal(value, other.value) &&
           Objects.equal(labels, other.labels);
+    }
+
+    /**
+     * @param other
+     * @return true if the family, qualifier and timestamps are the same
+     */
+    public boolean hasEqualKeys(Cell other) {
+      return other != null &&
+          Objects.equal(family, other.family) &&
+          Objects.equal(qualifier, other.qualifier) &&
+          timestamp == other.timestamp;
     }
 
     @Override

--- a/bigtable-hbase-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/RowMergerPerf.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/RowMergerPerf.java
@@ -46,18 +46,20 @@ public class RowMergerPerf {
 
     // It's ok if 100_000 / cellCount rounds down.  This only has to be approximate.
     int size = VALUE_SIZE_IN_BYTES / cellCount;
+    final int qualifiersPerFamily = 15;
     Preconditions.checkArgument(size > 0, "size has to be > 0.");
     final ByteString rowKey = ByteString.copyFrom(Bytes.toBytes("rowkey-0"));
     for (int i = 0; i < cellCount; i++) {
       CellChunk.Builder contentChunk =
           CellChunk.newBuilder()
               .setRowKey(i == 0 ? rowKey : ByteString.EMPTY)
-              .setQualifier(BytesValue.newBuilder().setValue(ByteString.copyFromUtf8("Qualifier" + (i%4))))
+              .setQualifier(BytesValue.newBuilder()
+                  .setValue(ByteString.copyFromUtf8("Qualifier" + (i % qualifiersPerFamily))))
               .setValue(ByteString.copyFrom(RandomStringUtils.randomAlphanumeric(size).getBytes()))
               .setTimestampMicros(330020L)
               .setCommitRow(i == cellCount - 1);
-      if (i % 4 == 0) {
-        contentChunk.setFamilyName(StringValue.newBuilder().setValue("Family" + (i / 4)));
+      if (i % qualifiersPerFamily == 0) {
+        contentChunk.setFamilyName(StringValue.newBuilder().setValue("Family" + (i / qualifiersPerFamily)));
       }
 
       readRowsResponse.addChunks(contentChunk);

--- a/bigtable-hbase-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/RowMergerPerf.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/RowMergerPerf.java
@@ -100,7 +100,7 @@ public class RowMergerPerf {
       // The adapter is slower than the RowMerger, so decrease the number of rows by a factor of 3
       // so that the test finishes faster. This will be enough of a sample to get an idea about the
       // adapter's performance
-      long rowCount = CUMULATIVE_CELL_COUNT / cellCountPerRow / 4;
+      long rowCount = CUMULATIVE_CELL_COUNT / cellCountPerRow;
 
       FlatRow flatRow = RowMerger.toRows(Arrays.asList(response)).get(0);
       long start = System.nanoTime();


### PR DESCRIPTION
Results from Bigtable are already ordered, although not ideally for HBase.  The order we get:
- family
- some internally ordered mechanism for qualifier
- reverse timestamp within the qualifier

Currently, we don't assume any ordering when we convert from the results we get from Cloud Bigtable.  We currently dedup using a TreeMap orderd by family/qualifier/timstamp via an HBase Comparator.  That's an expensive operation, or at least more expensive than it could be.  With the the assumptions of the server returning the order above, we can dedup within a single qualifer by simply checking against the previously returned response to see if the key matches, and if so, omit the value.  We can sort qualifier/timestamp within a family rather than sorting all cells across all families.

These changes made a 2-3X difference in the performance of the FlatRowAdapter as measured by RowMergerPerf.