### PR TITLE
Using a new endpoint for dataflow operations.

### DIFF
--- a/bigtable-dataflow-parent/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/CloudBigtableConfiguration.java
+++ b/bigtable-dataflow-parent/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/CloudBigtableConfiguration.java
@@ -253,6 +253,9 @@ public class CloudBigtableConfiguration implements Serializable {
   public Configuration toHBaseConfig() {
     Configuration config = new Configuration(false);
 
+    // Dataflow should use a different endpoint for data operations than online traffic.
+    config.set(BigtableOptionsFactory.BIGTABLE_HOST_KEY, "batch-bigtable.googleapis.com");
+
     // This setting can potentially decrease performance for large scale writes. However, this
     // setting prevents problems that occur when streaming Sources, such as PubSub, are used.
     // To override this behavior, call:


### PR DESCRIPTION
We want all of our users to use batch-bigtable.googleapis.com for their dataflow work.  That will isolate users with good latency requirements from batch users who need good throughput.

I tested reading and writing 1,000,000 rows through Dataflow with this change, both of which worked as expected.