### PR TITLE
BigtableClusterUtilities should have no-arg methods.

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableClusterName.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableClusterName.java
@@ -27,11 +27,15 @@ import java.util.regex.Pattern;
 public class BigtableClusterName {
   // Use a very loose pattern so we don't validate more strictly than the server.
   private static final Pattern PATTERN =
-      Pattern.compile("projects/.*/instances/(.*)/clusters/(.*)");
+      Pattern.compile("projects/[^/]+/instances/([^/]+)/clusters/([^/]+)");
 
   private final String clusterName;
   private final String instanceId;
   private final String clusterId;
+
+  public static BigtableClusterName parse(String clusterName) {
+    return new BigtableClusterName(clusterName);
+  }
 
   public BigtableClusterName(String clusterName) {
     this.clusterName = clusterName;
@@ -41,6 +45,9 @@ public class BigtableClusterName {
     this.clusterId = matcher.group(2);
   }
 
+  /**
+   * Returns the fully qualified cluster name same thing as {@link #getClusterName()}.
+   */
   @Override
   public String toString() {
     return clusterName;
@@ -48,22 +55,31 @@ public class BigtableClusterName {
 
   /**
    * @return The id of the instance that contains this cluster. It's the second group in the Cluster
-   *         name: projects/(.*)/instances/(.*)/clusters/(.*)
+   *         name: "projects/(.+)/instances/(.+)/clusters/(.+)".
    */
   public String getInstanceId() {
     return instanceId;
   }
 
   /**
-   * @return The id of this cluster. It's the third group in the Cluster name:
-   *         projects/(.*)/instances/(.*)/clusters/(.*)
+   * @return The id of this cluster. It will look like the following
+   *         projects/(.+)/instances/(.+)/clusters/(.+).
    */
   public String getClusterName() {
+    return clusterName;
+  }
+
+  /**
+   * @return The id of this cluster. It's the third group in the Cluster name:
+   *         "projects/(.+)/instances/(.+)/clusters/(.+)".
+   */
+  public String getClusterId() {
     return clusterId;
   }
 
   /**
    * Create a fully qualified snapshot name based on the the clusterName and the snapshotId.
+   * Snapshot name will look like: "projects/(.+)/instances/(.+)/clusters/(.+)/snapshots/(.+)"
    * @param snapshotId The id of the snapshot
    * @return A fully qualified snapshot name that contains the fully qualified cluster name as the
    *         parent and the snapshot name as the child.

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableClusterName.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableClusterName.java
@@ -27,16 +27,18 @@ import java.util.regex.Pattern;
 public class BigtableClusterName {
   // Use a very loose pattern so we don't validate more strictly than the server.
   private static final Pattern PATTERN =
-      Pattern.compile("projects/.*/instances/(.*)/clusters/.*");
+      Pattern.compile("projects/.*/instances/(.*)/clusters/(.*)");
 
   private final String clusterName;
   private final String instanceId;
+  private final String clusterId;
 
   public BigtableClusterName(String clusterName) {
     this.clusterName = clusterName;
     Matcher matcher = PATTERN.matcher(clusterName);
     Preconditions.checkArgument(matcher.matches(), "Malformed cluster name");
     this.instanceId = matcher.group(1);
+    this.clusterId = matcher.group(2);
   }
 
   @Override
@@ -45,9 +47,27 @@ public class BigtableClusterName {
   }
 
   /**
-   * @return The id of the instance that contains this cluster.
+   * @return The id of the instance that contains this cluster. It's the second entry in the Cluster
+   *         name: projects/(.*)/instances/(.*)/clusters/(.*)
    */
   public String getInstanceId() {
     return instanceId;
+  }
+
+  /**
+   * @return The id of this cluster. It's the thir entry in the Cluster name:
+   *         projects/(.*)/instances/(.*)/clusters/(.*)
+   */
+  public String getClusterName() {
+    return clusterId;
+  }
+
+  /**
+   * @param snapshotId The id of the snapshot
+   * @return A fully qualified snapshot name that contains the fully qualified cluster name as the
+   *         parent and the snapshot name as the child.
+   */
+  public String toSnapshotName(String snapshotId) {
+    return clusterName + "/snapshots/" + snapshotId;
   }
 }

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableClusterName.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableClusterName.java
@@ -55,15 +55,15 @@ public class BigtableClusterName {
 
   /**
    * @return The id of the instance that contains this cluster. It's the second group in the Cluster
-   *         name: "projects/(.+)/instances/(.+)/clusters/(.+)".
+   *         name: "projects/{projectId}/instances/{instanceId}/clusters/{clusterId}".
    */
   public String getInstanceId() {
     return instanceId;
   }
 
   /**
-   * @return The id of this cluster. It will look like the following
-   *         projects/(.+)/instances/(.+)/clusters/(.+).
+   * @return The name of this cluster. It will look like the following
+   *         "projects/{projectId}/instances/{instanceId}/clusters/{clusterId}".
    */
   public String getClusterName() {
     return clusterName;
@@ -71,7 +71,7 @@ public class BigtableClusterName {
 
   /**
    * @return The id of this cluster. It's the third group in the Cluster name:
-   *         "projects/(.+)/instances/(.+)/clusters/(.+)".
+   *         "projects/{projectId}/instances/{instanceId}/clusters/{clusterId}".
    */
   public String getClusterId() {
     return clusterId;
@@ -79,7 +79,8 @@ public class BigtableClusterName {
 
   /**
    * Create a fully qualified snapshot name based on the the clusterName and the snapshotId.
-   * Snapshot name will look like: "projects/(.+)/instances/(.+)/clusters/(.+)/snapshots/(.+)"
+   * Snapshot name will look like:
+   * "projects/{projectId}/instances/{instanceId}/clusters/{clusterId}/snapshots{snpashotId}".
    * @param snapshotId The id of the snapshot
    * @return A fully qualified snapshot name that contains the fully qualified cluster name as the
    *         parent and the snapshot name as the child.

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableClusterName.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableClusterName.java
@@ -47,7 +47,7 @@ public class BigtableClusterName {
   }
 
   /**
-   * @return The id of the instance that contains this cluster. It's the second entry in the Cluster
+   * @return The id of the instance that contains this cluster. It's the second group in the Cluster
    *         name: projects/(.*)/instances/(.*)/clusters/(.*)
    */
   public String getInstanceId() {
@@ -55,7 +55,7 @@ public class BigtableClusterName {
   }
 
   /**
-   * @return The id of this cluster. It's the thir entry in the Cluster name:
+   * @return The id of this cluster. It's the third group in the Cluster name:
    *         projects/(.*)/instances/(.*)/clusters/(.*)
    */
   public String getClusterName() {
@@ -63,6 +63,7 @@ public class BigtableClusterName {
   }
 
   /**
+   * Create a fully qualified snapshot name based on the the clusterName and the snapshotId.
    * @param snapshotId The id of the snapshot
    * @return A fully qualified snapshot name that contains the fully qualified cluster name as the
    *         parent and the snapshot name as the child.

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableClusterUtilities.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableClusterUtilities.java
@@ -70,7 +70,10 @@ public class BigtableClusterUtilities implements AutoCloseable {
   }
 
   /**
-   * @return The instance id associated with the given project, zone and cluster.
+   * @return The instance id associated with the given project, zone and cluster. We expect instance
+   *         and cluster to have one-to-one relationship.
+   *
+   * @throws IllegalStateException if the cluster is not found
    */
   public static String lookupInstanceId(String projectId, String clusterId, String zoneId)
     throws IOException {
@@ -94,7 +97,10 @@ public class BigtableClusterUtilities implements AutoCloseable {
   }
 
   /**
-   * @return The cluster associated with the given project and instance
+   * @return The cluster associated with the given project and instance. We expect instance and
+   *         cluster to have one-to-one relationship.
+   * @throws IllegalStateException if the cluster is not found or if there are many clusters in this
+   *           instance.
    */
   public static Cluster lookupCluster(String projectId, String instanceId)
     throws IOException {
@@ -152,6 +158,8 @@ public class BigtableClusterUtilities implements AutoCloseable {
    * @param clusterId
    * @param zoneId
    * @return the {@link Cluster#getServeNodes()} of the clusterId.
+   * @deprecated Use {@link #getCluster(String, String)} or {@link #getSingleCluster()} and then
+   *             call {@link Cluster#getServeNodes()}.
    */
   public int getClusterSize(String clusterId, String zoneId) {
     Cluster cluster = getCluster(clusterId, zoneId);

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestBigtableClusterName.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestBigtableClusterName.java
@@ -23,19 +23,19 @@ public class TestBigtableClusterName {
   @Test
   public void getInstanceId() {
     String clusterName = "projects/proj/instances/inst/clusters/cluster";
-    Assert.assertEquals("inst", new BigtableClusterName(clusterName).getInstanceId());
+    Assert.assertEquals("inst", BigtableClusterName.parse(clusterName).getInstanceId());
   }
 
   @Test
   public void getClusterId() {
     String clusterName = "projects/proj/instances/inst/clusters/cluster1";
-    Assert.assertEquals("cluster1", new BigtableClusterName(clusterName).getClusterName());
+    Assert.assertEquals("cluster1", BigtableClusterName.parse(clusterName).getClusterId());
   }
 
   @Test
   public void createSnapshotName() throws Exception {
     String clusterName = "projects/proj/instances/inst/clusters/cluster1";
     Assert.assertEquals(clusterName + "/snapshots/snp",
-      new BigtableClusterName(clusterName).toSnapshotName("snp"));
+      BigtableClusterName.parse(clusterName).toSnapshotName("snp"));
   }
 }

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestBigtableClusterName.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestBigtableClusterName.java
@@ -21,8 +21,21 @@ import org.junit.Test;
 public class TestBigtableClusterName {
 
   @Test
-  public void getInstanceId() throws Exception {
+  public void getInstanceId() {
     String clusterName = "projects/proj/instances/inst/clusters/cluster";
     Assert.assertEquals("inst", new BigtableClusterName(clusterName).getInstanceId());
+  }
+
+  @Test
+  public void getClusterId() {
+    String clusterName = "projects/proj/instances/inst/clusters/cluster1";
+    Assert.assertEquals("cluster1", new BigtableClusterName(clusterName).getClusterName());
+  }
+
+  @Test
+  public void createSnapshotName() throws Exception {
+    String clusterName = "projects/proj/instances/inst/clusters/cluster1";
+    Assert.assertEquals(clusterName + "/snapshots/snp",
+      new BigtableClusterName(clusterName).toSnapshotName("snp"));
   }
 }


### PR DESCRIPTION
BigtableClusterUtilities allows users to programmatically control the size of their cluster.  It is generally used with a user configuring a project and an instance.  A user can also set '-' as the instance id for all projects, which is useful when we know the cluster id but not the instance id.

Currently, one project/instance combination which only have a single cluster and zone is likely to be our most common scenario.  As such, users should not have to specify clusterId and zoneId.  In those scenarios, the code should look like:

`BigtableClusterUtilities.forInstance(projectId, instanceId).setClusterSize(30);`

It currently looks like:

`BigtableClusterUtilities.forInstance(projectId, instanceId).setClusterSize(clusterId, zone, 30);`

Add new methods for setSize, incrementSize, getClusterSize that don't have clusterId and zone.