### PR TITLE
Consistently applying Thread.currentThread().interrupt().

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataGrpcClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataGrpcClient.java
@@ -389,6 +389,7 @@ public class BigtableDataGrpcClient implements BigtableDataClient {
       listener.start();
       return listener.getCompletionFuture().get();
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       listener.cancel();
       throw Status.CANCELLED.withCause(e).asRuntimeException();
     } catch (ExecutionException e) {

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
@@ -561,6 +561,7 @@ public class BigtableSession implements Closeable {
       try {
         channel.awaitTermination(awaitTimeNanos, TimeUnit.NANOSECONDS);
       } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
         throw new IOException("Interrupted while closing the channelPools");
       }
     }

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AsyncExecutor.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AsyncExecutor.java
@@ -311,7 +311,7 @@ public class AsyncExecutor {
     ListenableFuture<ResponseT> future;
     try {
       future = rpc.call(client, request);
-    } catch (Exception e) {
+    } catch (Throwable e) {
       future = Futures.immediateFailedFuture(e);
     }
     rpcThrottler.addCallback(future, id);

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BulkMutation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BulkMutation.java
@@ -368,6 +368,9 @@ public class BulkMutation {
         }
         mutateRowsFuture = asyncExecutor.mutateRowsAsync(currentRequestManager.build());
         currentRequestManager.lastRpcSentTime = clock.currentTimeMillis();
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        mutateRowsFuture = Futures.<List<MutateRowsResponse>> immediateFailedFuture(e);
       } catch (Throwable e) {
         mutateRowsFuture = Futures.<List<MutateRowsResponse>> immediateFailedFuture(e);
       } finally {

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptor.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptor.java
@@ -249,6 +249,7 @@ public class RefreshingOAuth2CredentialsInterceptor implements HeaderInterceptor
           try {
             isRefreshing.wait(250);
           } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             throw new IOException(e);
           }
         }
@@ -416,7 +417,7 @@ public class RefreshingOAuth2CredentialsInterceptor implements HeaderInterceptor
       return RetryState.PerformRetry;
     } catch (InterruptedException e) {
       logger.warn("Interrupted while trying to refresh credentials.");
-      Thread.interrupted();
+      Thread.currentThread().interrupt();
       // If the thread is interrupted, terminate immediately.
       return RetryState.Interrupted;
     }

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/ResourceLimiterPerf.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/ResourceLimiterPerf.java
@@ -72,6 +72,7 @@ public class ResourceLimiterPerf {
                 registeredEvents.offer(underTest.registerOperationWithHeapSize(1));
               }
             } catch (InterruptedException e) {
+              Thread.currentThread().interrupt();
               e.printStackTrace();
               throw new RuntimeException(e);
             } finally {
@@ -102,6 +103,7 @@ public class ResourceLimiterPerf {
                 }
               }
             } catch (InterruptedException e) {
+              Thread.currentThread().interrupt();
               throw new RuntimeException(e);
             } finally {
               long totalTime = System.nanoTime() - startComplete;

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/RpcThrottlerPerf.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/RpcThrottlerPerf.java
@@ -72,6 +72,7 @@ public class RpcThrottlerPerf {
                 registeredEvents.add(underTest.registerOperationWithHeapSize(1));
               }
             } catch (InterruptedException e) {
+              Thread.currentThread().interrupt();
               e.printStackTrace();
               throw new RuntimeException(e);
             } finally {
@@ -102,6 +103,7 @@ public class RpcThrottlerPerf {
                 }
               }
             } catch (InterruptedException e) {
+              Thread.currentThread().interrupt();
               throw new RuntimeException(e);
             } finally {
               long totalTime = System.nanoTime() - startComplete;

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestRpcThrottler.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestRpcThrottler.java
@@ -99,6 +99,7 @@ public class TestRpcThrottler {
             underTest.registerOperationWithHeapSize(5l);
             secondRequestRegisteredLatch.countDown();
           } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             throw new RuntimeException(e);
           }
         }
@@ -137,6 +138,7 @@ public class TestRpcThrottler {
               allOperationsDone.notify();
             }
           } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             e.printStackTrace();
             throw new RuntimeException(e);
           }
@@ -159,6 +161,7 @@ public class TestRpcThrottler {
               }
             }
           } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             throw new RuntimeException(e);
           }
         }
@@ -217,6 +220,7 @@ public class TestRpcThrottler {
               allOperationsDone.notify();
             }
           } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             e.printStackTrace();
             throw new RuntimeException(e);
           }
@@ -235,6 +239,7 @@ public class TestRpcThrottler {
               }
             }
           } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             throw new RuntimeException(e);
           }
         }
@@ -290,7 +295,8 @@ public class TestRpcThrottler {
           try {
             underTest.awaitCompletion();
           } catch (InterruptedException e) {
-            e.printStackTrace();
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
           }
         }
       });

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestIncrement.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestIncrement.java
@@ -205,6 +205,7 @@ public class TestIncrement extends AbstractTest {
       TimeUnit.MILLISECONDS.sleep(10);  // Make sure the clock has a chance to move
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
+      throw new RuntimeException("sleep was interrupted", e);
     }
     table.increment(increment);
     result = table.get(get);

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestPut.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestPut.java
@@ -184,6 +184,7 @@ public class TestPut extends AbstractTest {
       TimeUnit.MILLISECONDS.sleep(10);  // Make sure the clock has a chance to move
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
+      throw new RuntimeException("sleep was interrupted", e);
     }
     table.put(put);
     get.addColumn(COLUMN_FAMILY, qualifier);

--- a/bigtable-hbase-parent/bigtable-hbase-mapreduce/src/main/java/com/google/cloud/bigtable/mapreduce/Import.java
+++ b/bigtable-hbase-parent/bigtable-hbase-mapreduce/src/main/java/com/google/cloud/bigtable/mapreduce/Import.java
@@ -100,6 +100,7 @@ public class Import extends Configured implements Tool {
      * @param context  The current context.
      * @throws IOException When something is broken with the data.
      */
+    @SuppressWarnings("deprecation")
     @Override
     public void map(ImmutableBytesWritable row, Result value, Context context) throws IOException {
       try {
@@ -117,7 +118,8 @@ public class Import extends Configured implements Tool {
           }
         }
       } catch (InterruptedException e) {
-        e.printStackTrace();
+        Thread.currentThread().interrupt();
+        throw new IOException("map process was interrupted", e);
       }
     }
 
@@ -147,7 +149,8 @@ public class Import extends Configured implements Tool {
       try {
         writeResult(row, value, context);
       } catch (InterruptedException e) {
-        e.printStackTrace();
+        Thread.currentThread().interrupt();
+        throw new IOException("map process was interrupted", e);
       }
     }
 

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BatchExecutor.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BatchExecutor.java
@@ -324,6 +324,7 @@ public class BatchExecutor {
       batch(actions, results);
       return results;
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       LOG.error("Encountered exception in batch(List<>).", e);
       throw new IOException("Batch error", e);
     }

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BatchExecutor.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BatchExecutor.java
@@ -244,7 +244,10 @@ public class BatchExecutor {
       } else if (row instanceof RowMutations) {
         return bulkOperation.mutateRowAsync(requestAdapter.adapt((RowMutations) row));
       }
-    } catch (Exception e) {
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      return Futures.immediateFailedFuture(new IOException("Could not process the batch due to interrupt", e));
+    } catch (Throwable e) {
       return Futures.immediateFailedFuture(new IOException("Could not process the batch", e));
     }
     LOG.error("Encountered unknown action type %s", row.getClass());

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutator.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutator.java
@@ -150,6 +150,7 @@ public class BigtableBufferedMutator implements BufferedMutator {
             }
             operation.run();
           } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             LOG.info("Interrupted. Shutting down the mutation worker.");
             break;
           } catch (Exception e) {
@@ -315,6 +316,7 @@ public class BigtableBufferedMutator implements BufferedMutator {
         }
       }
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       throw new IOException("Interrupted in buffered mutator while mutating row : '"
           + Bytes.toString(mutation.getRow()), e);
     }

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutator.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutator.java
@@ -373,7 +373,7 @@ public class BigtableBufferedMutator implements BufferedMutator {
       }
       return Futures.immediateFailedFuture(
         new IllegalArgumentException("Encountered unknown mutation type: " + mutation.getClass()));
-    } catch (Exception e) {
+    } catch (Throwable e) {
       // issueRequest(mutation) could throw an Exception for validation issues. Remove the heapsize
       // and inflight rpc count.
       return Futures.immediateFailedFuture(e);

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableConnection.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableConnection.java
@@ -312,6 +312,7 @@ public abstract class AbstractBigtableConnection implements Connection, Closeabl
           this.batchPool.shutdownNow();
         }
       } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
         this.batchPool.shutdownNow();
       }
     }


### PR DESCRIPTION
All InterruptedException handling should include Thread.currentThread().interrupt() as per:
http://stackoverflow.com/questions/4906799/why-invoke-thread-currentthread-interrupt-when-catch-any-interruptexception