### PR TITLE
Optimize the mapreduce Import job.

### DIFF
--- a/bigtable-hbase-parent/bigtable-hbase-mapreduce/src/main/java/com/google/cloud/bigtable/mapreduce/Import.java
+++ b/bigtable-hbase-parent/bigtable-hbase-mapreduce/src/main/java/com/google/cloud/bigtable/mapreduce/Import.java
@@ -408,7 +408,10 @@ public class Import extends Configured implements Tool {
     Job job = Job.getInstance(conf, conf.get(JOB_NAME_CONF_KEY, NAME + "_" + tableName));
     job.setJarByClass(Importer.class);
     FileInputFormat.setInputPaths(job, inputDir);
-    job.setInputFormatClass(SequenceFileInputFormat.class);
+    // Randomize the splits to avoid hot spotting a single tablet server
+    job.setInputFormatClass(ShuffledSequenceFileInputFormat.class);
+    // Give the mappers enough work to do otherwise each split will be dominated by spinup time
+    ShuffledSequenceFileInputFormat.setMinInputSplitSize(job, 1L*1024*1024*1024);
     String hfileOutPath = conf.get(BULK_OUTPUT_CONF_KEY);
 
     // make sure we get the filter in the jars

--- a/bigtable-hbase-parent/bigtable-hbase-mapreduce/src/main/java/com/google/cloud/bigtable/mapreduce/ShuffledSequenceFileInputFormat.java
+++ b/bigtable-hbase-parent/bigtable-hbase-mapreduce/src/main/java/com/google/cloud/bigtable/mapreduce/ShuffledSequenceFileInputFormat.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.mapreduce;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.hadoop.mapreduce.lib.input.SequenceFileInputFormat;
+
+/**
+ * An InputFormat randomizes the order of SequenceFile splits. This is needed for the Bigtable
+ * import job to spread the load across all of the Bigtable tablet servers.
+ * @author igorbernstein2
+ * @version $Id: $Id
+ */
+public class ShuffledSequenceFileInputFormat<K, V> extends SequenceFileInputFormat<K, V> {
+  @Override
+  public List<InputSplit> getSplits(JobContext job) throws IOException {
+    List<InputSplit> splits = super.getSplits(job);
+    Collections.shuffle(splits);
+    return splits;
+  }
+}


### PR DESCRIPTION
* Randomize the splits to spread load across all tablet servers
* Increase the min splitsize to give each mapper enough work to do