### PR TITLE
Minor refactornings

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableClusterName.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableClusterName.java
@@ -33,10 +33,6 @@ public class BigtableClusterName {
   private final String instanceId;
   private final String clusterId;
 
-  public static BigtableClusterName parse(String clusterName) {
-    return new BigtableClusterName(clusterName);
-  }
-
   public BigtableClusterName(String clusterName) {
     this.clusterName = clusterName;
     Matcher matcher = PATTERN.matcher(clusterName);

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableClusterUtilities.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableClusterUtilities.java
@@ -86,7 +86,7 @@ public class BigtableClusterUtilities implements AutoCloseable {
 
     try {
       Cluster cluster = utils.getCluster(clusterId, zoneId);
-      return BigtableClusterName.parse(cluster.getName()).getInstanceId();
+      return new BigtableClusterName(cluster.getName()).getInstanceId();
     } finally {
       try {
         utils.close();
@@ -256,7 +256,7 @@ public class BigtableClusterUtilities implements AutoCloseable {
    * @return the id portion of the {@link Cluster#getName()};
    */
   private String getClusterId(Cluster cluster) {
-    return BigtableClusterName.parse(cluster.getName()).getClusterId();
+    return new BigtableClusterName(cluster.getName()).getClusterId();
   }
 
   /**
@@ -329,7 +329,7 @@ public class BigtableClusterUtilities implements AutoCloseable {
    * @throws Exception
    */
   @Override
-  public void close() throws Exception {
+  public void close() {
     channelPool.shutdownNow();
   }
 }

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
@@ -237,6 +237,53 @@ public class BigtableSession implements Closeable {
       .synchronizedList(new ArrayList<ManagedChannel>());
   private final ImmutableList<HeaderInterceptor> headerInterceptors;
 
+
+  /**
+   * Use {@link com.google.cloud.bigtable.grpc.BigtableSession#BigtableSession(BigtableOptions)} instead;
+   *
+   * @param options a {@link com.google.cloud.bigtable.config.BigtableOptions} object.
+   * @param batchPool a {@link java.util.concurrent.ExecutorService} object.
+   * @throws java.io.IOException if any.
+   */
+  @Deprecated
+  public BigtableSession(
+      BigtableOptions options, @SuppressWarnings("unused") ExecutorService batchPool)
+      throws IOException {
+    this(options);
+  }
+
+  /**
+   * Use {@link com.google.cloud.bigtable.grpc.BigtableSession#BigtableSession(BigtableOptions)} instead;
+   *
+   * @param options a {@link com.google.cloud.bigtable.config.BigtableOptions} object.
+   * @param batchPool a {@link java.util.concurrent.ExecutorService} object.
+   * @param elg a {@link io.netty.channel.EventLoopGroup} object.
+   * @param scheduledRetries a {@link java.util.concurrent.ScheduledExecutorService} object.
+   * @throws java.io.IOException if any.
+   */
+  @Deprecated
+  public BigtableSession(
+      BigtableOptions options,
+      @SuppressWarnings("unused") @Nullable ExecutorService batchPool,
+      @Nullable EventLoopGroup elg,
+      @Nullable ScheduledExecutorService scheduledRetries)
+      throws IOException {
+    this(options);
+    if (elg != null) {
+      // There used to be a default EventLoopGroup if the elg is not passed in.
+      // AbstractBigtableConnection never sent one in, but some users may have. With the shared
+      // threadpools, the user supplied EventLoopGroup is no longer used. Previously, the elg would
+      // have been shut down in BigtableSession.close(), so shut it here.
+      elg.shutdown();
+    }
+    if (scheduledRetries != null) {
+      // Just like the EventLoopGroup, the schedule retries threadpool used to be a user feature
+      // that wasn't often used. It was shutdown in the close() method. Since it's no longer used,
+      // shut it down immediately.
+      scheduledRetries.shutdown();
+    }
+  }
+
   /**
    * <p>Constructor for BigtableSession.</p>
    *
@@ -328,52 +375,6 @@ public class BigtableSession implements Closeable {
       return options.toBuilder().setInstanceId(instanceId).build();
     }
     return options;
-  }
-
-  /**
-   * Use {@link com.google.cloud.bigtable.grpc.BigtableSession#BigtableSession(BigtableOptions)} instead;
-   *
-   * @param options a {@link com.google.cloud.bigtable.config.BigtableOptions} object.
-   * @param batchPool a {@link java.util.concurrent.ExecutorService} object.
-   * @throws java.io.IOException if any.
-   */
-  @Deprecated
-  public BigtableSession(
-      BigtableOptions options, @SuppressWarnings("unused") ExecutorService batchPool)
-      throws IOException {
-    this(options);
-  }
-
-  /**
-   * Use {@link com.google.cloud.bigtable.grpc.BigtableSession#BigtableSession(BigtableOptions)} instead;
-   *
-   * @param options a {@link com.google.cloud.bigtable.config.BigtableOptions} object.
-   * @param batchPool a {@link java.util.concurrent.ExecutorService} object.
-   * @param elg a {@link io.netty.channel.EventLoopGroup} object.
-   * @param scheduledRetries a {@link java.util.concurrent.ScheduledExecutorService} object.
-   * @throws java.io.IOException if any.
-   */
-  @Deprecated
-  public BigtableSession(
-      BigtableOptions options,
-      @SuppressWarnings("unused") @Nullable ExecutorService batchPool,
-      @Nullable EventLoopGroup elg,
-      @Nullable ScheduledExecutorService scheduledRetries)
-      throws IOException {
-    this(options);
-    if (elg != null) {
-      // There used to be a default EventLoopGroup if the elg is not passed in.
-      // AbstractBigtableConnection never sent one in, but some users may have. With the shared
-      // threadpools, the user supplied EventLoopGroup is no longer used. Previously, the elg would
-      // have been shut down in BigtableSession.close(), so shut it here.
-      elg.shutdown();
-    }
-    if (scheduledRetries != null) {
-      // Just like the EventLoopGroup, the schedule retries threadpool used to be a user feature
-      // that wasn't often used. It was shutdown in the close() method. Since it's no longer used,
-      // shut it down immediately.
-      scheduledRetries.shutdown();
-    }
   }
 
   /**

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestBigtableClusterName.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestBigtableClusterName.java
@@ -23,19 +23,19 @@ public class TestBigtableClusterName {
   @Test
   public void getInstanceId() {
     String clusterName = "projects/proj/instances/inst/clusters/cluster";
-    Assert.assertEquals("inst", BigtableClusterName.parse(clusterName).getInstanceId());
+    Assert.assertEquals("inst", new BigtableClusterName(clusterName).getInstanceId());
   }
 
   @Test
   public void getClusterId() {
     String clusterName = "projects/proj/instances/inst/clusters/cluster1";
-    Assert.assertEquals("cluster1", BigtableClusterName.parse(clusterName).getClusterId());
+    Assert.assertEquals("cluster1", new BigtableClusterName(clusterName).getClusterId());
   }
 
   @Test
   public void createSnapshotName() throws Exception {
     String clusterName = "projects/proj/instances/inst/clusters/cluster1";
     Assert.assertEquals(clusterName + "/snapshots/snp",
-      BigtableClusterName.parse(clusterName).toSnapshotName("snp"));
+      new BigtableClusterName(clusterName).toSnapshotName("snp"));
   }
 }


### PR DESCRIPTION
- Removing unnecessary parse method in BigtableClusterName
- Removing "throws Exception" in BigtableClusterUtilities
- Moving constructor in BigtableSession