### PR TITLE
Stop linking to the protobuf docs

### DIFF
--- a/javadoc/protobuf-docs/package-list
+++ b/javadoc/protobuf-docs/package-list
@@ -1,3 +1,2 @@
 com.google.protobuf
 com.google.protobuf.compiler
-com.google.protobuf.util

--- a/pom.xml
+++ b/pom.xml
@@ -637,7 +637,7 @@ limitations under the License.
                                 <location>${basedir}/javadoc/hbase-docs</location>
                             </offlineLink>
                             <offlineLink>
-                                <url>https://developers.google.com/protocol-buffers/docs/reference/java/</url>
+                                <url>http://atetric.com/atetric/javadoc/com.google.protobuf/protobuf-java/3.0.2/</url>
                                 <location>${basedir}/javadoc/protobuf-docs</location>
                             </offlineLink>
                         </offlineLinks>


### PR DESCRIPTION
Linking to the protobuf docs results in broken links to the class com.google.protobuf.GeneratedMessageV3, which doesn’t exist in the target docset.