### PR TITLE
Add option to autoflush the bulk mutations

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BulkOptions.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BulkOptions.java
@@ -49,6 +49,10 @@ public class BulkOptions implements Serializable {
    */
   public static final int BIGTABLE_BULK_MAX_ROW_KEY_COUNT_DEFAULT = 25;
 
+  /**
+   * The maximum amount of time a row will be buffered for. By default 0: indefinitely.
+   */
+  public static long BIGTABLE_BULK_AUTOFLUSH_MS_DEFAULT = 0;
 
   // Default rpc count per channel.
   /** Constant <code>BIGTABLE_MAX_INFLIGHT_RPCS_PER_CHANNEL_DEFAULT=50</code> */
@@ -69,6 +73,7 @@ public class BulkOptions implements Serializable {
     private boolean useBulkApi = false;
     private int bulkMaxRowKeyCount = BIGTABLE_BULK_MAX_ROW_KEY_COUNT_DEFAULT;
     private long bulkMaxRequestSize = BIGTABLE_BULK_MAX_REQUEST_SIZE_BYTES_DEFAULT;
+    private long autoflushMs = BIGTABLE_BULK_AUTOFLUSH_MS_DEFAULT;
     private int maxInflightRpcs = -1;
     private long maxMemory = BIGTABLE_MAX_MEMORY_DEFAULT;
 
@@ -80,6 +85,7 @@ public class BulkOptions implements Serializable {
       this.useBulkApi = original.useBulkApi;
       this.bulkMaxRowKeyCount = original.bulkMaxRowKeyCount;
       this.bulkMaxRequestSize = original.bulkMaxRequestSize;
+      this.autoflushMs = original.autoflushMs;
       this.maxInflightRpcs = original.maxInflightRpcs;
       this.maxMemory = original.maxMemory;
     }
@@ -110,6 +116,13 @@ public class BulkOptions implements Serializable {
       return this;
     }
 
+    public Builder setAutoflushMs(long autoflushMs) {
+      Preconditions.checkArgument(
+          autoflushMs >= 0, "autoflushMs must be greater or equal to 0.");
+      this.autoflushMs = autoflushMs;
+      return this;
+    }
+
     public Builder setMaxInflightRpcs(int maxInflightRpcs) {
       Preconditions.checkArgument(maxInflightRpcs > 0, "maxInflightRpcs must be greater than 0.");
       this.maxInflightRpcs = maxInflightRpcs;
@@ -128,6 +141,7 @@ public class BulkOptions implements Serializable {
           useBulkApi,
           bulkMaxRowKeyCount,
           bulkMaxRequestSize,
+          autoflushMs,
           maxInflightRpcs,
           maxMemory);
     }
@@ -137,6 +151,7 @@ public class BulkOptions implements Serializable {
   private final boolean useBulkApi;
   private final int bulkMaxRowKeyCount;
   private final long bulkMaxRequestSize;
+  private final long autoflushMs;
 
   private final int maxInflightRpcs;
   private final long maxMemory;
@@ -147,6 +162,7 @@ public class BulkOptions implements Serializable {
       useBulkApi = false;
       bulkMaxRowKeyCount = -1;
       bulkMaxRequestSize = -1;
+      autoflushMs = -1l;
       maxInflightRpcs = -1;
       maxMemory = -1l;
   }
@@ -156,12 +172,14 @@ public class BulkOptions implements Serializable {
       boolean useBulkApi,
       int bulkMaxKeyCount,
       long bulkMaxRequestSize,
+      long autoflushMs,
       int maxInflightRpcs,
       long maxMemory) {
     this.asyncMutatorCount = asyncMutatorCount;
     this.useBulkApi = useBulkApi;
     this.bulkMaxRowKeyCount = bulkMaxKeyCount;
     this.bulkMaxRequestSize = bulkMaxRequestSize;
+    this.autoflushMs = autoflushMs;
     this.maxInflightRpcs = maxInflightRpcs;
     this.maxMemory = maxMemory;
   }
@@ -200,6 +218,14 @@ public class BulkOptions implements Serializable {
    */
   public long getBulkMaxRequestSize() {
     return bulkMaxRequestSize;
+  }
+
+  /**
+   * <p>Getter for the field <code>autoflushMs</code>.</p>
+   * @return
+   */
+  public long getAutoflushMs() {
+    return autoflushMs;
   }
 
   /**

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BulkOptions.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BulkOptions.java
@@ -260,6 +260,7 @@ public class BulkOptions implements Serializable {
         && (useBulkApi == other.useBulkApi)
         && (bulkMaxRowKeyCount == other.bulkMaxRowKeyCount)
         && (bulkMaxRequestSize == other.bulkMaxRequestSize)
+        && (autoflushMs == other.autoflushMs)
         && (maxInflightRpcs == other.maxInflightRpcs)
         && (maxMemory == other.maxMemory);
   }
@@ -273,6 +274,7 @@ public class BulkOptions implements Serializable {
         .add("useBulkApi", useBulkApi)
         .add("bulkMaxKeyCount", bulkMaxRowKeyCount)
         .add("bulkMaxRequestSize", bulkMaxRequestSize)
+        .add("autoflushMs", autoflushMs)
         .add("maxInflightRpcs", maxInflightRpcs)
         .add("maxMemory", maxMemory)
         .toString();

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
@@ -440,7 +440,8 @@ public class BigtableSession implements Closeable {
         options.getRetryOptions(),
         BigtableSessionSharedThreadPools.getInstance().getRetryExecutor(),
         options.getBulkOptions().getBulkMaxRowKeyCount(),
-        options.getBulkOptions().getBulkMaxRequestSize());
+        options.getBulkOptions().getBulkMaxRequestSize(),
+        options.getBulkOptions().getAutoflushMs());
   }
 
   /**

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableOptionsFactory.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableOptionsFactory.java
@@ -21,6 +21,7 @@ import static com.google.cloud.bigtable.config.BigtableOptions.BIGTABLE_DATA_HOS
 import static com.google.cloud.bigtable.config.BigtableOptions.BIGTABLE_TABLE_ADMIN_HOST_DEFAULT;
 import static com.google.cloud.bigtable.config.BigtableOptions.BIGTABLE_PORT_DEFAULT;
 import static com.google.cloud.bigtable.config.BulkOptions.BIGTABLE_ASYNC_MUTATOR_COUNT_DEFAULT;
+import static com.google.cloud.bigtable.config.BulkOptions.BIGTABLE_BULK_AUTOFLUSH_MS_DEFAULT;
 import static com.google.cloud.bigtable.config.CallOptionsConfig.*;
 
 import com.google.cloud.bigtable.config.BigtableOptions;
@@ -183,6 +184,10 @@ public class BigtableOptionsFactory {
   public static final String BIGTABLE_BULK_MAX_ROW_KEY_COUNT =
       "google.bigtable.bulk.max.row.key.count";
 
+  /** Constant <code>BIGTABLE_BULK_AUTOFLUSH_MS_KEY="google.bigtable.bulk.autoflush.ms"</code>*/
+  public static final String BIGTABLE_BULK_AUTOFLUSH_MS_KEY =
+      "google.bigtable.bulk.autoflush.ms";
+
   /** Constant <code>MAX_INFLIGHT_RPCS_KEY="google.bigtable.buffered.mutator.max.in"{trunked}</code> */
   public static final String MAX_INFLIGHT_RPCS_KEY =
       "google.bigtable.buffered.mutator.max.inflight.rpcs";
@@ -322,6 +327,10 @@ public class BigtableOptionsFactory {
         configuration.getLong(
             BIGTABLE_BULK_MAX_REQUEST_SIZE_BYTES,
             BulkOptions.BIGTABLE_BULK_MAX_REQUEST_SIZE_BYTES_DEFAULT));
+    bulkOptionsBuilder.setAutoflushMs(
+        configuration.getLong(
+            BIGTABLE_BULK_AUTOFLUSH_MS_KEY,
+            BulkOptions.BIGTABLE_BULK_AUTOFLUSH_MS_DEFAULT));
 
     int defaultRpcCount = BulkOptions.BIGTABLE_MAX_INFLIGHT_RPCS_PER_CHANNEL_DEFAULT
         * bigtableOptionsBuilder.getDataChannelCount();


### PR DESCRIPTION
When enabled, this will ensure that rows don't linger in bulk mutations indefinitely