### PR TITLE
Removing an unnecessary generics argument.

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataGrpcClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataGrpcClient.java
@@ -164,8 +164,8 @@ public class BigtableDataGrpcClient implements BigtableDataClient {
   // Member variables
   private final ScheduledExecutorService retryExecutorService;
   private final RetryOptions retryOptions;
-  private final BigtableResultScannerFactory<ReadRowsRequest, FlatRow> streamingScannerFactory =
-      new BigtableResultScannerFactory<ReadRowsRequest, FlatRow>() {
+  private final BigtableResultScannerFactory<FlatRow> streamingScannerFactory =
+      new BigtableResultScannerFactory<FlatRow>() {
         @Override
         public ResultScanner<FlatRow> createScanner(ReadRowsRequest request) {
           return streamRows(request);

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
@@ -57,7 +57,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableList.Builder;
-import com.google.protobuf.ByteString;
 
 import io.grpc.ManagedChannel;
 import io.grpc.netty.GrpcSslContexts;

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/BigtableResultScannerFactory.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/BigtableResultScannerFactory.java
@@ -15,6 +15,8 @@
  */
 package com.google.cloud.bigtable.grpc.scanner;
 
+import com.google.bigtable.v2.ReadRowsRequest;
+
 /**
  * A factory for creating ResultScanners that can be used to scan over Rows for a
  * given ReadRowsRequest.
@@ -22,13 +24,13 @@ package com.google.cloud.bigtable.grpc.scanner;
  * @author sduskis
  * @version $Id: $Id
  */
-public interface BigtableResultScannerFactory<RequestT, ResponseT> {
+public interface BigtableResultScannerFactory<ResponseT> {
 
   /**
    * Create a scanner for the given request.
    *
-   * @param request a RequestT object.
+   * @param request a ReadRowsRequest object.
    * @return a {@link com.google.cloud.bigtable.grpc.scanner.ResultScanner} object.
    */
-  ResultScanner<ResponseT> createScanner(RequestT request);
+  ResultScanner<ResponseT> createScanner(ReadRowsRequest request);
 }

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ResumingStreamingResultScanner.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ResumingStreamingResultScanner.java
@@ -37,7 +37,7 @@ public class ResumingStreamingResultScanner extends AbstractBigtableResultScanne
 
   // Member variables from the constructor.
   private final ReadRowsRequestRetryHandler retryHandler;
-  private final BigtableResultScannerFactory<ReadRowsRequest, FlatRow> scannerFactory;
+  private final BigtableResultScannerFactory<FlatRow> scannerFactory;
   private final Logger logger;
   private final RpcMetrics rpcMetrics;
 
@@ -58,7 +58,7 @@ public class ResumingStreamingResultScanner extends AbstractBigtableResultScanne
    *          object to keep track of retries and failures.
    */
   public ResumingStreamingResultScanner(RetryOptions retryOptions, ReadRowsRequest originalRequest,
-      BigtableResultScannerFactory<ReadRowsRequest, FlatRow> scannerFactory, RpcMetrics rpcMetrics) {
+      BigtableResultScannerFactory<FlatRow> scannerFactory, RpcMetrics rpcMetrics) {
     this(retryOptions, originalRequest, scannerFactory, rpcMetrics, LOG);
   }
 
@@ -66,7 +66,7 @@ public class ResumingStreamingResultScanner extends AbstractBigtableResultScanne
   ResumingStreamingResultScanner(
       RetryOptions retryOptions,
       ReadRowsRequest originalRequest,
-      BigtableResultScannerFactory<ReadRowsRequest, FlatRow> scannerFactory,
+      BigtableResultScannerFactory<FlatRow> scannerFactory,
       RpcMetrics rpcMetrics,
       Logger logger) {
     this.operationContext = rpcMetrics.timeOperation();

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/scanner/ResumingStreamingResultScannerTest.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/scanner/ResumingStreamingResultScannerTest.java
@@ -79,7 +79,7 @@ public class ResumingStreamingResultScannerTest {
   @Mock
   ResultScanner<FlatRow> mockScannerPostResume;
   @Mock
-  BigtableResultScannerFactory<ReadRowsRequest, FlatRow> mockScannerFactory;
+  BigtableResultScannerFactory<FlatRow> mockScannerFactory;
   @Mock
   Logger logger;
 


### PR DESCRIPTION
For reference, this generic argument was added when we were upgrading between V1 and V2.  There were 2 versions of ReadRowsRequest, one for each version, and we wanted to support both.  At this point, we only need to specify the v2 ReadRowsRequest.