### PR TITLE
Refactoring ReadRowsRequestRetryHandler to only manage ReadRowsRequest

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ReadRowsRequestManager.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ReadRowsRequestManager.java
@@ -33,7 +33,7 @@ import java.nio.ByteBuffer;
  * @author sduskis
  * @version $Id: $Id
  */
-public class ReadRowsRequestManager {
+class ReadRowsRequestManager {
 
   // Member variables from the constructor.
   private final ReadRowsRequest originalRequest;
@@ -49,16 +49,16 @@ public class ReadRowsRequestManager {
    * </p>
    * @param originalRequest a {@link ReadRowsRequest} object.
    */
-  public ReadRowsRequestManager(ReadRowsRequest originalRequest) {
+  ReadRowsRequestManager(ReadRowsRequest originalRequest) {
     this.originalRequest = originalRequest;
   }
 
-  public void updateLastFoundKey(ByteString key) {
+  void updateLastFoundKey(ByteString key) {
     this.lastFoundKey = key;
     rowCount++;
   }
 
-  public ReadRowsRequest getUpdatedRequest() {
+  ReadRowsRequest buildUpdatedRequest() {
     ReadRowsRequest.Builder newRequest = ReadRowsRequest.newBuilder()
         .setRows(filterRows())
         .setTableName(originalRequest.getTableName());

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ResumingStreamingResultScanner.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ResumingStreamingResultScanner.java
@@ -124,7 +124,7 @@ public class ResumingStreamingResultScanner extends AbstractBigtableResultScanne
     }
   }
 
-  private synchronized ReadRowsRequest handleScanTimeout(ScanTimeoutException rte)
+  private ReadRowsRequest handleScanTimeout(ScanTimeoutException rte)
       throws IOException {
     logger.info("The client could not get a response in %d ms. Retrying the scan.",
       retryOptions.getReadPartialRowTimeoutMillis());
@@ -144,7 +144,7 @@ public class ResumingStreamingResultScanner extends AbstractBigtableResultScanne
     }
   }
 
-  private synchronized ReadRowsRequest handleIOException(IOExceptionWithStatus ioe)
+  private ReadRowsRequest handleIOException(IOExceptionWithStatus ioe)
       throws IOException {
     Status.Code code = ioe.getStatus().getCode();
     if (!retryOptions.enableRetries() || !retryOptions.isRetryable(code)) {

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/scanner/ReadRowsRequestManagerTest.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/scanner/ReadRowsRequestManagerTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.grpc.scanner;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import com.google.bigtable.v2.ReadRowsRequest;
+import com.google.bigtable.v2.RowRange;
+import com.google.bigtable.v2.RowSet;
+import com.google.protobuf.ByteString;
+
+/**
+ * Test for the {@link ResumingStreamingResultScanner}
+ */
+@RunWith(JUnit4.class)
+public class ReadRowsRequestManagerTest {
+
+  static final ByteString BLANK = ByteString.EMPTY;
+
+  static FlatRow buildRow(String rowKey) {
+    return FlatRow.newBuilder()
+        .withRowKey(ByteString.copyFromUtf8(rowKey))
+        .build();
+  }
+
+  private static ReadRowsRequest createRequest(RowRange range) {
+    return ReadRowsRequest.newBuilder().setRows(RowSet.newBuilder().addRowRanges(range)).build();
+  }
+
+  private static RowRange createRowRangeClosedStart(ByteString startClosed, ByteString endOpen) {
+    return RowRange.newBuilder().setStartKeyClosed(startClosed).setEndKeyOpen(endOpen).build();
+  }
+
+  private static RowRange createRowRangeOpenedStart(ByteString startOpened, ByteString endOpen) {
+    return RowRange.newBuilder().setStartKeyOpen(startOpened).setEndKeyOpen(endOpen).build();
+  }
+
+  private ReadRowsRequest createKeysRequest(Iterable<ByteString> keys) {
+    return ReadRowsRequest.newBuilder().setRows(createRowSet(keys)).build();
+  }
+
+  private RowSet createRowSet(Iterable<ByteString> keys) {
+    return RowSet.newBuilder().addAllRowKeys(keys).build();
+  }
+
+
+  /**
+   * Test a single, full table scan scenario for {@Link ResumingStreamingResultScanner#filterRows()}
+   * .
+   * @throws IOException
+   */
+  @Test
+  public void test_filterRows_testAllRange() throws IOException{
+    ByteString key1 = ByteString.copyFrom("row1".getBytes());
+
+    ReadRowsRequest originalRequest =
+        createRequest(createRowRangeClosedStart(ByteString.EMPTY, ByteString.EMPTY));
+
+    ReadRowsRequestManager underTest = new ReadRowsRequestManager(originalRequest);
+
+    underTest.updateLastFoundKey(key1);
+    Assert.assertEquals(createRequest(createRowRangeOpenedStart(key1, ByteString.EMPTY)),
+      underTest.getUpdatedRequest());
+  }
+
+  /**
+   * Test rowKeys scenario for {@Link ReadRowsRequestManager#getUpdatedRequest()}.
+   * @throws IOException
+   */
+  @Test
+  public void test_filterRows_rowKeys() throws IOException{
+    ByteString key1 = ByteString.copyFrom("row1".getBytes());
+    ByteString key2 = ByteString.copyFrom("row2".getBytes());
+    ByteString key3 = ByteString.copyFrom("row3".getBytes());
+
+    ReadRowsRequest originalRequest = createKeysRequest(Arrays.asList(key1, key2, key3));
+
+    ReadRowsRequestManager underTest = new ReadRowsRequestManager(originalRequest);
+
+    Assert.assertEquals(originalRequest, underTest.getUpdatedRequest());
+    underTest.updateLastFoundKey(key1);
+
+    Assert.assertEquals(createKeysRequest(Arrays.asList(key2, key3)),
+      underTest.getUpdatedRequest());
+  }
+
+  /**
+   * Test multiple rowset filter scenarios for {@Link ReadRowsRequestManager#getUpdatedRequest()}.
+   * @throws IOException
+   */
+  @Test
+  public void test_filterRows_multiRowSetFilters() throws IOException{
+    ByteString key1 = ByteString.copyFrom("row1".getBytes());
+    ByteString key2 = ByteString.copyFrom("row2".getBytes());
+    ByteString key3 = ByteString.copyFrom("row3".getBytes());
+
+    RowSet fullRowSet = RowSet.newBuilder()
+        .addAllRowKeys(Arrays.asList(key1, key2, key3)) // row1 should be filtered out
+        .addRowRanges(RowRange.newBuilder().setStartKeyOpen(BLANK).setEndKeyClosed(key1)) // should be filtered out
+        .addRowRanges(RowRange.newBuilder().setStartKeyOpen(BLANK).setEndKeyOpen(key1)) // should be filtered out
+        .addRowRanges(RowRange.newBuilder().setStartKeyOpen(key1).setEndKeyOpen(key2)) // should stay
+        .addRowRanges(RowRange.newBuilder().setStartKeyClosed(key1).setEndKeyOpen(key2)) // should be converted (key1 -> key2)
+        .addRowRanges(RowRange.newBuilder().setStartKeyClosed(key1).setEndKeyClosed(key2)) // should be converted (key1 -> key2]
+        .addRowRanges(RowRange.newBuilder().setStartKeyOpen(key2).setEndKeyOpen(key3)) // should stay
+        .addRowRanges(RowRange.newBuilder().setStartKeyClosed(key2).setEndKeyOpen(key3)) // should stay
+        .build();
+
+    RowSet filteredRowSet = RowSet.newBuilder()
+        .addAllRowKeys(Arrays.asList(key2, key3)) // row1 should be filtered out
+        .addRowRanges(RowRange.newBuilder().setStartKeyOpen(key1).setEndKeyOpen(key2)) // should stay
+        .addRowRanges(RowRange.newBuilder().setStartKeyOpen(key1).setEndKeyOpen(key2)) // should be converted (key1 -> key2)
+        .addRowRanges(RowRange.newBuilder().setStartKeyOpen(key1).setEndKeyClosed(key2)) // should be converted (key1 -> key2]
+        .addRowRanges(RowRange.newBuilder().setStartKeyOpen(key2).setEndKeyOpen(key3)) // should stay
+        .addRowRanges(RowRange.newBuilder().setStartKeyClosed(key2).setEndKeyOpen(key3)) // should stay
+        .build();
+
+    ReadRowsRequest originalRequest = ReadRowsRequest.newBuilder().setRows(fullRowSet).build();
+    ReadRowsRequest filteredRequest = ReadRowsRequest.newBuilder().setRows(filteredRowSet).build();
+
+    ReadRowsRequestManager underTest = new ReadRowsRequestManager(originalRequest);
+    Assert.assertEquals(originalRequest, underTest.getUpdatedRequest());
+    underTest.updateLastFoundKey(key1);
+    Assert.assertEquals(filteredRequest, underTest.getUpdatedRequest());
+  }
+}

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/scanner/ReadRowsRequestManagerTest.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/scanner/ReadRowsRequestManagerTest.java
@@ -79,7 +79,7 @@ public class ReadRowsRequestManagerTest {
 
     underTest.updateLastFoundKey(key1);
     Assert.assertEquals(createRequest(createRowRangeOpenedStart(key1, ByteString.EMPTY)),
-      underTest.getUpdatedRequest());
+      underTest.buildUpdatedRequest());
   }
 
   /**
@@ -96,11 +96,11 @@ public class ReadRowsRequestManagerTest {
 
     ReadRowsRequestManager underTest = new ReadRowsRequestManager(originalRequest);
 
-    Assert.assertEquals(originalRequest, underTest.getUpdatedRequest());
+    Assert.assertEquals(originalRequest, underTest.buildUpdatedRequest());
     underTest.updateLastFoundKey(key1);
 
     Assert.assertEquals(createKeysRequest(Arrays.asList(key2, key3)),
-      underTest.getUpdatedRequest());
+      underTest.buildUpdatedRequest());
   }
 
   /**
@@ -137,8 +137,8 @@ public class ReadRowsRequestManagerTest {
     ReadRowsRequest filteredRequest = ReadRowsRequest.newBuilder().setRows(filteredRowSet).build();
 
     ReadRowsRequestManager underTest = new ReadRowsRequestManager(originalRequest);
-    Assert.assertEquals(originalRequest, underTest.getUpdatedRequest());
+    Assert.assertEquals(originalRequest, underTest.buildUpdatedRequest());
     underTest.updateLastFoundKey(key1);
-    Assert.assertEquals(filteredRequest, underTest.getUpdatedRequest());
+    Assert.assertEquals(filteredRequest, underTest.buildUpdatedRequest());
   }
 }

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/scanner/ResumingStreamingResultScannerTest.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/scanner/ResumingStreamingResultScannerTest.java
@@ -27,7 +27,6 @@ import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import org.junit.Before;
@@ -82,6 +81,8 @@ public class ResumingStreamingResultScannerTest {
   BigtableResultScannerFactory<FlatRow> mockScannerFactory;
   @Mock
   Logger logger;
+  @Mock
+  ReadRowsRequestManager mockReadRowsRequestManager;
 
   static BigtableAsyncRpc.RpcMetrics metrics =
       BigtableAsyncRpc.RpcMetrics.createRpcMetrics(BigtableGrpc.METHOD_READ_ROWS);
@@ -220,9 +221,6 @@ public class ResumingStreamingResultScannerTest {
     }
     afterFailureStub.thenReturn(mockScannerPostResume);
 
-    ResumingStreamingResultScanner scanner = new ResumingStreamingResultScanner(retryOptions,
-        originalRequest, mockScannerFactory, metrics, logger);
-
     when(mockScanner.next())
         .thenReturn(row1)
         .thenReturn(row2)
@@ -246,6 +244,10 @@ public class ResumingStreamingResultScannerTest {
     when(mockScannerPostResume.next())
         .thenReturn(row3)
         .thenReturn(row4);
+
+    when(this.mockReadRowsRequestManager.getUpdatedRequest()).thenReturn(expectedResumeRequest);
+    ResumingStreamingResultScanner scanner = new ResumingStreamingResultScanner(retryOptions,
+        originalRequest, mockScannerFactory, metrics, mockReadRowsRequestManager, logger);
 
     assertRowKey("row1", scanner.next());
     assertRowKey("row2", scanner.next());
@@ -302,7 +304,7 @@ public class ResumingStreamingResultScannerTest {
         .thenReturn(mockScanner);
 
     ResumingStreamingResultScanner scanner = new ResumingStreamingResultScanner(retryOptions,
-        readRowsRequest, mockScannerFactory, metrics, logger);
+        readRowsRequest, mockScannerFactory, metrics, mockReadRowsRequestManager, logger);
 
     when(mockScanner.next())
         .thenReturn(row1)
@@ -355,8 +357,7 @@ public class ResumingStreamingResultScannerTest {
     when(mockScannerFactory.createScanner(eq(expectedResumeRequest))).thenReturn(afterError2Mock,
       mockScannerPostResume);
 
-    ResumingStreamingResultScanner scanner = new ResumingStreamingResultScanner(retryOptions,
-        readRowsRequest, mockScannerFactory, metrics, logger);
+    ResumingStreamingResultScanner scanner = createScanner();
 
     when(mockScanner.next())
         .thenReturn(row1)
@@ -377,6 +378,9 @@ public class ResumingStreamingResultScannerTest {
     when(mockScannerPostResume.next())
         .thenReturn(row3)
         .thenReturn(row4);
+    when(mockReadRowsRequestManager.getUpdatedRequest())
+        .thenReturn(expectedResumeRequest)
+        .thenReturn(expectedResumeRequest);
 
     assertRowKey("row1", scanner.next());
     assertRowKey("row2", scanner.next());
@@ -389,125 +393,9 @@ public class ResumingStreamingResultScannerTest {
     scanner.close();
   }
 
-  /**
-   * Test a single, full table scan scenario for {@Link ResumingStreamingResultScanner#filterRows()}
-   * .
-   * @throws IOException
-   */
-  @Test
-  public void test_filterRows_testAllRange() throws IOException{
-    ByteString key1 = ByteString.copyFrom("row1".getBytes());
-
-    FlatRow row1 = buildRow("row1");
-    FlatRow row2 = buildRow("row2");
-
-    when(mockScannerFactory.createScanner(any(ReadRowsRequest.class))).thenReturn(mockScanner);
-
-    try (ResumingStreamingResultScanner scanner = new ResumingStreamingResultScanner(retryOptions,
-        readRowsRequest, mockScannerFactory, metrics, logger)) {
-
-      verify(mockScannerFactory, times(1))
-          .createScanner(eq(readRowsRequest));
-
-      when(mockScanner.next())
-          .thenReturn(row1)
-          .thenThrow(new IOExceptionWithStatus("Test", Status.INTERNAL))
-          .thenReturn(row2);
-
-      scanner.next();
-      scanner.next();
-
-      verify(mockScannerFactory, times(1)).createScanner(
-          eq(createRequest(createRowRangeOpenedStart(key1, blank))));
-    }
+  private ResumingStreamingResultScanner createScanner() {
+    return new ResumingStreamingResultScanner(retryOptions, readRowsRequest, mockScannerFactory,
+        metrics, mockReadRowsRequestManager, logger);
   }
 
-
-  /**
-   * Test rowKeys scenario for {@Link ResumingStreamingResultScanner#filterRows()}.
-   * @throws IOException
-   */
-  @Test
-  public void test_filterRows_rowKeys() throws IOException{
-    ByteString key1 = ByteString.copyFrom("row1".getBytes());
-    ByteString key2 = ByteString.copyFrom("row2".getBytes());
-    ByteString key3 = ByteString.copyFrom("row3".getBytes());
-
-    FlatRow row1 = buildRow("row1");
-    FlatRow row2 = buildRow("row2");
-
-    when(mockScannerFactory.createScanner(any(ReadRowsRequest.class))).thenReturn(mockScanner);
-
-    ReadRowsRequest originalRequest = createKeysRequest(Arrays.asList(key1, key2, key3));
-    try (ResumingStreamingResultScanner scanner = new ResumingStreamingResultScanner(retryOptions,
-        originalRequest, mockScannerFactory, metrics, logger)) {
-
-      when(mockScanner.next())
-          .thenThrow(new IOExceptionWithStatus("Test", Status.INTERNAL))
-          .thenReturn(row1)
-          .thenThrow(new IOExceptionWithStatus("Test", Status.INTERNAL))
-          .thenReturn(row2);
-
-      verify(mockScannerFactory, times(1)).createScanner(eq(originalRequest));
-      scanner.next();
-      verify(mockScannerFactory, times(2)).createScanner(eq(originalRequest));
-
-      scanner.next();
-
-      verify(mockScannerFactory, times(1))
-          .createScanner(eq(createKeysRequest(Arrays.asList(key2, key3))));
-    }
-  }
-
-  /**
-   * Test multiple rowset filter scenarios for {@Link ResumingStreamingResultScanner#filterRows()}.
-   * @throws IOException
-   */
-  @Test
-  public void test_filterRows_multiRowSetFilters() throws IOException{
-    ByteString key1 = ByteString.copyFrom("row1".getBytes());
-    ByteString key2 = ByteString.copyFrom("row2".getBytes());
-    ByteString key3 = ByteString.copyFrom("row3".getBytes());
-
-    FlatRow row1 = buildRow("row1");
-    FlatRow row2 = buildRow("row2");
-
-    when(mockScannerFactory.createScanner(any(ReadRowsRequest.class))).thenReturn(mockScanner);
-
-    RowSet fullRowSet = RowSet.newBuilder()
-        .addAllRowKeys(Arrays.asList(key1, key2, key3)) // row1 should be filtered out
-        .addRowRanges(RowRange.newBuilder().setStartKeyOpen(blank).setEndKeyClosed(key1)) // should be filtered out
-        .addRowRanges(RowRange.newBuilder().setStartKeyOpen(blank).setEndKeyOpen(key1)) // should be filtered out
-        .addRowRanges(RowRange.newBuilder().setStartKeyOpen(key1).setEndKeyOpen(key2)) // should stay
-        .addRowRanges(RowRange.newBuilder().setStartKeyClosed(key1).setEndKeyOpen(key2)) // should be converted (key1 -> key2)
-        .addRowRanges(RowRange.newBuilder().setStartKeyClosed(key1).setEndKeyClosed(key2)) // should be converted (key1 -> key2]
-        .addRowRanges(RowRange.newBuilder().setStartKeyOpen(key2).setEndKeyOpen(key3)) // should stay
-        .addRowRanges(RowRange.newBuilder().setStartKeyClosed(key2).setEndKeyOpen(key3)) // should stay
-        .build();
-
-    RowSet filteredRowSet = RowSet.newBuilder()
-        .addAllRowKeys(Arrays.asList(key2, key3)) // row1 should be filtered out
-        .addRowRanges(RowRange.newBuilder().setStartKeyOpen(key1).setEndKeyOpen(key2)) // should stay
-        .addRowRanges(RowRange.newBuilder().setStartKeyOpen(key1).setEndKeyOpen(key2)) // should be converted (key1 -> key2)
-        .addRowRanges(RowRange.newBuilder().setStartKeyOpen(key1).setEndKeyClosed(key2)) // should be converted (key1 -> key2]
-        .addRowRanges(RowRange.newBuilder().setStartKeyOpen(key2).setEndKeyOpen(key3)) // should stay
-        .addRowRanges(RowRange.newBuilder().setStartKeyClosed(key2).setEndKeyOpen(key3)) // should stay
-        .build();
-
-    ReadRowsRequest originalRequest = ReadRowsRequest.newBuilder().setRows(fullRowSet).build();
-    ReadRowsRequest filteredRequest = ReadRowsRequest.newBuilder().setRows(filteredRowSet).build();
-    try (ResumingStreamingResultScanner scanner = new ResumingStreamingResultScanner(retryOptions,
-        originalRequest, mockScannerFactory, metrics, logger)) {
-
-      when(mockScanner.next())
-          .thenReturn(row1)
-          .thenThrow(new IOExceptionWithStatus("Test", Status.INTERNAL))
-          .thenReturn(row2);
-
-      scanner.next();
-      verify(mockScannerFactory, times(1)).createScanner(eq(originalRequest));
-      scanner.next();
-      verify(mockScannerFactory, times(1)).createScanner(eq(filteredRequest));
-    }
-  }
 }


### PR DESCRIPTION
- renaming ReadRowsRequestRetryHandler to ReadRowsRequestManager.
- ReadRowsRequestManager does not do backoffs and retries.  It only manages ReadRowsRequests for retries
- Retries and backoffs are performed by ResumingStreamingResultScanner
- Tests for ResumingStreamingResultScanner were broken up into tests to for ReadRowsRequest management in TestReadRowsRequestManager and tests for retry behavior in TestResumingStreamingResultScanner
- This is a step towards performing retries via AbstractRetryingRpcListener