### PR TITLE
AppEngine -> App Engine

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptor.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptor.java
@@ -83,7 +83,7 @@ public class RefreshingOAuth2CredentialsInterceptor implements HeaderInterceptor
 
   @VisibleForTesting
   static Clock clock = Clock.SYSTEM;
-  
+
 
   @VisibleForTesting
   static class HeaderCacheElement {
@@ -193,7 +193,7 @@ public class RefreshingOAuth2CredentialsInterceptor implements HeaderInterceptor
     this.logger = Preconditions.checkNotNull(logger);
 
     // com.google.auth.oauth2.AppEngineCredentials is package private, so we don't have direct
-    // visibility to it. This is a way to detect that this application runs on AppEngine so that
+    // visibility to it. This is a way to detect that this application runs on App Engine so that
     // we can always get credentials synchronously, which must be done for AppEngineCredentials
     // which relies on a ThreadLocal.
     this.isAppEngine = credentials.getClass().getName().contains("AppEngineCredentials");
@@ -207,9 +207,10 @@ public class RefreshingOAuth2CredentialsInterceptor implements HeaderInterceptor
 
   /**
    * Refreshes the OAuth2 token asynchronously. This method will only start an async refresh if
-   * there isn't a currently running asynchronous refresh or the credentials are for AppEngine.
-   * AppEngine has some credentials related state in a {@link ThreadLocal} which prevents it from
-   * running asynchronously. In the AppEngine case, this method will defer to {@link #syncRefresh()}
+   * there isn't a currently running asynchronous refresh or the credentials are for App Engine.
+   * App Engine has some credentials related state in a {@link ThreadLocal} which prevents it from
+   * running asynchronously. In the App Engine case, this method will defer to
+   * {@link #syncRefresh()}.
    *
    * @throws IOException
    */


### PR DESCRIPTION
This change (in addition to being more correct) fixes a warning that occurs when importing the generated Javadoc into Google's internal repo.