### PR TITLE
Batch timer is now Info level instead of debug

### DIFF
--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BatchExecutor.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BatchExecutor.java
@@ -210,7 +210,7 @@ public class BatchExecutor {
   protected final AsyncExecutor asyncExecutor;
   protected final BigtableOptions options;
   protected final HBaseRequestAdapter requestAdapter;
-  protected final Timer batchTimer = BigtableClientMetrics.timer(MetricLevel.Debug, "batch.latency");
+  protected final Timer batchTimer = BigtableClientMetrics.timer(MetricLevel.Info, "batch.latency");
 
   /**
    * Constructor for BatchExecutor.


### PR DESCRIPTION
This will allow batches to be part of the logging that's enabled via
SLF4J.