### PR TITLE
Fix tests after guava upgrade

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestBulkMutation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestBulkMutation.java
@@ -117,6 +117,7 @@ public class TestBulkMutation {
         return null;
       }
     }).when(mockFuture).addListener(any(Runnable.class), any(Executor.class));
+    doReturn(true).when(mockFuture).isDone();
 
     when(rpcThrottler.registerRetry(any(RetryHandler.class))).then(new Answer<Long>() {
       @Override

--- a/bigtable-hbase-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBatchExecutor.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBatchExecutor.java
@@ -19,6 +19,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.argThat;
 import static org.mockito.Matchers.same;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -180,6 +181,7 @@ public class TestBatchExecutor {
         return null;
       }
     }).when(mockFuture).addListener(any(Runnable.class), any(Executor.class));
+    doReturn(true).when(mockFuture).isDone();
   }
 
   @Test


### PR DESCRIPTION
Update ListenableFuture mocks to deal with new checks in guava 20