### PR TITLE
Adding ByteStringComparator to compare ByteStrings

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ReadRowsRequestManager.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ReadRowsRequestManager.java
@@ -22,6 +22,7 @@ import com.google.bigtable.v2.RowRange;
 import com.google.bigtable.v2.RowRange.EndKeyCase;
 import com.google.bigtable.v2.RowRange.StartKeyCase;
 import com.google.bigtable.v2.RowSet;
+import com.google.cloud.bigtable.util.ByteStringComparator;
 import com.google.protobuf.ByteString;
 
 /**
@@ -119,31 +120,13 @@ class ReadRowsRequestManager {
 
   private boolean startKeyIsAlreadyRead(ByteString startKey) {
     // empty startKey implies the smallest key
-    return lastFoundKey != null
-        && (startKey.isEmpty() || compareKeys(startKey, lastFoundKey) <= 0);
+    return lastFoundKey != null && (startKey.isEmpty()
+        || ByteStringComparator.INSTANCE.compare(startKey, lastFoundKey) <= 0);
   }
+
   private boolean endKeyIsAlreadyRead(ByteString endKey) {
     // empty endKey implies the largest key
-    return lastFoundKey != null && !endKey.isEmpty() && compareKeys(endKey, lastFoundKey) <= 0;
-  }
-
-  // TODO(igorbernstein2): move this to a better place
-  /**
-   * Lexicographically compare as a string of unsigned bytes
-   */
-  private static int compareKeys(ByteString key1, ByteString key2) {
-    int size1 = key1.size();
-    int size2 = key2.size();
-
-    for (int i = 0; i < Math.min(size1, size2); i++) {
-      // compare bytes as unsigned
-      int byte1 = key1.byteAt(i) & 0xff;
-      int byte2 = key2.byteAt(i) & 0xff;
-
-      if (byte1 != byte2) {
-        return Integer.compare(byte1, byte2);
-      }
-    }
-    return Integer.compare(size1, size2);
+    return lastFoundKey != null && !endKey.isEmpty()
+        && ByteStringComparator.INSTANCE.compare(endKey, lastFoundKey) <= 0;
   }
 }

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/util/ByteStringComparator.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/util/ByteStringComparator.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.util;
+
+import java.util.Comparator;
+
+import com.google.protobuf.ByteString;
+
+/**
+ * Compares {@link ByteString}s.
+ */
+public final class ByteStringComparator implements Comparator<ByteString>{
+
+  public static final ByteStringComparator INSTANCE = new ByteStringComparator();
+
+  @Override
+  public int compare(ByteString key1, ByteString key2) {
+    int size1 = key1.size();
+    int size2 = key2.size();
+    int size = Math.min(size1, size2);
+
+    for (int i = 0; i < size; i++) {
+      // compare bytes as unsigned
+      int byte1 = key1.byteAt(i) & 0xff;
+      int byte2 = key2.byteAt(i) & 0xff;
+
+      int comparison = Integer.compare(byte1, byte2);
+      if (comparison != 0) {
+        return comparison;
+      }
+    }
+    return Integer.compare(size1, size2);
+  }
+}

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/util/ByteStringComparatorTest.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/util/ByteStringComparatorTest.java
@@ -1,0 +1,37 @@
+package com.google.cloud.bigtable.util;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import com.google.protobuf.ByteString;
+
+import java.util.Comparator;
+
+import org.junit.Assert;
+
+@RunWith(JUnit4.class)
+public class ByteStringComparatorTest {
+
+  Comparator<ByteString> underTest = ByteStringComparator.INSTANCE;
+
+  @Test
+  public void testSimple(){
+    compare(ByteString.copyFromUtf8("a"), ByteString.copyFromUtf8("b"));
+    compare(ByteString.copyFromUtf8("aa"), ByteString.copyFromUtf8("bb"));
+    compare(ByteString.copyFromUtf8("aa"), ByteString.copyFromUtf8("b"));
+    compare(ByteString.copyFromUtf8("a"), ByteString.copyFromUtf8("bb"));
+    compare(ByteString.copyFromUtf8("aa"), ByteString.copyFromUtf8("aab"));
+  }
+
+  public void testUnsigned() {
+    compare(ByteString.copyFrom(new byte[] { 0x7f }),
+      ByteString.copyFrom(new byte[] { (byte) 0x80 }));
+  }
+
+  protected void compare(ByteString a, ByteString b) {
+    Assert.assertEquals(-1, underTest.compare(a, b));
+    Assert.assertEquals(1, underTest.compare(b, a));
+    Assert.assertEquals(0, underTest.compare(b, b));
+  }
+}


### PR DESCRIPTION
This is functionality that will be useful for other cases where we need to compare ByteStrings, including splitting BulkRead batches.