### PR TITLE
Fix ordering of ScanAdapter filter chaining

### DIFF
--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestScan.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestScan.java
@@ -29,7 +29,6 @@ import org.apache.hadoop.hbase.client.Table;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 
 import com.google.protobuf.ByteString;
 
@@ -70,7 +69,6 @@ public class TestScan extends AbstractTest {
   }
 
   @Test
-  @Category(KnownGap.class)
   public void testGetScannerBeforeTimestamp() throws IOException {
     Table table = getConnection().getTable(TABLE_NAME);
     byte[] rowKey = dataHelper.randomData("testrow-");

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/ScanAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/ScanAdapter.java
@@ -83,11 +83,9 @@ public class ScanAdapter implements ReadOperationAdapter<Scan> {
   public RowFilter buildFilter(Scan scan, ReadHooks hooks) {
     RowFilter.Chain.Builder chainBuilder = RowFilter.Chain.newBuilder();
     chainBuilder.addFilters(createColumnFamilyFilter(scan));
-    chainBuilder.addFilters(createColumnLimitFilter(scan.getMaxVersions()));
 
     if (scan.getTimeRange() != null && !scan.getTimeRange().isAllTime()) {
-      RowFilter timeRangeFilter = createTimeRangeFilter(scan.getTimeRange());
-      chainBuilder.addFilters(timeRangeFilter);
+      chainBuilder.addFilters(createTimeRangeFilter(scan.getTimeRange()));
     }
 
     if (scan.getFilter() != null) {
@@ -96,6 +94,8 @@ public class ScanAdapter implements ReadOperationAdapter<Scan> {
         chainBuilder.addFilters(userFilter.get());
       }
     }
+
+    chainBuilder.addFilters(createColumnLimitFilter(scan.getMaxVersions()));
 
     if (chainBuilder.getFiltersCount() == 1) {
       return chainBuilder.getFilters(0);


### PR DESCRIPTION
Max versions implies get the top N remaining cells.  Order matters with chaining, and the order was previously broken.  In most cases where a Column Family is configured with a single latest cell this doesn't matter.  In cases where there are multiple cells, and the user wants an earlier cell, the ordering of the chain of filters has to change from

1) max versions filter
2) timestamp filter
3) other filters

to

1) timestamp filter
2) other filters
3) max version filter