### PR TITLE
Removing the idle timeout scheduler.

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
@@ -558,7 +558,8 @@ public class BigtableSession implements Closeable {
     return NettyChannelBuilder
         .forAddress(host, options.getPort())
         .nameResolverFactory(new DnsNameResolverProvider())
-        .maxMessageSize(MAX_MESSAGE_SIZE)
+        .idleTimeout(Long.MAX_VALUE, TimeUnit.SECONDS)
+        .maxInboundMessageSize(MAX_MESSAGE_SIZE)
         .sslContext(createSslContext())
         .eventLoopGroup(sharedPools.getElg())
         .executor(sharedPools.getBatchThreadPool())


### PR DESCRIPTION
This is a feature of gRPC that will automatically shut down connections.  This feature is needed for lower throughput gRPC channels, and doesn't apply to Cloud Bigtable.  This feature isn't problematic in most cases, but caused problems in GAE as per #1223.

I also changed maxMessageSize to maxInboundMessageSize due to deprecations.  The change did not have any functional changes.