### PR TITLE
Add common base class to all filter adapters 

### DIFF
--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/ColumnCountGetFilterAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/ColumnCountGetFilterAdapter.java
@@ -29,7 +29,7 @@ import java.io.IOException;
  * @author sduskis
  * @version $Id: $Id
  */
-public class ColumnCountGetFilterAdapter implements TypedFilterAdapter<ColumnCountGetFilter> {
+public class ColumnCountGetFilterAdapter extends TypedFilterAdapterBase<ColumnCountGetFilter> {
 
   /** {@inheritDoc} */
   @Override

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/ColumnPaginationFilterAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/ColumnPaginationFilterAdapter.java
@@ -31,7 +31,7 @@ import java.io.IOException;
  * @author sduskis
  * @version $Id: $Id
  */
-public class ColumnPaginationFilterAdapter implements TypedFilterAdapter<ColumnPaginationFilter> {
+public class ColumnPaginationFilterAdapter extends TypedFilterAdapterBase<ColumnPaginationFilter> {
 
   private static final FilterSupportStatus UNSUPPORTED_STATUS =
       FilterSupportStatus.newNotSupported(

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/ColumnPrefixFilterAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/ColumnPrefixFilterAdapter.java
@@ -30,7 +30,7 @@ import java.io.IOException;
  * @author sduskis
  * @version $Id: $Id
  */
-public class ColumnPrefixFilterAdapter implements TypedFilterAdapter<ColumnPrefixFilter> {
+public class ColumnPrefixFilterAdapter extends TypedFilterAdapterBase<ColumnPrefixFilter> {
   ReaderExpressionHelper readerExpressionHelper = new ReaderExpressionHelper();
 
   /** {@inheritDoc} */

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/ColumnRangeFilterAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/ColumnRangeFilterAdapter.java
@@ -31,7 +31,7 @@ import java.io.IOException;
  * @author sduskis
  * @version $Id: $Id
  */
-public class ColumnRangeFilterAdapter implements TypedFilterAdapter<ColumnRangeFilter> {
+public class ColumnRangeFilterAdapter extends TypedFilterAdapterBase<ColumnRangeFilter> {
 
   private static final String REQUIRE_SINGLE_FAMILY_MESSAGE =
       "Scan or Get operations using ColumnRangeFilter must "

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/FilterListAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/FilterListAdapter.java
@@ -36,7 +36,7 @@ import java.util.List;
  * @version $Id: $Id
  */
 public class FilterListAdapter
-    implements TypedFilterAdapter<FilterList>, UnsupportedStatusCollector<FilterList> {
+    extends TypedFilterAdapterBase<FilterList> implements UnsupportedStatusCollector<FilterList> {
   private final FilterAdapter subFilterAdapter;
 
   /**

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/FirstKeyOnlyFilterAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/FirstKeyOnlyFilterAdapter.java
@@ -27,7 +27,7 @@ import java.io.IOException;
  * @author sduskis
  * @version $Id: $Id
  */
-public class FirstKeyOnlyFilterAdapter implements TypedFilterAdapter<FirstKeyOnlyFilter> {
+public class FirstKeyOnlyFilterAdapter extends TypedFilterAdapterBase<FirstKeyOnlyFilter> {
 
   /** {@inheritDoc} */
   @Override

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/FuzzyRowFilterAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/FuzzyRowFilterAdapter.java
@@ -37,7 +37,7 @@ import com.google.protobuf.ByteString;
  * @author sduskis
  * @version $Id: $Id
  */
-public class FuzzyRowFilterAdapter implements TypedFilterAdapter<FuzzyRowFilter> {
+public class FuzzyRowFilterAdapter extends TypedFilterAdapterBase<FuzzyRowFilter> {
   private static final RowFilter ALL_VALUES_FILTER =
       RowFilter.newBuilder()
           .setCellsPerColumnLimitFilter(Integer.MAX_VALUE)

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/KeyOnlyFilterAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/KeyOnlyFilterAdapter.java
@@ -30,7 +30,7 @@ import java.io.IOException;
  * @author sduskis
  * @version $Id: $Id
  */
-public class KeyOnlyFilterAdapter implements TypedFilterAdapter<KeyOnlyFilter> {
+public class KeyOnlyFilterAdapter extends TypedFilterAdapterBase<KeyOnlyFilter> {
   /** Constant <code>TEST_CELL</code> */
   protected static final Cell TEST_CELL = new KeyValue(
       Bytes.toBytes('r'), // Row

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/MultipleColumnPrefixFilterAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/MultipleColumnPrefixFilterAdapter.java
@@ -33,7 +33,7 @@ import java.io.IOException;
  * @version $Id: $Id
  */
 public class MultipleColumnPrefixFilterAdapter
-    implements TypedFilterAdapter<MultipleColumnPrefixFilter> {
+    extends TypedFilterAdapterBase<MultipleColumnPrefixFilter> {
 
   /** {@inheritDoc} */
   @Override

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/PageFilterAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/PageFilterAdapter.java
@@ -32,7 +32,7 @@ import java.io.IOException;
  * @author sduskis
  * @version $Id: $Id
  */
-public class PageFilterAdapter implements TypedFilterAdapter<PageFilter> {
+public class PageFilterAdapter extends TypedFilterAdapterBase<PageFilter> {
 
   private static final FilterSupportStatus TOP_LEVEL_ONLY =
       FilterSupportStatus.newNotSupported(

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/PrefixFilterAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/PrefixFilterAdapter.java
@@ -31,7 +31,7 @@ import java.io.IOException;
  * @author sduskis
  * @version $Id: $Id
  */
-public class PrefixFilterAdapter implements TypedFilterAdapter<PrefixFilter> {
+public class PrefixFilterAdapter extends TypedFilterAdapterBase<PrefixFilter> {
   /** {@inheritDoc} */
   @Override
   public RowFilter adapt(FilterAdapterContext context, PrefixFilter filter)

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/QualifierFilterAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/QualifierFilterAdapter.java
@@ -35,7 +35,7 @@ import java.io.IOException;
  * @author sduskis
  * @version $Id: $Id
  */
-public class QualifierFilterAdapter implements TypedFilterAdapter<QualifierFilter> {
+public class QualifierFilterAdapter extends TypedFilterAdapterBase<QualifierFilter> {
 
   private static final FilterSupportStatus SINGLE_FAMILY_REQUIRED =
       FilterSupportStatus.newNotSupported(

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/RandomRowFilterAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/RandomRowFilterAdapter.java
@@ -27,7 +27,7 @@ import java.io.IOException;
  * @author sduskis
  * @version $Id: $Id
  */
-public class RandomRowFilterAdapter implements TypedFilterAdapter<RandomRowFilter> {
+public class RandomRowFilterAdapter extends TypedFilterAdapterBase<RandomRowFilter> {
   /** {@inheritDoc} */
   @Override
   public RowFilter adapt(FilterAdapterContext context, RandomRowFilter filter)

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/RowFilterAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/RowFilterAdapter.java
@@ -41,8 +41,8 @@ import com.google.protobuf.ByteString;
  * @author sduskis
  * @version $Id: $Id
  */
-public class RowFilterAdapter implements 
-  TypedFilterAdapter<org.apache.hadoop.hbase.filter.RowFilter> {
+public class RowFilterAdapter
+    extends TypedFilterAdapterBase<org.apache.hadoop.hbase.filter.RowFilter> {
 
   /** {@inheritDoc} */
   @Override

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/SingleColumnValueExcludeFilterAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/SingleColumnValueExcludeFilterAdapter.java
@@ -34,7 +34,7 @@ import java.io.IOException;
  * @version $Id: $Id
  */
 public class SingleColumnValueExcludeFilterAdapter
-    implements TypedFilterAdapter<SingleColumnValueExcludeFilter> {
+    extends TypedFilterAdapterBase<SingleColumnValueExcludeFilter> {
 
   private static final String REQUIRE_SINGLE_FAMILY_MESSAGE =
       "Scan or Get operations using SingleColumnValueExcludeFilter must "

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/SingleColumnValueFilterAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/SingleColumnValueFilterAdapter.java
@@ -34,7 +34,8 @@ import com.google.cloud.bigtable.util.ByteStringer;
  * @author sduskis
  * @version $Id: $Id
  */
-public class SingleColumnValueFilterAdapter implements TypedFilterAdapter<SingleColumnValueFilter> {
+public class SingleColumnValueFilterAdapter
+    extends TypedFilterAdapterBase<SingleColumnValueFilter> {
 
   private static final RowFilter ALL_VALUES_FILTER =
       RowFilter.newBuilder()

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/TimestampsFilterAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/TimestampsFilterAdapter.java
@@ -30,7 +30,7 @@ import org.apache.hadoop.hbase.filter.TimestampsFilter;
  * @version $Id: $Id
  */
 public class TimestampsFilterAdapter
-    implements TypedFilterAdapter<TimestampsFilter> {
+    extends TypedFilterAdapterBase<TimestampsFilter> {
 
   /** {@inheritDoc} */
   @Override

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/TypedFilterAdapterBase.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/TypedFilterAdapterBase.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.adapters.filters;
+
+import org.apache.hadoop.hbase.filter.Filter;
+
+/**
+ * Base functionality for all filter adapters
+ * @param <S>
+ */
+public abstract class TypedFilterAdapterBase<S extends Filter> implements TypedFilterAdapter<S> {
+
+}

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/ValueFilterAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/ValueFilterAdapter.java
@@ -35,7 +35,7 @@ import java.io.IOException;
  * @author sduskis
  * @version $Id: $Id
  */
-public class ValueFilterAdapter implements TypedFilterAdapter<ValueFilter> {
+public class ValueFilterAdapter extends TypedFilterAdapterBase<ValueFilter> {
 
   /** {@inheritDoc} */
   @Override

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/WhileMatchFilterAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/WhileMatchFilterAdapter.java
@@ -39,7 +39,7 @@ import java.util.List;
  * @author sduskis
  * @version $Id: $Id
  */
-public class WhileMatchFilterAdapter implements TypedFilterAdapter<WhileMatchFilter> {
+public class WhileMatchFilterAdapter extends TypedFilterAdapterBase<WhileMatchFilter> {
   
   static final String IN_LABEL_SUFFIX = "-in";
   static final String OUT_LABEL_SUFFIX = "-out";


### PR DESCRIPTION
This will simplify extending functionality in the future (ie. adding index scan hints).
This the first part of #1237