### PR TITLE
Add index scan hint plumbing

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/util/RowKeyWrapper.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/util/RowKeyWrapper.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.util;
+
+import com.google.protobuf.ByteString;
+
+public class RowKeyWrapper implements Comparable<RowKeyWrapper> {
+  private final ByteString key;
+
+  public RowKeyWrapper(ByteString key) {
+    this.key = key;
+  }
+
+  public ByteString getKey() {
+    return key;
+  }
+
+  @Override
+  public int compareTo(RowKeyWrapper o) {
+    return ByteStringComparator.INSTANCE.compare(key, o.key);
+  }
+}

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/util/RowKeyWrapper.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/util/RowKeyWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Google Inc. All Rights Reserved.
+ * Copyright 2017 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package com.google.cloud.bigtable.util;
 import com.google.protobuf.ByteString;
 
 public class RowKeyWrapper implements Comparable<RowKeyWrapper> {
+
   private final ByteString key;
 
   public RowKeyWrapper(ByteString key) {

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableExtendedScan.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableExtendedScan.java
@@ -17,7 +17,6 @@ package com.google.cloud.bigtable.hbase;
 
 import com.google.bigtable.v2.RowRange;
 import com.google.bigtable.v2.RowSet;
-import com.google.cloud.bigtable.hbase.adapters.filters.PrefixFilterAdapter;
 import com.google.cloud.bigtable.util.ByteStringer;
 import com.google.cloud.bigtable.util.RowKeyUtil;
 import org.apache.hadoop.hbase.client.Scan;

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/Adapters.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/Adapters.java
@@ -51,7 +51,9 @@ public final class Adapters {
   /** Constant <code>ROW_RANGE_ADAPTER</code> */
   public static final RowRangeAdapter ROW_RANGE_ADAPTER = new RowRangeAdapter();
   /** Constant <code>SCAN_ADAPTER</code> */
-  public static final ScanAdapter SCAN_ADAPTER =  new ScanAdapter(FILTER_ADAPTER, ROW_RANGE_ADAPTER);
+  public static final ScanAdapter SCAN_ADAPTER =  new ScanAdapter(
+      FILTER_ADAPTER, ROW_RANGE_ADAPTER
+  );
   /** Constant <code>BIGTABLE_RESULT_SCAN_ADAPTER</code> */
   public static final BigtableResultScannerAdapter<FlatRow> BIGTABLE_RESULT_SCAN_ADAPTER =
       new BigtableResultScannerAdapter<>(FLAT_ROW_ADAPTER);

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/Adapters.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/Adapters.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.bigtable.hbase.adapters;
 
+import com.google.cloud.bigtable.hbase.adapters.read.RowRangeAdapter;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.client.Append;
 import org.apache.hadoop.hbase.client.Increment;
@@ -47,8 +48,10 @@ public final class Adapters {
   public static final DeleteAdapter DELETE_ADAPTER = new DeleteAdapter();
   /** Constant <code>FILTER_ADAPTER</code> */
   public static final FilterAdapter FILTER_ADAPTER = FilterAdapter.buildAdapter();
+  /** Constant <code>ROW_RANGE_ADAPTER</code> */
+  public static final RowRangeAdapter ROW_RANGE_ADAPTER = new RowRangeAdapter();
   /** Constant <code>SCAN_ADAPTER</code> */
-  public static final ScanAdapter SCAN_ADAPTER =  new ScanAdapter(FILTER_ADAPTER);
+  public static final ScanAdapter SCAN_ADAPTER =  new ScanAdapter(FILTER_ADAPTER, ROW_RANGE_ADAPTER);
   /** Constant <code>BIGTABLE_RESULT_SCAN_ADAPTER</code> */
   public static final BigtableResultScannerAdapter<FlatRow> BIGTABLE_RESULT_SCAN_ADAPTER =
       new BigtableResultScannerAdapter<>(FLAT_ROW_ADAPTER);

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/FilterAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/FilterAdapter.java
@@ -16,9 +16,11 @@
 package com.google.cloud.bigtable.hbase.adapters.filters;
 
 import com.google.bigtable.v2.RowFilter;
+import com.google.cloud.bigtable.util.RowKeyWrapper;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 
+import com.google.common.collect.RangeSet;
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.filter.ColumnCountGetFilter;
 import org.apache.hadoop.hbase.filter.ColumnPaginationFilter;
@@ -185,6 +187,10 @@ public class FilterAdapter {
     } else {
       adapter.collectUnsupportedStatuses(context, filter, statuses);
     }
+  }
+
+  public RangeSet<RowKeyWrapper> getIndexScanHint(Filter filter) {
+    return getAdapterForFilterOrThrow(filter).getIndexScanHint(filter);
   }
 
   /**

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/SingleFilterAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/SingleFilterAdapter.java
@@ -15,9 +15,11 @@
  */
 package com.google.cloud.bigtable.hbase.adapters.filters;
 
+import com.google.cloud.bigtable.util.RowKeyWrapper;
 import com.google.common.base.Preconditions;
 import com.google.bigtable.v2.RowFilter;
 
+import com.google.common.collect.RangeSet;
 import org.apache.hadoop.hbase.filter.Filter;
 
 import java.io.IOException;
@@ -105,6 +107,10 @@ public class SingleFilterAdapter<T extends Filter> {
         context,
         unchecked(filter),
         statuses);
+  }
+
+  public RangeSet<RowKeyWrapper> getIndexScanHint(Filter filter) {
+    return adapter.getIndexScanHint(unchecked(filter));
   }
 
   @SuppressWarnings("unchecked")

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/TypedFilterAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/TypedFilterAdapter.java
@@ -17,6 +17,10 @@ package com.google.cloud.bigtable.hbase.adapters.filters;
 
 import com.google.bigtable.v2.RowFilter;
 
+import com.google.bigtable.v2.RowRange;
+import com.google.cloud.bigtable.util.RowKeyWrapper;
+import com.google.common.collect.RangeSet;
+import java.util.List;
 import org.apache.hadoop.hbase.filter.Filter;
 
 import java.io.IOException;
@@ -49,4 +53,14 @@ public interface TypedFilterAdapter<S extends Filter> {
    * @return a {@link com.google.cloud.bigtable.hbase.adapters.filters.FilterSupportStatus} object.
    */
   FilterSupportStatus isFilterSupported(FilterAdapterContext context, S filter);
+
+  /**
+   * Get hints how to optimize the scan. For example if the filter will narrow the scan using
+   * the prefix "ab" then we can restrict the scan to ["ab" - "ac"). If the filter doesn't narrow
+   * the scan then it should return Range.all()
+   *
+   * @param filter
+   * @return
+   */
+  RangeSet<RowKeyWrapper> getIndexScanHint(S filter);
 }

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/TypedFilterAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/TypedFilterAdapter.java
@@ -16,14 +16,10 @@
 package com.google.cloud.bigtable.hbase.adapters.filters;
 
 import com.google.bigtable.v2.RowFilter;
-
-import com.google.bigtable.v2.RowRange;
 import com.google.cloud.bigtable.util.RowKeyWrapper;
 import com.google.common.collect.RangeSet;
-import java.util.List;
-import org.apache.hadoop.hbase.filter.Filter;
-
 import java.io.IOException;
+import org.apache.hadoop.hbase.filter.Filter;
 
 /**
  * An adapter that can adapt an HBase Filter instance into a Bigtable RowFilter.
@@ -58,9 +54,6 @@ public interface TypedFilterAdapter<S extends Filter> {
    * Get hints how to optimize the scan. For example if the filter will narrow the scan using
    * the prefix "ab" then we can restrict the scan to ["ab" - "ac"). If the filter doesn't narrow
    * the scan then it should return Range.all()
-   *
-   * @param filter
-   * @return
    */
   RangeSet<RowKeyWrapper> getIndexScanHint(S filter);
 }

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/TypedFilterAdapterBase.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/TypedFilterAdapterBase.java
@@ -24,9 +24,9 @@ import org.apache.hadoop.hbase.filter.Filter;
 
 /**
  * Base functionality for all filter adapters
- * @param <S>
  */
 public abstract class TypedFilterAdapterBase<S extends Filter> implements TypedFilterAdapter<S> {
+
   @Override
   public RangeSet<RowKeyWrapper> getIndexScanHint(S filter) {
     return ImmutableRangeSet.of(Range.<RowKeyWrapper>all());

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/TypedFilterAdapterBase.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/TypedFilterAdapterBase.java
@@ -15,12 +15,20 @@
  */
 package com.google.cloud.bigtable.hbase.adapters.filters;
 
+import com.google.cloud.bigtable.util.RowKeyWrapper;
+import com.google.common.collect.ImmutableRangeSet;
+import com.google.common.collect.Range;
+import com.google.common.collect.RangeSet;
 import org.apache.hadoop.hbase.filter.Filter;
+
 
 /**
  * Base functionality for all filter adapters
  * @param <S>
  */
 public abstract class TypedFilterAdapterBase<S extends Filter> implements TypedFilterAdapter<S> {
-
+  @Override
+  public RangeSet<RowKeyWrapper> getIndexScanHint(S filter) {
+    return ImmutableRangeSet.of(Range.<RowKeyWrapper>all());
+  }
 }

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/RowRangeAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/RowRangeAdapter.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.adapters.read;
+
+import com.google.bigtable.v2.RowRange;
+import com.google.bigtable.v2.RowSet;
+import com.google.cloud.bigtable.util.RowKeyWrapper;
+import com.google.common.collect.BoundType;
+import com.google.common.collect.Range;
+import com.google.common.collect.RangeSet;
+import com.google.common.collect.TreeRangeSet;
+import com.google.protobuf.ByteString;
+
+/**
+ * Adapter to convert between a Bigtable RowSet and guava's RangeSet.
+ */
+public class RowRangeAdapter {
+
+  /**
+   * Convert bigtable's RowSet -> Guava's RangeSet.
+   * Note that this will normalize the ranges, such that: overlapping keys and ranges will be merged
+   * and empty range keys will be converted in boundless ranges.
+   */
+  RangeSet<RowKeyWrapper> rowSetToRangeSet(RowSet rowSet) {
+    RangeSet<RowKeyWrapper> rangeSet = TreeRangeSet.create();
+    for (RowRange rowRange : rowSet.getRowRangesList()) {
+      rangeSet.add(rowRangeToRange(rowRange));
+    }
+    for (ByteString key : rowSet.getRowKeysList()) {
+      rangeSet.add(Range.singleton(new RowKeyWrapper(key)));
+    }
+    return rangeSet;
+  }
+
+  /**
+   * Convert Bigtable's RowRange -> guava Range.
+   */
+  private Range<RowKeyWrapper> rowRangeToRange(RowRange range) {
+    final BoundType startBound;
+    final ByteString startKey;
+
+    switch (range.getStartKeyCase()) {
+      case START_KEY_OPEN:
+        startBound = BoundType.OPEN;
+        startKey = range.getStartKeyOpen();
+        break;
+      case START_KEY_CLOSED:
+        startBound = BoundType.CLOSED;
+        startKey = range.getStartKeyClosed();
+        break;
+      case STARTKEY_NOT_SET:
+        startBound = BoundType.CLOSED;
+        startKey = ByteString.EMPTY;
+        break;
+      default:
+        throw new IllegalArgumentException("Unexpected start key case: " + range.getStartKeyCase());
+    }
+    // Bigtable doesn't allow empty row keys, so an empty start row which is open or closed is considered unbounded
+    // ie. all row keys are bigger than the empty key (no need to differentiate between open/closed)
+    final boolean startUnbounded = startKey.isEmpty();
+
+    final BoundType endBound;
+    final ByteString endKey;
+    switch (range.getEndKeyCase()) {
+      case END_KEY_OPEN:
+        endBound = BoundType.OPEN;
+        endKey = range.getEndKeyOpen();
+        break;
+      case END_KEY_CLOSED:
+        endBound = BoundType.CLOSED;
+        endKey = range.getEndKeyClosed();
+        break;
+      case ENDKEY_NOT_SET:
+        endBound = BoundType.OPEN;
+        endKey = ByteString.EMPTY;
+        break;
+      default:
+        throw new IllegalArgumentException("Unexpected end key case: " + range.getEndKeyCase());
+    }
+    // Bigtable doesn't allow empty row keys, so an empty end row which is open or closed is considered unbounded
+    // ie. all row keys are smaller than the empty end key (no need to differentiate between open/closed)
+    final boolean endUnbounded = endKey.isEmpty();
+
+    if (startUnbounded && endUnbounded) {
+      return Range.all();
+    } else if (startUnbounded) {
+      return Range.upTo(new RowKeyWrapper(endKey), endBound);
+    } else if (endUnbounded) {
+      return Range.downTo(new RowKeyWrapper(startKey), startBound);
+    } else {
+      return Range.range(new RowKeyWrapper(startKey), startBound, new RowKeyWrapper(endKey), endBound);
+    }
+  }
+
+  /**
+   * Convert guava's RangeSet to Bigtable's RowSet. Please note that this will convert
+   * boundless ranges into unset key cases.
+   */
+  RowSet rangeSetToRowSet(RangeSet<RowKeyWrapper> rangeSet) {
+    RowSet.Builder rowSet = RowSet.newBuilder();
+
+    for (Range<RowKeyWrapper> range1 : rangeSet.asRanges()) {
+      // Is it a point?
+      if (range1.hasLowerBound() && range1.lowerBoundType() == BoundType.CLOSED
+          && range1.hasUpperBound() && range1.upperBoundType() == BoundType.CLOSED
+          && range1.lowerEndpoint().equals(range1.upperEndpoint())) {
+
+        rowSet.addRowKeys(range1.lowerEndpoint().getKey());
+      } else {
+        RowRange.Builder range2 = RowRange.newBuilder();
+
+        // Handle start key
+        if (range1.hasLowerBound()) {
+          switch (range1.lowerBoundType()) {
+            case CLOSED:
+              range2.setStartKeyClosed(range1.lowerEndpoint().getKey());
+              break;
+            case OPEN:
+              range2.setStartKeyOpen(range1.lowerEndpoint().getKey());
+              break;
+            default:
+              throw new IllegalArgumentException("Unexpected lower bound type: " + range1.lowerBoundType());
+          }
+        }
+
+        // handle end key
+        if (range1.hasUpperBound()) {
+          switch (range1.upperBoundType()) {
+            case CLOSED:
+              range2.setEndKeyClosed(range1.upperEndpoint().getKey());
+              break;
+            case OPEN:
+              range2.setEndKeyOpen(range1.upperEndpoint().getKey());
+              break;
+            default:
+              throw new IllegalArgumentException("Unexpected upper bound type: " + range1.upperBoundType());
+          }
+        }
+        rowSet.addRowRanges(range2);
+      }
+    }
+    return rowSet.build();
+  }
+}

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/ScanAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/ScanAdapter.java
@@ -15,7 +15,6 @@
  */
 package com.google.cloud.bigtable.hbase.adapters.read;
 
-import com.google.bigtable.v2.RowRange;
 import com.google.common.collect.Range;
 import com.google.bigtable.v2.ReadRowsRequest;
 import com.google.bigtable.v2.ReadRowsRequest.Builder;
@@ -34,7 +33,6 @@ import com.google.common.base.Optional;
 import com.google.common.collect.RangeSet;
 import com.google.protobuf.ByteString;
 
-import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.filter.Filter;
 import org.apache.hadoop.hbase.io.TimeRange;
@@ -169,6 +167,7 @@ public class ScanAdapter implements ReadOperationAdapter<Scan> {
       return rowSet;
     }
     RangeSet<RowKeyWrapper> scanRangeSet = rowRangeAdapter.rowSetToRangeSet(rowSet);
+    // intersection of scan ranges & filter ranges
     scanRangeSet.removeAll(filterRangeSet.complement());
     return rowRangeAdapter.rangeSetToRowSet(scanRangeSet);
   }

--- a/bigtable-hbase-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/read/TestGetAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/read/TestGetAdapter.java
@@ -44,7 +44,7 @@ import java.nio.charset.StandardCharsets;
 public class TestGetAdapter {
 
   private GetAdapter getAdapter =
-      new GetAdapter(new ScanAdapter(FilterAdapter.buildAdapter()));
+      new GetAdapter(new ScanAdapter(FilterAdapter.buildAdapter(), new RowRangeAdapter()));
   private DataGenerationHelper dataHelper = new DataGenerationHelper();
   private ReadHooks throwingReadHooks = new ReadHooks() {
     @Override

--- a/bigtable-hbase-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/read/TestRowRangeAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/read/TestRowRangeAdapter.java
@@ -288,7 +288,7 @@ public class TestRowRangeAdapter {
         )
         .addRowRanges(
             RowRange.newBuilder()
-              .setStartKeyOpen(ByteString.copyFromUtf8("y"))
+                .setStartKeyOpen(ByteString.copyFromUtf8("y"))
         )
         .build();
 

--- a/bigtable-hbase-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/read/TestRowRangeAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/read/TestRowRangeAdapter.java
@@ -1,0 +1,313 @@
+/*
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.adapters.read;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.bigtable.v2.RowRange;
+import com.google.bigtable.v2.RowSet;
+import com.google.cloud.bigtable.util.RowKeyWrapper;
+import com.google.common.collect.ImmutableRangeSet;
+import com.google.common.collect.Range;
+import com.google.common.collect.RangeSet;
+import com.google.protobuf.ByteString;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class TestRowRangeAdapter {
+
+  private RowRangeAdapter adapter;
+
+  @Before
+  public void setup() {
+    this.adapter = new RowRangeAdapter();
+  }
+
+  @Test
+  public void testEmptyRowSet() {
+    RowSet in = RowSet.newBuilder().build();
+    RangeSet<RowKeyWrapper> out = adapter.rowSetToRangeSet(in);
+
+    assertEquals(ImmutableRangeSet.builder().build(), out);
+    assertEquals(in, adapter.rangeSetToRowSet(out));
+  }
+
+  @Test
+  public void testSingleKeyRowSet() {
+    ByteString key = ByteString.copyFromUtf8("myKey");
+    RowSet in = RowSet.newBuilder()
+        .addRowKeys(key)
+        .build();
+    RangeSet<RowKeyWrapper> out = adapter.rowSetToRangeSet(in);
+
+    RangeSet<RowKeyWrapper> expected = ImmutableRangeSet.<RowKeyWrapper>builder()
+        .add(Range.closed(new RowKeyWrapper(key), new RowKeyWrapper(key)))
+        .build();
+
+    assertEquals(expected, out);
+    assertEquals(in, adapter.rangeSetToRowSet(out));
+  }
+
+  @Test
+  public void testSingleClosedRangeRowSet() {
+    ByteString key1 = ByteString.copyFromUtf8("myKey");
+    ByteString key2 = ByteString.copyFromUtf8("otherKey");
+
+    RowSet in = RowSet.newBuilder()
+        .addRowRanges(
+            RowRange.newBuilder()
+                .setStartKeyClosed(key1)
+                .setEndKeyClosed(key2)
+        )
+        .build();
+    RangeSet<RowKeyWrapper> out = adapter.rowSetToRangeSet(in);
+
+    RangeSet<RowKeyWrapper> expected = ImmutableRangeSet.<RowKeyWrapper>builder()
+        .add(Range.closed(new RowKeyWrapper(key1), new RowKeyWrapper(key2)))
+        .build();
+
+    assertEquals(expected, out);
+    assertEquals(in, adapter.rangeSetToRowSet(out));
+  }
+
+  @Test
+  public void testSingleOpenRangeRowSet() {
+    ByteString key1 = ByteString.copyFromUtf8("myKey");
+    ByteString key2 = ByteString.copyFromUtf8("otherKey");
+
+    RowSet in = RowSet.newBuilder()
+        .addRowRanges(
+            RowRange.newBuilder()
+                .setStartKeyOpen(key1)
+                .setEndKeyOpen(key2)
+        )
+        .build();
+    RangeSet<RowKeyWrapper> out = adapter.rowSetToRangeSet(in);
+
+    RangeSet<RowKeyWrapper> expected = ImmutableRangeSet.<RowKeyWrapper>builder()
+        .add(Range.open(new RowKeyWrapper(key1), new RowKeyWrapper(key2)))
+        .build();
+
+    assertEquals(expected, out);
+    assertEquals(in, adapter.rangeSetToRowSet(out));
+  }
+
+  @Test
+  public void testSingleOpenClosedRangeRowSet() {
+    ByteString key1 = ByteString.copyFromUtf8("myKey");
+    ByteString key2 = ByteString.copyFromUtf8("otherKey");
+
+    RowSet in = RowSet.newBuilder()
+        .addRowRanges(
+            RowRange.newBuilder()
+                .setStartKeyOpen(key1)
+                .setEndKeyClosed(key2)
+        )
+        .build();
+    RangeSet<RowKeyWrapper> out = adapter.rowSetToRangeSet(in);
+
+    RangeSet<RowKeyWrapper> expected = ImmutableRangeSet.<RowKeyWrapper>builder()
+        .add(Range.openClosed(new RowKeyWrapper(key1), new RowKeyWrapper(key2)))
+        .build();
+
+    assertEquals(expected, out);
+    assertEquals(in, adapter.rangeSetToRowSet(out));
+  }
+
+  @Test
+  public void testSingleClosedOpenRangeRowSet() {
+    ByteString key1 = ByteString.copyFromUtf8("myKey");
+    ByteString key2 = ByteString.copyFromUtf8("otherKey");
+
+    RowSet in = RowSet.newBuilder()
+        .addRowRanges(
+            RowRange.newBuilder()
+                .setStartKeyClosed(key1)
+                .setEndKeyOpen(key2)
+        )
+        .build();
+    RangeSet<RowKeyWrapper> out = adapter.rowSetToRangeSet(in);
+
+    RangeSet<RowKeyWrapper> expected = ImmutableRangeSet.<RowKeyWrapper>builder()
+        .add(Range.closedOpen(new RowKeyWrapper(key1), new RowKeyWrapper(key2)))
+        .build();
+
+    assertEquals(expected, out);
+    assertEquals(in, adapter.rangeSetToRowSet(out));
+  }
+
+  @Test
+  public void testAllRowSet() {
+    RowSet in = RowSet.newBuilder()
+        .addRowRanges(RowRange.newBuilder())
+        .build();
+
+    RangeSet<RowKeyWrapper> out = adapter.rowSetToRangeSet(in);
+
+    RangeSet<RowKeyWrapper> expected = ImmutableRangeSet.<RowKeyWrapper>builder()
+        .add(Range.<RowKeyWrapper>all())
+        .build();
+
+    assertEquals(expected, out);
+    assertEquals(in, adapter.rangeSetToRowSet(out));
+  }
+
+  @Test
+  public void testAllRowSet2() {
+    RowSet in = RowSet.newBuilder()
+        .addRowRanges(
+            RowRange.newBuilder()
+                .setStartKeyClosed(ByteString.EMPTY)
+                .setEndKeyOpen(ByteString.EMPTY)
+        )
+        .build();
+
+    RangeSet<RowKeyWrapper> out = adapter.rowSetToRangeSet(in);
+
+    RangeSet<RowKeyWrapper> expected = ImmutableRangeSet.<RowKeyWrapper>builder()
+        .add(Range.<RowKeyWrapper>all())
+        .build();
+
+    assertEquals(expected, out);
+    // NOTE: this isn't symmetrical, ['','') is converted to its canonical form of unset bounds
+  }
+
+  @Test
+  public void testGreaterThan() {
+    ByteString key = ByteString.copyFromUtf8("hi");
+
+    RowSet in = RowSet.newBuilder()
+        .addRowRanges(
+            RowRange.newBuilder()
+                .setStartKeyOpen(key)
+        )
+        .build();
+
+    RangeSet<RowKeyWrapper> out = adapter.rowSetToRangeSet(in);
+
+    RangeSet<RowKeyWrapper> expected = ImmutableRangeSet.<RowKeyWrapper>builder()
+        .add(Range.greaterThan(new RowKeyWrapper(key)))
+        .build();
+
+    assertEquals(expected, out);
+    assertEquals(in, adapter.rangeSetToRowSet(out));
+  }
+
+  @Test
+  public void testGreaterOrEqThan() {
+    ByteString key = ByteString.copyFromUtf8("hi");
+
+    RowSet in = RowSet.newBuilder()
+        .addRowRanges(
+            RowRange.newBuilder()
+                .setStartKeyClosed(key)
+        )
+        .build();
+
+    RangeSet<RowKeyWrapper> out = adapter.rowSetToRangeSet(in);
+
+    RangeSet<RowKeyWrapper> expected = ImmutableRangeSet.<RowKeyWrapper>builder()
+        .add(Range.atLeast(new RowKeyWrapper(key)))
+        .build();
+
+    assertEquals(expected, out);
+    assertEquals(in, adapter.rangeSetToRowSet(out));
+  }
+
+  @Test
+  public void testLesserThan() {
+    ByteString key = ByteString.copyFromUtf8("hi");
+
+    RowSet in = RowSet.newBuilder()
+        .addRowRanges(
+            RowRange.newBuilder()
+                .setEndKeyOpen(key)
+        )
+        .build();
+
+    RangeSet<RowKeyWrapper> out = adapter.rowSetToRangeSet(in);
+
+    RangeSet<RowKeyWrapper> expected = ImmutableRangeSet.<RowKeyWrapper>builder()
+        .add(Range.lessThan(new RowKeyWrapper(key)))
+        .build();
+
+    assertEquals(expected, out);
+    assertEquals(in, adapter.rangeSetToRowSet(out));
+  }
+
+  @Test
+  public void testLesserOrEqThan() {
+    ByteString key = ByteString.copyFromUtf8("hi");
+
+    RowSet in = RowSet.newBuilder()
+        .addRowRanges(
+            RowRange.newBuilder()
+                .setEndKeyClosed(key)
+        )
+        .build();
+
+    RangeSet<RowKeyWrapper> out = adapter.rowSetToRangeSet(in);
+
+    RangeSet<RowKeyWrapper> expected = ImmutableRangeSet.<RowKeyWrapper>builder()
+        .add(Range.atMost(new RowKeyWrapper(key)))
+        .build();
+
+    assertEquals(expected, out);
+    assertEquals(in, adapter.rangeSetToRowSet(out));
+  }
+
+  @Test
+  public void testMultipleDisjoint() {
+    RowSet in = RowSet.newBuilder()
+        .addRowKeys(ByteString.copyFromUtf8("point1"))
+        .addRowKeys(ByteString.copyFromUtf8("point2"))
+        .addRowRanges(
+            RowRange.newBuilder()
+                .setEndKeyClosed(ByteString.copyFromUtf8("b"))
+        )
+        .addRowRanges(
+            RowRange.newBuilder()
+                .setStartKeyClosed(ByteString.copyFromUtf8("c"))
+                .setEndKeyClosed(ByteString.copyFromUtf8("d"))
+        )
+        .addRowRanges(
+            RowRange.newBuilder()
+              .setStartKeyOpen(ByteString.copyFromUtf8("y"))
+        )
+        .build();
+
+    RangeSet<RowKeyWrapper> out = adapter.rowSetToRangeSet(in);
+
+    RangeSet<RowKeyWrapper> expected = ImmutableRangeSet.<RowKeyWrapper>builder()
+        .add(Range.singleton(new RowKeyWrapper(ByteString.copyFromUtf8("point1"))))
+        .add(Range.singleton(new RowKeyWrapper(ByteString.copyFromUtf8("point2"))))
+        .add(Range.atMost(new RowKeyWrapper(ByteString.copyFromUtf8("b"))))
+        .add(
+            Range.closed(
+                new RowKeyWrapper(ByteString.copyFromUtf8("c")),
+                new RowKeyWrapper(ByteString.copyFromUtf8("d"))
+            )
+        )
+        .add(Range.greaterThan(new RowKeyWrapper(ByteString.copyFromUtf8("y"))))
+        .build();
+
+    assertEquals(expected, out);
+    assertEquals(in, adapter.rangeSetToRowSet(out));
+  }
+}

--- a/bigtable-hbase-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/read/TestScanAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/read/TestScanAdapter.java
@@ -16,6 +16,7 @@
 package com.google.cloud.bigtable.hbase.adapters.read;
 
 import com.google.bigtable.v2.ReadRowsRequest;
+import com.google.bigtable.v2.ReadRowsRequest.Builder;
 import com.google.bigtable.v2.RowFilter;
 import com.google.bigtable.v2.RowFilter.Chain;
 import com.google.bigtable.v2.RowRange;
@@ -169,6 +170,17 @@ public class TestScanAdapter {
     scan.setStopRow("z".getBytes());
     scan.setFilter(fakeFilter);
 
-    scanAdapter.adapt(scan, throwingReadHooks);
+    Builder adapted = scanAdapter.adapt(scan, throwingReadHooks);
+
+    Assert.assertEquals(
+        RowSet.newBuilder()
+            .addRowRanges(
+                RowRange.newBuilder()
+                    .setStartKeyClosed(ByteString.copyFromUtf8("b"))
+                    .setEndKeyOpen(ByteString.copyFromUtf8("d"))
+            )
+            .build(),
+        adapted.getRows()
+    );
   }
 }

--- a/bigtable-hbase-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/read/TestScanAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/read/TestScanAdapter.java
@@ -51,7 +51,7 @@ import org.mockito.Mockito;
 @RunWith(JUnit4.class)
 public class TestScanAdapter {
 
-  private final static ScanAdapter scanAdapter = new ScanAdapter(FilterAdapter.buildAdapter());
+  private final static ScanAdapter scanAdapter = new ScanAdapter(FilterAdapter.buildAdapter(), new RowRangeAdapter());
   private final static ReadHooks throwingReadHooks = new ReadHooks() {
     @Override
     public void composePreSendHook(Function<ReadRowsRequest, ReadRowsRequest> newHook) {
@@ -144,7 +144,7 @@ public class TestScanAdapter {
   @Test
   public void testNarrowedScan() throws IOException {
     FilterAdapter filterAdapter = Mockito.mock(FilterAdapter.class);
-    ScanAdapter scanAdapter = new ScanAdapter(filterAdapter);
+    ScanAdapter scanAdapter = new ScanAdapter(filterAdapter, new RowRangeAdapter());
 
     Filter fakeFilter = new FilterBase() {
       @Override

--- a/bigtable-hbase-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/read/TestScanAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/read/TestScanAdapter.java
@@ -15,6 +15,9 @@
  */
 package com.google.cloud.bigtable.hbase.adapters.read;
 
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+
 import com.google.bigtable.v2.ReadRowsRequest;
 import com.google.bigtable.v2.ReadRowsRequest.Builder;
 import com.google.bigtable.v2.RowFilter;
@@ -51,7 +54,9 @@ import org.mockito.Mockito;
 @RunWith(JUnit4.class)
 public class TestScanAdapter {
 
-  private final static ScanAdapter scanAdapter = new ScanAdapter(FilterAdapter.buildAdapter(), new RowRangeAdapter());
+  private final static ScanAdapter scanAdapter = new ScanAdapter(
+      FilterAdapter.buildAdapter(), new RowRangeAdapter()
+  );
   private final static ReadHooks throwingReadHooks = new ReadHooks() {
     @Override
     public void composePreSendHook(Function<ReadRowsRequest, ReadRowsRequest> newHook) {
@@ -159,11 +164,9 @@ public class TestScanAdapter {
             new RowKeyWrapper(ByteString.copyFromUtf8("d"))
         )
     );
-    Mockito.when(filterAdapter.getIndexScanHint(Mockito.any(Filter.class))).thenReturn(rangeSet);
-    Mockito.when(filterAdapter.adaptFilter(Mockito.any(FilterAdapterContext.class), Mockito.any(Filter.class)))
-        .thenReturn(
-            Optional.of(RowFilter.getDefaultInstance())
-        );
+    Mockito.when(filterAdapter.getIndexScanHint(any(Filter.class))).thenReturn(rangeSet);
+    Mockito.when(filterAdapter.adaptFilter(any(FilterAdapterContext.class), eq(fakeFilter)))
+        .thenReturn(Optional.of(RowFilter.getDefaultInstance()));
 
     Scan scan = new Scan();
     scan.setStartRow("a".getBytes());


### PR DESCRIPTION
This part of #1237. Adds scaffolding to support index hinting from filters.

It adds a getIndexScanHint method to the FilterAdapter's interface, which allows for filters to notify the scan that it can be narrowed.  Its implemented using guava's RangeSet, where the filter's hints are intersected with the row keys & ranges present in the scan. To avoid any performance penalties, it short circuits the computations if none of the filters gave any hints.