### PR TITLE
Keep unbounded start/end keys as unset rather then empty

### DIFF
--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/ScanAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/ScanAdapter.java
@@ -123,7 +123,7 @@ public class ScanAdapter implements ReadOperationAdapter<Scan> {
       if (scan.isGetScan()) {
         rowSetBuilder.addRowKeys(startRow);
       } else {
-        RowRange.Builder range = rowSetBuilder.addRowRangesBuilder();
+        RowRange.Builder range =  RowRange.newBuilder();
         if (!startRow.isEmpty()) {
           range.setStartKeyClosed(startRow);
         }

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/ScanAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/ScanAdapter.java
@@ -122,8 +122,16 @@ public class ScanAdapter implements ReadOperationAdapter<Scan> {
       if (scan.isGetScan()) {
         rowSetBuilder.addRowKeys(startRow);
       } else {
+        RowRange.Builder range = rowSetBuilder.addRowRangesBuilder();
+        if (!startRow.isEmpty()) {
+          range.setStartKeyClosed(startRow);
+        }
+
         ByteString stopRow = ByteString.copyFrom(scan.getStopRow());
-        rowSetBuilder.addRowRangesBuilder().setStartKeyClosed(startRow).setEndKeyOpen(stopRow);
+        if (!stopRow.isEmpty()) {
+          range.setEndKeyOpen(stopRow);
+        }
+        rowSetBuilder.addRowRanges(range);
       }
       return rowSetBuilder.build();
     }

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/ScanAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/ScanAdapter.java
@@ -20,6 +20,7 @@ import com.google.bigtable.v2.ReadRowsRequest.Builder;
 import com.google.bigtable.v2.RowFilter;
 import com.google.bigtable.v2.RowFilter.Chain;
 import com.google.bigtable.v2.RowFilter.Interleave;
+import com.google.bigtable.v2.RowRange;
 import com.google.bigtable.v2.RowSet;
 import com.google.bigtable.v2.TimestampRange;
 import com.google.cloud.bigtable.hbase.BigtableConstants;


### PR DESCRIPTION
This should have no functional difference, but should avoid ambiguity between an empty key thats open vs closed vs unset. (all 3 should be treated the same in bigtable). 