### PR TITLE
Refactoring ChannelPool

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AbstractRetryingRpcListener.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AbstractRetryingRpcListener.java
@@ -166,9 +166,10 @@ public abstract class AbstractRetryingRpcListener<RequestT, ResponseT, ResultT>
     }
 
     // Perform Retry
-    String channelId = trailers != null ? trailers.get(ChannelPool.CHANNEL_ID_KEY) : "";
-    LOG.info("Retrying failed call. Failure #%d, got: %s on channel %s",
-        status.getCause(), failedCount, status, channelId);
+    String channelId =
+        trailers != null ? trailers.get(ChannelPool.InstrumentedChannel.CHANNEL_ID_KEY) : "";
+    LOG.info("Retrying failed call. Failure #%d, got: %s on channel %s", status.getCause(),
+      failedCount, status, channelId);
 
     rpc.getRpcMetrics().markRetry();
     retryExecutorService.schedule(this, nextBackOff, TimeUnit.MILLISECONDS);

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/ChannelPool.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/ChannelPool.java
@@ -16,7 +16,6 @@
 package com.google.cloud.bigtable.grpc.io;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -52,57 +51,61 @@ public class ChannelPool extends ManagedChannel {
   /** Constant <code>LOG</code> */
   protected static final Logger LOG = new Logger(ChannelPool.class);
 
-  private static final AtomicInteger ChannelIdGenerator = new AtomicInteger();
-
-  public static ImmutableList<InstrumentedChannel>
-      toInstrummentedChannels(List<ManagedChannel> channels) {
-    Preconditions.checkArgument(channels != null && !channels.isEmpty(),
-      "Channels have to be non-null and not empty.");
-    ImmutableList.Builder<InstrumentedChannel> response = ImmutableList.builder();
-    for (ManagedChannel channel : channels) {
-      response.add(new InstrumentedChannel(channel));
-    }
-    return response.build();
-  }
-
-  protected static Stats STATS;
-
-  /** Constant <code>CHANNEL_ID_KEY</code> */
-  public static final Key<String> CHANNEL_ID_KEY =
-      Key.of("bigtable-channel-id", Metadata.ASCII_STRING_MARSHALLER);
-
-  private static class Stats {
-    /**
-     * Best effort counter of active channels. There may be some cases where channel termination
-     * counting may not accurately be decremented.
-     */
-    Counter ACTIVE_CHANNEL_COUNTER =
-        BigtableClientMetrics.counter(MetricLevel.Info, "grpc.channel.active");
-
-    /**
-     * Best effort counter of active RPCs.
-     */
-    Counter ACTIVE_RPC_COUNTER = BigtableClientMetrics.counter(MetricLevel.Info, "grpc.rpc.active");
-
-    /**
-     * Best effort counter of RPCs.
-     */
-    Meter RPC_METER = BigtableClientMetrics.meter(MetricLevel.Info, "grpc.rpc.performed");
-  }
-
-  protected static synchronized Stats getStats() {
-    if (STATS == null) {
-      STATS = new Stats();
-    }
-    return STATS;
-  }
-
   /**
    * Contains a {@link ManagedChannel} and metrics for the channel
    * @author sduskis
    *
    */
   public static class InstrumentedChannel extends ManagedChannel {
+
+    private static final AtomicInteger ChannelIdGenerator = new AtomicInteger();
+
+    /** Constant <code>CHANNEL_ID_KEY</code> */
+    public static final Key<String> CHANNEL_ID_KEY =
+        Key.of("bigtable-channel-id", Metadata.ASCII_STRING_MARSHALLER);
+
+    static ImmutableList<ManagedChannel> toInstrummentedChannels(List<ManagedChannel> channels) {
+      Preconditions.checkArgument(channels != null && !channels.isEmpty(),
+        "Channels have to be non-null and not empty.");
+      ImmutableList.Builder<ManagedChannel> instrummentedChannels = ImmutableList.builder();
+      for (ManagedChannel channel : channels) {
+        if (channel instanceof InstrumentedChannel) {
+          instrummentedChannels.add(channel);
+        } else {
+          instrummentedChannels.add(new InstrumentedChannel(channel));
+        }
+      }
+      return instrummentedChannels.build();
+    }
+
+    protected static Stats STATS;
+
+    private static class Stats {
+      /**
+       * Best effort counter of active channels. There may be some cases where channel termination
+       * counting may not accurately be decremented.
+       */
+      Counter ACTIVE_CHANNEL_COUNTER =
+          BigtableClientMetrics.counter(MetricLevel.Info, "grpc.channel.active");
+
+      /**
+       * Best effort counter of active RPCs.
+       */
+      Counter ACTIVE_RPC_COUNTER = BigtableClientMetrics.counter(MetricLevel.Info, "grpc.rpc.active");
+
+      /**
+       * Best effort counter of RPCs.
+       */
+      Meter RPC_METER = BigtableClientMetrics.meter(MetricLevel.Info, "grpc.rpc.performed");
+    }
+
+    static synchronized Stats getStats() {
+      if (STATS == null) {
+        STATS = new Stats();
+      }
+      return STATS;
+    }
+
     private final ManagedChannel delegate;
     // a uniquely named timer for this channel's latency
     private final Timer timer;
@@ -225,7 +228,7 @@ public class ChannelPool extends ManagedChannel {
     }
   }
 
-  private final ImmutableList<InstrumentedChannel> channels;
+  private final ImmutableList<ManagedChannel> channels;
   private final AtomicInteger requestCount = new AtomicInteger();
   private final ImmutableList<HeaderInterceptor> headerInterceptors;
   private final String authority;
@@ -236,37 +239,12 @@ public class ChannelPool extends ManagedChannel {
    * <p>Constructor for ChannelPool.</p>
    *
    * @param headerInterceptors a {@link java.util.List} object.
-   * @param factory a {@link com.google.cloud.bigtable.grpc.io.ChannelPool.ChannelFactory} object.
-   * @throws java.io.IOException if any.
-   */
-  public ChannelPool(List<HeaderInterceptor> headerInterceptors, ManagedChannel channel)
-      throws IOException {
-    this(headerInterceptors, Collections.singletonList(channel));
-  }
-
-  /**
-   * <p>Constructor for ChannelPool.</p>
-   *
-   * @param headerInterceptors a {@link java.util.List} object.
    * @param channels a {@link List} of {@link ManagedChannel}s.
    * @throws java.io.IOException if any.
    */
   public ChannelPool(List<HeaderInterceptor> headerInterceptors, List<ManagedChannel> channels)
       throws IOException {
-    this(headerInterceptors, toInstrummentedChannels(channels));
-  }
-
-  /**
-   * <p>
-   * Constructor for ChannelPool.
-   * </p>
-   * @param headerInterceptors a {@link java.util.List} object.
-   * @param channels a {@link ImmutableList} of {@link InstrumentedChannel}s.
-   * @throws java.io.IOException if any.
-   */
-  public ChannelPool(List<HeaderInterceptor> headerInterceptors,
-      ImmutableList<InstrumentedChannel> channels) throws IOException {
-    this.channels = channels;
+    this.channels = InstrumentedChannel.toInstrummentedChannels(channels);
     authority = this.channels.get(0).authority();
     if (headerInterceptors == null) {
       this.headerInterceptors = ImmutableList.of();
@@ -281,7 +259,7 @@ public class ChannelPool extends ManagedChannel {
    *
    * @return A {@link InstrumentedChannel} that can be used for a single RPC call.
    */
-  private InstrumentedChannel getNextChannel() {
+  private ManagedChannel getNextChannel() {
     int currentRequestNum = requestCount.getAndIncrement();
     int index = Math.abs(currentRequestNum % channels.size());
     return channels.get(index);
@@ -330,7 +308,7 @@ public class ChannelPool extends ManagedChannel {
   /** {@inheritDoc} */
   @Override
   public synchronized ManagedChannel shutdown() {
-    for (InstrumentedChannel channelWrapper : channels) {
+    for (ManagedChannel channelWrapper : channels) {
       channelWrapper.shutdown();
     }
     this.shutdown = true;
@@ -346,7 +324,7 @@ public class ChannelPool extends ManagedChannel {
   /** {@inheritDoc} */
   @Override
   public boolean isTerminated() {
-    for (InstrumentedChannel channel : channels) {
+    for (ManagedChannel channel : channels) {
       if (!channel.isTerminated()) {
         return false;
       }
@@ -357,7 +335,7 @@ public class ChannelPool extends ManagedChannel {
   /** {@inheritDoc} */
   @Override
   public ManagedChannel shutdownNow() {
-    for (InstrumentedChannel channel : channels) {
+    for (ManagedChannel channel : channels) {
       if (!channel.isTerminated()) {
         channel.shutdownNow();
       }
@@ -369,7 +347,7 @@ public class ChannelPool extends ManagedChannel {
   @Override
   public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
     long endTimeNanos = System.nanoTime() + unit.toNanos(timeout);
-    for (InstrumentedChannel channel : channels) {
+    for (ManagedChannel channel : channels) {
       if (channel.isTerminated()) {
         continue;
       }

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/io/ChannelPoolPerf.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/io/ChannelPoolPerf.java
@@ -15,7 +15,6 @@
  */
 package com.google.cloud.bigtable.grpc.io;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -83,14 +82,12 @@ public class ChannelPoolPerf {
     };
     int threads = 20;
     int concurrent = 400;
-    final ChannelPool.ChannelFactory pool = new ChannelPool.ChannelFactory() {
-      @Override
-      public ManagedChannel create() throws IOException {
-        return channel;
-      }
-    };
     List<HeaderInterceptor> headers = Collections.<HeaderInterceptor> emptyList();
-    final ChannelPool cp = new ChannelPool(headers, pool, 40);
+    List<ManagedChannel> channels = new ArrayList<>();
+    for (int i = 0; i < 40; i++) {
+      channels.add(channel);
+    }
+    final ChannelPool cp = new ChannelPool(headers, channels);
     ExecutorService es = Executors.newFixedThreadPool(threads);
     final List<Double> results = new ArrayList<>(1000);
     Callable<Void> runnable = new Callable<Void>() {

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/io/TestGoogleCloudResourcePrefixInterceptor.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/io/TestGoogleCloudResourcePrefixInterceptor.java
@@ -28,6 +28,8 @@ import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -53,7 +55,7 @@ public class TestGoogleCloudResourcePrefixInterceptor {
 
     cp = new ChannelPool(
         Arrays.<HeaderInterceptor> asList(new GoogleCloudResourcePrefixInterceptor(HEADER_VALUE)),
-        channel);
+        Collections.singletonList(channel));
   }
 
   @Test

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/io/TestGoogleCloudResourcePrefixInterceptor.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/io/TestGoogleCloudResourcePrefixInterceptor.java
@@ -21,7 +21,6 @@ import static org.mockito.Matchers.any;
 import com.google.bigtable.v2.BigtableGrpc;
 import com.google.bigtable.v2.MutateRowRequest;
 import com.google.bigtable.v2.MutateRowResponse;
-import com.google.cloud.bigtable.grpc.io.ChannelPool.ChannelFactory;
 import io.grpc.CallOptions;
 import io.grpc.ClientCall;
 import io.grpc.ManagedChannel;
@@ -45,22 +44,16 @@ public class TestGoogleCloudResourcePrefixInterceptor {
   @Mock
   ClientCall call;
   private ChannelPool cp;
-  
+
   @Before
   public void setup() throws IOException {
     MockitoAnnotations.initMocks(this);
     Mockito.when(channel.newCall(any(MethodDescriptor.class), any(CallOptions.class)))
         .thenReturn(call);
-    
-    cp = new ChannelPool(
-        Arrays.<HeaderInterceptor>asList(new GoogleCloudResourcePrefixInterceptor(HEADER_VALUE)),
-        new ChannelFactory() {
-          @Override
-          public ManagedChannel create() throws IOException {
-            return channel;
-          }
-        });
 
+    cp = new ChannelPool(
+        Arrays.<HeaderInterceptor> asList(new GoogleCloudResourcePrefixInterceptor(HEADER_VALUE)),
+        channel);
   }
 
   @Test

--- a/bigtable-hbase-parent/bigtable-hbase/src/test/java/org/apache/hadoop/hbase/client/PutMicroBenchmark.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/test/java/org/apache/hadoop/hbase/client/PutMicroBenchmark.java
@@ -42,6 +42,7 @@ import io.grpc.Status;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
+import java.util.Collections;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -82,8 +83,8 @@ public class PutMicroBenchmark {
     if (useRealConnection) {
       return BigtableSession.createChannelPool(options.getDataHost(), options);
     } else {
-      return new ChannelPool(
-          ImmutableList.<HeaderInterceptor>of(prefixInterceptor()), createFakeChannels());
+      return new ChannelPool(ImmutableList.<HeaderInterceptor> of(prefixInterceptor()),
+          Collections.singletonList(createFakeChannels()));
     }
   }
 

--- a/bigtable-hbase-parent/bigtable-hbase/src/test/java/org/apache/hadoop/hbase/client/PutMicroBenchmark.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/test/java/org/apache/hadoop/hbase/client/PutMicroBenchmark.java
@@ -23,13 +23,11 @@ import com.google.cloud.bigtable.grpc.BigtableDataGrpcClient;
 import com.google.cloud.bigtable.grpc.BigtableSession;
 import com.google.cloud.bigtable.grpc.BigtableSessionSharedThreadPools;
 import com.google.cloud.bigtable.grpc.io.ChannelPool;
-import com.google.cloud.bigtable.grpc.io.CredentialInterceptorCache;
 import com.google.cloud.bigtable.grpc.io.GoogleCloudResourcePrefixInterceptor;
 import com.google.cloud.bigtable.grpc.io.HeaderInterceptor;
 import com.google.cloud.bigtable.hbase.DataGenerationHelper;
 import com.google.cloud.bigtable.hbase.adapters.HBaseRequestAdapter;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableList.Builder;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.TableName;
@@ -93,14 +91,8 @@ public class PutMicroBenchmark {
     return new GoogleCloudResourcePrefixInterceptor(options.getInstanceName().toString());
   }
 
-  protected static ChannelPool.ChannelFactory createFakeChannels() {
-    final ManagedChannel channel = createFakeChannel();
-    return new ChannelPool.ChannelFactory() {
-      @Override
-      public ManagedChannel create() throws IOException {
-        return channel;
-      }
-    };
+  protected static ManagedChannel createFakeChannels() {
+    return createFakeChannel();
   }
 
   private static void createRandomData() {


### PR DESCRIPTION
InstrumentedChannel is now decoupled from header processing in ChannelPool.  This will allow a future PR to cache data API InstrumentedChannels for reuse across BigtableSession / AbstractBigtableConnection instances, which is a useful feature for Dataflow performance.