### PR TITLE
Remove paths to HConstants

### DIFF
--- a/bigtable-dataflow-parent/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/CloudBigtableIO.java
+++ b/bigtable-dataflow-parent/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/CloudBigtableIO.java
@@ -55,7 +55,7 @@ import com.google.bigtable.repackaged.com.google.cloud.grpc.BigtableSession;
 import com.google.bigtable.repackaged.com.google.cloud.grpc.BigtableTableName;
 import com.google.bigtable.repackaged.com.google.cloud.grpc.scanner.FlatRow;
 import com.google.bigtable.repackaged.com.google.cloud.grpc.scanner.ResultScanner;
-import com.google.bigtable.repackaged.com.google.cloud.hbase.adapters.Adapters;
+import com.google.bigtable.repackaged.com.google.cloud.hbase.adapters.read.FlatRowAdapter;
 import com.google.bigtable.repackaged.com.google.com.google.bigtable.v2.SampleRowKeysRequest;
 import com.google.bigtable.repackaged.com.google.com.google.bigtable.v2.SampleRowKeysResponse;
 import com.google.cloud.bigtable.dataflow.coders.HBaseMutationCoder;
@@ -154,6 +154,7 @@ public class CloudBigtableIO {
 
   private static AtomicCoder<Result> RESULT_CODER = new HBaseResultCoder();
   private static AtomicCoder<Result[]> RESULT_ARRAY_CODER = new HBaseResultArrayCoder();
+  private static final com.google.bigtable.repackaged.com.google.cloud.hbase.adapters.read.FlatRowAdapter FLAT_ROW_ADAPTER = new FlatRowAdapter();
 
   @SuppressWarnings("rawtypes")
   private static AtomicCoder HBASE_MUTATION_CODER = new HBaseMutationCoder();
@@ -212,7 +213,7 @@ public class CloudBigtableIO {
       FlatRow row = resultScanner.next();
       if (row != null
           && rangeTracker.tryReturnRecordAt(true, ByteStringUtil.toByteKey(row.getRowKey()))) {
-        return Adapters.FLAT_ROW_ADAPTER.adaptResponse(row);
+        return FLAT_ROW_ADAPTER.adaptResponse(row);
       }
       return null;
     }
@@ -255,7 +256,7 @@ public class CloudBigtableIO {
           // A split occurred and the split key was before this key.
           break;
         }
-        results.add(Adapters.FLAT_ROW_ADAPTER.adaptResponse(row));
+        results.add(FLAT_ROW_ADAPTER.adaptResponse(row));
       }
       return results.toArray(new Result[results.size()]);
     }

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/KeyOnlyFilterAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/KeyOnlyFilterAdapter.java
@@ -17,8 +17,9 @@ package com.google.cloud.bigtable.hbase.adapters.filters;
 
 import com.google.bigtable.v2.RowFilter;
 import com.google.bigtable.v2.RowFilter.Chain;
+import com.google.cloud.bigtable.hbase.adapters.read.RowCell;
+
 import org.apache.hadoop.hbase.Cell;
-import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.filter.KeyOnlyFilter;
 import org.apache.hadoop.hbase.util.Bytes;
 
@@ -32,7 +33,7 @@ import java.io.IOException;
  */
 public class KeyOnlyFilterAdapter extends TypedFilterAdapterBase<KeyOnlyFilter> {
   /** Constant <code>TEST_CELL</code> */
-  protected static final Cell TEST_CELL = new KeyValue(
+  protected static final Cell TEST_CELL = new RowCell(
       Bytes.toBytes('r'), // Row
       Bytes.toBytes('f'), // Family
       Bytes.toBytes('q'), // qualifier

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/KeyOnlyFilterAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/KeyOnlyFilterAdapter.java
@@ -17,9 +17,8 @@ package com.google.cloud.bigtable.hbase.adapters.filters;
 
 import com.google.bigtable.v2.RowFilter;
 import com.google.bigtable.v2.RowFilter.Chain;
-import com.google.cloud.bigtable.hbase.adapters.read.RowCell;
-
 import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.filter.KeyOnlyFilter;
 import org.apache.hadoop.hbase.util.Bytes;
 
@@ -33,7 +32,7 @@ import java.io.IOException;
  */
 public class KeyOnlyFilterAdapter extends TypedFilterAdapterBase<KeyOnlyFilter> {
   /** Constant <code>TEST_CELL</code> */
-  protected static final Cell TEST_CELL = new RowCell(
+  protected static final Cell TEST_CELL = new KeyValue(
       Bytes.toBytes('r'), // Row
       Bytes.toBytes('f'), // Family
       Bytes.toBytes('q'), // qualifier

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableConnection.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableConnection.java
@@ -30,6 +30,7 @@ import com.google.cloud.bigtable.hbase.adapters.HBaseRequestAdapter.MutationAdap
 import com.google.common.base.MoreObjects;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.BufferedMutator.ExceptionListener;
 import org.apache.hadoop.hbase.security.User;
@@ -73,6 +74,11 @@ public abstract class AbstractBigtableConnection implements Connection, Closeabl
       }
     };
     Runtime.getRuntime().addShutdownHook(new Thread(shutDownRunnable));
+
+    // Force the loading of HConstants.class, which shares a bi-directional reference with KeyValue.
+    // This bi-drectional relationship causes problems when KeyVale and HConstants are class loaded
+    // in different threads.  This forces a clean class loading of both classes.
+    HConstants.class.getName();
   }
 
   private final Logger LOG = new Logger(getClass());

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableConnection.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableConnection.java
@@ -25,6 +25,7 @@ import com.google.cloud.bigtable.hbase.BigtableBufferedMutator;
 import com.google.cloud.bigtable.hbase.BigtableOptionsFactory;
 import com.google.cloud.bigtable.hbase.BigtableRegionLocator;
 import com.google.cloud.bigtable.hbase.BigtableTable;
+import com.google.cloud.bigtable.hbase.adapters.Adapters;
 import com.google.cloud.bigtable.hbase.adapters.HBaseRequestAdapter;
 import com.google.cloud.bigtable.hbase.adapters.HBaseRequestAdapter.MutationAdapters;
 import com.google.common.base.MoreObjects;
@@ -76,9 +77,10 @@ public abstract class AbstractBigtableConnection implements Connection, Closeabl
     Runtime.getRuntime().addShutdownHook(new Thread(shutDownRunnable));
 
     // Force the loading of HConstants.class, which shares a bi-directional reference with KeyValue.
-    // This bi-drectional relationship causes problems when KeyVale and HConstants are class loaded
-    // in different threads.  This forces a clean class loading of both classes.
-    HConstants.class.getName();
+    // This bi-drectional relationship causes problems when KeyValue and HConstants are class loaded
+    // in different threads. This forces a clean class loading of both HConstants and KeyValue along
+    // with a whole bunch of other classes.
+    Adapters.class.getName();
   }
 
   private final Logger LOG = new Logger(getClass());


### PR DESCRIPTION
Some confluence of events in Dataflow caused a deadlock.  There were some strange stack traces that pointed towards the root cause being the class loading of HConstants.  Scans refer to HConstants.  KeyValues refer to HConstants.  Puts and Adapters -> KeyOnlyFilterAdapter both refer to HContants.

This PR removes a couple of paths to HConstants in hope that this removes the class loading issue.