### PR TITLE
Using ValueRange instead of value regex in ValueFilterAdapter.

### DIFF
--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/ValueFilterAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/ValueFilterAdapter.java
@@ -16,6 +16,7 @@
 package com.google.cloud.bigtable.hbase.adapters.filters;
 
 import com.google.bigtable.v2.RowFilter;
+import com.google.bigtable.v2.RowFilter.Chain;
 import com.google.bigtable.v2.RowFilter.Interleave;
 import com.google.bigtable.v2.ValueRange;
 import com.google.cloud.bigtable.hbase.adapters.read.ReaderExpressionHelper;
@@ -28,6 +29,8 @@ import org.apache.hadoop.hbase.filter.RegexStringComparator;
 import org.apache.hadoop.hbase.filter.ValueFilter;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Adapt a single HBase ValueFilter.
@@ -77,10 +80,8 @@ public class ValueFilterAdapter extends TypedFilterAdapterBase<ValueFilter> {
       case LESS_OR_EQUAL:
         return createRowFilter(ValueRange.newBuilder().setEndValueClosed(value));
       case EQUAL:
-        byte[] quotedBytes = ReaderExpressionHelper.quoteRegularExpression(comparator.getValue());
-        return RowFilter.newBuilder()
-            .setValueRegexFilter(ByteStringer.wrap(quotedBytes))
-            .build();
+      return createRowFilter(
+        ValueRange.newBuilder().setStartValueClosed(value).setEndValueClosed(value));
       case NOT_EQUAL:
         // This strictly less than + strictly greater than:
         return RowFilter.newBuilder()

--- a/bigtable-hbase-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestFilterListAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestFilterListAdapter.java
@@ -66,25 +66,23 @@ public class TestFilterListAdapter {
   @Test
   public void interleavedFiltersAreAdapted() throws IOException {
     FilterList filterList = makeFilterList(Operator.MUST_PASS_ONE);
-    RowFilter rowFilter = filterAdapter.adaptFilter(emptyScanContext, filterList).get();
-    Assert.assertEquals(
-        "value",
-        rowFilter.getInterleave().getFilters(0).getValueRegexFilter().toStringUtf8());
-    Assert.assertEquals(
-        "value2",
-        rowFilter.getInterleave().getFilters(1).getValueRegexFilter().toStringUtf8());
+    List<Filter> filters = filterList.getFilters();
+    RowFilter rowFilter = adapt(filterList);
+    Assert.assertEquals(filters.size(), rowFilter.getInterleave().getFiltersCount());
+    for (int i = 0; i < filters.size(); i++) {
+      Assert.assertEquals(adapt(filters.get(i)), rowFilter.getInterleave().getFilters(i));
+    }
   }
 
   @Test
   public void chainedFiltersAreAdapted() throws IOException {
     FilterList filterList = makeFilterList(Operator.MUST_PASS_ALL);
-    RowFilter rowFilter = filterAdapter.adaptFilter(emptyScanContext, filterList).get();
-    Assert.assertEquals(
-        "value",
-        rowFilter.getChain().getFilters(0).getValueRegexFilter().toStringUtf8());
-    Assert.assertEquals(
-        "value2",
-        rowFilter.getChain().getFilters(1).getValueRegexFilter().toStringUtf8());
+    List<Filter> filters = filterList.getFilters();
+    RowFilter rowFilter = adapt(filterList);
+    Assert.assertEquals(filters.size(), rowFilter.getChain().getFiltersCount());
+    for (int i = 0; i < filters.size(); i++) {
+      Assert.assertEquals(adapt(filters.get(i)), rowFilter.getChain().getFilters(i));
+    }
   }
 
   @Test
@@ -228,4 +226,9 @@ public class TestFilterListAdapter {
 
     Assert.assertEquals(expected, actual);
   }
+
+  protected RowFilter adapt(Filter filter) throws IOException {
+    return filterAdapter.adaptFilter(emptyScanContext, filter).get();
+  }
+
 }

--- a/bigtable-hbase-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestSingleColumnValueFilterAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestSingleColumnValueFilterAdapter.java
@@ -17,6 +17,7 @@ package com.google.cloud.bigtable.hbase.adapters.filters;
 
 import com.google.bigtable.v2.RowFilter;
 import com.google.bigtable.v2.RowFilter.Chain;
+import com.google.bigtable.v2.ValueRange;
 import com.google.protobuf.ByteString;
 
 import org.apache.hadoop.hbase.client.Scan;
@@ -123,8 +124,10 @@ public class TestSingleColumnValueFilterAdapter  {
 
     Assert.assertEquals(
         RowFilter.newBuilder()
-            .setValueRegexFilter(ByteString.copyFromUtf8("foobar"))
-            .build(),
+        .setValueRangeFilter(ValueRange.newBuilder()
+            .setStartValueClosed(ByteString.copyFromUtf8("foobar"))
+            .setEndValueClosed(ByteString.copyFromUtf8("foobar")))
+        .build(),
         adaptedFilter
             .getCondition()
             .getPredicateFilter()
@@ -204,7 +207,9 @@ public class TestSingleColumnValueFilterAdapter  {
     // Assert that the condition includes a value filter:
     Assert.assertEquals(
         RowFilter.newBuilder()
-            .setValueRegexFilter(ByteString.copyFrom(value))
+            .setValueRangeFilter(ValueRange.newBuilder()
+                .setStartValueClosed(ByteString.copyFrom(value))
+                .setEndValueClosed(ByteString.copyFrom(value)))
             .build(),
         cellExistsBranch
             .getCondition()


### PR DESCRIPTION
See issue #1264 for additional context.  TL;DR: ValueRegexFilter doesn't work for non-UTF8 bytes, so use a ValueRange instead.