### PR TITLE
AbstractBigtableAdmin now only contains 1.0 method.

### DIFF
--- a/bigtable-hbase-parent/bigtable-hbase-1.1/src/main/java/com/google/cloud/bigtable/hbase1_1/BigtableConnection.java
+++ b/bigtable-hbase-parent/bigtable-hbase-1.1/src/main/java/com/google/cloud/bigtable/hbase1_1/BigtableConnection.java
@@ -57,6 +57,48 @@ public class BigtableConnection extends AbstractBigtableConnection {
   @Override
   public Admin getAdmin() throws IOException {
     return new AbstractBigtableAdmin(getOptions(), getConfiguration(), this,
-        getBigtableTableAdminClient(), getDisabledTables()) {};
+        getBigtableTableAdminClient(), getDisabledTables()) {
+
+          @Override
+          public boolean isBalancerEnabled() throws IOException {
+            throw new UnsupportedOperationException("isBalancerEnabled");  // TODO
+          }
+
+          @Override
+          public long getLastMajorCompactionTimestamp(TableName tableName) throws IOException {
+            throw new UnsupportedOperationException("getLastMajorCompactionTimestamp");  // TODO
+          }
+
+          @Override
+          public long getLastMajorCompactionTimestampForRegion(byte[] regionName)
+              throws IOException {
+            throw new UnsupportedOperationException("getLastMajorCompactionTimestampForRegion");  // TODO
+          }
+
+          @Override
+          public void setQuota(QuotaSettings quota) throws IOException {
+            throw new UnsupportedOperationException("setQuota");  // TODO
+          }
+
+          @Override
+          public QuotaRetriever getQuotaRetriever(QuotaFilter filter) throws IOException {
+            throw new UnsupportedOperationException("getQuotaRetriever");  // TODO
+          }
+
+          @Override
+          public boolean abortProcedure(long arg0, boolean arg1) throws IOException {
+            throw new UnsupportedOperationException("abortProcedure");  // TODO
+          }
+
+          @Override
+          public Future<Boolean> abortProcedureAsync(long arg0, boolean arg1) throws IOException {
+            throw new UnsupportedOperationException("abortProcedureAsync");  // TODO
+          }
+
+          @Override
+          public ProcedureInfo[] listProcedures() throws IOException {
+            throw new UnsupportedOperationException("listProcedures");  // TODO
+          }
+    };
   }
 }

--- a/bigtable-hbase-parent/bigtable-hbase-1.2/src/main/java/com/google/cloud/bigtable/hbase1_2/BigtableConnection.java
+++ b/bigtable-hbase-parent/bigtable-hbase-1.2/src/main/java/com/google/cloud/bigtable/hbase1_2/BigtableConnection.java
@@ -59,6 +59,70 @@ public class BigtableConnection extends AbstractBigtableConnection {
   @Override
   public Admin getAdmin() throws IOException {
     return new AbstractBigtableAdmin(getOptions(), getConfiguration(), this,
-        getBigtableTableAdminClient(), getDisabledTables()) {};
+        getBigtableTableAdminClient(), getDisabledTables()) {
+
+          @Override
+          public boolean isBalancerEnabled() throws IOException {
+            throw new UnsupportedOperationException("isBalancerEnabled");  // TODO
+          }
+
+          @Override
+          public long getLastMajorCompactionTimestamp(TableName tableName) throws IOException {
+            throw new UnsupportedOperationException("getLastMajorCompactionTimestamp");  // TODO
+          }
+
+          @Override
+          public long getLastMajorCompactionTimestampForRegion(byte[] regionName)
+              throws IOException {
+            throw new UnsupportedOperationException("getLastMajorCompactionTimestampForRegion");  // TODO
+          }
+
+          @Override
+          public void setQuota(QuotaSettings quota) throws IOException {
+            throw new UnsupportedOperationException("setQuota");  // TODO
+          }
+
+          @Override
+          public QuotaRetriever getQuotaRetriever(QuotaFilter filter) throws IOException {
+            throw new UnsupportedOperationException("getQuotaRetriever");  // TODO
+          }
+
+          @Override
+          public boolean normalize() throws IOException {
+            throw new UnsupportedOperationException("normalize");  // TODO
+          }
+
+          @Override
+          public boolean isNormalizerEnabled() throws IOException {
+            throw new UnsupportedOperationException("isNormalizerEnabled");  // TODO
+          }
+
+          @Override
+          public boolean setNormalizerRunning(boolean on) throws IOException {
+            throw new UnsupportedOperationException("setNormalizerRunning");  // TODO
+          }
+
+          @Override
+          public boolean abortProcedure(long procId, boolean mayInterruptIfRunning)
+              throws IOException {
+            throw new UnsupportedOperationException("abortProcedure");  // TODO
+          }
+
+          @Override
+          public ProcedureInfo[] listProcedures() throws IOException {
+            throw new UnsupportedOperationException("listProcedures");  // TODO
+          }
+
+          @Override
+          public Future<Boolean> abortProcedureAsync(long procId, boolean mayInterruptIfRunning)
+              throws IOException {
+            throw new UnsupportedOperationException("abortProcedureAsync");  // TODO
+          }
+
+          @Override
+          public List<SecurityCapability> getSecurityCapabilities() throws IOException {
+            throw new UnsupportedOperationException("getSecurityCapabilities");  // TODO
+          }
+    };
   }
 }

--- a/bigtable-hbase-parent/bigtable-hbase-1.3/src/main/java/com/google/cloud/bigtable/hbase1_3/BigtableConnection.java
+++ b/bigtable-hbase-parent/bigtable-hbase-1.3/src/main/java/com/google/cloud/bigtable/hbase1_3/BigtableConnection.java
@@ -61,6 +61,108 @@ public class BigtableConnection extends AbstractBigtableConnection {
   @Override
   public Admin getAdmin() throws IOException {
     return new AbstractBigtableAdmin(getOptions(), getConfiguration(), this,
-        getBigtableTableAdminClient(), getDisabledTables()) {};
+        getBigtableTableAdminClient(), getDisabledTables()) {
+
+          @Override
+          public void deleteTableSnapshots(String arg0, String arg1) throws IOException {
+            throw new UnsupportedOperationException("deleteTableSnapshots");  // TODO
+          }
+    
+          @Override
+          public void deleteTableSnapshots(Pattern arg0, Pattern arg1) throws IOException {
+            throw new UnsupportedOperationException("deleteTableSnapshots");  // TODO
+          }
+    
+          @Override
+          public List<SnapshotDescription> listTableSnapshots(String arg0, String arg1)
+              throws IOException {
+            throw new UnsupportedOperationException("listTableSnapshots");  // TODO
+          }
+    
+          @Override
+          public List<SnapshotDescription> listTableSnapshots(Pattern arg0, Pattern arg1)
+              throws IOException {
+            throw new UnsupportedOperationException("listTableSnapshots");  // TODO
+          }
+
+          @Override
+          public boolean isBalancerEnabled() throws IOException {
+            throw new UnsupportedOperationException("isBalancerEnabled");  // TODO
+          }
+
+          @Override
+          public long getLastMajorCompactionTimestamp(TableName tableName) throws IOException {
+            throw new UnsupportedOperationException("getLastMajorCompactionTimestamp");  // TODO
+          }
+
+          @Override
+          public long getLastMajorCompactionTimestampForRegion(byte[] regionName)
+              throws IOException {
+            throw new UnsupportedOperationException("getLastMajorCompactionTimestampForRegion");  // TODO
+          }
+
+          @Override
+          public void setQuota(QuotaSettings quota) throws IOException {
+            throw new UnsupportedOperationException("setQuota");  // TODO
+          }
+
+          @Override
+          public QuotaRetriever getQuotaRetriever(QuotaFilter filter) throws IOException {
+            throw new UnsupportedOperationException("getQuotaRetriever");  // TODO
+          }
+
+          @Override
+          public boolean normalize() throws IOException {
+            throw new UnsupportedOperationException("normalize");  // TODO
+          }
+
+          @Override
+          public boolean isNormalizerEnabled() throws IOException {
+            throw new UnsupportedOperationException("isNormalizerEnabled");  // TODO
+          }
+
+          @Override
+          public boolean setNormalizerRunning(boolean on) throws IOException {
+            throw new UnsupportedOperationException("setNormalizerRunning");  // TODO
+          }
+
+          @Override
+          public boolean abortProcedure(long procId, boolean mayInterruptIfRunning)
+              throws IOException {
+            throw new UnsupportedOperationException("abortProcedure");  // TODO
+          }
+
+          @Override
+          public ProcedureInfo[] listProcedures() throws IOException {
+            throw new UnsupportedOperationException("listProcedures");  // TODO
+          }
+
+          @Override
+          public Future<Boolean> abortProcedureAsync(long procId, boolean mayInterruptIfRunning)
+              throws IOException {
+            throw new UnsupportedOperationException("abortProcedureAsync");  // TODO
+          }
+
+          @Override
+          public List<SecurityCapability> getSecurityCapabilities() throws IOException {
+            throw new UnsupportedOperationException("getSecurityCapabilities");  // TODO
+          }
+
+          @Override
+          public boolean balancer(boolean arg0) throws IOException {
+            throw new UnsupportedOperationException("balancer");  // TODO
+          }
+
+          @Override
+          public boolean isSplitOrMergeEnabled(MasterSwitchType arg0) throws IOException {
+            throw new UnsupportedOperationException("isSplitOrMergeEnabled");  // TODO
+          }
+
+          @Override
+          public boolean[] setSplitOrMergeEnabled(boolean arg0, boolean arg1,
+              MasterSwitchType... arg2) throws IOException {
+            throw new UnsupportedOperationException("setSplitOrMergeEnabled");  // TODO
+          }
+    };
   }
 }

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableAdmin.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableAdmin.java
@@ -23,7 +23,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
@@ -36,22 +35,17 @@ import org.apache.hadoop.hbase.HRegionLocation;
 import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.MasterNotRunningException;
 import org.apache.hadoop.hbase.NamespaceDescriptor;
-import org.apache.hadoop.hbase.ProcedureInfo;
 import org.apache.hadoop.hbase.ServerName;
 import org.apache.hadoop.hbase.TableExistsException;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.TableNotEnabledException;
 import org.apache.hadoop.hbase.TableNotFoundException;
 import org.apache.hadoop.hbase.ZooKeeperConnectionException;
-import org.apache.hadoop.hbase.client.security.SecurityCapability;
 import org.apache.hadoop.hbase.ipc.CoprocessorRpcChannel;
 import org.apache.hadoop.hbase.protobuf.generated.AdminProtos;
 import org.apache.hadoop.hbase.protobuf.generated.HBaseProtos;
 import org.apache.hadoop.hbase.protobuf.generated.HBaseProtos.SnapshotDescription;
 import org.apache.hadoop.hbase.protobuf.generated.MasterProtos;
-import org.apache.hadoop.hbase.quotas.QuotaFilter;
-import org.apache.hadoop.hbase.quotas.QuotaRetriever;
-import org.apache.hadoop.hbase.quotas.QuotaSettings;
 import org.apache.hadoop.hbase.regionserver.wal.FailedLogCloseException;
 import org.apache.hadoop.hbase.snapshot.HBaseSnapshotException;
 import org.apache.hadoop.hbase.snapshot.RestoreSnapshotException;
@@ -1371,103 +1365,4 @@ public abstract class AbstractBigtableAdmin implements Admin {
     throw new UnsupportedOperationException("rollWALWriter");  // TODO
   }
 
-
-  /* HBase 1.1 */
-  @Override
-  public boolean isBalancerEnabled() throws IOException {
-    throw new UnsupportedOperationException("isBalancerEnabled"); // TODO
-  }
-
-  @Override
-  public boolean abortProcedure(long l, boolean b) throws IOException {
-    throw new UnsupportedOperationException("abortProcedure"); // TODO
-  }
-
-  @Override
-  public ProcedureInfo[] listProcedures() throws IOException {
-    throw new UnsupportedOperationException("listProcedures"); // TODO
-  }
-
-  @Override
-  public Future<Boolean> abortProcedureAsync(long l, boolean b) throws IOException {
-    throw new UnsupportedOperationException("abortProcedureAsync"); // TODO
-  }
-
-  @Override
-  public long getLastMajorCompactionTimestamp(TableName tableName) throws IOException {
-    throw new UnsupportedOperationException("getLastMajorCompactionTimestamp"); // TODO
-  }
-
-  @Override
-  public long getLastMajorCompactionTimestampForRegion(byte[] bytes) throws IOException {
-    throw new UnsupportedOperationException("getLastMajorCompactionTimestampForRegion"); // TODO
-  }
-
-  @Override
-  public void setQuota(QuotaSettings quotaSettings) throws IOException {
-    throw new UnsupportedOperationException("setQuota"); // TODO
-  }
-
-  @Override
-  public QuotaRetriever getQuotaRetriever(QuotaFilter quotaFilter) throws IOException {
-    throw new UnsupportedOperationException("getQuotaRetriever"); // TODO
-  }
-
-  /* HBase 1.2 */
-  @Override
-  public boolean normalize() throws IOException {
-    throw new UnsupportedOperationException("normalize"); // TODO
-  }
-
-  @Override
-  public boolean isNormalizerEnabled() throws IOException {
-    throw new UnsupportedOperationException("isNormalizerEnabled"); // TODO
-  }
-
-  @Override
-  public boolean setNormalizerRunning(boolean on) throws IOException {
-    throw new UnsupportedOperationException("setNormalizerRunning"); // TODO
-  }
-
-  @Override
-  public List<SecurityCapability> getSecurityCapabilities() throws IOException {
-    throw new UnsupportedOperationException("getSecurityCapabilities"); // TODO
-  }
-
-  /* Hbase 1.3 */
-  @Override
-  public boolean balancer(boolean b) throws IOException {
-    throw new UnsupportedOperationException("balancer"); // TODO
-  }
-
-  @Override
-  public List<SnapshotDescription> listTableSnapshots(String s, String s1) throws IOException {
-    throw new UnsupportedOperationException("listTableSnapshots"); // TODO
-  }
-
-  @Override
-  public List<SnapshotDescription> listTableSnapshots(Pattern pattern, Pattern pattern1) throws IOException {
-    throw new UnsupportedOperationException("listTableSnapshots"); // TODO
-  }
-
-  @Override
-  public void deleteTableSnapshots(String s, String s1) throws IOException {
-    throw new UnsupportedOperationException("deleteTableSnapshots"); // TODO
-  }
-
-  @Override
-  public void deleteTableSnapshots(Pattern pattern, Pattern pattern1) throws IOException {
-    throw new UnsupportedOperationException("deleteTableSnapshots"); // TODO
-  }
-
-  @Override
-  public boolean[] setSplitOrMergeEnabled(boolean b, boolean b1, MasterSwitchType... masterSwitchTypes)
-      throws IOException {
-    throw new UnsupportedOperationException("setSplitOrMergeEnabled"); // TODO
-  }
-
-  @Override
-  public boolean isSplitOrMergeEnabled(MasterSwitchType masterSwitchType) throws IOException {
-    throw new UnsupportedOperationException("isSplitOrMergeEnabled"); // TODO
-  }
 }

--- a/bigtable-hbase-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableConnection.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableConnection.java
@@ -16,11 +16,21 @@
 package com.google.cloud.bigtable.hbase;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.Future;
+import java.util.regex.Pattern;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.ProcedureInfo;
+import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.AbstractBigtableAdmin;
 import org.apache.hadoop.hbase.client.AbstractBigtableConnection;
 import org.apache.hadoop.hbase.client.Admin;
+import org.apache.hadoop.hbase.client.security.SecurityCapability;
+import org.apache.hadoop.hbase.protobuf.generated.HBaseProtos.SnapshotDescription;
+import org.apache.hadoop.hbase.quotas.QuotaFilter;
+import org.apache.hadoop.hbase.quotas.QuotaRetriever;
+import org.apache.hadoop.hbase.quotas.QuotaSettings;
 
 public class TestBigtableConnection extends AbstractBigtableConnection {
 
@@ -28,11 +38,112 @@ public class TestBigtableConnection extends AbstractBigtableConnection {
     super(conf);
   }
 
+  /** {@inheritDoc} */
   @Override
   public Admin getAdmin() throws IOException {
     return new AbstractBigtableAdmin(getOptions(), getConfiguration(), this,
         getBigtableTableAdminClient(), getDisabledTables()) {
+
+          @Override
+          public void deleteTableSnapshots(String arg0, String arg1) throws IOException {
+            throw new UnsupportedOperationException("deleteTableSnapshots");  // TODO
+          }
+
+          @Override
+          public void deleteTableSnapshots(Pattern arg0, Pattern arg1) throws IOException {
+            throw new UnsupportedOperationException("deleteTableSnapshots");  // TODO
+          }
+
+          @Override
+          public List<SnapshotDescription> listTableSnapshots(String arg0, String arg1)
+              throws IOException {
+            throw new UnsupportedOperationException("listTableSnapshots");  // TODO
+          }
+
+          @Override
+          public List<SnapshotDescription> listTableSnapshots(Pattern arg0, Pattern arg1)
+              throws IOException {
+            throw new UnsupportedOperationException("listTableSnapshots");  // TODO
+          }
+
+          @Override
+          public boolean isBalancerEnabled() throws IOException {
+            throw new UnsupportedOperationException("isBalancerEnabled");  // TODO
+          }
+
+          @Override
+          public long getLastMajorCompactionTimestamp(TableName tableName) throws IOException {
+            throw new UnsupportedOperationException("getLastMajorCompactionTimestamp");  // TODO
+          }
+
+          @Override
+          public long getLastMajorCompactionTimestampForRegion(byte[] regionName)
+              throws IOException {
+            throw new UnsupportedOperationException("getLastMajorCompactionTimestampForRegion");  // TODO
+          }
+
+          @Override
+          public void setQuota(QuotaSettings quota) throws IOException {
+            throw new UnsupportedOperationException("setQuota");  // TODO
+          }
+
+          @Override
+          public QuotaRetriever getQuotaRetriever(QuotaFilter filter) throws IOException {
+            throw new UnsupportedOperationException("getQuotaRetriever");  // TODO
+          }
+
+          @Override
+          public boolean normalize() throws IOException {
+            throw new UnsupportedOperationException("normalize");  // TODO
+          }
+
+          @Override
+          public boolean isNormalizerEnabled() throws IOException {
+            throw new UnsupportedOperationException("isNormalizerEnabled");  // TODO
+          }
+
+          @Override
+          public boolean setNormalizerRunning(boolean on) throws IOException {
+            throw new UnsupportedOperationException("setNormalizerRunning");  // TODO
+          }
+
+          @Override
+          public boolean abortProcedure(long procId, boolean mayInterruptIfRunning)
+              throws IOException {
+            throw new UnsupportedOperationException("abortProcedure");  // TODO
+          }
+
+          @Override
+          public ProcedureInfo[] listProcedures() throws IOException {
+            throw new UnsupportedOperationException("listProcedures");  // TODO
+          }
+
+          @Override
+          public Future<Boolean> abortProcedureAsync(long procId, boolean mayInterruptIfRunning)
+              throws IOException {
+            throw new UnsupportedOperationException("abortProcedureAsync");  // TODO
+          }
+
+          @Override
+          public List<SecurityCapability> getSecurityCapabilities() throws IOException {
+            throw new UnsupportedOperationException("getSecurityCapabilities");  // TODO
+          }
+
+          @Override
+          public boolean balancer(boolean arg0) throws IOException {
+            throw new UnsupportedOperationException("balancer");  // TODO
+          }
+
+          @Override
+          public boolean isSplitOrMergeEnabled(MasterSwitchType arg0) throws IOException {
+            throw new UnsupportedOperationException("isSplitOrMergeEnabled");  // TODO
+          }
+
+          @Override
+          public boolean[] setSplitOrMergeEnabled(boolean arg0, boolean arg1,
+              MasterSwitchType... arg2) throws IOException {
+            throw new UnsupportedOperationException("setSplitOrMergeEnabled");  // TODO
+          }
     };
   }
-
 }


### PR DESCRIPTION
The extra `Admin` methods were causing problems for our YCSB performance tests that use HBase 1.0