### PR TITLE
Relocating common protos in the hbase shading process.

### DIFF
--- a/bigtable-hbase-parent/bigtable-hbase-shaded/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-shaded/pom.xml
@@ -140,6 +140,10 @@ limitations under the License.
                                     <shadedPattern>com.google.bigtable.repackaged.com.google.auth</shadedPattern>
                                 </relocation>
                                 <relocation>
+                                    <pattern>com.google.cloud.audit</pattern>
+                                    <shadedPattern>com.google.bigtable.repackaged.com.google.cloud.audit</shadedPattern>
+                                </relocation>
+                                <relocation>
                                     <pattern>com.google.common</pattern>
                                     <shadedPattern>com.google.bigtable.repackaged.com.google.common</shadedPattern>
                                 </relocation>
@@ -148,12 +152,28 @@ limitations under the License.
                                     <shadedPattern>com.google.bigtable.repackaged.com.google.instrumentation</shadedPattern>
                                 </relocation>
                                 <relocation>
+                                    <pattern>com.google.logging</pattern>
+                                    <shadedPattern>com.google.bigtable.repackaged.com.google.logging</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.google.longrunning</pattern>
+                                    <shadedPattern>com.google.bigtable.repackaged.com.google.longrunning</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.google.rpc</pattern>
+                                    <shadedPattern>com.google.bigtable.repackaged.com.google.rpc</shadedPattern>
+                                </relocation>
+                                <relocation>
                                     <pattern>com.google.thirdparty</pattern>
                                     <shadedPattern>com.google.bigtable.repackaged.com.google.thirdparty</shadedPattern>
                                 </relocation>
                                 <relocation>
                                     <pattern>com.google.protobuf</pattern>
                                     <shadedPattern>com.google.bigtable.repackaged.com.google.protobuf</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.google.type</pattern>
+                                    <shadedPattern>com.google.bigtable.repackaged.com.google.type</shadedPattern>
                                 </relocation>
                                 <relocation>
                                     <pattern>com.twitter</pattern>


### PR DESCRIPTION
This should be a short term fix for #1274
This PR relocates the following packages:

- com/google/type/
- com/google/rpc/
- com/google/logging/
- com/google/cloud/audit/
- com/google/longrunning/