### PR TITLE
WIP: refactor authentication

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/RetryOptions.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/RetryOptions.java
@@ -54,7 +54,8 @@ public class RetryOptions implements Serializable {
       Status.Code.DEADLINE_EXCEEDED,
       Status.Code.INTERNAL,
       Status.Code.UNAVAILABLE,
-      Status.Code.ABORTED);
+      Status.Code.ABORTED,
+      Code.UNAUTHENTICATED);
 
   /** We can timeout when reading large cells with a low value here. With a 10MB
    * cell limit, 60 seconds allows our connection to drop to ~170kbyte/s. A 10 second

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/CredentialInterceptorCache.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/CredentialInterceptorCache.java
@@ -110,11 +110,8 @@ public class CredentialInterceptorCache {
     // The RefreshingOAuth2CredentialsInterceptor uses the credentials to get a security token that
     // will live for a short time.  That token is added on all calls by the gRPC interceptor to
     // allow users to access secure resources.
-    //
-    // Perform that token lookup asynchronously. This permits other work to be done in
-    // parallel. The RefreshingOAuth2CredentialsInterceptor has internal locking that assures that
-    // the oauth2 token is loaded before the interceptor proceeds with any calls.
-    oauth2Interceptor.asyncRefresh();
+    oauth2Interceptor.syncRefresh();
+
     if (isDefaultCredentials) {
       defaultCredentialInterceptor = oauth2Interceptor;
     }

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/CredentialInterceptorCache.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/CredentialInterceptorCache.java
@@ -104,8 +104,7 @@ public class CredentialInterceptorCache {
             credentials.getClass().getName()));
 
     RefreshingOAuth2CredentialsInterceptor oauth2Interceptor =
-        new RefreshingOAuth2CredentialsInterceptor(executor, (OAuth2Credentials) credentials,
-            retryOptions);
+        new RefreshingOAuth2CredentialsInterceptor(executor, (OAuth2Credentials) credentials);
 
     // The RefreshingOAuth2CredentialsInterceptor uses the credentials to get a security token that
     // will live for a short time.  That token is added on all calls by the gRPC interceptor to

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptor.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptor.java
@@ -246,14 +246,16 @@ public class RefreshingOAuth2CredentialsInterceptor implements ClientInterceptor
         this.futureToken = executor.submit(new Callable<HeaderCacheElement>() {
           @Override
           public HeaderCacheElement call() throws Exception {
-            HeaderCacheElement newToken = refreshCredentialsWithRetry();
-
-            synchronized (RefreshingOAuth2CredentialsInterceptor.this) {
+            try {
+              HeaderCacheElement newToken = refreshCredentialsWithRetry();
               headerCache.set(newToken);
-              futureToken = null;
-              isRefreshing.set(false);
+              return newToken;
+            } finally {
+              synchronized (isRefreshing) {
+                futureToken = null;
+                isRefreshing.set(false);
+              }
             }
-            return newToken;
           }
         });
       }

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptor.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptor.java
@@ -153,7 +153,6 @@ public class RefreshingOAuth2CredentialsInterceptor implements ClientInterceptor
   final AtomicBoolean isRefreshing = new AtomicBoolean(false);
 
   private final ListeningExecutorService executor;
-  private final Logger logger;
   private final boolean isAppEngine;
 
   private OAuth2Credentials credentials;
@@ -169,15 +168,8 @@ public class RefreshingOAuth2CredentialsInterceptor implements ClientInterceptor
    */
   public RefreshingOAuth2CredentialsInterceptor(ExecutorService scheduler,
       OAuth2Credentials credentials) {
-    this(scheduler, credentials, LOG);
-  }
-
-  @VisibleForTesting
-  RefreshingOAuth2CredentialsInterceptor(ExecutorService scheduler, OAuth2Credentials credentials,
-      Logger logger) {
     this.executor = MoreExecutors.listeningDecorator(Preconditions.checkNotNull(scheduler));
     this.credentials = Preconditions.checkNotNull(credentials);
-    this.logger = Preconditions.checkNotNull(logger);
 
     // From MoreExecutors
     this.isAppEngine = System.getProperty("com.google.appengine.runtime.environment") != null;
@@ -307,11 +299,11 @@ public class RefreshingOAuth2CredentialsInterceptor implements ClientInterceptor
     }
 
     try {
-      logger.info("Refreshing the OAuth token");
+      LOG.info("Refreshing the OAuth token");
       AccessToken newToken = credentials.refreshAccessToken();
       return new HeaderCacheElement(newToken);
     } catch (Exception e) {
-      logger.warn("Got an unexpected exception while trying to refresh google credentials.", e);
+      LOG.warn("Got an unexpected exception while trying to refresh google credentials.", e);
       return new HeaderCacheElement(
           Status.UNAUTHENTICATED
               .withDescription("Unexpected error trying to authenticate")

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptor.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptor.java
@@ -287,7 +287,6 @@ public class RefreshingOAuth2CredentialsInterceptor implements ClientInterceptor
       try {
         return readerFuture.get(250, TimeUnit.MILLISECONDS);
       } catch (ExecutionException|TimeoutException e) {
-        // Should never happen
         throw new IOException(e.getCause());
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptorTest.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptorTest.java
@@ -112,25 +112,21 @@ public class RefreshingOAuth2CredentialsInterceptorTest {
   @Test
   public void testSyncRefresh() throws IOException {
     initialize(HeaderCacheElement.TOKEN_STALENESS_MS + 1);
-    Assert.assertEquals(CacheState.Good,
-      RefreshingOAuth2CredentialsInterceptor.getCacheState(underTest.headerCache.get()));
+    Assert.assertEquals(CacheState.Good, underTest.headerCache.get().getCacheState());
   }
 
   @Test
   public void testStaleAndExpired() throws IOException {
     int expiration = HeaderCacheElement.TOKEN_STALENESS_MS + 1;
     initialize(expiration);
-    Assert.assertEquals(CacheState.Good,
-      RefreshingOAuth2CredentialsInterceptor.getCacheState(underTest.headerCache.get()));
+    Assert.assertEquals(CacheState.Good, underTest.headerCache.get().getCacheState());
     long startTime = 2L;
     setTimeInMillieconds(startTime);
-    Assert.assertEquals(CacheState.Stale,
-      RefreshingOAuth2CredentialsInterceptor.getCacheState(underTest.headerCache.get()));
+    Assert.assertEquals(CacheState.Stale, underTest.headerCache.get().getCacheState());
     long expiredStaleDiff =
         HeaderCacheElement.TOKEN_STALENESS_MS - HeaderCacheElement.TOKEN_EXPIRES_MS;
     setTimeInMillieconds(startTime + expiredStaleDiff);
-    Assert.assertEquals(CacheState.Expired,
-      RefreshingOAuth2CredentialsInterceptor.getCacheState(underTest.headerCache.get()));
+    Assert.assertEquals(CacheState.Expired, underTest.headerCache.get().getCacheState());
   }
 
   @Test
@@ -158,7 +154,7 @@ public class RefreshingOAuth2CredentialsInterceptorTest {
     HeaderCacheElement header = underTest.refreshCredentialsWithRetry();
 
     Assert.assertNull(header.header);
-    Assert.assertSame(ioException, header.exception);
+    Assert.assertSame(ioException, header.status.getCause());
 
     // Make sure that the system "slept" for more than the retryOption max millis. The Backoff logic
     // adds some random variability to the exact elapsed time, so add in a bit of wiggle room.
@@ -173,8 +169,6 @@ public class RefreshingOAuth2CredentialsInterceptorTest {
   public void testNullExpiration(){
     setTimeInMillieconds(100);
     HeaderCacheElement element = new HeaderCacheElement(new AccessToken("", null));
-    Assert.assertNull(element.expiresTimeMs);
-    Assert.assertNull(element.staleTimeMs);
     Assert.assertEquals(CacheState.Good, element.getCacheState());
 
     // Make sure that the header doesn't expire in the distant future.
@@ -230,14 +224,12 @@ public class RefreshingOAuth2CredentialsInterceptorTest {
 
     // At this point, the access token wasn't retrieved yet. The
     // RefreshingOAuth2CredentialsInterceptor considers null to be Expired.
-    Assert.assertEquals(CacheState.Expired,
-      RefreshingOAuth2CredentialsInterceptor.getCacheState(underTest.headerCache.get()));
+    Assert.assertEquals(CacheState.Expired, underTest.headerCache.get().getCacheState());
 
     syncCall(lock, syncRefreshCallable);
 
     // Check to make sure that the AccessToken was retrieved.
-    Assert.assertEquals(CacheState.Stale,
-      RefreshingOAuth2CredentialsInterceptor.getCacheState(underTest.headerCache.get()));
+    Assert.assertEquals(CacheState.Stale, underTest.headerCache.get().getCacheState());
 
     // Check to make sure we're no longer refreshing.
     Assert.assertFalse(underTest.isRefreshing.get());

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptorTest.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptorTest.java
@@ -284,6 +284,6 @@ public class RefreshingOAuth2CredentialsInterceptorTest {
       new AccessToken("", new Date(expiration)));
     underTest = new RefreshingOAuth2CredentialsInterceptor(executorService, credentials,
         retryOptions, logger);
-    Assert.assertTrue(underTest.doRefresh());
+    underTest.syncRefresh();
   }
 }

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptorTest.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptorTest.java
@@ -18,7 +18,6 @@ package com.google.cloud.bigtable.grpc.io;
 import com.google.api.client.util.Clock;
 import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.OAuth2Credentials;
-import com.google.cloud.bigtable.config.Logger;
 import com.google.cloud.bigtable.grpc.io.RefreshingOAuth2CredentialsInterceptor.CacheState;
 import com.google.cloud.bigtable.grpc.io.RefreshingOAuth2CredentialsInterceptor.HeaderCacheElement;
 import java.io.IOException;
@@ -64,9 +63,6 @@ public class RefreshingOAuth2CredentialsInterceptorTest {
 
   @Mock
   private OAuth2Credentials credentials;
-
-  @Mock
-  private Logger logger;
 
   @Before
   public void setupMocks() {
@@ -157,7 +153,7 @@ public class RefreshingOAuth2CredentialsInterceptorTest {
     };
 
     underTest =
-        new RefreshingOAuth2CredentialsInterceptor(executorService, credentials, logger);
+        new RefreshingOAuth2CredentialsInterceptor(executorService, credentials);
     underTest.rateLimiter.setRate(10);
 
     // At this point, the access token wasn't retrieved yet. The
@@ -212,7 +208,7 @@ public class RefreshingOAuth2CredentialsInterceptorTest {
   private void initialize(long expiration) throws IOException {
     Mockito.when(credentials.refreshAccessToken()).thenReturn(
       new AccessToken("", new Date(expiration)));
-    underTest = new RefreshingOAuth2CredentialsInterceptor(executorService, credentials, logger);
+    underTest = new RefreshingOAuth2CredentialsInterceptor(executorService, credentials);
     underTest.syncRefresh();
   }
 }


### PR DESCRIPTION
Still a work in progress, just requesting feedback.  The major change here is that authentication retries are now handled by the general retry mechanism. This was a necessary change to be able to handle tokens that were revoked before their expiration. 

* bubble retries to RetryingListener
* run all token refreshes in a background thread (even appengine)
* cimplify OAuth interceptor by using futures & avoiding throwing exceptions
* handle tokens that were revoked serverside
