### PR TITLE
Auth refactor 1: minor

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptor.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptor.java
@@ -194,11 +194,8 @@ public class RefreshingOAuth2CredentialsInterceptor implements ClientInterceptor
     this.retryOptions = Preconditions.checkNotNull(retryOptions);
     this.logger = Preconditions.checkNotNull(logger);
 
-    // com.google.auth.oauth2.AppEngineCredentials is package private, so we don't have direct
-    // visibility to it. This is a way to detect that this application runs on App Engine so that
-    // we can always get credentials synchronously, which must be done for AppEngineCredentials
-    // which relies on a ThreadLocal.
-    this.isAppEngine = credentials.getClass().getName().contains("AppEngineCredentials");
+    // From MoreExecutors
+    this.isAppEngine = System.getProperty("com.google.appengine.runtime.environment") != null;
   }
 
   /**

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptor.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptor.java
@@ -120,7 +120,7 @@ public class RefreshingOAuth2CredentialsInterceptor implements ClientInterceptor
     @Nullable
     final Long expiresTimeMs;
 
-    public HeaderCacheElement(AccessToken token) {
+    HeaderCacheElement(AccessToken token) {
       this.exception = null;
       this.header = "Bearer " + token.getTokenValue();
       Date expirationTime = token.getExpirationTime();
@@ -136,14 +136,14 @@ public class RefreshingOAuth2CredentialsInterceptor implements ClientInterceptor
       }
     }
 
-    public HeaderCacheElement(IOException exception) {
+    HeaderCacheElement(IOException exception) {
       this.exception = exception;
       this.header = null;
       this.staleTimeMs = null;
       this.expiresTimeMs = null;
     }
 
-    public CacheState getCacheState() {
+    CacheState getCacheState() {
       if (exception != null) {
         return CacheState.Exception;
       }
@@ -252,7 +252,7 @@ public class RefreshingOAuth2CredentialsInterceptor implements ClientInterceptor
    *
    * @throws java.io.IOException if any.
    */
-  public void syncRefresh() throws IOException {
+  void syncRefresh() throws IOException {
     synchronized (isRefreshing) {
       if (!isRefreshing.get()) {
         doRefresh();
@@ -276,7 +276,7 @@ public class RefreshingOAuth2CredentialsInterceptor implements ClientInterceptor
    * running asynchronously. In the App Engine case, this method will defer to
    * {@link #syncRefresh()}.
    */
-  public void asyncRefresh() throws IOException {
+  void asyncRefresh() throws IOException {
     if (isAppEngine) {
       syncRefresh();
     } else if (canRefresh()) {
@@ -355,7 +355,7 @@ public class RefreshingOAuth2CredentialsInterceptor implements ClientInterceptor
    *
    * @return HeaderCacheElement containing either a valid {@link com.google.auth.oauth2.AccessToken} or an exception.
    */
-  protected HeaderCacheElement refreshCredentialsWithRetry() {
+  HeaderCacheElement refreshCredentialsWithRetry() {
     final BackOff backoff = retryOptions.createBackoff();
 
     while (true) {
@@ -386,7 +386,7 @@ public class RefreshingOAuth2CredentialsInterceptor implements ClientInterceptor
    * @param backoff a {@link com.google.api.client.util.BackOff} object.
    * @return RetryState indicating the current state of the retry logic.
    */
-  protected RetryState getRetryState(BackOff backoff) {
+  RetryState getRetryState(BackOff backoff) {
     final long nextBackOffMillis;
     try {
       nextBackOffMillis = backoff.nextBackOffMillis();

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptor.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptor.java
@@ -158,21 +158,22 @@ public class RefreshingOAuth2CredentialsInterceptor implements ClientInterceptor
     }
   }
 
+  private final Logger logger;
+  private final ExecutorService executor;
+  @VisibleForTesting
+  Sleeper sleeper = Sleeper.DEFAULT;
+
+  private final RetryOptions retryOptions;
+  private final boolean isAppEngine;
+
+  private final OAuth2Credentials credentials;
+
   @VisibleForTesting
   final AtomicReference<HeaderCacheElement> headerCache = new AtomicReference<>();
 
   @VisibleForTesting
   final AtomicBoolean isRefreshing = new AtomicBoolean(false);
-
-  @VisibleForTesting
-  Sleeper sleeper = Sleeper.DEFAULT;
-
-  private final ExecutorService executor;
-  private final RetryOptions retryOptions;
-  private final Logger logger;
-  private final boolean isAppEngine;
-
-  private final OAuth2Credentials credentials;
+  
 
   /**
    * <p>Constructor for RefreshingOAuth2CredentialsInterceptor.</p>

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptor.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptor.java
@@ -272,7 +272,9 @@ public class RefreshingOAuth2CredentialsInterceptor implements ClientInterceptor
   }
 
   private boolean canRefresh() {
-    return !isRefreshing && getCacheState(this.headerCache.get()) != CacheState.Good;
+    synchronized (lock) {
+      return !isRefreshing && getCacheState(this.headerCache.get()) != CacheState.Good;
+    }
   }
 
   private static StatusRuntimeException asUnauthenticatedException(Exception e) {

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptor.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptor.java
@@ -85,6 +85,8 @@ public class RefreshingOAuth2CredentialsInterceptor implements ClientInterceptor
   @VisibleForTesting
   static Clock clock = Clock.SYSTEM;
 
+  // From MoreExecutors
+  private static final boolean isAppEngine = System.getProperty("com.google.appengine.runtime.environment") != null;
 
   @VisibleForTesting
   static class HeaderCacheElement {
@@ -143,7 +145,6 @@ public class RefreshingOAuth2CredentialsInterceptor implements ClientInterceptor
   Sleeper sleeper = Sleeper.DEFAULT;
 
   private final RetryOptions retryOptions;
-  private final boolean isAppEngine;
 
   private final OAuth2Credentials credentials;
 
@@ -178,9 +179,6 @@ public class RefreshingOAuth2CredentialsInterceptor implements ClientInterceptor
     this.credentials = Preconditions.checkNotNull(credentials);
     this.retryOptions = Preconditions.checkNotNull(retryOptions);
     this.logger = Preconditions.checkNotNull(logger);
-
-    // From MoreExecutors
-    this.isAppEngine = System.getProperty("com.google.appengine.runtime.environment") != null;
   }
 
   /**

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptorTest.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptorTest.java
@@ -237,7 +237,7 @@ public class RefreshingOAuth2CredentialsInterceptorTest {
         RefreshingOAuth2CredentialsInterceptor.getCacheState(underTest.headerCache.get()));
 
     // Check to make sure we're no longer refreshing.
-    Assert.assertFalse(underTest.isRefreshing.get());
+    Assert.assertFalse(underTest.isRefreshing);
 
     // Kick off a couple of asynchronous refreshes. Kicking off more than one shouldn't be
     // necessary, but also should not be harmful, since there are likely to be multiple concurrent
@@ -247,7 +247,7 @@ public class RefreshingOAuth2CredentialsInterceptorTest {
     underTest.asyncRefresh();
 
     syncCall(lock, syncRefreshCallable);
-    Assert.assertFalse(underTest.isRefreshing.get());
+    Assert.assertFalse(underTest.isRefreshing);
   }
 
   private void syncCall(final Object lock, Callable<Void> syncRefreshCallable)
@@ -264,7 +264,7 @@ public class RefreshingOAuth2CredentialsInterceptorTest {
     // actually doing a refresh at this point; the other ones will have see that a refresh is in
     // progress and finish the invocation of the Thread without performing a refres().. Make sure
     // that at least 1 refresh process is in progress.
-    Assert.assertTrue(underTest.isRefreshing.get());
+    Assert.assertTrue(underTest.isRefreshing);
 
     synchronized (lock) {
       lock.notifyAll();

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptorTest.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptorTest.java
@@ -54,7 +54,6 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 
-
 @RunWith(JUnit4.class)
 public class RefreshingOAuth2CredentialsInterceptorTest {
 
@@ -113,7 +112,7 @@ public class RefreshingOAuth2CredentialsInterceptorTest {
   public void testSyncRefresh() throws IOException {
     initialize(HeaderCacheElement.TOKEN_STALENESS_MS + 1);
     Assert.assertEquals(CacheState.Good,
-      RefreshingOAuth2CredentialsInterceptor.getCacheState(underTest.headerCache.get()));
+        RefreshingOAuth2CredentialsInterceptor.getCacheState(underTest.headerCache.get()));
   }
 
   @Test
@@ -121,16 +120,16 @@ public class RefreshingOAuth2CredentialsInterceptorTest {
     int expiration = HeaderCacheElement.TOKEN_STALENESS_MS + 1;
     initialize(expiration);
     Assert.assertEquals(CacheState.Good,
-      RefreshingOAuth2CredentialsInterceptor.getCacheState(underTest.headerCache.get()));
+        RefreshingOAuth2CredentialsInterceptor.getCacheState(underTest.headerCache.get()));
     long startTime = 2L;
     setTimeInMillieconds(startTime);
     Assert.assertEquals(CacheState.Stale,
-      RefreshingOAuth2CredentialsInterceptor.getCacheState(underTest.headerCache.get()));
+        RefreshingOAuth2CredentialsInterceptor.getCacheState(underTest.headerCache.get()));
     long expiredStaleDiff =
         HeaderCacheElement.TOKEN_STALENESS_MS - HeaderCacheElement.TOKEN_EXPIRES_MS;
     setTimeInMillieconds(startTime + expiredStaleDiff);
     Assert.assertEquals(CacheState.Expired,
-      RefreshingOAuth2CredentialsInterceptor.getCacheState(underTest.headerCache.get()));
+        RefreshingOAuth2CredentialsInterceptor.getCacheState(underTest.headerCache.get()));
   }
 
   @Test
@@ -170,7 +169,7 @@ public class RefreshingOAuth2CredentialsInterceptorTest {
   }
 
   @Test
-  public void testNullExpiration(){
+  public void testNullExpiration() {
     setTimeInMillieconds(100);
     HeaderCacheElement element = new HeaderCacheElement(new AccessToken("", null));
     Assert.assertNull(element.expiresTimeMs);
@@ -231,13 +230,13 @@ public class RefreshingOAuth2CredentialsInterceptorTest {
     // At this point, the access token wasn't retrieved yet. The
     // RefreshingOAuth2CredentialsInterceptor considers null to be Expired.
     Assert.assertEquals(CacheState.Expired,
-      RefreshingOAuth2CredentialsInterceptor.getCacheState(underTest.headerCache.get()));
+        RefreshingOAuth2CredentialsInterceptor.getCacheState(underTest.headerCache.get()));
 
     syncCall(lock, syncRefreshCallable);
 
     // Check to make sure that the AccessToken was retrieved.
     Assert.assertEquals(CacheState.Stale,
-      RefreshingOAuth2CredentialsInterceptor.getCacheState(underTest.headerCache.get()));
+        RefreshingOAuth2CredentialsInterceptor.getCacheState(underTest.headerCache.get()));
 
     // Check to make sure we're no longer refreshing.
     Assert.assertFalse(underTest.isRefreshing.get());
@@ -269,7 +268,7 @@ public class RefreshingOAuth2CredentialsInterceptorTest {
     // that at least 1 refresh process is in progress.
     Assert.assertTrue(underTest.isRefreshing.get());
 
-    synchronized(lock) {
+    synchronized (lock) {
       lock.notifyAll();
     }
 
@@ -281,7 +280,7 @@ public class RefreshingOAuth2CredentialsInterceptorTest {
 
   private void initialize(long expiration) throws IOException {
     Mockito.when(credentials.refreshAccessToken()).thenReturn(
-      new AccessToken("", new Date(expiration)));
+        new AccessToken("", new Date(expiration)));
     underTest = new RefreshingOAuth2CredentialsInterceptor(executorService, credentials,
         retryOptions, logger);
     Assert.assertTrue(underTest.doRefresh());

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptorTest.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptorTest.java
@@ -172,8 +172,6 @@ public class RefreshingOAuth2CredentialsInterceptorTest {
   public void testNullExpiration() {
     setTimeInMillieconds(100);
     HeaderCacheElement element = new HeaderCacheElement(new AccessToken("", null));
-    Assert.assertNull(element.expiresTimeMs);
-    Assert.assertNull(element.staleTimeMs);
     Assert.assertEquals(CacheState.Good, element.getCacheState());
 
     // Make sure that the header doesn't expire in the distant future.


### PR DESCRIPTION
This part 1 of the #1285. This should have no behavioral changes.

* Only store real expiration time in HeaderCacheElement & compute derived
* use explicit lock object & refresh flag instead of AtomicBoolean
* rearrange method order to make it easier to read the class top down
* update visibility
* reformat code