### PR TITLE
Auth refactor 2: futures

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptor.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptor.java
@@ -256,6 +256,7 @@ public class RefreshingOAuth2CredentialsInterceptor implements ClientInterceptor
 
       switch (state) {
         case Good:
+        case Exception:
           return headerCache;
         case Stale:
           asyncRefresh();
@@ -264,12 +265,6 @@ public class RefreshingOAuth2CredentialsInterceptor implements ClientInterceptor
           // defer the future resolution (asyncRefresh will spin up a thread that will try to acquire the lock)
           deferredResult = asyncRefresh();
           break;
-        case Exception:
-          // If we aren't on appengine, try a background refresh in case of failure
-          if (!isAppEngine) {
-            asyncRefresh();
-          }
-          return headerCache;
         default:
           return new HeaderCacheElement(
               Status.UNAUTHENTICATED

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptor.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptor.java
@@ -39,6 +39,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import javax.annotation.concurrent.GuardedBy;
 
 /**
@@ -230,7 +231,7 @@ public class RefreshingOAuth2CredentialsInterceptor implements ClientInterceptor
   /**
    * Get the http credential header we need from a new oauth2 AccessToken.
    */
-  private HeaderCacheElement getHeader() throws ExecutionException, InterruptedException {
+  private HeaderCacheElement getHeader() throws ExecutionException, InterruptedException, TimeoutException {
     final Future<HeaderCacheElement> deferredResult;
 
     synchronized (lock) {
@@ -256,7 +257,7 @@ public class RefreshingOAuth2CredentialsInterceptor implements ClientInterceptor
         );
       }
     }
-    return deferredResult.get();
+    return deferredResult.get(250, TimeUnit.MILLISECONDS);
   }
 
   /**

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptor.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptor.java
@@ -170,8 +170,9 @@ public class RefreshingOAuth2CredentialsInterceptor implements ClientInterceptor
   @GuardedBy("lock")
   boolean isRefreshing = false;
 
+  @VisibleForTesting
   @GuardedBy("lock")
-  private Future<HeaderCacheElement> futureToken = null;
+  Future<HeaderCacheElement> futureToken = null;
 
 
   /**
@@ -217,7 +218,8 @@ public class RefreshingOAuth2CredentialsInterceptor implements ClientInterceptor
     };
   }
 
-  private HeaderCacheElement getHeaderSafe() {
+  @VisibleForTesting
+  HeaderCacheElement getHeaderSafe() {
     try {
       return getHeader();
     } catch (Exception e) {
@@ -232,7 +234,10 @@ public class RefreshingOAuth2CredentialsInterceptor implements ClientInterceptor
   /**
    * Get the http credential header we need from a new oauth2 AccessToken.
    */
-  private HeaderCacheElement getHeader() throws ExecutionException, InterruptedException, TimeoutException {
+  @VisibleForTesting
+  HeaderCacheElement getHeader() throws ExecutionException, InterruptedException, TimeoutException {
+    LOG.info("Getting header");
+
     final Future<HeaderCacheElement> deferredResult;
 
     // Optimize for the common case: do a volatile read to peek for a Good cache value

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptor.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptor.java
@@ -77,7 +77,7 @@ public class RefreshingOAuth2CredentialsInterceptor implements ClientInterceptor
   }
 
   enum RetryState {
-    PerformRetry, RetriesExhausted, Interrupted
+    PerformRetry, RetriesExhausted, Interrupted, Error
   }
 
   private static final Logger LOG = new Logger(RefreshingOAuth2CredentialsInterceptor.class);
@@ -394,7 +394,8 @@ public class RefreshingOAuth2CredentialsInterceptor implements ClientInterceptor
       nextBackOffMillis = backoff.nextBackOffMillis();
     } catch (IOException e) {
       // Should never happen since we use an ExponentialBackoff
-      throw Throwables.propagate(e);
+      logger.error("Unexpected error while getting next back time", e);
+      return RetryState.Error;
     }
     if (nextBackOffMillis == BackOff.STOP) {
       logger.warn("Exhausted the number of retries for credentials refresh after "

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptor.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptor.java
@@ -249,7 +249,7 @@ public class RefreshingOAuth2CredentialsInterceptor implements ClientInterceptor
         state = CacheState.Good;
       }
 
-      if (state == CacheState.Good || state == CacheState.Exception) {
+      if (state == CacheState.Good) {
         return headerCache;
       } else if (state == CacheState.Stale) {
         asyncRefresh();
@@ -257,6 +257,12 @@ public class RefreshingOAuth2CredentialsInterceptor implements ClientInterceptor
       } else if (state == CacheState.Expired) {
         // defer the future resolution (asyncRefresh will spin up a thread that will try to acquire the lock)
         deferredResult = asyncRefresh();
+      } else if (state == CacheState.Exception) {
+        // If we aren't on appengine, try a background refresh in case of failure
+        if (!isAppEngine) {
+          asyncRefresh();
+        }
+        return headerCache;
       } else {
         return new HeaderCacheElement(
             Status.UNAUTHENTICATED

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptor.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptor.java
@@ -236,8 +236,6 @@ public class RefreshingOAuth2CredentialsInterceptor implements ClientInterceptor
    */
   @VisibleForTesting
   HeaderCacheElement getHeader() throws ExecutionException, InterruptedException, TimeoutException {
-    LOG.info("Getting header");
-
     final Future<HeaderCacheElement> deferredResult;
 
     // Optimize for the common case: do a volatile read to peek for a Good cache value

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptor.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptor.java
@@ -87,9 +87,6 @@ public class RefreshingOAuth2CredentialsInterceptor implements ClientInterceptor
   @VisibleForTesting
   static Clock clock = Clock.SYSTEM;
 
-  // From MoreExecutors
-  private static final boolean isAppEngine = System.getProperty("com.google.appengine.runtime.environment") != null;
-
   @VisibleForTesting
   static class HeaderCacheElement {
 
@@ -244,13 +241,9 @@ public class RefreshingOAuth2CredentialsInterceptor implements ClientInterceptor
       return headerCacheUnsync;
     }
 
+    // TODO(igorbernstein2): figure out how to make this work with appengine request scoped threads
     synchronized (lock) {
       CacheState state = headerCache.getCacheState();
-
-      // AppEngine doesn't allow threads to outlive the request, so disable background refresh
-      if (isAppEngine && state == CacheState.Stale) {
-        state = CacheState.Good;
-      }
 
       switch (state) {
         case Good:

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptor.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptor.java
@@ -256,12 +256,12 @@ public class RefreshingOAuth2CredentialsInterceptor implements ClientInterceptor
 
       switch (state) {
         case Good:
-        case Exception:
           return headerCache;
         case Stale:
           asyncRefresh();
           return headerCache;
         case Expired:
+        case Exception:
           // defer the future resolution (asyncRefresh will spin up a thread that will try to acquire the lock)
           deferredResult = asyncRefresh();
           break;

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptorTest.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptorTest.java
@@ -31,6 +31,7 @@ import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.OAuth2Credentials;
 import com.google.cloud.bigtable.config.Logger;
 import com.google.cloud.bigtable.config.RetryOptions;
+import com.google.cloud.bigtable.config.RetryOptions.Builder;
 import com.google.cloud.bigtable.config.RetryOptionsUtil;
 import com.google.cloud.bigtable.grpc.io.RefreshingOAuth2CredentialsInterceptor.CacheState;
 import com.google.cloud.bigtable.grpc.io.RefreshingOAuth2CredentialsInterceptor.HeaderCacheElement;
@@ -182,8 +183,13 @@ public class RefreshingOAuth2CredentialsInterceptorTest {
 
   @Test
   public void testRefreshAfterFailure() throws Exception {
+    RetryOptions disabledRetryOptions = new Builder()
+        .setEnableRetries(false)
+        .setMaxElapsedBackoffMillis(0)
+        .build();
+
     underTest = new RefreshingOAuth2CredentialsInterceptor(executorService, credentials,
-        retryOptions, logger);
+        disabledRetryOptions, logger);
 
     final AccessToken accessToken = new AccessToken("hi", new Date(HeaderCacheElement.TOKEN_STALENESS_MS + 1));
 
@@ -210,7 +216,7 @@ public class RefreshingOAuth2CredentialsInterceptorTest {
   @Test
   public void testRefreshAfterStale() throws Exception {
     underTest = new RefreshingOAuth2CredentialsInterceptor(executorService, credentials,
-        retryOptions, logger);
+        retryOptions);
 
     final AccessToken staleToken = new AccessToken("stale", new Date(HeaderCacheElement.TOKEN_STALENESS_MS + 1));
     AccessToken goodToken = new AccessToken("good", new Date(HeaderCacheElement.TOKEN_STALENESS_MS + 11));

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptorTest.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptorTest.java
@@ -189,7 +189,7 @@ public class RefreshingOAuth2CredentialsInterceptorTest {
         .build();
 
     underTest = new RefreshingOAuth2CredentialsInterceptor(executorService, credentials,
-        disabledRetryOptions, logger);
+        disabledRetryOptions);
 
     final AccessToken accessToken = new AccessToken("hi", new Date(HeaderCacheElement.TOKEN_STALENESS_MS + 1));
 
@@ -302,7 +302,7 @@ public class RefreshingOAuth2CredentialsInterceptorTest {
 
     underTest =
         new RefreshingOAuth2CredentialsInterceptor(executorService, credentials,
-            new RetryOptions.Builder().build(), logger);
+            new RetryOptions.Builder().build());
 
     // At this point, the access token wasn't retrieved yet. The
     // RefreshingOAuth2CredentialsInterceptor considers null to be Expired.

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptorTest.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptorTest.java
@@ -112,7 +112,7 @@ public class RefreshingOAuth2CredentialsInterceptorTest {
   public void testSyncRefresh() throws IOException {
     initialize(HeaderCacheElement.TOKEN_STALENESS_MS + 1);
     Assert.assertEquals(CacheState.Good,
-        RefreshingOAuth2CredentialsInterceptor.getCacheState(underTest.headerCache.get()));
+        RefreshingOAuth2CredentialsInterceptor.getCacheState(underTest.headerCache));
   }
 
   @Test
@@ -120,16 +120,16 @@ public class RefreshingOAuth2CredentialsInterceptorTest {
     int expiration = HeaderCacheElement.TOKEN_STALENESS_MS + 1;
     initialize(expiration);
     Assert.assertEquals(CacheState.Good,
-        RefreshingOAuth2CredentialsInterceptor.getCacheState(underTest.headerCache.get()));
+        RefreshingOAuth2CredentialsInterceptor.getCacheState(underTest.headerCache));
     long startTime = 2L;
     setTimeInMillieconds(startTime);
     Assert.assertEquals(CacheState.Stale,
-        RefreshingOAuth2CredentialsInterceptor.getCacheState(underTest.headerCache.get()));
+        RefreshingOAuth2CredentialsInterceptor.getCacheState(underTest.headerCache));
     long expiredStaleDiff =
         HeaderCacheElement.TOKEN_STALENESS_MS - HeaderCacheElement.TOKEN_EXPIRES_MS;
     setTimeInMillieconds(startTime + expiredStaleDiff);
     Assert.assertEquals(CacheState.Expired,
-        RefreshingOAuth2CredentialsInterceptor.getCacheState(underTest.headerCache.get()));
+        RefreshingOAuth2CredentialsInterceptor.getCacheState(underTest.headerCache));
   }
 
   @Test
@@ -228,13 +228,13 @@ public class RefreshingOAuth2CredentialsInterceptorTest {
     // At this point, the access token wasn't retrieved yet. The
     // RefreshingOAuth2CredentialsInterceptor considers null to be Expired.
     Assert.assertEquals(CacheState.Expired,
-        RefreshingOAuth2CredentialsInterceptor.getCacheState(underTest.headerCache.get()));
+        RefreshingOAuth2CredentialsInterceptor.getCacheState(underTest.headerCache));
 
     syncCall(lock, syncRefreshCallable);
 
     // Check to make sure that the AccessToken was retrieved.
     Assert.assertEquals(CacheState.Stale,
-        RefreshingOAuth2CredentialsInterceptor.getCacheState(underTest.headerCache.get()));
+        RefreshingOAuth2CredentialsInterceptor.getCacheState(underTest.headerCache));
 
     // Check to make sure we're no longer refreshing.
     Assert.assertFalse(underTest.isRefreshing);
@@ -281,6 +281,6 @@ public class RefreshingOAuth2CredentialsInterceptorTest {
         new AccessToken("", new Date(expiration)));
     underTest = new RefreshingOAuth2CredentialsInterceptor(executorService, credentials,
         retryOptions, logger);
-    Assert.assertTrue(underTest.doRefresh());
+    underTest.syncRefresh();
   }
 }

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptorTest.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptorTest.java
@@ -111,25 +111,21 @@ public class RefreshingOAuth2CredentialsInterceptorTest {
   @Test
   public void testSyncRefresh() throws IOException {
     initialize(HeaderCacheElement.TOKEN_STALENESS_MS + 1);
-    Assert.assertEquals(CacheState.Good,
-        RefreshingOAuth2CredentialsInterceptor.getCacheState(underTest.headerCache));
+    Assert.assertEquals(CacheState.Good, underTest.headerCache.getCacheState());
   }
 
   @Test
   public void testStaleAndExpired() throws IOException {
     int expiration = HeaderCacheElement.TOKEN_STALENESS_MS + 1;
     initialize(expiration);
-    Assert.assertEquals(CacheState.Good,
-        RefreshingOAuth2CredentialsInterceptor.getCacheState(underTest.headerCache));
+    Assert.assertEquals(CacheState.Good, underTest.headerCache.getCacheState());
     long startTime = 2L;
     setTimeInMillieconds(startTime);
-    Assert.assertEquals(CacheState.Stale,
-        RefreshingOAuth2CredentialsInterceptor.getCacheState(underTest.headerCache));
+    Assert.assertEquals(CacheState.Stale, underTest.headerCache.getCacheState());
     long expiredStaleDiff =
         HeaderCacheElement.TOKEN_STALENESS_MS - HeaderCacheElement.TOKEN_EXPIRES_MS;
     setTimeInMillieconds(startTime + expiredStaleDiff);
-    Assert.assertEquals(CacheState.Expired,
-        RefreshingOAuth2CredentialsInterceptor.getCacheState(underTest.headerCache));
+    Assert.assertEquals(CacheState.Expired, underTest.headerCache.getCacheState());
   }
 
   @Test
@@ -157,7 +153,7 @@ public class RefreshingOAuth2CredentialsInterceptorTest {
     HeaderCacheElement header = underTest.refreshCredentialsWithRetry();
 
     Assert.assertNull(header.header);
-    Assert.assertSame(ioException, header.exception);
+    Assert.assertSame(ioException, header.status.getCause());
 
     // Make sure that the system "slept" for more than the retryOption max millis. The Backoff logic
     // adds some random variability to the exact elapsed time, so add in a bit of wiggle room.
@@ -227,14 +223,12 @@ public class RefreshingOAuth2CredentialsInterceptorTest {
 
     // At this point, the access token wasn't retrieved yet. The
     // RefreshingOAuth2CredentialsInterceptor considers null to be Expired.
-    Assert.assertEquals(CacheState.Expired,
-        RefreshingOAuth2CredentialsInterceptor.getCacheState(underTest.headerCache));
+    Assert.assertEquals(CacheState.Expired, underTest.headerCache.getCacheState());
 
     syncCall(lock, syncRefreshCallable);
 
     // Check to make sure that the AccessToken was retrieved.
-    Assert.assertEquals(CacheState.Stale,
-        RefreshingOAuth2CredentialsInterceptor.getCacheState(underTest.headerCache));
+    Assert.assertEquals(CacheState.Stale, underTest.headerCache.getCacheState());
 
     // Check to make sure we're no longer refreshing.
     Assert.assertFalse(underTest.isRefreshing);


### PR DESCRIPTION
This PR depends on #1290 and includes it. See here for actual differences:
https://github.com/igorbernstein2/cloud-bigtable-client/compare/auth-refactor-minor...igorbernstein2:auth-refactor-futures?expand=0

This PR uses Futures to manage background auth refreshes & uses grpc statuses instead of exceptions to communicate failure