### PR TITLE
Using a default of 5 seconds for initial backoff in DF.

### DIFF
--- a/bigtable-dataflow-parent/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/CloudBigtableConfiguration.java
+++ b/bigtable-dataflow-parent/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/CloudBigtableConfiguration.java
@@ -20,6 +20,7 @@ import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 import java.util.Map.Entry;
 
 import org.apache.hadoop.conf.Configuration;
@@ -254,9 +255,16 @@ public class CloudBigtableConfiguration implements Serializable {
     Configuration config = new Configuration(false);
 
     config.set(BigtableOptionsFactory.BIGTABLE_USE_CACHED_DATA_CHANNEL_POOL, "true");
+
     // Dataflow should use a different endpoint for data operations than online traffic.
     config.set(BigtableOptionsFactory.BIGTABLE_HOST_KEY,
       BigtableOptions.BIGTABLE_BATCH_DATA_HOST_DEFAULT);
+
+    config.set(BigtableOptionsFactory.INITIAL_ELAPSED_BACKOFF_MILLIS_KEY,
+      String.valueOf(TimeUnit.SECONDS.toMillis(5)));
+
+    config.set(BigtableOptionsFactory.MAX_ELAPSED_BACKOFF_MILLIS_KEY,
+      String.valueOf(TimeUnit.MINUTES.toMillis(5)));
 
     // This setting can potentially decrease performance for large scale writes. However, this
     // setting prevents problems that occur when streaming Sources, such as PubSub, are used.

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableOptionsFactory.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableOptionsFactory.java
@@ -41,7 +41,6 @@ import com.google.common.base.Strings;
 import io.grpc.Status;
 
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.util.VersionInfo;
 
 import java.io.FileInputStream;
@@ -148,6 +147,14 @@ public class BigtableOptionsFactory {
    */
   public static final String ENABLE_GRPC_RETRY_DEADLINEEXCEEDED_KEY =
       "google.bigtable.grpc.retry.deadlineexceeded.enable";
+
+  /**
+   * Key to set the initial amount of time to wait for retries, given a backoff policy on errors.
+   * This flag is used only when grpc retries is enabled.
+   */
+  public static final String INITIAL_ELAPSED_BACKOFF_MILLIS_KEY =
+      "google.bigtable.grpc.retry.initial.elapsed.backoff.ms";
+
   /**
    * Key to set the maximum amount of time to wait for retries, given a backoff policy on errors.
    * This flag is used only when grpc retries is enabled.
@@ -444,6 +451,12 @@ public class BigtableOptionsFactory {
         configuration.getBoolean(ENABLE_GRPC_RETRY_DEADLINEEXCEEDED_KEY, true);
     LOG.debug("gRPC retry on deadline exceeded enabled: %s", retryOnDeadlineExceeded);
     retryOptionsBuilder.setRetryOnDeadlineExceeded(retryOnDeadlineExceeded);
+
+    int initialElapsedBackoffMillis = configuration.getInt(
+      INITIAL_ELAPSED_BACKOFF_MILLIS_KEY,
+      RetryOptions.DEFAULT_INITIAL_BACKOFF_MILLIS);
+    LOG.debug("gRPC retry initialElapsedBackoffMillis: %d", initialElapsedBackoffMillis);
+    retryOptionsBuilder.setInitialBackoffMillis(initialElapsedBackoffMillis);
 
     int maxElapsedBackoffMillis = configuration.getInt(
         MAX_ELAPSED_BACKOFF_MILLIS_KEY,


### PR DESCRIPTION
Dataflow (or other batch systems) should have a different wetry behavior than online systems.  Dataflow can push hard on a Cloud Bigtable instance.  In cases where there's a failure, it's better to aggressively back off and let the instance stabilize.  Waiting 5 seconds for the first retry seems to be more appropriate than 5 milliseconds in those cases.  Also, Dataflow jobs run longer, so the max retry per operation can also be extended so that Dataflow's behavior of retrying the entire bundle is is less likely to kick in.