### PR TITLE
Remove ImmutableList from BigtableDataClient's API surface

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataClient.java
@@ -32,7 +32,6 @@ import com.google.bigtable.v2.SampleRowKeysResponse;
 import com.google.cloud.bigtable.grpc.scanner.FlatRow;
 import com.google.cloud.bigtable.grpc.scanner.ResultScanner;
 import com.google.cloud.bigtable.grpc.scanner.ScanHandler;
-import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
 
 import io.grpc.stub.StreamObserver;
@@ -119,9 +118,9 @@ public interface BigtableDataClient {
    * Sample row keys from a table.
    *
    * @param request a {@link com.google.bigtable.v2.SampleRowKeysRequest} object.
-   * @return a {@link com.google.common.collect.ImmutableList} object.
+   * @return an immutable {@link List} object.
    */
-  ImmutableList<SampleRowKeysResponse> sampleRowKeys(SampleRowKeysRequest request);
+  List<SampleRowKeysResponse> sampleRowKeys(SampleRowKeysRequest request);
 
   /**
    * Sample row keys from a table, returning a Future that will complete when the sampling has

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableRegionLocator.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableRegionLocator.java
@@ -32,7 +32,6 @@ import com.google.cloud.bigtable.config.Logger;
 import com.google.cloud.bigtable.grpc.BigtableDataClient;
 import com.google.cloud.bigtable.grpc.BigtableTableName;
 import com.google.cloud.bigtable.hbase.adapters.SampledRowKeysAdapter;
-import com.google.common.collect.ImmutableList;
 
 /**
  * <p>BigtableRegionLocator class.</p>
@@ -85,7 +84,7 @@ public class BigtableRegionLocator implements RegionLocator {
     LOG.debug("Sampling rowkeys for table %s", request.getTableName());
 
     try {
-      ImmutableList<SampleRowKeysResponse> responses = client.sampleRowKeys(request.build());
+      List<SampleRowKeysResponse> responses = client.sampleRowKeys(request.build());
       regions = adapter.adaptResponse(responses);
       regionsFetchTimeMillis = System.currentTimeMillis();
       return regions;


### PR DESCRIPTION
This will let Apache Beam shade Guava without shading and bundling Bigtable.
Otherwise, we get a method not found error for something like
"method BigtableDataClient.. that returns a org.apache.beam...shaded...ImmutableList".