### PR TITLE
Moving ScanIterator to batch/common.

### DIFF
--- a/bigtable-dataflow-parent/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/batch/common/CloudBigtableServiceImpl.java
+++ b/bigtable-dataflow-parent/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/batch/common/CloudBigtableServiceImpl.java
@@ -20,19 +20,17 @@ import com.google.bigtable.repackaged.com.google.cloud.grpc.BigtableSession;
 import com.google.bigtable.repackaged.com.google.cloud.grpc.BigtableTableName;
 import com.google.bigtable.repackaged.com.google.com.google.bigtable.v2.SampleRowKeysRequest;
 import com.google.bigtable.repackaged.com.google.com.google.bigtable.v2.SampleRowKeysResponse;
-import com.google.cloud.bigtable.dataflow.CloudBigtableTableConfiguration;
 import java.io.IOException;
 import java.util.List;
 
 public class CloudBigtableServiceImpl implements CloudBigtableService {
 
   @Override
-  public List<SampleRowKeysResponse> getSampleRowKeys(CloudBigtableTableConfiguration config)
-      throws IOException {
-    BigtableOptions bigtableOptions = config.toBigtableOptions();
+  public List<SampleRowKeysResponse> getSampleRowKeys(BigtableOptions bigtableOptions,
+      String tableId) throws IOException {
     try (BigtableSession session = new BigtableSession(bigtableOptions)) {
       BigtableTableName tableName =
-          bigtableOptions.getInstanceName().toTableName(config.getTableId());
+          bigtableOptions.getInstanceName().toTableName(tableId);
       SampleRowKeysRequest request =
           SampleRowKeysRequest.newBuilder().setTableName(tableName.toString()).build();
       return session.getDataClient().sampleRowKeys(request);

--- a/bigtable-dataflow-parent/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/batch/common/ScanIterator.java
+++ b/bigtable-dataflow-parent/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/batch/common/ScanIterator.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.batch.common;
+
+import java.io.IOException;
+import java.io.Serializable;
+
+import org.apache.hadoop.hbase.client.Result;
+
+import com.google.bigtable.repackaged.com.google.cloud.grpc.scanner.FlatRow;
+import com.google.bigtable.repackaged.com.google.cloud.grpc.scanner.ResultScanner;
+
+/**
+ * Performs a {@link ResultScanner#next()} or {@link ResultScanner#next(int)}.  It also checks if
+ * the ResultOutputType marks the last value in the {@link ResultScanner}.
+ *
+ * @param <ResultOutputType> is either a {@link Result} or {@link Result}[];
+ */
+public interface ScanIterator<ResultOutputType> extends Serializable {
+  /**
+   * Get the next unit of work.
+   * @param resultScanner The {@link ResultScanner} on which to operate.
+   * @param splitTracker The {@link SplitTracker} that determines if a split occurred.
+   */
+  ResultOutputType next(ResultScanner<FlatRow> resultScanner, SplitTracker splitTracker)
+      throws IOException;
+
+  /**
+   * Is the work complete? Checks for null in the case of {@link Result}, or empty in the case of an
+   * array of ResultOutputType.
+   */
+  boolean isCompletionMarker(ResultOutputType result);
+
+  /**
+   * This is used to figure out how many results were read. This is more useful for
+   * {@link Result}[].
+   */
+  long getRowCount(ResultOutputType result);
+}

--- a/bigtable-dataflow-parent/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/batch/common/ScanIteratorFactory.java
+++ b/bigtable-dataflow-parent/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/batch/common/ScanIteratorFactory.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.batch.common;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.hadoop.hbase.client.Result;
+
+import com.google.bigtable.repackaged.com.google.cloud.grpc.scanner.FlatRow;
+import com.google.bigtable.repackaged.com.google.cloud.grpc.scanner.ResultScanner;
+import com.google.bigtable.repackaged.com.google.cloud.hbase.adapters.read.FlatRowAdapter;
+
+public final class ScanIteratorFactory {
+
+  private static final FlatRowAdapter FLAT_ROW_ADAPTER = new FlatRowAdapter();
+
+  /**
+   * Iterates the {@link ResultScanner} via {@link ResultScanner#next()}.
+   */
+  private static final ScanIterator<Result> RESULT_ADVANCER = new ScanIterator<Result>() {
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public Result next(ResultScanner<FlatRow> resultScanner, SplitTracker splitTracker)
+        throws IOException {
+      FlatRow row = resultScanner.next();
+      if (row != null && !splitTracker.isAfterSplit(row.getRowKey())) {
+        return FLAT_ROW_ADAPTER.adaptResponse(row);
+      }
+      return null;
+    }
+
+    @Override
+    public boolean isCompletionMarker(Result result) {
+      return result == null;
+    }
+
+    @Override
+    public long getRowCount(Result result) {
+      return result == null ? 0 : 1;
+    }
+  };
+
+  /**
+   * Iterates the {@link ResultScanner} via {@link ResultScanner#next(int)}.
+   */
+  private static final class ResultArrayIterator implements ScanIterator<Result[]> {
+    private static final long serialVersionUID = 1L;
+    private final int arraySize;
+
+    public ResultArrayIterator(int arraySize) {
+      this.arraySize = arraySize;
+    }
+
+
+    @Override
+    public Result[] next(ResultScanner<FlatRow> resultScanner, SplitTracker splitTracker)
+        throws IOException {
+      List<Result> results = new ArrayList<>();
+      for (int i = 0; i < arraySize; i++) {
+        FlatRow row = resultScanner.next();
+        if (row == null) {
+          // The scan completed.
+          break;
+        }
+        if (splitTracker.isAfterSplit(row.getRowKey())) {
+          // A split occurred and the split key was before this key.
+          break;
+        }
+        results.add(FLAT_ROW_ADAPTER.adaptResponse(row));
+      }
+      return results.toArray(new Result[results.size()]);
+    }
+
+
+    @Override
+    public boolean isCompletionMarker(Result[] result) {
+      return result == null || result.length == 0;
+    }
+
+    @Override
+    public long getRowCount(Result[] result) {
+      return result == null ? 0 : result.length;
+    }
+  }
+
+  public static ScanIterator<Result> getSingleResultIterator() {
+    return RESULT_ADVANCER;
+  }
+
+  public static ScanIterator<Result[]> getMultiResultIterator(int resultCount) {
+    return new ResultArrayIterator(resultCount);
+  }
+}

--- a/bigtable-dataflow-parent/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/batch/common/SplitTracker.java
+++ b/bigtable-dataflow-parent/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/batch/common/SplitTracker.java
@@ -15,15 +15,12 @@
  */
 package com.google.cloud.bigtable.batch.common;
 
-import com.google.bigtable.repackaged.com.google.cloud.config.BigtableOptions;
-import com.google.bigtable.repackaged.com.google.com.google.bigtable.v2.SampleRowKeysResponse;
-import java.io.IOException;
-import java.util.List;
+import com.google.bigtable.repackaged.com.google.protobuf.ByteString;
 
 /**
- * This interface describes functionality required by a Dataflow Cloud Bigtable connector.
+ * Determines whether or not a split occurred before a rowKey.
+ *
  */
-public interface CloudBigtableService {
-  List<SampleRowKeysResponse> getSampleRowKeys(BigtableOptions bigtableOptions, String tableId)
-      throws IOException;
+public interface SplitTracker {
+  public boolean isAfterSplit(ByteString rowKey);
 }

--- a/bigtable-dataflow-parent/bigtable-hbase-dataflow/src/test/java/com/google/cloud/bigtable/dataflow/CloudBigtableIOReaderTest.java
+++ b/bigtable-dataflow-parent/bigtable-hbase-dataflow/src/test/java/com/google/cloud/bigtable/dataflow/CloudBigtableIOReaderTest.java
@@ -32,6 +32,7 @@ import com.google.bigtable.repackaged.com.google.cloud.grpc.scanner.FlatRow;
 import com.google.bigtable.repackaged.com.google.cloud.grpc.scanner.ResultScanner;
 import com.google.bigtable.repackaged.com.google.com.google.bigtable.v2.ReadRowsRequest;
 import com.google.bigtable.repackaged.com.google.protobuf.ByteString;
+import com.google.cloud.bigtable.batch.common.ScanIteratorFactory;
 import com.google.cloud.bigtable.dataflow.CloudBigtableScanConfiguration.Builder;
 import com.google.cloud.dataflow.sdk.io.range.ByteKey;
 import com.google.cloud.dataflow.sdk.io.range.ByteKeyRange;
@@ -88,7 +89,8 @@ public class CloudBigtableIOReaderTest {
 
   private CloudBigtableIO.Reader<Result> initializeReader(CloudBigtableScanConfiguration config) {
     when(mockSource.getConfiguration()).thenReturn(config);
-    return new CloudBigtableIO.Reader<Result>(mockSource, CloudBigtableIO.RESULT_ADVANCER) {
+    return new CloudBigtableIO.Reader<Result>(mockSource,
+        ScanIteratorFactory.getSingleResultIterator()) {
       @Override
       void initializeScanner() throws IOException {
         setSession(mockSession);


### PR DESCRIPTION
This is part of an effort to move all of the Cloud Bigtable operations into batch/common.  This refactor is part of an effort to create a Beam connector.