### PR TITLE
Fixes to BigtableClusterUtilities

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/BigtableClusterUtilitiesTest.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/BigtableClusterUtilitiesTest.java
@@ -1,0 +1,34 @@
+/*
+
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.grpc;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+
+@RunWith(JUnit4.class)
+public class BigtableClusterUtilitiesTest {
+
+  @Test
+  public void testZoneIdExtraction() {
+    String zone = "my-zone";
+    String fullZone = "/something/something-else/locations/" + zone;
+    Assert.assertEquals(zone, BigtableClusterUtilities.getZoneId(fullZone));
+  }
+}


### PR DESCRIPTION
- fixed a problem with zoneId extraction
- returning Cluster from setClusterSize()
This is intended to be used in a Java autoscaler example