### PR TITLE
Some cleanup of grpc channel creation.

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableInstanceGrpcClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableInstanceGrpcClient.java
@@ -49,8 +49,12 @@ public class BigtableInstanceGrpcClient implements BigtableInstanceClient {
    * @param channel a {@link io.grpc.Channel} object.
    */
   public BigtableInstanceGrpcClient(Channel channel) {
-    this.instanceClient = BigtableInstanceAdminGrpc.newBlockingStub(channel);
-    operationsStub = OperationsGrpc.newBlockingStub(channel);
+    this.instanceClient = BigtableInstanceAdminGrpc
+        .newBlockingStub(channel)
+        .withWaitForReady();
+    this.operationsStub = OperationsGrpc
+        .newBlockingStub(channel)
+        .withWaitForReady();
   }
 
   /** {@inheritDoc} */

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
@@ -60,8 +60,6 @@ import io.grpc.internal.DnsNameResolverProvider;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.NettyChannelBuilder;
-import io.netty.handler.ssl.SslContext;
-import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.util.Recycler;
 
 /**
@@ -83,7 +81,6 @@ public class BigtableSession implements Closeable {
   private static ChannelPool cachedDataChannelPool = null;
   private static final Logger LOG = new Logger(BigtableSession.class);
   private static ResourceLimiter resourceLimiter;
-  private static SslContextBuilder sslBuilder;
 
   // 256 MB, server has 256 MB limit.
   private final static int MAX_MESSAGE_SIZE = 1 << 28;
@@ -119,13 +116,6 @@ public class BigtableSession implements Closeable {
     }
   }
 
-  private synchronized static SslContext createSslContext() throws SSLException {
-    if (sslBuilder == null) {
-      sslBuilder = GrpcSslContexts.forClient().ciphers(null);
-    }
-    return sslBuilder.build();
-  }
-
   private static void performWarmup() {
     // Initialize some core dependencies in parallel.  This can speed up startup by 150+ ms.
     ExecutorService connectionStartupExecutor = Executors
@@ -148,7 +138,7 @@ public class BigtableSession implements Closeable {
         try {
           // We create multiple channels via refreshing and pooling channel implementation.
           // Each one needs its own SslContext.
-          createSslContext();
+          GrpcSslContexts.forClient().build();
         } catch (SSLException e) {
           // ignore.  This doesn't happen frequently, but even if it does, it's inconsequential.
         }
@@ -477,10 +467,7 @@ public class BigtableSession implements Closeable {
 
     // Ideally, this should be ManagedChannelBuilder.forAddress(...) rather than an explicit
     // call to NettyChannelBuilder.  Unfortunately, that doesn't work for shaded artifacts.
-    ManagedChannelBuilder<?> builder = NettyChannelBuilder
-        .forAddress(host, options.getPort())
-        .sslContext(createSslContext())
-        ;
+    ManagedChannelBuilder<?> builder = NettyChannelBuilder.forAddress(host, options.getPort());
 
     if (options.usePlaintextNegotiation()) {
       builder.usePlaintext(true);

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableTableAdminGrpcClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableTableAdminGrpcClient.java
@@ -43,7 +43,9 @@ public class BigtableTableAdminGrpcClient implements BigtableTableAdminClient {
    * @param channel a {@link io.grpc.Channel} object.
    */
   public BigtableTableAdminGrpcClient(Channel channel) {
-    blockingStub = BigtableTableAdminGrpc.newBlockingStub(channel);
+    blockingStub = BigtableTableAdminGrpc
+        .newBlockingStub(channel)
+        .withWaitForReady();
   }
 
   /** {@inheritDoc} */

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/CallOptionsFactory.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/CallOptionsFactory.java
@@ -53,10 +53,15 @@ public interface CallOptionsFactory {
    * Always returns {@link CallOptions#DEFAULT}.
    */
   public static class Default implements CallOptionsFactory {
+    public static CallOptions DEFAULT =
+        CallOptions.DEFAULT
+          //.withCompression("gzip")
+          .withWaitForReady();
+
     @Override
     public <RequestT> CallOptions create(MethodDescriptor<RequestT, ?> descriptor,
         RequestT request) {
-      return CallOptions.DEFAULT;
+      return DEFAULT;
     }
   }
 
@@ -72,14 +77,14 @@ public interface CallOptionsFactory {
     public <RequestT> CallOptions create(
         MethodDescriptor<RequestT, ?> descriptor, RequestT request) {
       if (!config.isUseTimeout() || request == null) {
-        return CallOptions.DEFAULT;
+        return Default.DEFAULT;
       }
 
       int timeout = config.getShortRpcTimeoutMs();
       if (isLongRequest(request)) {
         timeout = config.getLongRpcTimeoutMs();
       }
-      return CallOptions.DEFAULT.withDeadline(Deadline.after(timeout, TimeUnit.MILLISECONDS));
+      return Default.DEFAULT.withDeadline(Deadline.after(timeout, TimeUnit.MILLISECONDS));
     }
 
     /**

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestBigtableDataGrpcClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestBigtableDataGrpcClient.java
@@ -210,7 +210,6 @@ public class TestBigtableDataGrpcClient {
   }
 
   private void checkHeader(Metadata metadata) {
-    System.out.println("Checking header" ); 
     Assert.assertEquals(
         TABLE_NAME, metadata.get(GoogleCloudResourcePrefixInterceptor.GRPC_RESOURCE_PREFIX_KEY));
   }


### PR DESCRIPTION
- Slow connection creation can get an exception that the channel is not ready.  Adding withWaitForReady() to the call options
- Removing the custom SSL context which we needed back in the day for alpn-boot.
- I tried adding withCompression("gzip"), but I get an internal exception which would need to be explored.