### PR TITLE
Refactor ResoureLimiterStats

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AsyncExecutor.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AsyncExecutor.java
@@ -164,7 +164,7 @@ public class AsyncExecutor {
    *          the mutate operation is completed.
    * @return a {@link com.google.common.util.concurrent.ListenableFuture} which can be listened to for completion events.
    */
-  public ListenableFuture<List<MutateRowsResponse>> mutateRowAsync(MutateRowsRequest request,
+  public ListenableFuture<List<MutateRowsResponse>> mutateRowsAsync(MutateRowsRequest request,
       long operationId) {
     return call(MUTATE_ROWS_ASYNC, request, operationId);
   }

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BulkMutation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BulkMutation.java
@@ -385,10 +385,13 @@ public class BulkMutation {
           retryId = Long.valueOf(
             asyncExecutor.getOperationAccountant().registerComplexOperation(createRetryHandler()));
         }
+        MutateRowsRequest request = currentRequestManager.build();
         long start = clock.nanoTime();
-        mutateRowsFuture = asyncExecutor.mutateRowsAsync(currentRequestManager.build());
+        long operationId = asyncExecutor.getOperationAccountant()
+            .registerOperationWithHeapSize(request.getSerializedSize());
         long now = clock.nanoTime();
         BulkMutationsStats.getInstance().markThrottling(now - start);
+        mutateRowsFuture = asyncExecutor.mutateRowsAsync(request, operationId);
         currentRequestManager.lastRpcSentTimeNanos = now;
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BulkMutationsStats.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BulkMutationsStats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Google Inc. All Rights Reserved.
+ * Copyright 2017 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,6 @@
 package com.google.cloud.bigtable.grpc.async;
 
 import java.util.concurrent.TimeUnit;
-
-import javax.annotation.Nullable;
 
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
@@ -36,83 +34,23 @@ public class BulkMutationsStats {
     return instance;
   }
 
-  /**
-   * This class is a point in time summary of mean latency and mutaiton throughput.
-   */
-  public static class StatsSnapshot {
-    private final Long mutationRpcLatencyInMillis;
-    private final Long mutationRatePerSecond;
-    private final Long throttlingPerRpcInMicros;
-
-    public StatsSnapshot(@Nullable Long mutationRpcLatencyInMillis,
-        @Nullable Long mutationRatePerSecond, @Nullable Long throttlingPerRpcInMicros) {
-      this.mutationRpcLatencyInMillis = mutationRpcLatencyInMillis;
-      this.mutationRatePerSecond = mutationRatePerSecond;
-      this.throttlingPerRpcInMicros = throttlingPerRpcInMicros;
-    }
-
-    /**
-     * @return latency of RPCs in milliseconds.  Return null if no RPCs have been made.
-     */
-    @Nullable
-    public Long getMutationRpcLatencyInMillis() {
-      return mutationRpcLatencyInMillis;
-    }
-
-    /**
-     * @return mutations per second.  Return null if no RPCs have been made.
-     */
-    @Nullable
-    public Long getMutationRatePerSecond() {
-      return mutationRatePerSecond;
-    }
-
-    /**
-     * @return throttling per RPC in microseconds.  Return null if no RPCs have been made.
-     */
-    @Nullable
-    public Long getThrottlingPerRpcInMicros() {
-      return throttlingPerRpcInMicros;
-    }
+  @VisibleForTesting
+  static void reset(){
+    instance = new BulkMutationsStats();
   }
 
   private final MetricRegistry registry = new MetricRegistry();
 
-  private Timer mutationTimer;
-  private Meter mutationMeter;
-  private Timer throttlingTimer;
-
-  public synchronized StatsSnapshot getSnapshot() {
-    return new StatsSnapshot(getRpcLatencyMs(), getMutationRate(), getThrottlingMicros());
-  }
-
-  @VisibleForTesting
-  void reset() {
-    mutationTimer = null;
-    mutationMeter = null;
-    throttlingTimer = null;
-  }
-
-  private Long getRpcLatencyMs() {
-    return mutationTimer == null ? null
-        : TimeUnit.NANOSECONDS.toMillis((long) mutationTimer.getSnapshot().getMean());
-  }
-
-  private Long getMutationRate() {
-    return mutationMeter == null ? null : (long) mutationMeter.getMeanRate();
-  }
-
-  private Long getThrottlingMicros() {
-    return throttlingTimer == null ? null
-        : TimeUnit.NANOSECONDS.toMicros((long) throttlingTimer.getSnapshot().getMean());
-  }
+  private final Timer mutationTimer = registry.timer("MutationStats.mutation.timer");
+  private final Meter mutationMeter = registry.meter("MutationStats.mutation.meter");
+  private final Timer throttlingTimer = registry.timer("MutationStats.throttling.timer");
 
   /**
    * This method updates rpc time statistics statistics.
    * @param rpcDurationInNanos
    */
-  synchronized void markMutationsRpcCompletion(long rpcDurationInNanos) {
-    getMutationTimer().update(rpcDurationInNanos, TimeUnit.NANOSECONDS);
+  void markMutationsRpcCompletion(long rpcDurationInNanos) {
+    mutationTimer.update(rpcDurationInNanos, TimeUnit.NANOSECONDS);
   }
 
   /**
@@ -120,36 +58,27 @@ public class BulkMutationsStats {
    * @param mutationCount
    * @param rpcTimeInNanos
    */
-  synchronized void markMutationsSuccess(long mutationCount) {
-    getMutationMeter().mark(mutationCount);
+  void markMutationsSuccess(long mutationCount) {
+    mutationMeter.mark(mutationCount);
   }
 
   /**
    * This method updates throttling statistics.
    * @param throttlingTimeinNanos
    */
-  synchronized void markThrottling(long throttlingDurationInNanos) {
-    getThrottlingTimer().update(throttlingDurationInNanos, TimeUnit.NANOSECONDS);
+  void markThrottling(long throttlingDurationInNanos) {
+    throttlingTimer.update(throttlingDurationInNanos, TimeUnit.NANOSECONDS);
   }
 
-  private Timer getMutationTimer() {
-    if (mutationTimer == null) {
-      mutationTimer = registry.timer("MutationStats.mutation.timer");
-    }
+  public Timer getMutationTimer() {
     return mutationTimer;
   }
 
-  private Meter getMutationMeter() {
-    if (mutationMeter == null) {
-      mutationMeter = registry.meter("MutationStats.mutations.meter");
-    }
+  public Meter getMutationMeter() {
     return mutationMeter;
   }
 
-  private Timer getThrottlingTimer() {
-    if (throttlingTimer == null) {
-      throttlingTimer = registry.timer("MutationStats.throttle.timer");
-    }
+  public Timer getThrottlingTimer() {
     return throttlingTimer;
   }
 }

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BulkMutationsStats.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BulkMutationsStats.java
@@ -22,6 +22,7 @@ import javax.annotation.Nullable;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
+import com.google.common.annotations.VisibleForTesting;
 
 /**
  * This class tracks timing and counts of mutations performed by {@link BulkMutation} and throttling
@@ -81,32 +82,12 @@ public class BulkMutationsStats {
   private Meter mutationMeter;
   private Timer throttlingTimer;
 
-  /**
-   * <p>
-   * This method is useful for throttling. Periodically, throttling will need some statistics to
-   * make decisions about whether to throttle or increase throughput. The decisions need to be made
-   * with recent information, rather than with information gathered since the inception of the
-   * application.
-   * </p>
-   * <p>
-   * This method will reset all of the statistics so that the next time throttling decisions have to
-   * be made, the decisions will be made on near-term information.
-   * </p>
-   *
-   * @return a {@link StatsSnapshot} that summarizes the stats as of the time right before the
-   *         reset.
-   */
-  public synchronized StatsSnapshot snapshotAndReset() {
-    StatsSnapshot snap = getSnapshot();
-    reset();
-    return snap;
-  }
-
   public synchronized StatsSnapshot getSnapshot() {
     return new StatsSnapshot(getRpcLatencyMs(), getMutationRate(), getThrottlingMicros());
   }
 
-  public void reset() {
+  @VisibleForTesting
+  void reset() {
     mutationTimer = null;
     mutationMeter = null;
     throttlingTimer = null;

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/OperationAccountant.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/OperationAccountant.java
@@ -293,10 +293,6 @@ public class OperationAccountant {
     resetNoSuccessWarningDeadline();
   }
 
-  public ResourceLimiterStats getResourceLimiterStats(){
-    return resourceLimiter.getResourceLimiterStats();
-  }
-
   @VisibleForTesting
   void awaitCompletionPing(){
     lock.lock();

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/ResourceLimiter.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/ResourceLimiter.java
@@ -27,7 +27,6 @@ public class ResourceLimiter {
   private final Map<Long, Long> pendingOperationsWithSize = new HashMap<>();
   private final LinkedBlockingDeque<Long> completedOperationIds = new LinkedBlockingDeque<>();
   private long currentWriteBufferSize;
-  private final ResourceLimiterStats resourceLimiterStats = new ResourceLimiterStats();
 
   /**
    * <p>Constructor for ResourceLimiter.</p>
@@ -53,20 +52,13 @@ public class ResourceLimiter {
   public synchronized long registerOperationWithHeapSize(long heapSize)
       throws InterruptedException {
     long operationId = operationSequenceGenerator.incrementAndGet();
-    long start = System.nanoTime();
     while (unsynchronizedIsFull()) {
       waitForCompletions(REGISTER_WAIT_MILLIS);
     }
-    resourceLimiterStats.markThrottling(System.nanoTime() - start);
 
     pendingOperationsWithSize.put(operationId, heapSize);
     currentWriteBufferSize += heapSize;
     return operationId;
-  }
-
-
-  public ResourceLimiterStats getResourceLimiterStats() {
-	return resourceLimiterStats;
   }
 
   /**

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestBulkMutation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestBulkMutation.java
@@ -142,7 +142,7 @@ public class TestBulkMutation {
 
   @Test
   public void testAdd() {
-    BulkMutationsStats.getInstance().snapshotAndReset();
+    BulkMutationsStats.getInstance().reset();
     MutateRowRequest mutateRowRequest = createRequest();
     BulkMutation.RequestManager requestManager = createTestRequestManager();
     requestManager.add(null, BulkMutation.convert(mutateRowRequest));
@@ -156,7 +156,7 @@ public class TestBulkMutation {
         .build();
     Assert.assertEquals(expected, requestManager.build());
     Assert
-        .assertNull(BulkMutationsStats.getInstance().snapshotAndReset().getMutationRatePerSecond());
+        .assertNull(BulkMutationsStats.getInstance().getSnapshot().getMutationRatePerSecond());
   }
 
   private RequestManager createTestRequestManager() {
@@ -180,7 +180,7 @@ public class TestBulkMutation {
   @Test
   public void testCallableSuccess()
       throws InterruptedException, ExecutionException, TimeoutException {
-    BulkMutationsStats.getInstance().snapshotAndReset();
+    BulkMutationsStats.getInstance().reset();
     long preRunId = retryIdGenerator.get();
     underTest.clock = mockNanoClock;
 
@@ -192,7 +192,7 @@ public class TestBulkMutation {
     Assert.assertTrue(rowFuture.isDone());
     Assert.assertEquals(MutateRowResponse.getDefaultInstance(), result);
     verify(operationAccountant, times(1)).onComplexOperationCompletion(eq(retryIdGenerator.get()));
-    StatsSnapshot snap = BulkMutationsStats.getInstance().snapshotAndReset();
+    StatsSnapshot snap = BulkMutationsStats.getInstance().getSnapshot();
     Assert.assertNotNull(snap.getMutationRatePerSecond());
     Assert.assertNotNull(snap.getMutationRpcLatencyInMillis());
     Assert.assertNotNull(snap.getThrottlingPerRpcInMicros());


### PR DESCRIPTION
- All touch-points of resource limiter stats relate to `BulkMutation`, so all uses were move to BulkMutation.  I renamed `ResourceLimiterStats` to `BulkMutationsStats` to clarify the relationship
- There was a bug in `BulkMutationsStats` relating to throttler stats that is now fixed.
- Adding simple test
- Adding a stats snapshot/reset method, which will be useful for the throttling logic.