### PR TITLE
Removing `OperationAccountant.addCallback()`.

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AsyncExecutor.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AsyncExecutor.java
@@ -31,6 +31,7 @@ import com.google.bigtable.v2.Row;
 import com.google.cloud.bigtable.config.Logger;
 import com.google.cloud.bigtable.grpc.BigtableDataClient;
 import com.google.cloud.bigtable.grpc.scanner.FlatRow;
+import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.protobuf.GeneratedMessageV3;
@@ -139,11 +140,11 @@ public class AsyncExecutor {
   /**
    * Performs a {@link com.google.cloud.bigtable.grpc.BigtableDataClient#mutateRowAsync(MutateRowRequest)} on the
    * {@link com.google.bigtable.v2.MutateRowRequest} given an operationId generated from
-   * {@link com.google.cloud.bigtable.grpc.async.OperationAccountant#registerOperationWithHeapSize(long)}.
+   * {@link com.google.cloud.bigtable.grpc.async.ResourceLimiter#registerOperationWithHeapSize(long)}.
    *
    * @param request The {@link com.google.bigtable.v2.MutateRowRequest} to send.
    * @param operationId The Id generated from
-   *          {@link com.google.cloud.bigtable.grpc.async.OperationAccountant#registerOperationWithHeapSize(long)} that will be released when
+   *          {@link com.google.cloud.bigtable.grpc.async.ResourceLimiter#registerOperationWithHeapSize(long)} that will be released when
    *          the mutate operation is completed.
    * @return a {@link com.google.common.util.concurrent.ListenableFuture} which can be listened to for completion events.
    */
@@ -155,11 +156,11 @@ public class AsyncExecutor {
   /**
    * Performs a {@link com.google.cloud.bigtable.grpc.BigtableDataClient#mutateRowsAsync(MutateRowsRequest)} on the
    * {@link com.google.bigtable.v2.MutateRowsRequest} given an operationId generated from
-   * {@link com.google.cloud.bigtable.grpc.async.OperationAccountant#registerOperationWithHeapSize(long)}.
+   * {@link com.google.cloud.bigtable.grpc.async.ResourceLimiter#registerOperationWithHeapSize(long)}.
    *
    * @param request The {@link com.google.bigtable.v2.MutateRowsRequest} to send.
    * @param operationId The Id generated from
-   *          {@link com.google.cloud.bigtable.grpc.async.OperationAccountant#registerOperationWithHeapSize(long)} that will be released when
+   *          {@link com.google.cloud.bigtable.grpc.async.ResourceLimiter#registerOperationWithHeapSize(long)} that will be released when
    *          the mutate operation is completed.
    * @return a {@link com.google.common.util.concurrent.ListenableFuture} which can be listened to for completion events.
    */
@@ -171,11 +172,11 @@ public class AsyncExecutor {
   /**
    * Performs a {@link com.google.cloud.bigtable.grpc.BigtableDataClient#checkAndMutateRowAsync(CheckAndMutateRowRequest)} on the
    * {@link com.google.bigtable.v2.CheckAndMutateRowRequest} given an operationId generated from
-   * {@link com.google.cloud.bigtable.grpc.async.OperationAccountant#registerOperationWithHeapSize(long)}.
+   * {@link com.google.cloud.bigtable.grpc.async.ResourceLimiter#registerOperationWithHeapSize(long)}.
    *
    * @param request The {@link com.google.bigtable.v2.CheckAndMutateRowRequest} to send.
    * @param operationId The Id generated from
-   *          {@link com.google.cloud.bigtable.grpc.async.OperationAccountant#registerOperationWithHeapSize(long)} that will be released when
+   *          {@link com.google.cloud.bigtable.grpc.async.ResourceLimiter#registerOperationWithHeapSize(long)} that will be released when
    *          the checkAndMutateRow operation is completed.
    * @return a {@link com.google.common.util.concurrent.ListenableFuture} which can be listened to for completion events.
    */
@@ -187,11 +188,11 @@ public class AsyncExecutor {
   /**
    * Performs a {@link com.google.cloud.bigtable.grpc.BigtableDataClient#readModifyWriteRowAsync(ReadModifyWriteRowRequest)} on the
    * {@link com.google.bigtable.v2.ReadModifyWriteRowRequest} given an operationId generated from
-   * {@link com.google.cloud.bigtable.grpc.async.OperationAccountant#registerOperationWithHeapSize(long)}.
+   * {@link com.google.cloud.bigtable.grpc.async.ResourceLimiter#registerOperationWithHeapSize(long)}.
    *
    * @param request The {@link com.google.bigtable.v2.ReadModifyWriteRowRequest} to send.
    * @param operationId The Id generated from
-   *          {@link com.google.cloud.bigtable.grpc.async.OperationAccountant#registerOperationWithHeapSize(long)} that will be released when
+   *          {@link com.google.cloud.bigtable.grpc.async.ResourceLimiter#registerOperationWithHeapSize(long)} that will be released when
    *          the readModifyWriteRowAsync operation is completed.
    * @return a {@link com.google.common.util.concurrent.ListenableFuture} which can be listened to for completion events.
    */
@@ -203,7 +204,7 @@ public class AsyncExecutor {
   /**
    * Performs a {@link com.google.cloud.bigtable.grpc.BigtableDataClient#readRowsAsync(ReadRowsRequest)} on the
    * {@link com.google.bigtable.v2.ReadRowsRequest} given an operationId generated from
-   * {@link com.google.cloud.bigtable.grpc.async.OperationAccountant#registerOperationWithHeapSize(long)}.
+   * {@link com.google.cloud.bigtable.grpc.async.ResourceLimiter#registerOperationWithHeapSize(long)}.
    *
    * @param request The {@link com.google.bigtable.v2.ReadRowsRequest} to send.
    * @return a {@link com.google.common.util.concurrent.ListenableFuture} which can be listened to for completion events.
@@ -216,7 +217,7 @@ public class AsyncExecutor {
   /**
    * Performs a {@link com.google.cloud.bigtable.grpc.BigtableDataClient#mutateRowAsync(MutateRowRequest)} on the
    * {@link com.google.bigtable.v2.MutateRowRequest}. This method may block if
-   * {@link com.google.cloud.bigtable.grpc.async.OperationAccountant#registerOperationWithHeapSize(long)} blocks.
+   * {@link com.google.cloud.bigtable.grpc.async.ResourceLimiter#registerOperationWithHeapSize(long)} blocks.
    *
    * @param request The {@link com.google.bigtable.v2.MutateRowRequest} to send.
    * @return a {@link com.google.common.util.concurrent.ListenableFuture} which can be listened to for completion events.
@@ -230,7 +231,7 @@ public class AsyncExecutor {
   /**
    * Performs a {@link com.google.cloud.bigtable.grpc.BigtableDataClient#mutateRowsAsync(MutateRowsRequest)} on the
    * {@link com.google.bigtable.v2.MutateRowsRequest}. This method may block if
-   * {@link com.google.cloud.bigtable.grpc.async.OperationAccountant#registerOperationWithHeapSize(long)} blocks.
+   * {@link com.google.cloud.bigtable.grpc.async.ResourceLimiter#registerOperationWithHeapSize(long)} blocks.
    *
    * @param request The {@link com.google.bigtable.v2.MutateRowRequest} to send.
    * @return a {@link com.google.common.util.concurrent.ListenableFuture} which can be listened to for completion events.
@@ -244,7 +245,7 @@ public class AsyncExecutor {
   /**
    * Performs a {@link com.google.cloud.bigtable.grpc.BigtableDataClient#checkAndMutateRowAsync(CheckAndMutateRowRequest)} on the
    * {@link com.google.bigtable.v2.CheckAndMutateRowRequest}. This method may block if
-   * {@link com.google.cloud.bigtable.grpc.async.OperationAccountant#registerOperationWithHeapSize(long)} blocks.
+   * {@link com.google.cloud.bigtable.grpc.async.ResourceLimiter#registerOperationWithHeapSize(long)} blocks.
    *
    * @param request The {@link com.google.bigtable.v2.CheckAndMutateRowRequest} to send.
    * @return a {@link com.google.common.util.concurrent.ListenableFuture} which can be listened to for completion events.
@@ -258,7 +259,7 @@ public class AsyncExecutor {
   /**
    * Performs a {@link com.google.cloud.bigtable.grpc.BigtableDataClient#readModifyWriteRow(ReadModifyWriteRowRequest)} on the
    * {@link com.google.bigtable.v2.ReadModifyWriteRowRequest}. This method may block if
-   * {@link com.google.cloud.bigtable.grpc.async.OperationAccountant#registerOperationWithHeapSize(long)} blocks.
+   * {@link com.google.cloud.bigtable.grpc.async.ResourceLimiter#registerOperationWithHeapSize(long)} blocks.
    *
    * @param request The {@link com.google.bigtable.v2.ReadModifyWriteRowRequest} to send.
    * @return a {@link com.google.common.util.concurrent.ListenableFuture} which can be listened to for completion events.
@@ -272,7 +273,7 @@ public class AsyncExecutor {
   /**
    * Performs a {@link com.google.cloud.bigtable.grpc.BigtableDataClient#readRowsAsync(ReadRowsRequest)} on the
    * {@link com.google.bigtable.v2.ReadRowsRequest}. This method may block if
-   * {@link com.google.cloud.bigtable.grpc.async.OperationAccountant#registerOperationWithHeapSize(long)} blocks.
+   * {@link com.google.cloud.bigtable.grpc.async.ResourceLimiter#registerOperationWithHeapSize(long)} blocks.
    *
    * @param request The {@link com.google.bigtable.v2.ReadRowsRequest} to send.
    * @return a {@link com.google.common.util.concurrent.ListenableFuture} which can be listened to for completion events.
@@ -287,7 +288,7 @@ public class AsyncExecutor {
   /**
    * Performs a {@link com.google.cloud.bigtable.grpc.BigtableDataClient#readRowsAsync(ReadRowsRequest)} on the
    * {@link com.google.bigtable.v2.ReadRowsRequest}. This method may block if
-   * {@link com.google.cloud.bigtable.grpc.async.OperationAccountant#registerOperationWithHeapSize(long)} blocks.
+   * {@link com.google.cloud.bigtable.grpc.async.ResourceLimiter#registerOperationWithHeapSize(long)} blocks.
    *
    * @param request The {@link com.google.bigtable.v2.ReadRowsRequest} to send.
    * @return a {@link com.google.common.util.concurrent.ListenableFuture} which can be listened to for completion events.
@@ -307,14 +308,24 @@ public class AsyncExecutor {
   }
 
   private <ResponseT, RequestT> ListenableFuture<ResponseT> call(AsyncCall<RequestT, ResponseT> rpc,
-      RequestT request, long id) {
+      RequestT request, final long id) {
     ListenableFuture<ResponseT> future;
     try {
       future = rpc.call(client, request);
     } catch (Throwable e) {
       future = Futures.immediateFailedFuture(e);
     }
-    operationsAccountant.addCallback(future, id);
+    Futures.addCallback(future, new FutureCallback<ResponseT>() {
+      @Override
+      public void onSuccess(ResponseT result) {
+        operationsAccountant.onOperationCompletion(id);
+      }
+
+      @Override
+      public void onFailure(Throwable t) {
+        operationsAccountant.onOperationCompletion(id);
+      }
+    });
     return future;
   }
 

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/OperationAccountant.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/OperationAccountant.java
@@ -20,9 +20,6 @@ import com.google.api.client.util.NanoClock;
 import com.google.cloud.bigtable.config.Logger;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
-import com.google.common.util.concurrent.FutureCallback;
-import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.ListenableFuture;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -91,9 +88,8 @@ public class OperationAccountant {
   }
 
   /**
-   * Register a new RPC operation. Blocks until the requested resources are available.
-   * This method must be paired with a call to {@code addCallback}.
-   *
+   * Register a new RPC operation. Blocks until the requested resources are available. This method
+   * must be paired with a call to {@link #onOperationCompletion(long)}.
    * @param heapSize The serialized size of the RPC
    * @return An operation id
    * @throws java.lang.InterruptedException if any.
@@ -109,31 +105,6 @@ public class OperationAccountant {
       lock.unlock();
     }
     return id;
-  }
-
-  /**
-   * Add a callback to a Future representing an RPC call with the given operation id that will clean
-   * upon completion and reclaim any utilized resources. This method must be paired with every call
-   * to {@code registerOperationWithHeapSize}.
-   * @param future a {@link com.google.common.util.concurrent.ListenableFuture} object.
-   * @param id a long.
-   * @param <T> a T object.
-   * @return a {@link com.google.common.util.concurrent.FutureCallback} object.
-   */
-  public <T> FutureCallback<T> addCallback(ListenableFuture<T> future, final long id) {
-    FutureCallback<T> callback = new FutureCallback<T>() {
-      @Override
-      public void onSuccess(T result) {
-        onOperationCompletion(id);
-      }
-
-      @Override
-      public void onFailure(Throwable t) {
-        onOperationCompletion(id);
-      }
-    };
-    Futures.addCallback(future, callback);
-    return callback;
   }
 
   /**

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestOperationAccountant.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestOperationAccountant.java
@@ -77,7 +77,7 @@ public class TestOperationAccountant {
     assertTrue(underTest.hasInflightOperations());
 
     assertTrue(underTest.hasInflightOperations());
-    underTest.onComplexOperationCompletion(id);
+    underTest.onOperationCompletion(id);
     assertFalse(underTest.hasInflightOperations());
   }
 

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestOperationAccountant.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestOperationAccountant.java
@@ -70,15 +70,14 @@ public class TestOperationAccountant {
   }
 
   @Test
-  public void testCallback() throws InterruptedException {
+  public void testOnOperationCompletion() throws InterruptedException {
     ResourceLimiter resourceLimiter = new ResourceLimiter(10l, 1000);
     OperationAccountant underTest = new OperationAccountant(resourceLimiter);
     long id = underTest.registerOperationWithHeapSize(5l);
     assertTrue(underTest.hasInflightOperations());
 
-    FutureCallback<?> callback = underTest.addCallback(future, id);
     assertTrue(underTest.hasInflightOperations());
-    callback.onSuccess(null);
+    underTest.onComplexOperationCompletion(id);
     assertFalse(underTest.hasInflightOperations());
   }
 


### PR DESCRIPTION
`OperationAccountant.addCallback()` was added as a testing mechanism.  There were easier ways to accomplish the same task.  This is a cleanup task in preparation for a larger refactor of OperationAccountant.