### PR TITLE
Removing the link between OperationAccountant and ResourceLimiter

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
@@ -42,7 +42,6 @@ import com.google.cloud.bigtable.grpc.async.AsyncExecutor;
 import com.google.cloud.bigtable.grpc.async.BulkMutation;
 import com.google.cloud.bigtable.grpc.async.BulkRead;
 import com.google.cloud.bigtable.grpc.async.ResourceLimiter;
-import com.google.cloud.bigtable.grpc.async.OperationAccountant;
 import com.google.cloud.bigtable.grpc.io.ChannelPool;
 import com.google.cloud.bigtable.grpc.io.CredentialInterceptorCache;
 import com.google.cloud.bigtable.grpc.io.GoogleCloudResourcePrefixInterceptor;
@@ -333,7 +332,7 @@ public class BigtableSession implements Closeable {
    * @return a {@link com.google.cloud.bigtable.grpc.async.AsyncExecutor} object.
    */
   public AsyncExecutor createAsyncExecutor() {
-    return new AsyncExecutor(dataClient, new OperationAccountant(resourceLimiter));
+    return new AsyncExecutor(dataClient, resourceLimiter);
   }
 
   /**

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestAsyncExecutor.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestAsyncExecutor.java
@@ -42,7 +42,6 @@ import com.google.bigtable.v2.ReadRowsResponse;
 import com.google.cloud.bigtable.grpc.BigtableDataClient;
 import com.google.cloud.bigtable.grpc.async.AsyncExecutor;
 import com.google.cloud.bigtable.grpc.async.ResourceLimiter;
-import com.google.cloud.bigtable.grpc.async.OperationAccountant;
 import com.google.common.util.concurrent.SettableFuture;
 import com.google.protobuf.ByteString;
 
@@ -60,14 +59,11 @@ public class TestAsyncExecutor {
   private SettableFuture future;
 
   private AsyncExecutor underTest;
-  private OperationAccountant operationAccountant;
 
   @Before
   public void setUp() {
     MockitoAnnotations.initMocks(this);
-    operationAccountant = new OperationAccountant(new ResourceLimiter(1000, 10));
-
-    underTest = new AsyncExecutor(client, operationAccountant);
+    underTest = new AsyncExecutor(client, new ResourceLimiter(1000, 10));
     future = SettableFuture.create();
   }
 

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestBulkMutation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestBulkMutation.java
@@ -96,8 +96,8 @@ public class TestBulkMutation {
     future = SettableFuture.create();
     when(client.mutateRowsAsync(any(MutateRowsRequest.class))).thenReturn(future);
     ResourceLimiter resourceLimiter = new ResourceLimiter(1000, 10);
-    operationAccountant = new OperationAccountant(resourceLimiter);
-    asyncExecutor = new AsyncExecutor(client, operationAccountant);
+    operationAccountant = new OperationAccountant();
+    asyncExecutor = new AsyncExecutor(client, resourceLimiter, operationAccountant);
     underTest = createBulkMutation();
   }
 

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestBulkMutationAwaitCompletion.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestBulkMutationAwaitCompletion.java
@@ -256,9 +256,10 @@ public class TestBulkMutationAwaitCompletion {
    * Creates a fully formed {@link BulkMutation}
    */
   private BulkMutation createBulkMutation() {
-    OperationAccountant operationAccountant = new OperationAccountant(
-        resourceLimiter, clock, OperationAccountant.DEFAULT_FINISH_WAIT_MILLIS);
-    AsyncExecutor asyncExecutor = new AsyncExecutor(mockClient, operationAccountant);
+    OperationAccountant operationAccountant =
+        new OperationAccountant(clock, OperationAccountant.DEFAULT_FINISH_WAIT_MILLIS);
+    AsyncExecutor asyncExecutor =
+        new AsyncExecutor(mockClient, resourceLimiter, operationAccountant);
     BulkMutation bulkMutation =
         new BulkMutation(
             TestBulkMutation.TABLE_NAME,

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestOperationAccountant.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestOperationAccountant.java
@@ -72,10 +72,9 @@ public class TestOperationAccountant {
 
   @Test
   public void testOnOperationCompletion() throws InterruptedException {
-    ResourceLimiter resourceLimiter = new ResourceLimiter(10l, 1000);
-    OperationAccountant underTest = new OperationAccountant(resourceLimiter);
+    OperationAccountant underTest = new OperationAccountant();
     int size = (int) (100 * Math.random());
-    long id = underTest.registerOperationWithHeapSize(size);
+    long id = underTest.registerOperation(size);
     assertTrue(underTest.hasInflightOperations());
     underTest.onOperationCompletion(id);
     assertFalse(underTest.hasInflightOperations());
@@ -122,14 +121,14 @@ public class TestOperationAccountant {
     final int registerCount = 1000;
     ExecutorService pool = Executors.newCachedThreadPool();
     try {
-      final ResourceLimiter resourceLimiter = new ResourceLimiter(100l, 100);
-      final OperationAccountant underTest = new OperationAccountant(resourceLimiter);
+      final OperationAccountant underTest = new OperationAccountant();
       final LinkedBlockingQueue<Long> registeredEvents = new LinkedBlockingQueue<>();
       Future<Boolean> writeFuture = pool.submit(new Callable<Boolean>() {
         @Override
         public Boolean call() throws InterruptedException {
-          for (int i = 0; i < registerCount; i++) {
-            registeredEvents.offer(underTest.registerOperationWithHeapSize(i));
+          for (long i = 0; i < registerCount; i++) {
+            underTest.registerOperation(i);
+            registeredEvents.offer(i);
           }
           underTest.awaitCompletion();
           return true;
@@ -161,8 +160,7 @@ public class TestOperationAccountant {
     final int registerCount = 1000;
     ExecutorService pool = Executors.newCachedThreadPool();
     try {
-      ResourceLimiter resourceLimiter = new ResourceLimiter(100l, 100);
-      final OperationAccountant underTest = new OperationAccountant(resourceLimiter);
+      final OperationAccountant underTest = new OperationAccountant();
       final AtomicBoolean allOperationsDone = new AtomicBoolean();
       final LinkedBlockingQueue<Long> registeredEvents = new LinkedBlockingQueue<>();
       final List<SettableFuture<Boolean>> retryFutures = new ArrayList<>();
@@ -173,10 +171,11 @@ public class TestOperationAccountant {
         public void run() {
           try {
             for (int i = 0; i < registerCount; i++) {
-              registeredEvents.offer(underTest.registerOperationWithHeapSize(1));
+              registeredEvents.offer(underTest.registerOperation(1));
 
               // Add a retry for each rpc
-              final long id = underTest.registerComplexOperation(handler);
+              final long id = i + 10000;
+              underTest.registerComplexOperation(id, handler);
               SettableFuture<Boolean> future = SettableFuture.create();
               Futures.addCallback(future, new FutureCallback<Boolean>(){
 
@@ -207,22 +206,18 @@ public class TestOperationAccountant {
           }
         }
       });
-      Future<?> readFuture = pool.submit(new Runnable() {
+      Future<?> readFuture = pool.submit(new Callable<Void>() {
         @Override
-        public void run() {
-          try {
-            for (int i = 0; i < registerCount; i++) {
-              Long registeredId = registeredEvents.poll(1, TimeUnit.SECONDS);
-              if (registeredId == null){
-                i--;
-              } else {
-                underTest.onOperationCompletion(registeredId);
-              }
+        public Void call() throws InterruptedException {
+          for (int i = 0; i < registerCount; i++) {
+            Long registeredId = registeredEvents.poll(1, TimeUnit.SECONDS);
+            if (registeredId == null){
+              i--;
+            } else {
+              underTest.onOperationCompletion(registeredId);
             }
-          } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new RuntimeException(e);
           }
+          return null;
         }
       });
 
@@ -261,24 +256,19 @@ public class TestOperationAccountant {
     });
 
     long finishWaitTime = 100;
-    ResourceLimiter resourceLimiter = new ResourceLimiter(100l, 100);
-    final OperationAccountant underTest =
-        new OperationAccountant(resourceLimiter, clock, finishWaitTime);
+    final OperationAccountant underTest = new OperationAccountant(clock, finishWaitTime);
 
-    long complexOpId = underTest.registerComplexOperation(handler);
+    long complexOpId = 1000;
+    underTest.registerComplexOperation(complexOpId, handler);
     final int iterations = 4;
 
     ExecutorService pool = Executors.newCachedThreadPool();
     try {
-      pool.submit(new Runnable() {
+      pool.submit(new Callable<Void>() {
         @Override
-        public void run() {
-          try {
-            underTest.awaitCompletion();
-          } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new RuntimeException(e);
-          }
+        public Void call() throws Exception {
+          underTest.awaitCompletion();
+          return null;
         }
       });
       // Sleep a multiple of the finish wait time to force a few iterations

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutator.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutator.java
@@ -305,8 +305,7 @@ public class BigtableBufferedMutator implements BufferedMutator {
         // TODO: Do this logic asynchronously.
         addExceptionCallback(bulkMutation.add(adapt(mutation)), mutation);
       } else {
-        long operationId = asyncExecutor.getOperationAccountant()
-            .registerOperationWithHeapSize(mutation.heapSize());
+        long operationId = asyncExecutor.registerOperation(mutation.heapSize());
         operation = new MutationOperation(mutation, operationId);
         if (executorService != null && bulkOptions.getAsyncMutatorCount() > 0) {
           initializeAsyncMutators();

--- a/bigtable-hbase-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableBufferedMutator.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableBufferedMutator.java
@@ -61,7 +61,6 @@ import com.google.cloud.bigtable.grpc.BigtableSessionSharedThreadPools;
 import com.google.cloud.bigtable.grpc.BigtableTableName;
 import com.google.cloud.bigtable.grpc.async.AsyncExecutor;
 import com.google.cloud.bigtable.grpc.async.BulkMutation;
-import com.google.cloud.bigtable.grpc.async.OperationAccountant;
 import com.google.cloud.bigtable.grpc.async.ResourceLimiter;
 import com.google.cloud.bigtable.hbase.adapters.HBaseRequestAdapter;
 import com.google.common.util.concurrent.SettableFuture;
@@ -102,11 +101,9 @@ public class TestBigtableBufferedMutator {
             new Answer<AsyncExecutor>() {
               @Override
               public AsyncExecutor answer(InvocationOnMock invocation) throws Throwable {
-                OperationAccountant operationAccountant =
-                    new OperationAccountant(new ResourceLimiter(BulkOptions.BIGTABLE_MAX_MEMORY_DEFAULT,
-                      BulkOptions.BIGTABLE_MAX_INFLIGHT_RPCS_PER_CHANNEL_DEFAULT));
-
-                return new AsyncExecutor(mockClient, operationAccountant);
+                ResourceLimiter resourceLimiter = new ResourceLimiter(BulkOptions.BIGTABLE_MAX_MEMORY_DEFAULT,
+                  BulkOptions.BIGTABLE_MAX_INFLIGHT_RPCS_PER_CHANNEL_DEFAULT);
+                return new AsyncExecutor(mockClient, resourceLimiter);
               }
             });
     when(mockSession.createBulkMutation(any(BigtableTableName.class), any(AsyncExecutor.class)))


### PR DESCRIPTION
I plan on changing OperationAccountant to allow for an abstract implementation that will server as a base class for different classes responsible for `registerOperation()` and `registerComplexOperation()`.  I wanted to start with removing `ResourceLimiter` use from `OperationAccountant` for separation of concerns.  Eventually, we'll move the `ResourceLimiter` functionality into a `ClientInterceptor`