### PR TITLE
Readding cached grpc ssl builder.

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
@@ -60,6 +60,8 @@ import io.grpc.internal.DnsNameResolverProvider;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.NettyChannelBuilder;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.util.Recycler;
 
 /**
@@ -81,6 +83,7 @@ public class BigtableSession implements Closeable {
   private static ChannelPool cachedDataChannelPool = null;
   private static final Logger LOG = new Logger(BigtableSession.class);
   private static ResourceLimiter resourceLimiter;
+  private static SslContextBuilder sslBuilder;
 
   // 256 MB, server has 256 MB limit.
   private final static int MAX_MESSAGE_SIZE = 1 << 28;
@@ -116,6 +119,13 @@ public class BigtableSession implements Closeable {
     }
   }
 
+  private synchronized static SslContext createSslContext() throws SSLException {
+    if (sslBuilder == null) {
+      sslBuilder = GrpcSslContexts.forClient().ciphers(null);
+    }
+    return sslBuilder.build();
+  }
+
   private static void performWarmup() {
     // Initialize some core dependencies in parallel.  This can speed up startup by 150+ ms.
     ExecutorService connectionStartupExecutor = Executors
@@ -138,7 +148,7 @@ public class BigtableSession implements Closeable {
         try {
           // We create multiple channels via refreshing and pooling channel implementation.
           // Each one needs its own SslContext.
-          GrpcSslContexts.forClient().build();
+          createSslContext();
         } catch (SSLException e) {
           // ignore.  This doesn't happen frequently, but even if it does, it's inconsequential.
         }
@@ -471,7 +481,10 @@ public class BigtableSession implements Closeable {
 
     // Ideally, this should be ManagedChannelBuilder.forAddress(...) rather than an explicit
     // call to NettyChannelBuilder.  Unfortunately, that doesn't work for shaded artifacts.
-    ManagedChannelBuilder<?> builder = NettyChannelBuilder.forAddress(host, options.getPort());
+    ManagedChannelBuilder<?> builder = NettyChannelBuilder
+        .forAddress(host, options.getPort())
+        .sslContext(createSslContext())
+        ;
 
     if (options.usePlaintextNegotiation()) {
       builder.usePlaintext(true);


### PR DESCRIPTION
Using the default ssl builder seems to cause grpc race conditions that manifest as "not started" RPCs.