### PR TITLE
Staleness handling is now scheduled in BulkMutation.

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/OperationAccountant.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/OperationAccountant.java
@@ -124,7 +124,7 @@ public class OperationAccountant {
     long lastUpdated = TimeUnit.NANOSECONDS.toSeconds(lastUpdateNanos);
     LOG.warn(
       "No operations completed within the last %d seconds. "
-          + "There are still %d simple operations in progress.",
+          + "There are still %d operations in progress.",
       lastUpdated, operations.size());
     noSuccessWarningCount++;
   }

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestBulkMutationAwaitCompletion.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestBulkMutationAwaitCompletion.java
@@ -171,7 +171,6 @@ public class TestBulkMutationAwaitCompletion {
         try {
           performTimeout();
         } catch (InterruptedException e) {
-          // TODO Auto-generated catch block
           e.printStackTrace();
         }
       }


### PR DESCRIPTION
Removing the notion of complex operation in favor of a `Batch` scheduling its own staleness cleanup.