### PR TITLE
exclude unused api-common from protos

### DIFF
--- a/bigtable-client-core-parent/bigtable-protos/pom.xml
+++ b/bigtable-client-core-parent/bigtable-protos/pom.xml
@@ -66,6 +66,10 @@ limitations under the License.
                     <groupId>io.grpc</groupId>
                     <artifactId>grpc-all</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.google.api</groupId>
+                    <artifactId>api-common</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
This dep is pulled in as a transitive dep of grpc-google-common-protos. But we don't need any of the functionality that it provides. We only need the generated stubs