### PR TITLE
Introducing 1.x artifacts.

### DIFF
--- a/bigtable-dataflow-parent/bigtable-hbase-dataflow/src/test/java/com/google/cloud/bigtable/dataflow/CloudBigtableIOIntegrationTest.java
+++ b/bigtable-dataflow-parent/bigtable-hbase-dataflow/src/test/java/com/google/cloud/bigtable/dataflow/CloudBigtableIOIntegrationTest.java
@@ -47,7 +47,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import com.google.bigtable.repackaged.com.google.cloud.bigtable.config.Logger;
-import com.google.bigtable.repackaged.com.google.cloud.bigtable.hbase1_0.BigtableConnection;
+import com.google.bigtable.repackaged.com.google.cloud.bigtable.hbase1_x.BigtableConnection;
 import com.google.bigtable.repackaged.com.google.bigtable.v2.SampleRowKeysResponse;
 import com.google.cloud.bigtable.dataflow.CloudBigtableIO.Source;
 import com.google.cloud.dataflow.sdk.io.BoundedSource;

--- a/bigtable-dataflow-parent/bigtable-hbase-dataflow/src/test/java/com/google/cloud/bigtable/dataflow/CloudBigtableIOIntegrationTest.java
+++ b/bigtable-dataflow-parent/bigtable-hbase-dataflow/src/test/java/com/google/cloud/bigtable/dataflow/CloudBigtableIOIntegrationTest.java
@@ -15,6 +15,7 @@
  */
  package com.google.cloud.bigtable.dataflow;
 
+import com.google.bigtable.repackaged.com.google.cloud.bigtable.hbase.BigtableConfiguration;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -47,7 +48,6 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import com.google.bigtable.repackaged.com.google.cloud.bigtable.config.Logger;
-import com.google.bigtable.repackaged.com.google.cloud.bigtable.hbase1_x.BigtableConnection;
 import com.google.bigtable.repackaged.com.google.bigtable.v2.SampleRowKeysResponse;
 import com.google.cloud.bigtable.dataflow.CloudBigtableIO.Source;
 import com.google.cloud.dataflow.sdk.io.BoundedSource;
@@ -107,7 +107,7 @@ public class CloudBigtableIOIntegrationTest {
               .withZoneId(zoneId)
               .build();
     }
-    connection = new BigtableConnection(config.toHBaseConfig());
+    connection = BigtableConfiguration.connect(config.toHBaseConfig());
   }
 
   @AfterClass

--- a/bigtable-dataflow-parent/bigtable-hbase-shaded-for-dataflow/pom.xml
+++ b/bigtable-dataflow-parent/bigtable-hbase-shaded-for-dataflow/pom.xml
@@ -29,7 +29,7 @@ limitations under the License.
     <dependencies>
         <dependency>
             <groupId>com.google.cloud.bigtable</groupId>
-            <artifactId>bigtable-hbase-1.0</artifactId>
+            <artifactId>bigtable-hbase-1.x-shaded</artifactId>
             <version>${project.version}</version>
         </dependency>
     </dependencies>
@@ -51,7 +51,7 @@ limitations under the License.
                             <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
                             <artifactSet>
                                 <includes>
-                                    <include>${project.groupId}:bigtable-hbase-1.0</include>
+                                    <include>${project.groupId}:bigtable-hbase-1.x-shaded</include>
                                 </includes>
                             </artifactSet>
                             <relocations>

--- a/bigtable-hbase-parent/bigtable-hbase-1.0/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-1.0/pom.xml
@@ -37,9 +37,23 @@ limitations under the License.
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>bigtable-hbase-shaded</artifactId>
+            <artifactId>bigtable-hbase-1.x-hadoop</artifactId>
             <version>${project.version}</version>
+
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.hbase</groupId>
+                    <artifactId>hbase-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.hbase</groupId>
+            <artifactId>hbase-client</artifactId>
+            <version>${hbase.version}</version>
+        </dependency>
+
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
@@ -50,62 +64,5 @@ limitations under the License.
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
-
     </dependencies>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-eclipse-plugin</artifactId>
-                <configuration>
-                    <useProjectReferences>false</useProjectReferences>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                        <configuration>
-                            <shadeTestJar>true</shadeTestJar>
-                            <!--
-                                KEEP shadedArtifactAttached=false.  DO NOTE CHANGE shadedArtifactAttached to true!
-
-                                Dependencies get messed up if shadedArtifactAttached=true.  The relocations
-                                are vital to get around dependency mismatches between hbase and cloud bigtable.
-                                Specifically, CBT and hbase use different versions of guava and netty.  Relocations
-                                are a way to get around those types of incompatibilities.
-
-                                Using shadedArtifactAttached=true causes some tricky issues.  If =true is on,
-                                then the main artifact isn't usable, because of the incompatibility issues in the artifacts found
-                                in the relocations section.  If HBase updates its dependencies to compatible versions, then
-                                this project will not need to relocate and include those dependencies in a shaded jar.
-
-                                As an example, the start up of hbase requires guava, and using a newer version of guava causes
-                                startup issues.  If an older version of guava is in the classpath, then HBase classes will load
-                                fine, but CBT will have runtime issues.
-
-                                Additionally, if shadedArtifactAttached=true there are even ssues using the shaded classifier.
-                                Using the shaded classifier will pull in the right bigtable-hbase-1.0-shaded-${project.version}.jar,
-                                but it will also pull in bigtable-hbase and bigtable-protos as dependencies, which might
-                                cause classloading issues in some cases like web apps.
-                            -->
-                            <shadedArtifactAttached>false</shadedArtifactAttached>
-                            <createDependencyReducedPom>true</createDependencyReducedPom>
-                            <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
-                            <artifactSet>
-                                <includes>
-                                    <include>com.google.cloud.bigtable:bigtable-hbase-shaded</include>
-                                </includes>
-                            </artifactSet>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/bigtable-hbase-parent/bigtable-hbase-1.0/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-1.0/pom.xml
@@ -27,6 +27,7 @@ limitations under the License.
     <packaging>jar</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>
+        DEPRECATED: Please use hbase-1.x-hadoop artifact.
        This project contains hbase 1.0 specific implementation of bigtable hbase.
     </description>
 

--- a/bigtable-hbase-parent/bigtable-hbase-1.1/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-1.1/pom.xml
@@ -27,6 +27,7 @@ limitations under the License.
     <packaging>jar</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>
+       DEPRECATED: Please use hbase-1.x-hadoop artifact.
        This project contains hbase 1.1 specific implementation of bigtable hbase.
     </description>
 

--- a/bigtable-hbase-parent/bigtable-hbase-1.1/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-1.1/pom.xml
@@ -37,9 +37,22 @@ limitations under the License.
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>bigtable-hbase-shaded</artifactId>
+            <artifactId>bigtable-hbase-1.x-hadoop</artifactId>
             <version>${project.version}</version>
+
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.hbase</groupId>
+                    <artifactId>hbase-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.apache.hbase</groupId>
+            <artifactId>hbase-client</artifactId>
+            <version>${hbase.version}</version>
+        </dependency>
+
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
@@ -50,62 +63,5 @@ limitations under the License.
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
-
     </dependencies>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-eclipse-plugin</artifactId>
-                <configuration>
-                    <useProjectReferences>false</useProjectReferences>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                        <configuration>
-                            <shadeTestJar>true</shadeTestJar>
-                            <!--
-                                KEEP shadedArtifactAttached=false.  DO NOTE CHANGE shadedArtifactAttached to true!
-
-                                Dependencies get messed up if shadedArtifactAttached=true.  The relocations
-                                are vital to get around dependency mismatches between hbase and cloud bigtable.
-                                Specifically, CBT and hbase use different versions of guava and netty.  Relocations
-                                are a way to get around those types of incompatibilities.
-
-                                Using shadedArtifactAttached=true causes some tricky issues.  If =true is on,
-                                then the main artifact isn't usable, because of the incompatibility issues in the artifacts found
-                                in the relocations section.  If HBase updates its dependencies to compatible versions, then
-                                this project will not need to relocate and include those dependencies in a shaded jar.
-
-                                As an example, the start up of hbase requires guava, and using a newer version of guava causes
-                                startup issues.  If an older version of guava is in the classpath, then HBase classes will load
-                                fine, but CBT will have runtime issues.
-
-                                Additionally, if shadedArtifactAttached=true there are even ssues using the shaded classifier.
-                                Using the shaded classifier will pull in the right bigtable-hbase-1.1-shaded-${project.version}.jar,
-                                but it will also pull in bigtable-hbase and bigtable-protos as dependencies, which might
-                                cause classloading issues in some cases like web apps.
-                            -->
-                            <shadedArtifactAttached>false</shadedArtifactAttached>
-                            <createDependencyReducedPom>true</createDependencyReducedPom>
-                            <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
-                            <artifactSet>
-                                <includes>
-                                    <include>com.google.cloud.bigtable:bigtable-hbase-shaded</include>
-                                </includes>
-                            </artifactSet>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/bigtable-hbase-parent/bigtable-hbase-1.2/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-1.2/pom.xml
@@ -27,6 +27,7 @@ limitations under the License.
     <packaging>jar</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>
+       DEPRECATED: Please use hbase-1.x-hadoop artifact.
        This project contains hbase 1.2 specific implementation of bigtable hbase.
     </description>
 

--- a/bigtable-hbase-parent/bigtable-hbase-1.2/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-1.2/pom.xml
@@ -37,9 +37,23 @@ limitations under the License.
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>bigtable-hbase-shaded</artifactId>
+            <artifactId>bigtable-hbase-1.x-hadoop</artifactId>
             <version>${project.version}</version>
+
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.hbase</groupId>
+                    <artifactId>hbase-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.hbase</groupId>
+            <artifactId>hbase-client</artifactId>
+            <version>${hbase.version}</version>
+        </dependency>
+
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-tcnative-boringssl-static</artifactId>
@@ -62,53 +76,4 @@ limitations under the License.
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                        <configuration>
-                            <shadeTestJar>true</shadeTestJar>
-                            <!--
-                                KEEP shadedArtifactAttached=false.  DO NOTE CHANGE shadedArtifactAttached to true!
-
-                                Dependencies get messed up if shadedArtifactAttached=true.  The relocations
-                                are vital to get around dependency mismatches between hbase and cloud bigtable.
-                                Specifically, CBT and hbase use different versions of guava and netty.  Relocations
-                                are a way to get around those types of incompatibilities.
-
-                                Using shadedArtifactAttached=true causes some tricky issues.  If =true is on,
-                                then the main artifact isn't usable, because of the incompatibility issues in the artifacts found
-                                in the relocations section.  If HBase updates its dependencies to compatible versions, then
-                                this project will not need to relocate and include those dependencies in a shaded jar.
-
-                                As an example, the start up of hbase requires guava, and using a newer version of guava causes
-                                startup issues.  If an older version of guava is in the classpath, then HBase classes will load
-                                fine, but CBT will have runtime issues.
-
-                                Additionally, if shadedArtifactAttached=true there are even ssues using the shaded classifier.
-                                Using the shaded classifier will pull in the right bigtable-hbase-1.2-shaded-${project.version}.jar,
-                                but it will also pull in bigtable-hbase and bigtable-protos as dependencies, which might
-                                cause classloading issues in some cases like web apps.
-                            -->
-                            <shadedArtifactAttached>false</shadedArtifactAttached>
-                            <createDependencyReducedPom>true</createDependencyReducedPom>
-                            <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
-                            <artifactSet>
-                                <includes>
-                                    <include>com.google.cloud.bigtable:bigtable-hbase-shaded</include>
-                                </includes>
-                            </artifactSet>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/bigtable-hbase-parent/bigtable-hbase-1.3/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-1.3/pom.xml
@@ -37,9 +37,23 @@ limitations under the License.
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>bigtable-hbase-shaded</artifactId>
+            <artifactId>bigtable-hbase-1.x-hadoop</artifactId>
             <version>${project.version}</version>
+
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.hbase</groupId>
+                    <artifactId>hbase-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.hbase</groupId>
+            <artifactId>hbase-client</artifactId>
+            <version>${hbase.version}</version>
+        </dependency>
+
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
@@ -52,53 +66,4 @@ limitations under the License.
         </dependency>
 
     </dependencies>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                        <configuration>
-                            <shadeTestJar>true</shadeTestJar>
-                            <!--
-                                KEEP shadedArtifactAttached=false.  DO NOTE CHANGE shadedArtifactAttached to true!
-
-                                Dependencies get messed up if shadedArtifactAttached=true.  The relocations
-                                are vital to get around dependency mismatches between hbase and cloud bigtable.
-                                Specifically, CBT and hbase use different versions of guava and netty.  Relocations
-                                are a way to get around those types of incompatibilities.
-
-                                Using shadedArtifactAttached=true causes some tricky issues.  If =true is on,
-                                then the main artifact isn't usable, because of the incompatibility issues in the artifacts found
-                                in the relocations section.  If HBase updates its dependencies to compatible versions, then
-                                this project will not need to relocate and include those dependencies in a shaded jar.
-
-                                As an example, the start up of hbase requires guava, and using a newer version of guava causes
-                                startup issues.  If an older version of guava is in the classpath, then HBase classes will load
-                                fine, but CBT will have runtime issues.
-
-                                Additionally, if shadedArtifactAttached=true there are even ssues using the shaded classifier.
-                                Using the shaded classifier will pull in the right bigtable-hbase-1.2-shaded-${project.version}.jar,
-                                but it will also pull in bigtable-hbase and bigtable-protos as dependencies, which might
-                                cause classloading issues in some cases like web apps.
-                            -->
-                            <shadedArtifactAttached>false</shadedArtifactAttached>
-                            <createDependencyReducedPom>true</createDependencyReducedPom>
-                            <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
-                            <artifactSet>
-                                <includes>
-                                    <include>com.google.cloud.bigtable:bigtable-hbase-shaded</include>
-                                </includes>
-                            </artifactSet>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/bigtable-hbase-parent/bigtable-hbase-1.3/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-1.3/pom.xml
@@ -27,6 +27,7 @@ limitations under the License.
     <packaging>jar</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>
+       DEPRECATED: Please use hbase-1.x-hadoop artifact.
        This project contains hbase 1.3 specific implementation of bigtable hbase.
     </description>
 

--- a/bigtable-hbase-parent/bigtable-hbase-1.x-hadoop/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-1.x-hadoop/pom.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright 2017 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>bigtable-hbase-parent</artifactId>
+    <groupId>com.google.cloud.bigtable</groupId>
+    <version>0.9.8-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>bigtable-hbase-1.x-hadoop</artifactId>
+  <description>
+    This project shaded bigtable-hbase for used in hadoop projects.
+  </description>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.cloud.bigtable</groupId>
+      <artifactId>bigtable-hbase-1.x-shaded</artifactId>
+      <version>0.9.8-SNAPSHOT</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.hbase</groupId>
+          <artifactId>hbase-shaded-client</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-client</artifactId>
+      <version>${hbase.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <shadeTestJar>true</shadeTestJar>
+              <!--
+                  KEEP shadedArtifactAttached=false.  DO NOTE CHANGE shadedArtifactAttached to true!
+
+                  Dependencies get messed up if shadedArtifactAttached=true.  The relocations
+                  are vital to get around dependency mismatches between hbase and cloud bigtable.
+                  Specifically, CBT and hbase use different versions of guava and netty.  Relocations
+                  are a way to get around those types of incompatibilities.
+
+                  Using shadedArtifactAttached=true causes some tricky issues.  If =true is on,
+                  then the main artifact isn't usable, because of the incompatibility issues in the artifacts found
+                  in the relocations section.  If HBase updates its dependencies to compatible versions, then
+                  this project will not need to relocate and include those dependencies in a shaded jar.
+
+                  As an example, the start up of hbase requires guava, and using a newer version of guava causes
+                  startup issues.  If an older version of guava is in the classpath, then HBase classes will load
+                  fine, but CBT will have runtime issues.
+
+                  Additionally, if shadedArtifactAttached=true there are even issues using the shaded classifier.
+                  Using the shaded classifier will pull in the right bigtable-hbase-1.2-shaded-${project.version}.jar,
+                  but it will also pull in bigtable-hbase and bigtable-protos as dependencies, which might
+                  cause classloading issues in some cases like web apps.
+              -->
+              <shadedArtifactAttached>false</shadedArtifactAttached>
+              <createDependencyReducedPom>true</createDependencyReducedPom>
+              <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
+              <artifactSet>
+                <includes>
+                  <include>com.google.cloud.bigtable:bigtable-hbase-1.x-shaded</include>
+                </includes>
+              </artifactSet>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/bigtable-hbase-parent/bigtable-hbase-1.x-hadoop/src/main/java/com/google/cloud/bigtable/hbase/hadoop/MavenPlaceholder.java
+++ b/bigtable-hbase-parent/bigtable-hbase-1.x-hadoop/src/main/java/com/google/cloud/bigtable/hbase/hadoop/MavenPlaceholder.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.hadoop;
+
+/**
+ * This class is here to force generation of source javadoc jars so that the maven release process
+ * doesn't complain. The shading plugin generated a shaded jar of bigtable-hbase, but it doesn't
+ * generate javadoc or source files; this class is here as a hack and better methods should be
+ * employed.
+ *
+ * @author sduskis
+ * @version $Id: $Id
+ */
+public final class MavenPlaceholder {
+
+  private MavenPlaceholder() {
+
+  }
+}

--- a/bigtable-hbase-parent/bigtable-hbase-1.x-shaded/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-1.x-shaded/pom.xml
@@ -32,7 +32,7 @@ limitations under the License.
 <dependencies>
   <dependency>
     <groupId>${project.groupId}</groupId>
-    <artifactId>bigtable-hbase</artifactId>
+    <artifactId>bigtable-hbase-1.x</artifactId>
     <version>${project.version}</version>
   </dependency>
 </dependencies>

--- a/bigtable-hbase-parent/bigtable-hbase-1.x-shaded/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-1.x-shaded/pom.xml
@@ -1,0 +1,197 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright 2017 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>bigtable-hbase-parent</artifactId>
+    <groupId>com.google.cloud.bigtable</groupId>
+    <version>0.9.8-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>bigtable-hbase-1.x-shaded</artifactId>
+  <description>
+    This project shaded bigtable-hbase for used in other projects.
+  </description>
+
+<dependencies>
+  <dependency>
+    <groupId>com.google.cloud.bigtable</groupId>
+    <artifactId>bigtable-hbase-1.x</artifactId>
+    <version>${project.version}</version>
+  </dependency>
+
+  <!-- Manually promote dependencies: This is necessary to avoid flattening hbase-shaded-client's dependency tree -->
+  <dependency>
+    <groupId>org.apache.hbase</groupId>
+    <artifactId>hbase-shaded-client</artifactId>
+    <version>${hbase.version}</version>
+  </dependency>
+
+  <dependency>
+    <groupId>com.google.code.findbugs</groupId>
+    <artifactId>jsr305</artifactId>
+    <version>${jsr305.version}</version>
+  </dependency>
+  <dependency>
+    <groupId>commons-logging</groupId>
+    <artifactId>commons-logging</artifactId>
+    <version>${commons-logging.version}</version>
+  </dependency>
+  <dependency>
+    <groupId>io.dropwizard.metrics</groupId>
+    <artifactId>metrics-core</artifactId>
+    <version>${dropwizard.metrics.version}</version>
+  </dependency>
+</dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <shadeTestJar>true</shadeTestJar>
+              <!--
+                  KEEP shadedArtifactAttached=false.  DO NOTE CHANGE shadedArtifactAttached to true!
+
+                  Dependencies get messed up if shadedArtifactAttached=true.  The relocations
+                  are vital to get around dependency mismatches between hbase and cloud bigtable.
+                  Specifically, CBT and hbase use different versions of guava and netty.  Relocations
+                  are a way to get around those types of incompatibilities.
+
+                  Using shadedArtifactAttached=true causes some tricky issues.  If =true is on,
+                  then the main artifact isn't usable, because of the incompatibility issues in the artifacts found
+                  in the relocations section.  If HBase updates its dependencies to compatible versions, then
+                  this project will not need to relocate and include those dependencies in a shaded jar.
+
+                  As an example, the start up of hbase requires guava, and using a newer version of guava causes
+                  startup issues.  If an older version of guava is in the classpath, then HBase classes will load
+                  fine, but CBT will have runtime issues.
+
+                  Additionally, if shadedArtifactAttached=true there are even ssues using the shaded classifier.
+                  Using the shaded classifier will pull in the right bigtable-hbase-1.0-shaded-${project.version}.jar,
+                  but it will also pull in bigtable-hbase and bigtable-protos as dependencies, which might
+                  cause classloading issues in some cases like web apps.
+              -->
+              <shadedArtifactAttached>false</shadedArtifactAttached>
+              <createDependencyReducedPom>true</createDependencyReducedPom>
+              <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
+              <artifactSet>
+                <includes>
+                  <include>com.fasterxml.jackson.core:*</include>
+                  <include>com.google.cloud.bigtable:bigtable-protos</include>
+                  <include>com.google.api.grpc:grpc-google-common-protos</include>
+                  <include>com.google.cloud.bigtable:bigtable-client-core</include>
+                  <include>com.google.cloud.bigtable:bigtable-hbase</include>
+                  <include>com.google.cloud.bigtable:bigtable-hbase-1.x</include>
+                  <include>com.google.api-client:*</include>
+                  <include>com.google.auth:*</include>
+                  <include>com.google.guava:guava</include>
+                  <include>com.google.http-client:*</include>
+                  <include>com.google.instrumentation:instrumentation-api</include>
+                  <include>com.google.oauth-client:*</include>
+                  <include>com.google.protobuf:*</include>
+                  <include>com.twitter:hpack</include>
+                  <include>io.netty:*</include>
+                  <include>io.grpc:*</include>
+                  <include>io.dropwizard.metrics:metrics-core</include>
+                </includes>
+                <excludes>
+                  <exclude>io.netty:netty-tcnative-boringssl-static</exclude>
+                </excludes>
+              </artifactSet>
+              <relocations>
+                <relocation>
+                  <pattern>com.fasterxml</pattern>
+                  <shadedPattern>com.google.bigtable.repackaged.com.faster.xml</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.google.api</pattern>
+                  <shadedPattern>com.google.bigtable.repackaged.com.google.api</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.google.auth</pattern>
+                  <shadedPattern>com.google.bigtable.repackaged.com.google.auth</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.google.cloud.audit</pattern>
+                  <shadedPattern>com.google.bigtable.repackaged.com.google.cloud.audit</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.google.common</pattern>
+                  <shadedPattern>com.google.bigtable.repackaged.com.google.common</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.google.instrumentation</pattern>
+                  <shadedPattern>com.google.bigtable.repackaged.com.google.instrumentation</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.google.logging</pattern>
+                  <shadedPattern>com.google.bigtable.repackaged.com.google.logging</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.google.longrunning</pattern>
+                  <shadedPattern>com.google.bigtable.repackaged.com.google.longrunning</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.google.rpc</pattern>
+                  <shadedPattern>com.google.bigtable.repackaged.com.google.rpc</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.google.thirdparty</pattern>
+                  <shadedPattern>com.google.bigtable.repackaged.com.google.thirdparty</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.google.protobuf</pattern>
+                  <shadedPattern>com.google.bigtable.repackaged.com.google.protobuf</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.google.type</pattern>
+                  <shadedPattern>com.google.bigtable.repackaged.com.google.type</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.twitter</pattern>
+                  <shadedPattern>com.google.bigtable.repackaged.com.twitter</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>io.grpc</pattern>
+                  <shadedPattern>com.google.bigtable.repackaged.io.grpc</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>io.netty</pattern>
+                  <shadedPattern>com.google.bigtable.repackaged.io.netty</shadedPattern>
+                  <!-- Don't relocate jni jar references -->
+                  <excludes>
+                    <exclude>io.netty.internal.tcnative.*</exclude>
+                  </excludes>
+                </relocation>
+              </relocations>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/bigtable-hbase-parent/bigtable-hbase-1.x-shaded/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-1.x-shaded/pom.xml
@@ -31,32 +31,9 @@ limitations under the License.
 
 <dependencies>
   <dependency>
-    <groupId>com.google.cloud.bigtable</groupId>
-    <artifactId>bigtable-hbase-1.x</artifactId>
+    <groupId>${project.groupId}</groupId>
+    <artifactId>bigtable-hbase</artifactId>
     <version>${project.version}</version>
-  </dependency>
-
-  <!-- Manually promote dependencies: This is necessary to avoid flattening hbase-shaded-client's dependency tree -->
-  <dependency>
-    <groupId>org.apache.hbase</groupId>
-    <artifactId>hbase-shaded-client</artifactId>
-    <version>${hbase.version}</version>
-  </dependency>
-
-  <dependency>
-    <groupId>com.google.code.findbugs</groupId>
-    <artifactId>jsr305</artifactId>
-    <version>${jsr305.version}</version>
-  </dependency>
-  <dependency>
-    <groupId>commons-logging</groupId>
-    <artifactId>commons-logging</artifactId>
-    <version>${commons-logging.version}</version>
-  </dependency>
-  <dependency>
-    <groupId>io.dropwizard.metrics</groupId>
-    <artifactId>metrics-core</artifactId>
-    <version>${dropwizard.metrics.version}</version>
   </dependency>
 </dependencies>
 

--- a/bigtable-hbase-parent/bigtable-hbase-1.x-shaded/src/main/java/com/google/cloud/bigtable/hbase/shaded/MavenPlaceholder.java
+++ b/bigtable-hbase-parent/bigtable-hbase-1.x-shaded/src/main/java/com/google/cloud/bigtable/hbase/shaded/MavenPlaceholder.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.shaded;
+
+/**
+ * This class is here to force generation of source javadoc jars so that the maven release process
+ * doesn't complain. The shading plugin generated a shaded jar of bigtable-hbase, but it doesn't
+ * generate javadoc or source files; this class is here as a hack and better methods should be
+ * employed.
+ *
+ * @author sduskis
+ * @version $Id: $Id
+ */
+public final class MavenPlaceholder {
+
+  private MavenPlaceholder() {
+
+  }
+}

--- a/bigtable-hbase-parent/bigtable-hbase-1.x/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-1.x/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright 2017 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.google.cloud.bigtable</groupId>
+    <artifactId>bigtable-hbase-parent</artifactId>
+    <version>0.9.8-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>bigtable-hbase-1.x</artifactId>
+  <packaging>jar</packaging>
+  <name>${project.groupId}:${project.artifactId}</name>
+  <description>
+    Bigtable connector compatible with HBase 1.x. It uses hbase-shaded-client and exposes unshaded bigtable-client-core.
+    Its meant to be used in standalone applications and apache beam. Please use bigtable-hbase-1.x-hadoop for hadoop
+    classpath compatible applications.
+  </description>
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>bigtable-hbase</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-tcnative-boringssl-static</artifactId>
+      <version>${netty-tcnative-boringssl-static.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.dropwizard.metrics</groupId>
+      <artifactId>metrics-graphite</artifactId>
+      <version>3.1.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>${mockito.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/bigtable-hbase-parent/bigtable-hbase-1.x/src/main/java/com/google/cloud/bigtable/hbase1_x/BigtableConnection.java
+++ b/bigtable-hbase-parent/bigtable-hbase-1.x/src/main/java/com/google/cloud/bigtable/hbase1_x/BigtableConnection.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase1_x;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.regex.Pattern;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.ProcedureInfo;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.AbstractBigtableAdmin;
+import org.apache.hadoop.hbase.client.AbstractBigtableConnection;
+import org.apache.hadoop.hbase.client.Admin;
+import org.apache.hadoop.hbase.client.security.SecurityCapability;
+import org.apache.hadoop.hbase.protobuf.generated.HBaseProtos.SnapshotDescription;
+import org.apache.hadoop.hbase.quotas.QuotaFilter;
+import org.apache.hadoop.hbase.quotas.QuotaRetriever;
+import org.apache.hadoop.hbase.quotas.QuotaSettings;
+import org.apache.hadoop.hbase.security.User;
+
+/**
+ * HBase 1.3 specific implementation of {@link AbstractBigtableConnection}.
+ *
+ * @author sduskis
+ * @version $Id: $Id
+ */
+@SuppressWarnings("deprecation")
+public class BigtableConnection extends AbstractBigtableConnection {
+
+  /**
+   * <p>Constructor for BigtableConnection.</p>
+   *
+   * @param conf a {@link Configuration} object.
+   * @throws IOException if any.
+   */
+  public BigtableConnection(Configuration conf) throws IOException {
+    super(conf);
+  }
+
+  BigtableConnection(Configuration conf, boolean managed, ExecutorService pool, User user)
+      throws IOException {
+    super(conf, managed, pool, user);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public Admin getAdmin() throws IOException {
+    return new AbstractBigtableAdmin(getOptions(), getConfiguration(), this,
+        getBigtableTableAdminClient(), getDisabledTables()) {
+
+          @Override
+          public void deleteTableSnapshots(String arg0, String arg1) throws IOException {
+            throw new UnsupportedOperationException("deleteTableSnapshots");  // TODO
+          }
+    
+          @Override
+          public void deleteTableSnapshots(Pattern arg0, Pattern arg1) throws IOException {
+            throw new UnsupportedOperationException("deleteTableSnapshots");  // TODO
+          }
+    
+          @Override
+          public List<SnapshotDescription> listTableSnapshots(String arg0, String arg1)
+              throws IOException {
+            throw new UnsupportedOperationException("listTableSnapshots");  // TODO
+          }
+    
+          @Override
+          public List<SnapshotDescription> listTableSnapshots(Pattern arg0, Pattern arg1)
+              throws IOException {
+            throw new UnsupportedOperationException("listTableSnapshots");  // TODO
+          }
+
+          @Override
+          public boolean isBalancerEnabled() throws IOException {
+            throw new UnsupportedOperationException("isBalancerEnabled");  // TODO
+          }
+
+          @Override
+          public long getLastMajorCompactionTimestamp(TableName tableName) throws IOException {
+            throw new UnsupportedOperationException("getLastMajorCompactionTimestamp");  // TODO
+          }
+
+          @Override
+          public long getLastMajorCompactionTimestampForRegion(byte[] regionName)
+              throws IOException {
+            throw new UnsupportedOperationException("getLastMajorCompactionTimestampForRegion");  // TODO
+          }
+
+          @Override
+          public void setQuota(QuotaSettings quota) throws IOException {
+            throw new UnsupportedOperationException("setQuota");  // TODO
+          }
+
+          @Override
+          public QuotaRetriever getQuotaRetriever(QuotaFilter filter) throws IOException {
+            throw new UnsupportedOperationException("getQuotaRetriever");  // TODO
+          }
+
+          @Override
+          public boolean normalize() throws IOException {
+            throw new UnsupportedOperationException("normalize");  // TODO
+          }
+
+          @Override
+          public boolean isNormalizerEnabled() throws IOException {
+            throw new UnsupportedOperationException("isNormalizerEnabled");  // TODO
+          }
+
+          @Override
+          public boolean setNormalizerRunning(boolean on) throws IOException {
+            throw new UnsupportedOperationException("setNormalizerRunning");  // TODO
+          }
+
+          @Override
+          public boolean abortProcedure(long procId, boolean mayInterruptIfRunning)
+              throws IOException {
+            throw new UnsupportedOperationException("abortProcedure");  // TODO
+          }
+
+          @Override
+          public ProcedureInfo[] listProcedures() throws IOException {
+            throw new UnsupportedOperationException("listProcedures");  // TODO
+          }
+
+          @Override
+          public Future<Boolean> abortProcedureAsync(long procId, boolean mayInterruptIfRunning)
+              throws IOException {
+            throw new UnsupportedOperationException("abortProcedureAsync");  // TODO
+          }
+
+          @Override
+          public List<SecurityCapability> getSecurityCapabilities() throws IOException {
+            throw new UnsupportedOperationException("getSecurityCapabilities");  // TODO
+          }
+
+          @Override
+          public boolean balancer(boolean arg0) throws IOException {
+            throw new UnsupportedOperationException("balancer");  // TODO
+          }
+
+          @Override
+          public boolean isSplitOrMergeEnabled(MasterSwitchType arg0) throws IOException {
+            throw new UnsupportedOperationException("isSplitOrMergeEnabled");  // TODO
+          }
+
+          @Override
+          public boolean[] setSplitOrMergeEnabled(boolean arg0, boolean arg1,
+              MasterSwitchType... arg2) throws IOException {
+            throw new UnsupportedOperationException("setSplitOrMergeEnabled");  // TODO
+          }
+    };
+  }
+}

--- a/bigtable-hbase-parent/bigtable-hbase-1.x/src/test/java/com/google/cloud/bigtable/hbase/ManyThreadDriver.java
+++ b/bigtable-hbase-parent/bigtable-hbase-1.x/src/test/java/com/google/cloud/bigtable/hbase/ManyThreadDriver.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase;
+
+import io.grpc.internal.GrpcUtil;
+import org.apache.commons.lang.RandomStringUtils;
+import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Admin;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.Get;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Table;
+import org.apache.hadoop.hbase.util.Bytes;
+import com.codahale.metrics.MetricFilter;
+import com.codahale.metrics.graphite.GraphiteReporter;
+import com.codahale.metrics.graphite.PickledGraphite;
+import com.google.cloud.bigtable.metrics.BigtableClientMetrics;
+import com.google.cloud.bigtable.metrics.DropwizardMetricRegistry;
+import com.google.cloud.bigtable.metrics.MetricRegistry;
+import com.google.cloud.bigtable.metrics.BigtableClientMetrics.MetricLevel;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class ManyThreadDriver {
+  
+  static GraphiteReporter reporter = null;
+  static final byte[] COLUMN_FAMILY = Bytes.toBytes("cf");
+
+  static {
+    setupGraphite();
+  }
+
+  static void setupGraphite() {
+    String serverIp = System.getProperty("graphite.server.ip");
+    if (serverIp != null) {
+      MetricRegistry registry = BigtableClientMetrics.getMetricRegistry(MetricLevel.Info);
+      DropwizardMetricRegistry dropwizardRegistry;
+      if (registry instanceof DropwizardMetricRegistry) {
+        dropwizardRegistry = (DropwizardMetricRegistry) registry;
+      } else {
+        dropwizardRegistry = new DropwizardMetricRegistry();
+        BigtableClientMetrics.setMetricRegistry(dropwizardRegistry);
+      }
+
+      int port = -1;
+      if (serverIp.contains(":")) {
+        String[] split = serverIp.split(":");
+        serverIp = split[0];
+        port = Integer.parseInt(split[1]);
+      } else {
+        port = Integer.parseInt(System.getProperty("graphite.server.port"));
+      }
+      System.out.println("Graphite server: " + serverIp + " port: " + port);
+      final String prefix = System.getProperty("graphite.prefix");
+      final PickledGraphite pickledGraphite =
+          new PickledGraphite(new InetSocketAddress(serverIp, port));
+      reporter =
+          GraphiteReporter.forRegistry(dropwizardRegistry.getRegistry())
+              .prefixedWith(prefix)
+              .convertRatesTo(TimeUnit.SECONDS)
+              .convertDurationsTo(TimeUnit.MILLISECONDS)
+              .filter(MetricFilter.ALL)
+              .build(pickledGraphite);
+      reporter.start(20, TimeUnit.SECONDS);
+      BigtableClientMetrics.setMetricRegistry(dropwizardRegistry);
+      System.out.println("created registry with prefix: " + prefix);
+    }
+  }
+
+  private static long recordCount;
+  private static int valueSize;
+  private static int runtimeHours;
+  private static int numThreads;
+  private static int numQualifiers;
+
+  private static void runTest(
+      String projectId, String instanceId, final String tableNameStr)
+      throws Exception {
+    byte[][] qualifiers = generateQualifiers(numQualifiers);
+    final TableName tableName = TableName.valueOf(tableNameStr);
+    final AtomicBoolean finished = new AtomicBoolean(false);
+    ExecutorService executor = Executors.newFixedThreadPool(numThreads,
+      GrpcUtil.getThreadFactory("WORK_EXECUTOR-%d", true));
+    ScheduledExecutorService finishExecutor = setupShutdown(finished);
+    try (Connection connection = BigtableConfiguration.connect(projectId, instanceId)) {
+      setupTable(tableName, connection);
+
+      System.out.println("Starting the executors.");
+      for (int i = 0; i < numThreads; i++) {
+        executor.execute(createWorker(connection, tableName, finished, qualifiers));
+      }
+      System.out.println("This will be running for " + runtimeHours + " hours.");
+      executor.shutdown();
+      executor.awaitTermination(runtimeHours, TimeUnit.HOURS);
+      // Sleep 10 seconds to allow stragglers to finish.
+      Thread.sleep(10000);
+    } finally {
+      finished.set(true);
+      executor.shutdownNow();
+      finishExecutor.shutdownNow();
+    }
+  }
+
+  static void setupTable(final TableName tableName, Connection connection) throws IOException {
+    try(Admin admin = connection.getAdmin()) {
+      HTableDescriptor descriptor = new HTableDescriptor(tableName);
+      descriptor.addFamily(new HColumnDescriptor(COLUMN_FAMILY));
+      try {
+        admin.createTable(descriptor);
+        System.out.println("Created the table");
+      } catch (IOException ignore) {
+        // Soldier on, maybe the table already exists.
+      }
+  
+      try {
+        System.out.println("Truncating the table");
+        admin.truncateTable(tableName, false);
+      } catch (IOException ignore) {
+        // Soldier on.
+      }
+    }
+  }
+
+  static ScheduledExecutorService setupShutdown(final AtomicBoolean finished) {
+    ScheduledExecutorService finishExecutor =
+        Executors.newScheduledThreadPool(1, GrpcUtil.getThreadFactory("FINISH_SCHEDULER-%d", true));
+    finishExecutor.schedule(new Runnable() {
+      @Override
+      public void run() {
+        finished.set(true);
+      }
+    }, runtimeHours, TimeUnit.HOURS);
+    return finishExecutor;
+  }
+
+  static Runnable createWorker(
+      final Connection connection,
+      TableName tableName,
+      final AtomicBoolean finished,
+      final byte[][] qualifiers)
+      throws IOException {
+    final Table table = connection.getTable(tableName);
+    final byte[][] values = new byte[qualifiers.length][];
+    for (int i = 0; i < qualifiers.length; i++) {
+      values[i] = Bytes.toBytes(RandomStringUtils.randomAlphanumeric(valueSize / values.length));
+    }
+    return new Runnable() {
+      @Override
+      public void run() {
+        while (!finished.get()) {
+          try {
+            // Workload: two reads and a write.
+            final byte[] key = Bytes.toBytes(key());
+            table.get(new Get(key));
+            table.get(new Get(key));
+            Put p = new Put(key);
+            for (int i = 0; i < qualifiers.length; i++) {
+              p.addColumn(COLUMN_FAMILY, qualifiers[i], values[i]);
+            }
+            table.put(p);
+          } catch(Throwable t) {
+            t.printStackTrace();
+          }
+        }
+      }
+    };
+  }
+
+  private static byte[][] generateQualifiers(int qualifierCount) {
+    final byte[][] qualifiers = new byte[qualifierCount][];
+    for (int i = 0; i < qualifierCount; i++) {
+      qualifiers[i] = Bytes.toBytes("qualifier_" + i);
+    }
+    return qualifiers;
+  }
+
+  private static String key() {
+    // TODO Make a parameter?
+    return "key-" + String.format("%19d", ThreadLocalRandom.current().nextLong(recordCount));
+  }
+
+  public static void main(String[] args) throws Exception {
+    // Consult system properties to get project/instance
+    // TODO Use standard hbase system properties?
+    String projectId = requiredProperty("bigtable.projectID");
+    String instanceId = requiredProperty("bigtable.instanceID");
+    String table = System.getProperty("bigtable.table", "ManyThreadDriver");
+    recordCount = Long.parseLong(System.getProperty("recordCount", "100000"));
+    valueSize = Integer.parseInt(System.getProperty("valueSize", "1024"));
+    runtimeHours = Integer.parseInt(System.getProperty("runtimeHours", "1"));
+    numThreads = Integer.parseInt(System.getProperty("numThreads", "1000"));
+    numQualifiers = Integer.parseInt(System.getProperty("numQualifiers", "20"));
+    runTest(projectId, instanceId, table);
+  }
+
+  private static String requiredProperty(String prop) {
+      String value = System.getProperty(prop);
+      if (value == null) {
+        throw new IllegalArgumentException("Missing required system property: " + prop);
+      }
+      return value;
+  }
+}

--- a/bigtable-hbase-parent/bigtable-hbase-1.x/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableConnection.java
+++ b/bigtable-hbase-parent/bigtable-hbase-1.x/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableConnection.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import com.google.cloud.bigtable.hbase1_x.BigtableConnection;
+
+/**
+ * This is a test to ensure that BigtableConnection can find {@link BigtableConnection}
+ *
+ */
+@RunWith(JUnit4.class)
+public class TestBigtableConnection {
+
+  @Test
+  public void testBigtableConnectionExists() {
+    Assert.assertEquals(BigtableConnection.class, BigtableConfiguration.getConnectionClass());
+  }
+}

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests/pom.xml
@@ -32,7 +32,7 @@ limitations under the License.
 
     <properties>
         <hbase.version>1.3.0</hbase.version>
-        <google.bigtable.project.under.test>bigtable-hbase-1.x</google.bigtable.project.under.test>
+        <google.bigtable.project.under.test>bigtable-hbase-1.x-hadoop</google.bigtable.project.under.test>
         <google.bigtable.connection.impl>com.google.cloud.bigtable.hbase1_x.BigtableConnection</google.bigtable.connection.impl>
         <protobuff-java.version>2.5.0</protobuff-java.version>
     </properties>

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests/pom.xml
@@ -32,8 +32,8 @@ limitations under the License.
 
     <properties>
         <hbase.version>1.3.0</hbase.version>
-        <google.bigtable.project.under.test>bigtable-hbase-1.0</google.bigtable.project.under.test>
-        <google.bigtable.connection.impl>com.google.cloud.bigtable.hbase1_0.BigtableConnection</google.bigtable.connection.impl>
+        <google.bigtable.project.under.test>bigtable-hbase-1.x</google.bigtable.project.under.test>
+        <google.bigtable.connection.impl>com.google.cloud.bigtable.hbase1_x.BigtableConnection</google.bigtable.connection.impl>
         <protobuff-java.version>2.5.0</protobuff-java.version>
     </properties>
 

--- a/bigtable-hbase-parent/bigtable-hbase-mapreduce/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-mapreduce/pom.xml
@@ -33,7 +33,7 @@ limitations under the License.
     </description>
 
     <properties>
-        <hbase.version>${hbase.version.1.2}</hbase.version>
+        <hbase.version>${hbase.version.1.3}</hbase.version>
         <hadoop.version>2.7.3</hadoop.version>
         <hadoop.scope>provided</hadoop.scope>
     </properties>
@@ -92,7 +92,7 @@ limitations under the License.
 
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>bigtable-hbase-1.2</artifactId>
+            <artifactId>bigtable-hbase-1.x-hadoop</artifactId>
             <version>${project.version}</version>
             <exclusions>
                 <exclusion>

--- a/bigtable-hbase-parent/bigtable-hbase-mapreduce/src/main/java/com/google/cloud/bigtable/mapreduce/Export.java
+++ b/bigtable-hbase-parent/bigtable-hbase-mapreduce/src/main/java/com/google/cloud/bigtable/mapreduce/Export.java
@@ -19,7 +19,7 @@
 package com.google.cloud.bigtable.mapreduce;
 
 import com.google.cloud.bigtable.hbase.BigtableOptionsFactory;
-import com.google.cloud.bigtable.hbase1_2.BigtableConnection;
+import com.google.cloud.bigtable.hbase1_x.BigtableConnection;
 import java.io.IOException;
 
 import org.apache.commons.logging.Log;

--- a/bigtable-hbase-parent/bigtable-hbase-mapreduce/src/main/java/com/google/cloud/bigtable/mapreduce/Import.java
+++ b/bigtable-hbase-parent/bigtable-hbase-mapreduce/src/main/java/com/google/cloud/bigtable/mapreduce/Import.java
@@ -16,7 +16,7 @@
 package com.google.cloud.bigtable.mapreduce;
 
 import com.google.cloud.bigtable.hbase.BigtableOptionsFactory;
-import com.google.cloud.bigtable.hbase1_2.BigtableConnection;
+import com.google.cloud.bigtable.hbase1_x.BigtableConnection;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;

--- a/bigtable-hbase-parent/bigtable-hbase-shaded/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-shaded/pom.xml
@@ -27,6 +27,7 @@ limitations under the License.
     <packaging>jar</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>
+       DEPRECATED: Please use hbase-1.x-hadoop artifact.
        This project shaded bigtable-hbase for used in other projects.
     </description>
 

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableConfiguration.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableConfiguration.java
@@ -34,6 +34,7 @@ public class BigtableConfiguration {
     "com.google.cloud.bigtable.hbase1_1.BigtableConnection",
     "com.google.cloud.bigtable.hbase1_2.BigtableConnection",
     "com.google.cloud.bigtable.hbase1_3.BigtableConnection",
+    "com.google.cloud.bigtable.hbase1_x.BigtableConnection",
   };
 
   private static final Class<? extends Connection> CONNECTION_CLASS = chooseConnectionClass();

--- a/bigtable-hbase-parent/pom.xml
+++ b/bigtable-hbase-parent/pom.xml
@@ -34,6 +34,8 @@ limitations under the License.
         <module>bigtable-hbase</module>
         <module>bigtable-hbase-integration-tests</module>
         <module>bigtable-hbase-mapreduce</module>
+        <module>bigtable-hbase-1.x</module>
+        <module>bigtable-hbase-1.x-hadoop</module>
     </modules>
 
     <profiles>
@@ -47,6 +49,7 @@ limitations under the License.
                 </property>
             </activation>
             <modules>
+                <module>bigtable-hbase-1.x-shaded</module>
                 <module>bigtable-hbase-shaded</module>
                 <module>bigtable-hbase-1.0</module>
                 <module>bigtable-hbase-1.1</module>

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,11 @@ limitations under the License.
         <guava.version>19.0</guava.version>
         <google.auth.library.version>0.6.1</google.auth.library.version>
         <dropwizard.metrics.version>3.1.2</dropwizard.metrics.version>
+        <netty-tcnative-boringssl-static.version>1.1.33.Fork26</netty-tcnative-boringssl-static.version>
+
+        <jsr305.version>3.0.2</jsr305.version>
+        <commons-logging.version>1.2</commons-logging.version>
+        <hamcrest.version>1.3</hamcrest.version>
 
         <!-- Values for integration testing. Set these in ~/.m2/settings.xml or
              via command-line -D flags. -->


### PR DESCRIPTION
This is the first step in the shading refactor. This PR introduces a set of new artifacts:
bigtable-hbase-1.x
bigtable-hbase-1.x-shaded
bigtable-hbase-1.x-hadoop

These artifacts will track hbase 1 api. Old artifacts have been deprecated.

The general idea is that to allow for 2 things:
- support of hbase 2, which is not binary compatible with hbase 1
- clean shading

bigtable-hbase will contain abstract logic that is common to hbase 1 & 2
bigtable-hbase-1.x will implement logic for latest hbase 1.x release.
bigtable-hbase-1.x-shaded will produce a minimal dependency jar
bigtable-hbase-1.x-hadoop will expose hadoop compatible dependencies

Currently shaded & hadoop are the same. Next PR will separate them.