### PR TITLE
Round down when writing timestamps to the nearest 1000 usecs, 

### DIFF
--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/PutAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/PutAdapter.java
@@ -22,6 +22,7 @@ import com.google.bigtable.v2.Mutation.MutationCase;
 import com.google.bigtable.v2.Mutation.SetCell;
 import com.google.cloud.bigtable.hbase.BigtableConstants;
 import com.google.cloud.bigtable.hbase.adapters.read.RowCell;
+import com.google.cloud.bigtable.hbase.util.TimestampConverter;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.ByteString;
 
@@ -109,8 +110,7 @@ public class PutAdapter extends MutationAdapter<Put> {
 
         long timestampMicros = currentTimestampMicros;
         if (cell.getTimestamp() != HConstants.LATEST_TIMESTAMP) {
-          timestampMicros = BigtableConstants.BIGTABLE_TIMEUNIT.convert(cell.getTimestamp(),
-            BigtableConstants.HBASE_TIMEUNIT);
+          timestampMicros = TimestampConverter.hbase2bigtable(cell.getTimestamp());
         }
 
         mutations.add(Mutation.newBuilder()

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/FlatRowAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/FlatRowAdapter.java
@@ -18,6 +18,7 @@ package com.google.cloud.bigtable.hbase.adapters.read;
 import com.google.cloud.bigtable.grpc.scanner.FlatRow;
 import com.google.cloud.bigtable.hbase.BigtableConstants;
 import com.google.cloud.bigtable.hbase.adapters.ResponseAdapter;
+import com.google.cloud.bigtable.hbase.util.TimestampConverter;
 import com.google.cloud.bigtable.util.ByteStringer;
 import com.google.common.base.Objects;
 
@@ -76,8 +77,7 @@ public class FlatRowAdapter implements ResponseAdapter<FlatRow, Result> {
         // Bigtable timestamp has more granularity than HBase one. It is possible that Bigtable
         // cells are deduped unintentionally here. On the other hand, if we don't dedup them,
         // HBase will treat them as duplicates.
-        cell.getTimestamp() == HConstants.LATEST_TIMESTAMP ?
-            HConstants.LATEST_TIMESTAMP : cell.getTimestamp() / TIME_CONVERSION_UNIT,
+        TimestampConverter.bigtable2hbase(cell.getTimestamp()),
         ByteStringer.extract(cell.getValue()));
   }
 
@@ -106,8 +106,7 @@ public class FlatRowAdapter implements ResponseAdapter<FlatRow, Result> {
           ByteStringer.wrap(rawCell.getQualifierArray(),
               rawCell.getQualifierOffset(), rawCell.getQualifierLength()
           ),
-          rawCell.getTimestamp() == HConstants.LATEST_TIMESTAMP ?
-              HConstants.LATEST_TIMESTAMP : rawCell.getTimestamp() * TIME_CONVERSION_UNIT,
+          TimestampConverter.hbase2bigtable(rawCell.getTimestamp()),
           ByteStringer.wrap(rawCell.getValueArray(),
               rawCell.getValueOffset(), rawCell.getValueLength()
           )

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/RowAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/RowAdapter.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.bigtable.hbase.adapters.read;
 
+import com.google.cloud.bigtable.hbase.util.TimestampConverter;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
@@ -37,11 +38,6 @@ import com.google.cloud.bigtable.util.ByteStringer;
  * @version $Id: $Id
  */
 public class RowAdapter implements ResponseAdapter<Row, Result> {
-  // This only works because BIGTABLE_TIMEUNIT is smaller than HBASE_TIMEUNIT, otherwise we will get
-  // 0.
-  static final long TIME_CONVERSION_UNIT = BigtableConstants.BIGTABLE_TIMEUNIT.convert(1,
-    BigtableConstants.HBASE_TIMEUNIT);
-
   /**
    * {@inheritDoc}
    *
@@ -72,7 +68,7 @@ public class RowAdapter implements ResponseAdapter<Row, Result> {
           // Bigtable timestamp has more granularity than HBase one. It is possible that Bigtable
           // cells are deduped unintentionally here. On the other hand, if we don't dedup them,
           // HBase will treat them as duplicates.
-          long hbaseTimestamp = cell.getTimestampMicros() / TIME_CONVERSION_UNIT;
+          long hbaseTimestamp = TimestampConverter.bigtable2hbase(cell.getTimestampMicros());
           RowCell keyValue = new RowCell(
               rowKey,
               familyNameBytes,

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/util/TimestampConverter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/util/TimestampConverter.java
@@ -1,0 +1,39 @@
+package com.google.cloud.bigtable.hbase.util;
+
+
+import com.google.cloud.bigtable.hbase.BigtableConstants;
+import org.apache.hadoop.hbase.HConstants;
+
+public class TimestampConverter {
+  private static final long STEP = BigtableConstants.BIGTABLE_TIMEUNIT
+      .convert(1, BigtableConstants.HBASE_TIMEUNIT);
+
+  /**
+   * Maximum timestamp (in usecs) that bigtable can handle while preserving lossless conversion to hbase timestamps in
+   * ms)
+   */
+  private static final long BIGTABLE_MAX_TIMESTAMP = Long.MAX_VALUE - (Long.MAX_VALUE % STEP);
+
+  /**
+   * Maximum timestamp that hbase can send to bigtable in ms. This limitation exists because bigtable operates on usecs,
+   * while hbase operates on ms.
+   */
+  private static final long HBASE_EFFECTIVE_MAX_TIMESTAMP = BigtableConstants.HBASE_TIMEUNIT
+      .convert(BIGTABLE_MAX_TIMESTAMP, BigtableConstants.BIGTABLE_TIMEUNIT);
+
+  public static long hbase2bigtable(long timestamp) {
+    if (timestamp < HBASE_EFFECTIVE_MAX_TIMESTAMP) {
+      return BigtableConstants.BIGTABLE_TIMEUNIT.convert(timestamp, BigtableConstants.HBASE_TIMEUNIT);
+    } else {
+      return BIGTABLE_MAX_TIMESTAMP;
+    }
+  }
+
+  public static long bigtable2hbase(long timestamp) {
+    if (timestamp >= BIGTABLE_MAX_TIMESTAMP) {
+      return HConstants.LATEST_TIMESTAMP;
+    } else {
+      return BigtableConstants.HBASE_TIMEUNIT.convert(timestamp, BigtableConstants.BIGTABLE_TIMEUNIT);
+    }
+  }
+}


### PR DESCRIPTION
while still taking care to preserve the LATEST_TIMESTAMP on read