### PR TITLE
shade proto-google-common-protos as well

### DIFF
--- a/bigtable-hbase-parent/bigtable-hbase-shaded/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-shaded/pom.xml
@@ -110,6 +110,7 @@ limitations under the License.
                                     <include>com.fasterxml.jackson.core:*</include>
                                     <include>com.google.cloud.bigtable:bigtable-protos</include>
                                     <include>com.google.api.grpc:grpc-google-common-protos</include>
+                                    <include>com.google.api.grpc:proto-google-common-protos</include>
                                     <include>com.google.cloud.bigtable:bigtable-client-core</include>
                                     <include>com.google.cloud.bigtable:bigtable-hbase</include>
                                     <include>com.google.api-client:*</include>


### PR DESCRIPTION
grpc-google-common-protos no longer includes the protos, need to shade proto-google-common-protos