### PR TITLE
Introducing hbase 1.x artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,20 +30,26 @@ which makes it easy for development teams to get started.
 
 ### Using the Java client
 
-* Add the appropriate [Cloud Bigtable artifact dependencies](http://mvnrepository.com/artifact/com.google.cloud.bigtable) to your [Maven project](https://cloud.google.com/bigtable/docs/using-maven), e.g.:
- ```xml
-  <dependency>
-      <groupId>com.google.cloud.bigtable</groupId>
-      <artifactId>bigtable-hbase-1.2</artifactId>
-      <version>0.9.6.2</version>
-  </dependency>
+* Add the appropriate [Cloud Bigtable artifact dependencies](http://mvnrepository.com/artifact/com.google.cloud.bigtable) to your [Maven project](https://cloud.google.com/bigtable/docs/using-maven).
+  * bigtable-hbase-1.x: use for standalone applications where you are in control your dependencies.
+  * bigtable-hbase-1.x-hadoop: use in hadoop environments
+  * bigtable-hbase-1.x-shaded: use in environments (other than hadoop) that require older versions of protobuf, guava, etc.  
 
-  <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-tcnative-boringssl-static</artifactId>
-      <version>1.1.33.Fork26</version>
-  </dependency>
-```
+* Example:
+   ```xml
+    <dependency>
+        <groupId>com.google.cloud.bigtable</groupId>
+        <artifactId>bigtable-hbase-1.x</artifactId>
+        <version>0.10.0</version>
+    </dependency>
+  
+    <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-tcnative-boringssl-static</artifactId>
+        <version>1.1.33.Fork26</version>
+    </dependency>
+  ```
+
 * Refer to the [Java samples documentation](https://cloud.google.com/bigtable/docs/samples) for detailed demonstrations of how to read and write data with Cloud Bigtable. The code for these samples is available in the [Cloud Bigtable examples project](https://github.com/GoogleCloudPlatform/cloud-bigtable-examples).
 
 ## Questions and discussions

--- a/bigtable-hbase-parent/bigtable-hbase-1.0/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-1.0/pom.xml
@@ -27,7 +27,8 @@ limitations under the License.
     <packaging>jar</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>
-       This project contains hbase 1.0 specific implementation of bigtable hbase.
+        DEPRECATED: Please use bigtable-hbase-1.x or bigtable-hbase-1.x-hadoop.
+        This project contains hbase 1.0 specific implementation of bigtable hbase.
     </description>
 
     <properties>

--- a/bigtable-hbase-parent/bigtable-hbase-1.1/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-1.1/pom.xml
@@ -27,7 +27,8 @@ limitations under the License.
     <packaging>jar</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>
-       This project contains hbase 1.1 specific implementation of bigtable hbase.
+        DEPRECATED: Please use bigtable-hbase-1.x or bigtable-hbase-1.x-hadoop.
+        This project contains hbase 1.1 specific implementation of bigtable hbase.
     </description>
 
     <properties>

--- a/bigtable-hbase-parent/bigtable-hbase-1.2/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-1.2/pom.xml
@@ -27,7 +27,8 @@ limitations under the License.
     <packaging>jar</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>
-       This project contains hbase 1.2 specific implementation of bigtable hbase.
+        DEPRECATED: Please use bigtable-hbase-1.x or bigtable-hbase-1.x-hadoop.
+        This project contains hbase 1.2 specific implementation of bigtable hbase.
     </description>
 
     <properties>

--- a/bigtable-hbase-parent/bigtable-hbase-1.3/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-1.3/pom.xml
@@ -27,7 +27,8 @@ limitations under the License.
     <packaging>jar</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>
-       This project contains hbase 1.3 specific implementation of bigtable hbase.
+        DEPRECATED: Please use bigtable-hbase-1.x or bigtable-hbase-1.x-hadoop.
+        This project contains hbase 1.3 specific implementation of bigtable hbase.
     </description>
 
     <properties>

--- a/bigtable-hbase-parent/bigtable-hbase-1.x-hadoop/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-1.x-hadoop/pom.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright 2017 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>bigtable-hbase-parent</artifactId>
+    <groupId>com.google.cloud.bigtable</groupId>
+    <version>0.9.8-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>bigtable-hbase-1.x-hadoop</artifactId>
+  <description>
+    Bigtable connector compatible with HBase 1.x. It most of its dependencies (hbase &amp; grpc). Its mainly intended to
+    be used by dataflow 1.x to avoid version conflicts with grpc &amp; protobuf. Prefer to use bigtable-hbase-1.x.
+  </description>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.cloud.bigtable</groupId>
+      <artifactId>bigtable-hbase-1.x-shaded</artifactId>
+      <version>0.9.8-SNAPSHOT</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.hbase</groupId>
+          <artifactId>hbase-shaded-client</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-client</artifactId>
+      <version>${hbase.version}</version>
+    </dependency>
+
+    <!-- Manually promote dependencies: This is necessary to avoid flattening hbase-shaded-client's dependency tree -->
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <version>${jsr305.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-logging</groupId>
+      <artifactId>commons-logging</artifactId>
+      <version>${commons-logging.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.dropwizard.metrics</groupId>
+      <artifactId>metrics-core</artifactId>
+      <version>${dropwizard.metrics.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <shadeTestJar>true</shadeTestJar>
+              <shadedArtifactAttached>false</shadedArtifactAttached>
+              <createDependencyReducedPom>true</createDependencyReducedPom>
+              <!-- Need to manually promote to dependencies to keep the structure of hbase-shade-client -->
+              <promoteTransitiveDependencies>false</promoteTransitiveDependencies>
+              <artifactSet>
+                <includes>
+                  <include>com.google.cloud.bigtable:bigtable-hbase-1.x-shaded</include>
+                </includes>
+              </artifactSet>
+              <relocations>
+                <!-- Undo the relocation that hbase-shaded-client did to make it compatible with the regular hbase-client -->
+                <relocation>
+                  <pattern>org.apache.hadoop.hbase.shaded.com.google.protobuf</pattern>
+                  <shadedPattern>com.google.protobuf</shadedPattern>
+                </relocation>
+              </relocations>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/bigtable-hbase-parent/bigtable-hbase-1.x-shaded/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-1.x-shaded/pom.xml
@@ -109,6 +109,7 @@ limitations under the License.
                      and references to com.google.cloud.bigtable.hbase1_x in the version specific jars.
                     -->
                     <exclude>com.google.cloud.bigtable.hbase*.**</exclude>
+                    <exclude>com.google.cloud.bigtable.metrics.**</exclude>
                   </excludes>
                 </relocation>
 

--- a/bigtable-hbase-parent/bigtable-hbase-1.x-shaded/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-1.x-shaded/pom.xml
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright 2017 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>bigtable-hbase-parent</artifactId>
+    <groupId>com.google.cloud.bigtable</groupId>
+    <version>0.9.8-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>bigtable-hbase-1.x-shaded</artifactId>
+  <description>
+    Bigtable connector compatible with HBase 1.x. It exposes the minimal set of dependencies. Its mainly intended to
+    be used by dataflow 1.x to avoid version conflicts with grpc &amp; protobuf. Prefer to use bigtable-hbase-1.x in
+    general and bigtable-hbase-1.x-hadoop for hadoop classpath compatible applications.
+  </description>
+
+<dependencies>
+  <dependency>
+    <groupId>com.google.cloud.bigtable</groupId>
+    <artifactId>bigtable-hbase-1.x</artifactId>
+    <version>0.9.8-SNAPSHOT</version>
+  </dependency>
+
+  <!-- Manually promote dependencies: This is necessary to avoid flattening hbase-shaded-client's dependency tree -->
+  <dependency>
+    <groupId>org.apache.hbase</groupId>
+    <artifactId>hbase-shaded-client</artifactId>
+    <version>${hbase.version}</version>
+  </dependency>
+
+  <dependency>
+    <groupId>com.google.code.findbugs</groupId>
+    <artifactId>jsr305</artifactId>
+    <version>${jsr305.version}</version>
+  </dependency>
+  <dependency>
+    <groupId>commons-logging</groupId>
+    <artifactId>commons-logging</artifactId>
+    <version>${commons-logging.version}</version>
+  </dependency>
+  <dependency>
+    <groupId>io.dropwizard.metrics</groupId>
+    <artifactId>metrics-core</artifactId>
+    <version>${dropwizard.metrics.version}</version>
+  </dependency>
+</dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <shadeTestJar>true</shadeTestJar>
+              <shadedArtifactAttached>false</shadedArtifactAttached>
+              <createDependencyReducedPom>true</createDependencyReducedPom>
+              <!-- Need to manually promote to dependencies to keep the structure of hbase-shade-client -->
+              <promoteTransitiveDependencies>false</promoteTransitiveDependencies>
+              <artifactSet>
+                <excludes>
+                  <!-- exclude user visible deps -->
+                  <exclude>io.dropwizard.metrics:metrics-core</exclude>
+                  <exclude>commons-logging:commons-logging</exclude>
+                  <exclude>com.google.code.findbugs:jsr305</exclude>
+                  <!-- exclude hbase-shaded-client & all of its dependencies -->
+                  <exclude>org.apache.hbase:hbase-shaded-client</exclude>
+                  <exclude>org.slf4j:slf4j-api</exclude>
+                  <exclude>org.slf4j:slf4j-log4j12</exclude>
+                  <exclude>org.slf4j:slf4j-api</exclude>
+                  <exclude>log4j:log4j</exclude>
+                  <exclude>org.apache.htrace:htrace-core</exclude>
+                  <exclude>com.github.stephenc.findbugs:findbugs-annotations</exclude>
+                  <exclude>log4j:log4j</exclude>
+                  <exclude>junit:junit</exclude>
+                  <exclude>org.hamcrest:hamcrest-core</exclude>
+                  <exclude>javax.inject:javax.inject</exclude>
+                </excludes>
+              </artifactSet>
+              <relocations>
+                <relocation>
+                  <pattern>com.google</pattern>
+                  <shadedPattern>com.google.bigtable.repackaged.com.google</shadedPattern>
+                  <excludes>
+                    <!-- don't shade our public hbase implementation. This includes com.google.cloud.bigtable.hbase.*
+                     and references to com.google.cloud.bigtable.hbase1_x in the version specific jars.
+                    -->
+                    <exclude>com.google.cloud.bigtable.hbase*.**</exclude>
+                  </excludes>
+                </relocation>
+
+                <relocation>
+                  <pattern>com.fasterxml</pattern>
+                  <shadedPattern>com.google.bigtable.repackaged.com.faster.xml</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.twitter</pattern>
+                  <shadedPattern>com.google.bigtable.repackaged.com.twitter</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>io.grpc</pattern>
+                  <shadedPattern>com.google.bigtable.repackaged.io.grpc</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>io.netty</pattern>
+                  <shadedPattern>com.google.bigtable.repackaged.io.netty</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.joda</pattern>
+                  <shadedPattern>com.google.bigtable.repackaged.org.joda</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.http</pattern>
+                  <shadedPattern>com.google.bigtable.repackaged.org.apache.http</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.commons.codec</pattern>
+                  <shadedPattern>com.google.bigtable.repackaged.org.apache.commons.codec</shadedPattern>
+                </relocation>
+              </relocations>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/bigtable-hbase-parent/bigtable-hbase-1.x-shaded/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-1.x-shaded/pom.xml
@@ -26,6 +26,7 @@ limitations under the License.
 
   <artifactId>bigtable-hbase-1.x-shaded</artifactId>
   <description>
+    DEPRECATED: Please use bigtable-hbase-1.x or bigtable-hbase-1.x-hadoop.
     Bigtable connector compatible with HBase 1.x. It exposes the minimal set of dependencies. Its mainly intended to
     be used by dataflow 1.x to avoid version conflicts with grpc &amp; protobuf. Prefer to use bigtable-hbase-1.x in
     general and bigtable-hbase-1.x-hadoop for hadoop classpath compatible applications.

--- a/bigtable-hbase-parent/bigtable-hbase-1.x/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-1.x/pom.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright 2017 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.google.cloud.bigtable</groupId>
+    <artifactId>bigtable-hbase-parent</artifactId>
+    <version>0.9.8-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>bigtable-hbase-1.x</artifactId>
+  <packaging>jar</packaging>
+  <name>${project.groupId}:${project.artifactId}</name>
+  <description>
+    Bigtable connector compatible with HBase 1.x. It uses hbase-shaded-client and exposes unshaded bigtable-client-core.
+    Its meant to be used in standalone applications and apache beam. Please use bigtable-hbase-1.x-hadoop for hadoop
+    classpath compatible applications.
+  </description>
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>bigtable-hbase</artifactId>
+      <version>${project.version}</version>
+
+      <!-- TODO(igorbernstein2): remove exclusions after migration to hbase-shaded-client -->
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.hbase</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-cli</groupId>
+          <artifactId>commons-cli</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-lang</groupId>
+          <artifactId>commons-lang</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <!-- TODO(igorbernstein2): move this dep to bigtable-hbase -->
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-shaded-client</artifactId>
+      <version>${hbase.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-tcnative-boringssl-static</artifactId>
+      <version>${netty-tcnative-boringssl-static.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.dropwizard.metrics</groupId>
+      <artifactId>metrics-graphite</artifactId>
+      <version>3.1.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>${mockito.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/bigtable-hbase-parent/bigtable-hbase-1.x/src/main/java/com/google/cloud/bigtable/hbase1_x/BigtableConnection.java
+++ b/bigtable-hbase-parent/bigtable-hbase-1.x/src/main/java/com/google/cloud/bigtable/hbase1_x/BigtableConnection.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase1_x;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.regex.Pattern;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.ProcedureInfo;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.AbstractBigtableAdmin;
+import org.apache.hadoop.hbase.client.AbstractBigtableConnection;
+import org.apache.hadoop.hbase.client.Admin;
+import org.apache.hadoop.hbase.client.security.SecurityCapability;
+import org.apache.hadoop.hbase.protobuf.generated.HBaseProtos.SnapshotDescription;
+import org.apache.hadoop.hbase.quotas.QuotaFilter;
+import org.apache.hadoop.hbase.quotas.QuotaRetriever;
+import org.apache.hadoop.hbase.quotas.QuotaSettings;
+import org.apache.hadoop.hbase.security.User;
+
+/**
+ * HBase 1.x specific implementation of {@link AbstractBigtableConnection}.
+ *
+ * @author sduskis
+ * @version $Id: $Id
+ */
+@SuppressWarnings("deprecation")
+public class BigtableConnection extends AbstractBigtableConnection {
+
+  /**
+   * <p>Constructor for BigtableConnection.</p>
+   *
+   * @param conf a {@link Configuration} object.
+   * @throws IOException if any.
+   */
+  public BigtableConnection(Configuration conf) throws IOException {
+    super(conf);
+  }
+
+  BigtableConnection(Configuration conf, boolean managed, ExecutorService pool, User user)
+      throws IOException {
+    super(conf, managed, pool, user);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public Admin getAdmin() throws IOException {
+    return new AbstractBigtableAdmin(getOptions(), getConfiguration(), this,
+        getBigtableTableAdminClient(), getDisabledTables()) {
+
+          @Override
+          public void deleteTableSnapshots(String arg0, String arg1) throws IOException {
+            throw new UnsupportedOperationException("deleteTableSnapshots");  // TODO
+          }
+    
+          @Override
+          public void deleteTableSnapshots(Pattern arg0, Pattern arg1) throws IOException {
+            throw new UnsupportedOperationException("deleteTableSnapshots");  // TODO
+          }
+    
+          @Override
+          public List<SnapshotDescription> listTableSnapshots(String arg0, String arg1)
+              throws IOException {
+            throw new UnsupportedOperationException("listTableSnapshots");  // TODO
+          }
+    
+          @Override
+          public List<SnapshotDescription> listTableSnapshots(Pattern arg0, Pattern arg1)
+              throws IOException {
+            throw new UnsupportedOperationException("listTableSnapshots");  // TODO
+          }
+
+          @Override
+          public boolean isBalancerEnabled() throws IOException {
+            throw new UnsupportedOperationException("isBalancerEnabled");  // TODO
+          }
+
+          @Override
+          public long getLastMajorCompactionTimestamp(TableName tableName) throws IOException {
+            throw new UnsupportedOperationException("getLastMajorCompactionTimestamp");  // TODO
+          }
+
+          @Override
+          public long getLastMajorCompactionTimestampForRegion(byte[] regionName)
+              throws IOException {
+            throw new UnsupportedOperationException("getLastMajorCompactionTimestampForRegion");  // TODO
+          }
+
+          @Override
+          public void setQuota(QuotaSettings quota) throws IOException {
+            throw new UnsupportedOperationException("setQuota");  // TODO
+          }
+
+          @Override
+          public QuotaRetriever getQuotaRetriever(QuotaFilter filter) throws IOException {
+            throw new UnsupportedOperationException("getQuotaRetriever");  // TODO
+          }
+
+          @Override
+          public boolean normalize() throws IOException {
+            throw new UnsupportedOperationException("normalize");  // TODO
+          }
+
+          @Override
+          public boolean isNormalizerEnabled() throws IOException {
+            throw new UnsupportedOperationException("isNormalizerEnabled");  // TODO
+          }
+
+          @Override
+          public boolean setNormalizerRunning(boolean on) throws IOException {
+            throw new UnsupportedOperationException("setNormalizerRunning");  // TODO
+          }
+
+          @Override
+          public boolean abortProcedure(long procId, boolean mayInterruptIfRunning)
+              throws IOException {
+            throw new UnsupportedOperationException("abortProcedure");  // TODO
+          }
+
+          @Override
+          public ProcedureInfo[] listProcedures() throws IOException {
+            throw new UnsupportedOperationException("listProcedures");  // TODO
+          }
+
+          @Override
+          public Future<Boolean> abortProcedureAsync(long procId, boolean mayInterruptIfRunning)
+              throws IOException {
+            throw new UnsupportedOperationException("abortProcedureAsync");  // TODO
+          }
+
+          @Override
+          public List<SecurityCapability> getSecurityCapabilities() throws IOException {
+            throw new UnsupportedOperationException("getSecurityCapabilities");  // TODO
+          }
+
+          @Override
+          public boolean balancer(boolean arg0) throws IOException {
+            throw new UnsupportedOperationException("balancer");  // TODO
+          }
+
+          @Override
+          public boolean isSplitOrMergeEnabled(MasterSwitchType arg0) throws IOException {
+            throw new UnsupportedOperationException("isSplitOrMergeEnabled");  // TODO
+          }
+
+          @Override
+          public boolean[] setSplitOrMergeEnabled(boolean arg0, boolean arg1,
+              MasterSwitchType... arg2) throws IOException {
+            throw new UnsupportedOperationException("setSplitOrMergeEnabled");  // TODO
+          }
+    };
+  }
+}

--- a/bigtable-hbase-parent/bigtable-hbase-1.x/src/test/java/com/google/cloud/bigtable/hbase/ManyThreadDriver.java
+++ b/bigtable-hbase-parent/bigtable-hbase-1.x/src/test/java/com/google/cloud/bigtable/hbase/ManyThreadDriver.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase;
+
+import io.grpc.internal.GrpcUtil;
+import org.apache.hadoop.hbase.shaded.org.apache.commons.lang.RandomStringUtils;
+import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Admin;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.Get;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Table;
+import org.apache.hadoop.hbase.util.Bytes;
+import com.codahale.metrics.MetricFilter;
+import com.codahale.metrics.graphite.GraphiteReporter;
+import com.codahale.metrics.graphite.PickledGraphite;
+import com.google.cloud.bigtable.metrics.BigtableClientMetrics;
+import com.google.cloud.bigtable.metrics.DropwizardMetricRegistry;
+import com.google.cloud.bigtable.metrics.MetricRegistry;
+import com.google.cloud.bigtable.metrics.BigtableClientMetrics.MetricLevel;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class ManyThreadDriver {
+  
+  static GraphiteReporter reporter = null;
+  static final byte[] COLUMN_FAMILY = Bytes.toBytes("cf");
+
+  static {
+    setupGraphite();
+  }
+
+  static void setupGraphite() {
+    String serverIp = System.getProperty("graphite.server.ip");
+    if (serverIp != null) {
+      MetricRegistry registry = BigtableClientMetrics.getMetricRegistry(MetricLevel.Info);
+      DropwizardMetricRegistry dropwizardRegistry;
+      if (registry instanceof DropwizardMetricRegistry) {
+        dropwizardRegistry = (DropwizardMetricRegistry) registry;
+      } else {
+        dropwizardRegistry = new DropwizardMetricRegistry();
+        BigtableClientMetrics.setMetricRegistry(dropwizardRegistry);
+      }
+
+      int port = -1;
+      if (serverIp.contains(":")) {
+        String[] split = serverIp.split(":");
+        serverIp = split[0];
+        port = Integer.parseInt(split[1]);
+      } else {
+        port = Integer.parseInt(System.getProperty("graphite.server.port"));
+      }
+      System.out.println("Graphite server: " + serverIp + " port: " + port);
+      final String prefix = System.getProperty("graphite.prefix");
+      final PickledGraphite pickledGraphite =
+          new PickledGraphite(new InetSocketAddress(serverIp, port));
+      reporter =
+          GraphiteReporter.forRegistry(dropwizardRegistry.getRegistry())
+              .prefixedWith(prefix)
+              .convertRatesTo(TimeUnit.SECONDS)
+              .convertDurationsTo(TimeUnit.MILLISECONDS)
+              .filter(MetricFilter.ALL)
+              .build(pickledGraphite);
+      reporter.start(20, TimeUnit.SECONDS);
+      BigtableClientMetrics.setMetricRegistry(dropwizardRegistry);
+      System.out.println("created registry with prefix: " + prefix);
+    }
+  }
+
+  private static long recordCount;
+  private static int valueSize;
+  private static int runtimeHours;
+  private static int numThreads;
+  private static int numQualifiers;
+
+  private static void runTest(
+      String projectId, String instanceId, final String tableNameStr)
+      throws Exception {
+    byte[][] qualifiers = generateQualifiers(numQualifiers);
+    final TableName tableName = TableName.valueOf(tableNameStr);
+    final AtomicBoolean finished = new AtomicBoolean(false);
+    ExecutorService executor = Executors.newFixedThreadPool(numThreads,
+      GrpcUtil.getThreadFactory("WORK_EXECUTOR-%d", true));
+    ScheduledExecutorService finishExecutor = setupShutdown(finished);
+    try (Connection connection = BigtableConfiguration.connect(projectId, instanceId)) {
+      setupTable(tableName, connection);
+
+      System.out.println("Starting the executors.");
+      for (int i = 0; i < numThreads; i++) {
+        executor.execute(createWorker(connection, tableName, finished, qualifiers));
+      }
+      System.out.println("This will be running for " + runtimeHours + " hours.");
+      executor.shutdown();
+      executor.awaitTermination(runtimeHours, TimeUnit.HOURS);
+      // Sleep 10 seconds to allow stragglers to finish.
+      Thread.sleep(10000);
+    } finally {
+      finished.set(true);
+      executor.shutdownNow();
+      finishExecutor.shutdownNow();
+    }
+  }
+
+  static void setupTable(final TableName tableName, Connection connection) throws IOException {
+    try(Admin admin = connection.getAdmin()) {
+      HTableDescriptor descriptor = new HTableDescriptor(tableName);
+      descriptor.addFamily(new HColumnDescriptor(COLUMN_FAMILY));
+      try {
+        admin.createTable(descriptor);
+        System.out.println("Created the table");
+      } catch (IOException ignore) {
+        // Soldier on, maybe the table already exists.
+      }
+  
+      try {
+        System.out.println("Truncating the table");
+        admin.truncateTable(tableName, false);
+      } catch (IOException ignore) {
+        // Soldier on.
+      }
+    }
+  }
+
+  static ScheduledExecutorService setupShutdown(final AtomicBoolean finished) {
+    ScheduledExecutorService finishExecutor =
+        Executors.newScheduledThreadPool(1, GrpcUtil.getThreadFactory("FINISH_SCHEDULER-%d", true));
+    finishExecutor.schedule(new Runnable() {
+      @Override
+      public void run() {
+        finished.set(true);
+      }
+    }, runtimeHours, TimeUnit.HOURS);
+    return finishExecutor;
+  }
+
+  static Runnable createWorker(
+      final Connection connection,
+      TableName tableName,
+      final AtomicBoolean finished,
+      final byte[][] qualifiers)
+      throws IOException {
+    final Table table = connection.getTable(tableName);
+    final byte[][] values = new byte[qualifiers.length][];
+    for (int i = 0; i < qualifiers.length; i++) {
+      values[i] = Bytes.toBytes(RandomStringUtils.randomAlphanumeric(valueSize / values.length));
+    }
+    return new Runnable() {
+      @Override
+      public void run() {
+        while (!finished.get()) {
+          try {
+            // Workload: two reads and a write.
+            final byte[] key = Bytes.toBytes(key());
+            table.get(new Get(key));
+            table.get(new Get(key));
+            Put p = new Put(key);
+            for (int i = 0; i < qualifiers.length; i++) {
+              p.addColumn(COLUMN_FAMILY, qualifiers[i], values[i]);
+            }
+            table.put(p);
+          } catch(Throwable t) {
+            t.printStackTrace();
+          }
+        }
+      }
+    };
+  }
+
+  private static byte[][] generateQualifiers(int qualifierCount) {
+    final byte[][] qualifiers = new byte[qualifierCount][];
+    for (int i = 0; i < qualifierCount; i++) {
+      qualifiers[i] = Bytes.toBytes("qualifier_" + i);
+    }
+    return qualifiers;
+  }
+
+  private static String key() {
+    // TODO Make a parameter?
+    return "key-" + String.format("%19d", ThreadLocalRandom.current().nextLong(recordCount));
+  }
+
+  public static void main(String[] args) throws Exception {
+    // Consult system properties to get project/instance
+    // TODO Use standard hbase system properties?
+    String projectId = requiredProperty("bigtable.projectID");
+    String instanceId = requiredProperty("bigtable.instanceID");
+    String table = System.getProperty("bigtable.table", "ManyThreadDriver");
+    recordCount = Long.parseLong(System.getProperty("recordCount", "100000"));
+    valueSize = Integer.parseInt(System.getProperty("valueSize", "1024"));
+    runtimeHours = Integer.parseInt(System.getProperty("runtimeHours", "1"));
+    numThreads = Integer.parseInt(System.getProperty("numThreads", "1000"));
+    numQualifiers = Integer.parseInt(System.getProperty("numQualifiers", "20"));
+    runTest(projectId, instanceId, table);
+  }
+
+  private static String requiredProperty(String prop) {
+      String value = System.getProperty(prop);
+      if (value == null) {
+        throw new IllegalArgumentException("Missing required system property: " + prop);
+      }
+      return value;
+  }
+}

--- a/bigtable-hbase-parent/bigtable-hbase-1.x/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableConnection.java
+++ b/bigtable-hbase-parent/bigtable-hbase-1.x/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableConnection.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import com.google.cloud.bigtable.hbase1_x.BigtableConnection;
+
+/**
+ * This is a test to ensure that BigtableConnection can find {@link BigtableConnection}
+ *
+ */
+@RunWith(JUnit4.class)
+public class TestBigtableConnection {
+
+  @Test
+  public void testBigtableConnectionExists() {
+    Assert.assertEquals(BigtableConnection.class, BigtableConfiguration.getConnectionClass());
+  }
+}

--- a/bigtable-hbase-parent/pom.xml
+++ b/bigtable-hbase-parent/pom.xml
@@ -34,6 +34,7 @@ limitations under the License.
         <module>bigtable-hbase</module>
         <module>bigtable-hbase-integration-tests</module>
         <module>bigtable-hbase-mapreduce</module>
+        <module>bigtable-hbase-1.x</module>
     </modules>
 
     <profiles>
@@ -47,6 +48,9 @@ limitations under the License.
                 </property>
             </activation>
             <modules>
+                <module>bigtable-hbase-1.x-shaded</module>
+                <module>bigtable-hbase-1.x-hadoop</module>
+
                 <module>bigtable-hbase-shaded</module>
                 <module>bigtable-hbase-1.0</module>
                 <module>bigtable-hbase-1.1</module>


### PR DESCRIPTION
This is step 2 of #1386.
It introduces a set of new artifacts that are based on hbase-shaded-client. Since hbase uses semantic versioning we only need to implement connectors for major versions.  Each version will need 3 variants for various environments that the connectors will be used in.  The hierarchy that I'm aiming for here is:

**bigtable-hbase**: contains the core implementation that can be shared in both hbase 1 & 2
- **bigtable-hbase-1.x**: contains concrete connection implementation for latest hbase 1 connection interfaces
  - **bigtable-hbase-1.x-hadoop**: repackages bigtable-hbase-1.x to be used in hadoop environments exposing hadoop compatible dependencies (will relocate the core client & its dependencies)
  - **bigtable-hbase-1.x-shaded**: will use hbase-shaded-client in addition to relocating the  core client.  This will be used in dataflow 1.x that uses protobuf 2.0.0beta
- **bigtable-hbase-2.x**: same subtree as bigtable-hbase-1.x, except for hbase 2

This PR introduces 3 new artifacts:
- bigtable-hbase-1.x: hbase connector that will track the latest version of hbase 1.
- bigtable-hbase-1.x-shaded
- bigtable-hbase-1.x-hadoop

And deprecates the old bitable-hbase-shaded, bigtable-hbase-1.0, etc artifacts. 

The next PR will update all of the artifacts to depend on hbase-bigtable-1.x-*