### PR TITLE
WIP: V0.9.7 sanity check

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/pom.xml
+++ b/bigtable-client-core-parent/bigtable-client-core/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
     <parent>
         <groupId>com.google.cloud.bigtable</groupId>
         <artifactId>bigtable-client-core-parent</artifactId>
-        <version>0.9.7.1-SNAPSHOT</version>
+        <version>0.9.7.1</version>
     </parent>
 
     <artifactId>bigtable-client-core</artifactId>

--- a/bigtable-client-core-parent/bigtable-client-core/pom.xml
+++ b/bigtable-client-core-parent/bigtable-client-core/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
     <parent>
         <groupId>com.google.cloud.bigtable</groupId>
         <artifactId>bigtable-client-core-parent</artifactId>
-        <version>0.9.7</version>
+        <version>0.9.7.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>bigtable-client-core</artifactId>

--- a/bigtable-client-core-parent/bigtable-client-core/pom.xml
+++ b/bigtable-client-core-parent/bigtable-client-core/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
     <parent>
         <groupId>com.google.cloud.bigtable</groupId>
         <artifactId>bigtable-client-core-parent</artifactId>
-        <version>0.9.7.1</version>
+        <version>0.9.7.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>bigtable-client-core</artifactId>

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptor.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptor.java
@@ -250,7 +250,7 @@ public class RefreshingOAuth2CredentialsInterceptor implements ClientInterceptor
           );
       }
     }
-    return deferredResult.get(250, TimeUnit.MILLISECONDS);
+    return deferredResult.get(5, TimeUnit.SECONDS);
   }
 
   /**
@@ -260,7 +260,7 @@ public class RefreshingOAuth2CredentialsInterceptor implements ClientInterceptor
    */
   HeaderCacheElement syncRefresh() {
     try {
-      return asyncRefresh().get(250, TimeUnit.MILLISECONDS);
+      return asyncRefresh().get(5, TimeUnit.SECONDS);
     } catch (Exception e) {
       return new HeaderCacheElement(
           Status.UNAUTHENTICATED

--- a/bigtable-client-core-parent/bigtable-protos/pom.xml
+++ b/bigtable-client-core-parent/bigtable-protos/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
     <parent>
         <groupId>com.google.cloud.bigtable</groupId>
         <artifactId>bigtable-client-core-parent</artifactId>
-        <version>0.9.7</version>
+        <version>0.9.7.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>bigtable-protos</artifactId>

--- a/bigtable-client-core-parent/bigtable-protos/pom.xml
+++ b/bigtable-client-core-parent/bigtable-protos/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
     <parent>
         <groupId>com.google.cloud.bigtable</groupId>
         <artifactId>bigtable-client-core-parent</artifactId>
-        <version>0.9.7.1-SNAPSHOT</version>
+        <version>0.9.7.1</version>
     </parent>
 
     <artifactId>bigtable-protos</artifactId>

--- a/bigtable-client-core-parent/bigtable-protos/pom.xml
+++ b/bigtable-client-core-parent/bigtable-protos/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
     <parent>
         <groupId>com.google.cloud.bigtable</groupId>
         <artifactId>bigtable-client-core-parent</artifactId>
-        <version>0.9.7.1</version>
+        <version>0.9.7.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>bigtable-protos</artifactId>

--- a/bigtable-client-core-parent/pom.xml
+++ b/bigtable-client-core-parent/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
     <parent>
         <groupId>com.google.cloud.bigtable</groupId>
         <artifactId>bigtable-client-parent</artifactId>
-        <version>0.9.7.1</version>
+        <version>0.9.7.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>bigtable-client-core-parent</artifactId>

--- a/bigtable-client-core-parent/pom.xml
+++ b/bigtable-client-core-parent/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
     <parent>
         <groupId>com.google.cloud.bigtable</groupId>
         <artifactId>bigtable-client-parent</artifactId>
-        <version>0.9.7</version>
+        <version>0.9.7.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>bigtable-client-core-parent</artifactId>

--- a/bigtable-client-core-parent/pom.xml
+++ b/bigtable-client-core-parent/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
     <parent>
         <groupId>com.google.cloud.bigtable</groupId>
         <artifactId>bigtable-client-parent</artifactId>
-        <version>0.9.7.1-SNAPSHOT</version>
+        <version>0.9.7.1</version>
     </parent>
 
     <artifactId>bigtable-client-core-parent</artifactId>

--- a/bigtable-dataflow-parent/bigtable-dataflow-import/pom.xml
+++ b/bigtable-dataflow-parent/bigtable-dataflow-import/pom.xml
@@ -16,7 +16,7 @@ limitations under the License.
     <parent>
         <groupId>com.google.cloud.bigtable</groupId>
         <artifactId>bigtable-dataflow-parent</artifactId>
-        <version>0.9.7</version>
+        <version>0.9.7.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>bigtable-dataflow-import</artifactId>

--- a/bigtable-dataflow-parent/bigtable-dataflow-import/pom.xml
+++ b/bigtable-dataflow-parent/bigtable-dataflow-import/pom.xml
@@ -16,7 +16,7 @@ limitations under the License.
     <parent>
         <groupId>com.google.cloud.bigtable</groupId>
         <artifactId>bigtable-dataflow-parent</artifactId>
-        <version>0.9.7.1</version>
+        <version>0.9.7.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>bigtable-dataflow-import</artifactId>

--- a/bigtable-dataflow-parent/bigtable-dataflow-import/pom.xml
+++ b/bigtable-dataflow-parent/bigtable-dataflow-import/pom.xml
@@ -16,7 +16,7 @@ limitations under the License.
     <parent>
         <groupId>com.google.cloud.bigtable</groupId>
         <artifactId>bigtable-dataflow-parent</artifactId>
-        <version>0.9.7.1-SNAPSHOT</version>
+        <version>0.9.7.1</version>
     </parent>
 
     <artifactId>bigtable-dataflow-import</artifactId>

--- a/bigtable-dataflow-parent/bigtable-hbase-dataflow/pom.xml
+++ b/bigtable-dataflow-parent/bigtable-hbase-dataflow/pom.xml
@@ -16,7 +16,7 @@ limitations under the License.
     <parent>
         <groupId>com.google.cloud.bigtable</groupId>
         <artifactId>bigtable-dataflow-parent</artifactId>
-        <version>0.9.7.1-SNAPSHOT</version>
+        <version>0.9.7.1</version>
     </parent>
 
     <artifactId>bigtable-hbase-dataflow</artifactId>

--- a/bigtable-dataflow-parent/bigtable-hbase-dataflow/pom.xml
+++ b/bigtable-dataflow-parent/bigtable-hbase-dataflow/pom.xml
@@ -16,7 +16,7 @@ limitations under the License.
     <parent>
         <groupId>com.google.cloud.bigtable</groupId>
         <artifactId>bigtable-dataflow-parent</artifactId>
-        <version>0.9.7.1</version>
+        <version>0.9.7.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>bigtable-hbase-dataflow</artifactId>

--- a/bigtable-dataflow-parent/bigtable-hbase-dataflow/pom.xml
+++ b/bigtable-dataflow-parent/bigtable-hbase-dataflow/pom.xml
@@ -16,7 +16,7 @@ limitations under the License.
     <parent>
         <groupId>com.google.cloud.bigtable</groupId>
         <artifactId>bigtable-dataflow-parent</artifactId>
-        <version>0.9.7</version>
+        <version>0.9.7.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>bigtable-hbase-dataflow</artifactId>

--- a/bigtable-dataflow-parent/bigtable-hbase-shaded-for-dataflow/pom.xml
+++ b/bigtable-dataflow-parent/bigtable-hbase-shaded-for-dataflow/pom.xml
@@ -16,7 +16,7 @@ limitations under the License.
     <parent>
         <groupId>com.google.cloud.bigtable</groupId>
         <artifactId>bigtable-dataflow-parent</artifactId>
-        <version>0.9.7.1</version>
+        <version>0.9.7.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>bigtable-hbase-shaded-for-dataflow</artifactId>

--- a/bigtable-dataflow-parent/bigtable-hbase-shaded-for-dataflow/pom.xml
+++ b/bigtable-dataflow-parent/bigtable-hbase-shaded-for-dataflow/pom.xml
@@ -16,7 +16,7 @@ limitations under the License.
     <parent>
         <groupId>com.google.cloud.bigtable</groupId>
         <artifactId>bigtable-dataflow-parent</artifactId>
-        <version>0.9.7</version>
+        <version>0.9.7.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>bigtable-hbase-shaded-for-dataflow</artifactId>

--- a/bigtable-dataflow-parent/bigtable-hbase-shaded-for-dataflow/pom.xml
+++ b/bigtable-dataflow-parent/bigtable-hbase-shaded-for-dataflow/pom.xml
@@ -16,7 +16,7 @@ limitations under the License.
     <parent>
         <groupId>com.google.cloud.bigtable</groupId>
         <artifactId>bigtable-dataflow-parent</artifactId>
-        <version>0.9.7.1-SNAPSHOT</version>
+        <version>0.9.7.1</version>
     </parent>
 
     <artifactId>bigtable-hbase-shaded-for-dataflow</artifactId>

--- a/bigtable-dataflow-parent/pom.xml
+++ b/bigtable-dataflow-parent/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
     <parent>
         <groupId>com.google.cloud.bigtable</groupId>
         <artifactId>bigtable-client-parent</artifactId>
-        <version>0.9.7.1</version>
+        <version>0.9.7.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>bigtable-dataflow-parent</artifactId>

--- a/bigtable-dataflow-parent/pom.xml
+++ b/bigtable-dataflow-parent/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
     <parent>
         <groupId>com.google.cloud.bigtable</groupId>
         <artifactId>bigtable-client-parent</artifactId>
-        <version>0.9.7.1-SNAPSHOT</version>
+        <version>0.9.7.1</version>
     </parent>
 
     <artifactId>bigtable-dataflow-parent</artifactId>

--- a/bigtable-dataflow-parent/pom.xml
+++ b/bigtable-dataflow-parent/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
     <parent>
         <groupId>com.google.cloud.bigtable</groupId>
         <artifactId>bigtable-client-parent</artifactId>
-        <version>0.9.7</version>
+        <version>0.9.7.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>bigtable-dataflow-parent</artifactId>

--- a/bigtable-hbase-parent/bigtable-hbase-1.0/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-1.0/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
     <parent>
         <groupId>com.google.cloud.bigtable</groupId>
         <artifactId>bigtable-hbase-parent</artifactId>
-        <version>0.9.7.1</version>
+        <version>0.9.7.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>bigtable-hbase-1.0</artifactId>

--- a/bigtable-hbase-parent/bigtable-hbase-1.0/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-1.0/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
     <parent>
         <groupId>com.google.cloud.bigtable</groupId>
         <artifactId>bigtable-hbase-parent</artifactId>
-        <version>0.9.7.1-SNAPSHOT</version>
+        <version>0.9.7.1</version>
     </parent>
 
     <artifactId>bigtable-hbase-1.0</artifactId>

--- a/bigtable-hbase-parent/bigtable-hbase-1.0/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-1.0/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
     <parent>
         <groupId>com.google.cloud.bigtable</groupId>
         <artifactId>bigtable-hbase-parent</artifactId>
-        <version>0.9.7</version>
+        <version>0.9.7.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>bigtable-hbase-1.0</artifactId>

--- a/bigtable-hbase-parent/bigtable-hbase-1.1/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-1.1/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
     <parent>
         <groupId>com.google.cloud.bigtable</groupId>
         <artifactId>bigtable-hbase-parent</artifactId>
-        <version>0.9.7</version>
+        <version>0.9.7.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>bigtable-hbase-1.1</artifactId>

--- a/bigtable-hbase-parent/bigtable-hbase-1.1/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-1.1/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
     <parent>
         <groupId>com.google.cloud.bigtable</groupId>
         <artifactId>bigtable-hbase-parent</artifactId>
-        <version>0.9.7.1-SNAPSHOT</version>
+        <version>0.9.7.1</version>
     </parent>
 
     <artifactId>bigtable-hbase-1.1</artifactId>

--- a/bigtable-hbase-parent/bigtable-hbase-1.1/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-1.1/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
     <parent>
         <groupId>com.google.cloud.bigtable</groupId>
         <artifactId>bigtable-hbase-parent</artifactId>
-        <version>0.9.7.1</version>
+        <version>0.9.7.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>bigtable-hbase-1.1</artifactId>

--- a/bigtable-hbase-parent/bigtable-hbase-1.2/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-1.2/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
     <parent>
         <groupId>com.google.cloud.bigtable</groupId>
         <artifactId>bigtable-hbase-parent</artifactId>
-        <version>0.9.7.1</version>
+        <version>0.9.7.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>bigtable-hbase-1.2</artifactId>

--- a/bigtable-hbase-parent/bigtable-hbase-1.2/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-1.2/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
     <parent>
         <groupId>com.google.cloud.bigtable</groupId>
         <artifactId>bigtable-hbase-parent</artifactId>
-        <version>0.9.7</version>
+        <version>0.9.7.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>bigtable-hbase-1.2</artifactId>

--- a/bigtable-hbase-parent/bigtable-hbase-1.2/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-1.2/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
     <parent>
         <groupId>com.google.cloud.bigtable</groupId>
         <artifactId>bigtable-hbase-parent</artifactId>
-        <version>0.9.7.1-SNAPSHOT</version>
+        <version>0.9.7.1</version>
     </parent>
 
     <artifactId>bigtable-hbase-1.2</artifactId>

--- a/bigtable-hbase-parent/bigtable-hbase-1.3/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-1.3/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
     <parent>
         <groupId>com.google.cloud.bigtable</groupId>
         <artifactId>bigtable-hbase-parent</artifactId>
-        <version>0.9.7.1-SNAPSHOT</version>
+        <version>0.9.7.1</version>
     </parent>
 
     <artifactId>bigtable-hbase-1.3</artifactId>

--- a/bigtable-hbase-parent/bigtable-hbase-1.3/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-1.3/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
     <parent>
         <groupId>com.google.cloud.bigtable</groupId>
         <artifactId>bigtable-hbase-parent</artifactId>
-        <version>0.9.7.1</version>
+        <version>0.9.7.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>bigtable-hbase-1.3</artifactId>

--- a/bigtable-hbase-parent/bigtable-hbase-1.3/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-1.3/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
     <parent>
         <groupId>com.google.cloud.bigtable</groupId>
         <artifactId>bigtable-hbase-parent</artifactId>
-        <version>0.9.7</version>
+        <version>0.9.7.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>bigtable-hbase-1.3</artifactId>

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
     <parent>
         <groupId>com.google.cloud.bigtable</groupId>
         <artifactId>bigtable-hbase-parent</artifactId>
-        <version>0.9.7</version>
+        <version>0.9.7.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>bigtable-hbase-integration-tests</artifactId>

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
     <parent>
         <groupId>com.google.cloud.bigtable</groupId>
         <artifactId>bigtable-hbase-parent</artifactId>
-        <version>0.9.7.1-SNAPSHOT</version>
+        <version>0.9.7.1</version>
     </parent>
 
     <artifactId>bigtable-hbase-integration-tests</artifactId>

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
     <parent>
         <groupId>com.google.cloud.bigtable</groupId>
         <artifactId>bigtable-hbase-parent</artifactId>
-        <version>0.9.7.1</version>
+        <version>0.9.7.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>bigtable-hbase-integration-tests</artifactId>

--- a/bigtable-hbase-parent/bigtable-hbase-mapreduce/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-mapreduce/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
     <parent>
         <groupId>com.google.cloud.bigtable</groupId>
         <artifactId>bigtable-hbase-parent</artifactId>
-        <version>0.9.7</version>
+        <version>0.9.7.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>bigtable-hbase-mapreduce</artifactId>

--- a/bigtable-hbase-parent/bigtable-hbase-mapreduce/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-mapreduce/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
     <parent>
         <groupId>com.google.cloud.bigtable</groupId>
         <artifactId>bigtable-hbase-parent</artifactId>
-        <version>0.9.7.1-SNAPSHOT</version>
+        <version>0.9.7.1</version>
     </parent>
 
     <artifactId>bigtable-hbase-mapreduce</artifactId>

--- a/bigtable-hbase-parent/bigtable-hbase-mapreduce/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-mapreduce/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
     <parent>
         <groupId>com.google.cloud.bigtable</groupId>
         <artifactId>bigtable-hbase-parent</artifactId>
-        <version>0.9.7.1</version>
+        <version>0.9.7.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>bigtable-hbase-mapreduce</artifactId>

--- a/bigtable-hbase-parent/bigtable-hbase-shaded/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-shaded/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
     <parent>
         <groupId>com.google.cloud.bigtable</groupId>
         <artifactId>bigtable-hbase-parent</artifactId>
-        <version>0.9.7</version>
+        <version>0.9.7.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>bigtable-hbase-shaded</artifactId>

--- a/bigtable-hbase-parent/bigtable-hbase-shaded/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-shaded/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
     <parent>
         <groupId>com.google.cloud.bigtable</groupId>
         <artifactId>bigtable-hbase-parent</artifactId>
-        <version>0.9.7.1</version>
+        <version>0.9.7.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>bigtable-hbase-shaded</artifactId>

--- a/bigtable-hbase-parent/bigtable-hbase-shaded/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-shaded/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
     <parent>
         <groupId>com.google.cloud.bigtable</groupId>
         <artifactId>bigtable-hbase-parent</artifactId>
-        <version>0.9.7.1-SNAPSHOT</version>
+        <version>0.9.7.1</version>
     </parent>
 
     <artifactId>bigtable-hbase-shaded</artifactId>

--- a/bigtable-hbase-parent/bigtable-hbase/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
     <parent>
         <groupId>com.google.cloud.bigtable</groupId>
         <artifactId>bigtable-hbase-parent</artifactId>
-        <version>0.9.7.1</version>
+        <version>0.9.7.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>bigtable-hbase</artifactId>

--- a/bigtable-hbase-parent/bigtable-hbase/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
     <parent>
         <groupId>com.google.cloud.bigtable</groupId>
         <artifactId>bigtable-hbase-parent</artifactId>
-        <version>0.9.7</version>
+        <version>0.9.7.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>bigtable-hbase</artifactId>

--- a/bigtable-hbase-parent/bigtable-hbase/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
     <parent>
         <groupId>com.google.cloud.bigtable</groupId>
         <artifactId>bigtable-hbase-parent</artifactId>
-        <version>0.9.7.1-SNAPSHOT</version>
+        <version>0.9.7.1</version>
     </parent>
 
     <artifactId>bigtable-hbase</artifactId>

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/FamilyFilterAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/FamilyFilterAdapter.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.adapters.filters;
+
+import com.google.bigtable.v2.RowFilter;
+import com.google.bigtable.v2.RowFilter.Builder;
+import com.google.cloud.bigtable.hbase.adapters.read.ReaderExpressionHelper;
+import com.google.cloud.bigtable.util.ByteStringer;
+
+import org.apache.hadoop.hbase.filter.BinaryComparator;
+import org.apache.hadoop.hbase.filter.ByteArrayComparable;
+import org.apache.hadoop.hbase.filter.CompareFilter;
+import org.apache.hadoop.hbase.filter.FamilyFilter;
+import org.apache.hadoop.hbase.filter.RegexStringComparator;
+import org.apache.hadoop.hbase.filter.CompareFilter.CompareOp;
+
+import java.io.IOException;
+
+/**
+ * Adapter for a single {@lnk FamilyFilter} to a Cloud Bigtable RowFilter.
+ */
+public class FamilyFilterAdapter extends TypedFilterAdapterBase<FamilyFilter> {
+  ReaderExpressionHelper readerExpressionHelper = new ReaderExpressionHelper();
+
+  /** {@inheritDoc} */
+  @Override
+  public RowFilter adapt(FilterAdapterContext context, FamilyFilter filter)
+      throws IOException {
+    CompareOp compareOp = filter.getOperator();
+    if (compareOp != CompareFilter.CompareOp.EQUAL) {
+      throw new IllegalStateException(String.format("Cannot adapt operator %s",
+        compareOp == null ? null : compareOp.getClass().getCanonicalName()));
+    }
+
+    ByteArrayComparable comparator = filter.getComparator();
+    Builder builder = RowFilter.newBuilder();
+    if (comparator == null) {
+      throw new IllegalStateException("Comparator cannot be null"); 
+    } else if (comparator instanceof RegexStringComparator) {
+      builder.setFamilyNameRegexFilterBytes(ByteStringer.wrap(comparator.getValue()));
+    } else if (comparator instanceof BinaryComparator) {
+      byte[] quotedRegularExpression =
+          ReaderExpressionHelper.quoteRegularExpression(comparator.getValue());
+      builder.setFamilyNameRegexFilterBytes(ByteStringer.wrap(quotedRegularExpression));
+    } else {
+      throw new IllegalStateException(
+          "Cannot adapt comparator " + comparator.getClass().getCanonicalName());
+    }
+    return builder.build();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public FilterSupportStatus isFilterSupported(
+      FilterAdapterContext context,
+      FamilyFilter filter) {
+    ByteArrayComparable comparator = filter.getComparator();
+    if (!(comparator instanceof RegexStringComparator) && !(comparator instanceof BinaryComparator)) {
+      return FilterSupportStatus.newNotSupported(comparator.getClass().getName()
+          + " comparator is not supported");
+    }
+    if (filter.getOperator() != CompareFilter.CompareOp.EQUAL) {
+      return FilterSupportStatus.newNotSupported(filter.getOperator()
+          + " operator is not supported");
+    }
+    return FilterSupportStatus.SUPPORTED;
+  }
+}

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/FilterAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/FilterAdapter.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.hbase.filter.ColumnCountGetFilter;
 import org.apache.hadoop.hbase.filter.ColumnPaginationFilter;
 import org.apache.hadoop.hbase.filter.ColumnPrefixFilter;
 import org.apache.hadoop.hbase.filter.ColumnRangeFilter;
+import org.apache.hadoop.hbase.filter.FamilyFilter;
 import org.apache.hadoop.hbase.filter.Filter;
 import org.apache.hadoop.hbase.filter.FilterList;
 import org.apache.hadoop.hbase.filter.FirstKeyOnlyFilter;
@@ -102,6 +103,7 @@ public class FilterAdapter {
     adapter.addFilterAdapter(
         org.apache.hadoop.hbase.filter.RowFilter.class, new RowFilterAdapter());
     adapter.addFilterAdapter(FuzzyRowFilter.class, new FuzzyRowFilterAdapter());
+    adapter.addFilterAdapter(FamilyFilter.class, new FamilyFilterAdapter());
 
     // MultiRowRangeFilter only exists in hbase >= 1.1
     try {

--- a/bigtable-hbase-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestFamilyFilterAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestFamilyFilterAdapter.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.adapters.filters;
+
+import java.io.IOException;
+
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.filter.BinaryComparator;
+import org.apache.hadoop.hbase.filter.ByteArrayComparable;
+import org.apache.hadoop.hbase.filter.CompareFilter;
+import org.apache.hadoop.hbase.filter.LongComparator;
+import org.apache.hadoop.hbase.filter.RegexStringComparator;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import com.google.bigtable.v2.RowFilter;
+import com.google.cloud.bigtable.hbase.adapters.read.ReaderExpressionHelper;
+import com.google.protobuf.ByteString;
+
+@RunWith(JUnit4.class)
+public class TestFamilyFilterAdapter {
+  private static RowFilterAdapter adapter = new RowFilterAdapter();
+
+  private FilterAdapterContext context;
+
+  @Before
+  public void before() {
+    Scan emptyScan = new Scan();
+    context = new FilterAdapterContext(emptyScan, null);
+  }
+
+  @Test
+  public void testAdapt_RegexAndEquals() throws IOException {
+    String regexp = "^.*hello world.*$";
+    RegexStringComparator comparator = new RegexStringComparator(regexp);
+    org.apache.hadoop.hbase.filter.RowFilter filter =
+        new org.apache.hadoop.hbase.filter.RowFilter(
+            CompareFilter.CompareOp.EQUAL, comparator);
+    Assert.assertEquals(
+        RowFilter.newBuilder()
+            .setRowKeyRegexFilter(
+                ByteString.copyFrom(regexp.getBytes()))
+            .build(),
+        adapter.adapt(context, filter));
+  }
+
+  @Test
+  public void testAdapt_BinaryAndEquals() throws IOException {
+    byte[] bytes = new byte[] { 0, 1, 2 };
+    BinaryComparator comparator = new BinaryComparator(bytes);
+    org.apache.hadoop.hbase.filter.RowFilter filter =
+        new org.apache.hadoop.hbase.filter.RowFilter(
+            CompareFilter.CompareOp.EQUAL, comparator);
+    Assert.assertEquals(
+        RowFilter.newBuilder()
+            .setRowKeyRegexFilter(
+                ByteString.copyFrom(ReaderExpressionHelper.quoteRegularExpression(bytes)))
+            .build(),
+        adapter.adapt(context, filter));
+  }
+
+  @Test
+  public void testAdapt_EmptyRegex() throws IOException {
+    // What does BigTable do in this case?
+    String regexp = "";
+    RegexStringComparator comparator = new RegexStringComparator(regexp);
+    org.apache.hadoop.hbase.filter.RowFilter filter =
+        new org.apache.hadoop.hbase.filter.RowFilter(
+            CompareFilter.CompareOp.EQUAL, comparator);
+    Assert.assertEquals(
+        RowFilter.newBuilder()
+            .setRowKeyRegexFilter(
+                ByteString.copyFrom(regexp.getBytes()))
+            .build(),
+        adapter.adapt(context, filter));
+  }
+
+
+  @Test
+  public void testAdapt_EmptyBinary() throws IOException {
+    // What does BigTable do in this case?
+    BinaryComparator comparator = new BinaryComparator(new byte[0]);
+    org.apache.hadoop.hbase.filter.RowFilter filter =
+        new org.apache.hadoop.hbase.filter.RowFilter(
+            CompareFilter.CompareOp.EQUAL, comparator);
+    Assert.assertEquals(
+        RowFilter.newBuilder()
+            .setRowKeyRegexFilter(
+                ByteString.copyFrom(new byte[0]))
+            .build(),
+        adapter.adapt(context, filter));
+  }
+
+  @Test
+  public void testNotSupported_RegexNotEquals() {
+    String regexp = "^.*hello world.*$";
+    RegexStringComparator comparator = new RegexStringComparator(regexp);
+    org.apache.hadoop.hbase.filter.RowFilter filter =
+        new org.apache.hadoop.hbase.filter.RowFilter(
+            CompareFilter.CompareOp.GREATER_OR_EQUAL, comparator);
+    Assert.assertFalse(adapter.isFilterSupported(context, filter).isSupported());
+  }
+
+  @Test
+  public void testSupported_BinaryComparatorEquals() {
+    BinaryComparator comparator = new BinaryComparator(new byte[] { 0, 1, 2 });
+    org.apache.hadoop.hbase.filter.RowFilter filter =
+        new org.apache.hadoop.hbase.filter.RowFilter(
+            CompareFilter.CompareOp.EQUAL, comparator);
+    Assert.assertTrue(adapter.isFilterSupported(context, filter).isSupported());
+  }
+
+  @Test
+  public void testNotSupported_BinaryNotEquals() {
+    BinaryComparator comparator = new BinaryComparator(new byte[] { 0, 1, 2 });
+    org.apache.hadoop.hbase.filter.RowFilter filter =
+        new org.apache.hadoop.hbase.filter.RowFilter(
+            CompareFilter.CompareOp.GREATER_OR_EQUAL, comparator);
+    Assert.assertFalse(adapter.isFilterSupported(context, filter).isSupported());
+  }
+
+  @Test
+  public void testNotSupported_OtherComparator () {
+    ByteArrayComparable comparator = new LongComparator(1L);
+    org.apache.hadoop.hbase.filter.RowFilter filter =
+        new org.apache.hadoop.hbase.filter.RowFilter(
+            CompareFilter.CompareOp.EQUAL, comparator);
+    Assert.assertFalse(adapter.isFilterSupported(context, filter).isSupported());
+  }
+}

--- a/bigtable-hbase-parent/pom.xml
+++ b/bigtable-hbase-parent/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
     <parent>
         <groupId>com.google.cloud.bigtable</groupId>
         <artifactId>bigtable-client-parent</artifactId>
-        <version>0.9.7.1</version>
+        <version>0.9.7.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>bigtable-hbase-parent</artifactId>

--- a/bigtable-hbase-parent/pom.xml
+++ b/bigtable-hbase-parent/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
     <parent>
         <groupId>com.google.cloud.bigtable</groupId>
         <artifactId>bigtable-client-parent</artifactId>
-        <version>0.9.7.1-SNAPSHOT</version>
+        <version>0.9.7.1</version>
     </parent>
 
     <artifactId>bigtable-hbase-parent</artifactId>

--- a/bigtable-hbase-parent/pom.xml
+++ b/bigtable-hbase-parent/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
     <parent>
         <groupId>com.google.cloud.bigtable</groupId>
         <artifactId>bigtable-client-parent</artifactId>
-        <version>0.9.7</version>
+        <version>0.9.7.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>bigtable-hbase-parent</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -395,7 +395,7 @@ limitations under the License.
         <connection>scm:git:https://github.com/GoogleCloudPlatform/cloud-bigtable-client.git</connection>
         <url>scm:git:https://github.com/GoogleCloudPlatform/cloud-bigtable-client.git</url>
         <developerConnection>scm:git:https://github.com/GoogleCloudPlatform/cloud-bigtable-client.git</developerConnection>
-        <tag>bigtable-client-0.9.7.1-SNAPSHOT</tag>
+        <tag>v0.9.7</tag>
     </scm>
 
     <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@ limitations under the License.
 
     <groupId>com.google.cloud.bigtable</groupId>
     <artifactId>bigtable-client-parent</artifactId>
-    <version>0.9.7.1</version>
+    <version>0.9.7.2-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
     <url>https://cloud.google.com/bigtable/</url>
@@ -395,7 +395,7 @@ limitations under the License.
         <connection>scm:git:https://github.com/GoogleCloudPlatform/cloud-bigtable-client.git</connection>
         <url>scm:git:https://github.com/GoogleCloudPlatform/cloud-bigtable-client.git</url>
         <developerConnection>scm:git:https://github.com/GoogleCloudPlatform/cloud-bigtable-client.git</developerConnection>
-        <tag>bigtable-client-0.9.7.1</tag>
+        <tag>v0.9.7</tag>
     </scm>
 
     <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@ limitations under the License.
 
     <groupId>com.google.cloud.bigtable</groupId>
     <artifactId>bigtable-client-parent</artifactId>
-    <version>0.9.7.1-SNAPSHOT</version>
+    <version>0.9.7.1</version>
     <packaging>pom</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
     <url>https://cloud.google.com/bigtable/</url>
@@ -395,7 +395,7 @@ limitations under the License.
         <connection>scm:git:https://github.com/GoogleCloudPlatform/cloud-bigtable-client.git</connection>
         <url>scm:git:https://github.com/GoogleCloudPlatform/cloud-bigtable-client.git</url>
         <developerConnection>scm:git:https://github.com/GoogleCloudPlatform/cloud-bigtable-client.git</developerConnection>
-        <tag>v0.9.7</tag>
+        <tag>bigtable-client-0.9.7.1</tag>
     </scm>
 
     <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@ limitations under the License.
 
     <groupId>com.google.cloud.bigtable</groupId>
     <artifactId>bigtable-client-parent</artifactId>
-    <version>0.9.7</version>
+    <version>0.9.7.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
     <url>https://cloud.google.com/bigtable/</url>
@@ -395,7 +395,7 @@ limitations under the License.
         <connection>scm:git:https://github.com/GoogleCloudPlatform/cloud-bigtable-client.git</connection>
         <url>scm:git:https://github.com/GoogleCloudPlatform/cloud-bigtable-client.git</url>
         <developerConnection>scm:git:https://github.com/GoogleCloudPlatform/cloud-bigtable-client.git</developerConnection>
-        <tag>bigtable-client-0.9.7</tag>
+        <tag>bigtable-client-0.9.7.1-SNAPSHOT</tag>
     </scm>
 
     <developers>


### PR DESCRIPTION
I built a 0.9.7.1 release in the v0.9.7 branch.  This PR compares the 0.9.7 tag with the v0.9.7 branch that contains v0.9.7.1 changes.  There are 3 changes in this branch:

1. Fix for the client auth interceptor.  A) timeouts were extended from 250 ms to 5 seconds.  B) If a timeout occurs, the `UNAUTHORIZED` should bubble up.
2. Fix for Dataflow reads that incurred dynamic rebalancing.
3. Added support for `FamilyFilter`

A sanity check would be greatly appreciated before I push the build to the maven repo.
