### PR TITLE
Integration test fixes

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
@@ -470,14 +470,15 @@ public class BigtableSession implements Closeable {
 
     // Ideally, this should be ManagedChannelBuilder.forAddress(...) rather than an explicit
     // call to NettyChannelBuilder.  Unfortunately, that doesn't work for shaded artifacts.
-    ManagedChannelBuilder<?> builder = NettyChannelBuilder
-        .forAddress(host, options.getPort())
-        .sslContext(createSslContext())
-        ;
+    NettyChannelBuilder builder = NettyChannelBuilder
+        .forAddress(host, options.getPort());
 
     if (options.usePlaintextNegotiation()) {
       builder.usePlaintext(true);
+    } else {
+      builder.sslContext(createSslContext());
     }
+
     return builder
         .nameResolverFactory(new DnsNameResolverProvider())
         .idleTimeout(Long.MAX_VALUE, TimeUnit.SECONDS)

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests/pom.xml
@@ -30,6 +30,10 @@ limitations under the License.
        This project contains test cases that ought to work for either bigtable-hbase or hbase proper.
     </description>
 
+    <properties>
+        <google.bigtable.connection.impl>com.google.cloud.bigtable.hbase1_x.BigtableConnection</google.bigtable.connection.impl>
+    </properties>
+
     <profiles>
        <profile>
             <id>bigtableIntegrationTest</id>

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/test_env/BigtableEnv.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/test_env/BigtableEnv.java
@@ -15,6 +15,8 @@
  */
 package com.google.cloud.bigtable.hbase.test_env;
 
+import com.google.bigtable.repackaged.com.google.cloud.bigtable.config.BigtableOptions;
+import com.google.cloud.bigtable.hbase.BigtableOptionsFactory;
 import com.google.common.collect.Sets;
 import java.io.IOException;
 import java.util.Map.Entry;
@@ -29,16 +31,14 @@ class BigtableEnv extends SharedTestEnv {
 
   private static final Set<String> KEYS = Sets.newHashSet(
       "hbase.client.connection.impl",
-      "google.bigtable.endpoint.host",
-      "google.bigtable.endpoint.port",
-      "google.bigtable.admin.endpoint.host",
-      "google.bigtable.cluster.admin.endpoint.host",
-      "google.bigtable.project.id",
-      "google.bigtable.instance.id",
-      "google.bigtable.zone.name",
-      "google.bigtable.cluster.name",
-      "google.bigtable.use.bulk.api",
-      "google.bigtable.use.plaintext.negotiation"
+      BigtableOptionsFactory.BIGTABLE_PORT_KEY,
+      BigtableOptionsFactory.BIGTABLE_HOST_KEY,
+      BigtableOptionsFactory.BIGTABLE_INSTANCE_ADMIN_HOST_KEY,
+      BigtableOptionsFactory.BIGTABLE_TABLE_ADMIN_HOST_KEY,
+      BigtableOptionsFactory.PROJECT_ID_KEY,
+      BigtableOptionsFactory.INSTANCE_ID_KEY,
+      BigtableOptionsFactory.BIGTABLE_USE_BULK_API,
+      BigtableOptionsFactory.BIGTABLE_USE_PLAINTEXT_NEGOTIATION
   );
   private Configuration configuration;
 


### PR DESCRIPTION
- get the integration test to run against prod again (the property that targets prod was accidentally removed in the dep refactor)
- fix connection to emulator to allow by skipping the ssl context when plain text negotiation is enabled
- update the integration test config setup to use constants