### PR TITLE
Using fast checking for exists()

### DIFF
--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestFilters.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestFilters.java
@@ -73,7 +73,6 @@ import org.junit.experimental.categories.Category;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
@@ -1123,6 +1122,24 @@ public class TestFilters extends AbstractTest {
   }
 
   @Test
+  public void testWhileMatchFilter_withUpdate() throws IOException {
+    String rowKeyPrefix = dataHelper.randomString("wmf-wu-");
+    byte[] qualA = dataHelper.randomData("qualA");
+    Table table = addDataForTesting(rowKeyPrefix, qualA);
+
+    table.put(new Put(Bytes.toBytes(rowKeyPrefix + "14")).addColumn(COLUMN_FAMILY, qualA,
+      Bytes.toBytes(String.valueOf(2))));
+
+    ByteArrayComparable valueComparable = new BinaryComparator(String.valueOf(2).getBytes());
+    SingleColumnValueFilter valueFilter = new SingleColumnValueFilter(
+        COLUMN_FAMILY, qualA, CompareFilter.CompareOp.NOT_EQUAL, valueComparable);
+    Scan scan = new Scan().setFilter(new WhileMatchFilter(valueFilter));
+
+    int[] expected = {0, 1, 10, 11, 12, 13};
+    assertWhileMatchFilterResult(qualA, table, scan, expected);
+  }
+
+  @Test
   public void testSingleValueFilterAscii() throws IOException {
     byte[] qual = dataHelper.randomData("testSingleValueFilterCompOps");
     // Add {, }, and @ to make sure that they do not need to be encoded
@@ -1269,14 +1286,16 @@ public class TestFilters extends AbstractTest {
     int[] actual = new int[expected.length];
     int i = 0;
     try (ResultScanner scanner = table.getScanner(scan)) {
-      Iterator<Result> iterator = scanner.iterator();
-      while (iterator.hasNext()) {
-        for (Cell cell : iterator.next().getColumnCells(COLUMN_FAMILY, qualA)) {
-          int cellIntValue = Integer.parseInt(Bytes.toString(CellUtil.cloneValue(cell)));
-          actual[i++] = cellIntValue;
+      for (Result r : scanner) {
+        List<Cell> cells = r.getColumnCells(COLUMN_FAMILY, qualA);
+        Assert.assertEquals("Expected 1 result, but got " + cells.size(), 1, cells.size());
+        if (i < expected.length) {
+          actual[i] = Integer.parseInt(Bytes.toString(CellUtil.cloneValue(cells.get(0))));
         }
+        i++;
       }
     }
+    Assert.assertEquals(expected.length, i);
     Assert.assertArrayEquals(expected, actual);
   }
 

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BatchExecutor.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BatchExecutor.java
@@ -263,7 +263,7 @@ public class BatchExecutor {
   public Result[] batch(List<? extends Row> actions) throws IOException {
     try {
       Object[] resultsOrErrors = new Object[actions.size()];
-      batch(actions, resultsOrErrors);
+      batchCallback(actions, resultsOrErrors, null);
       // At this point we are guaranteed that the array only contains results,
       // if it had any errors, batch would've thrown an exception
       Result[] results = new Result[resultsOrErrors.length];
@@ -327,11 +327,11 @@ public class BatchExecutor {
    * @return an array of {@link java.lang.Boolean} objects.
    * @throws java.io.IOException if any.
    */
-  public Boolean[] exists(List<Get> gets) throws IOException {
+  public boolean[] exists(List<Get> gets) throws IOException {
     // get(gets) will throw if there are any errors:
     Result[] getResults = batch(gets);
 
-    Boolean[] exists = new Boolean[getResults.length];
+    boolean[] exists = new boolean[getResults.length];
     for (int index = 0; index < getResults.length; index++) {
       exists[index] = !getResults[index].isEmpty();
     }

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/KeyOnlyFilterAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/KeyOnlyFilterAdapter.java
@@ -39,16 +39,17 @@ public class KeyOnlyFilterAdapter extends TypedFilterAdapterBase<KeyOnlyFilter> 
       1L,
       Bytes.toBytes('v'));
 
+  protected static RowFilter KEY_ONLY_FILTER =
+      RowFilter.newBuilder()
+          .setChain(Chain.newBuilder()
+              .addFilters(RowFilter.newBuilder().setCellsPerRowLimitFilter(1).build())
+              .addFilters(RowFilter.newBuilder().setStripValueTransformer(true).build()).build())
+          .build();
+
   /** {@inheritDoc} */
   @Override
   public RowFilter adapt(FilterAdapterContext context, KeyOnlyFilter filter) throws IOException {
-    return RowFilter.newBuilder()
-        .setChain(
-            Chain.newBuilder()
-                .addFilters(RowFilter.newBuilder().setCellsPerRowLimitFilter(1).build())
-                .addFilters(RowFilter.newBuilder().setStripValueTransformer(true).build())
-                .build())
-        .build();
+    return KEY_ONLY_FILTER;
   }
 
   /** {@inheritDoc} */


### PR DESCRIPTION
KeyOnlyFilter is a filter that returns an empty value for the first qualifier in a row.  This functionality was created to make exist() fast, but the client never took advantage of it.