### PR TITLE
Fixing a problem with scan relating to version checking

### DIFF
--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestCheckAndMutate.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestCheckAndMutate.java
@@ -352,4 +352,27 @@ public class TestCheckAndMutate extends AbstractTest {
       CompareOp.NOT_EQUAL, Bytes.toBytes(4000l), someRandomPut);
     Assert.assertTrue("4000 != 2000 should succeed", success);
   }
+
+  @Test
+  public void testCompareOpsVersions() throws IOException {
+    byte[] rowKey = dataHelper.randomData("rowKey-");
+    byte[] qualToCheck = dataHelper.randomData("toCheck-");
+    byte[] otherQual = dataHelper.randomData("other-");
+    boolean success;
+
+    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Put someRandomPut =
+        new Put(rowKey).addColumn(SharedTestEnvRule.COLUMN_FAMILY, otherQual, Bytes.toBytes(1l));
+
+    table.put(new Put(rowKey, System.currentTimeMillis() - 10000)
+        .addColumn(SharedTestEnvRule.COLUMN_FAMILY, qualToCheck, Bytes.toBytes(2000l)));
+
+    table.put(new Put(rowKey, System.currentTimeMillis()).addColumn(SharedTestEnvRule.COLUMN_FAMILY,
+      qualToCheck, Bytes.toBytes(4000l)));
+
+    success = table.checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qualToCheck,
+      CompareOp.GREATER, Bytes.toBytes(3000l), someRandomPut);
+    Assert.assertFalse("3000 > 4000 should fail", success);
+
+  }
 }

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/ScanAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/ScanAdapter.java
@@ -96,6 +96,8 @@ public class ScanAdapter implements ReadOperationAdapter<Scan> {
       chainBuilder.addFilters(createTimeRangeFilter(scan.getTimeRange()));
     }
 
+    chainBuilder.addFilters(createColumnLimitFilter(scan.getMaxVersions()));
+
     if (scan.getFilter() != null) {
       Optional<RowFilter> userFilter = createUserFilter(scan, hooks);
       if (userFilter.isPresent()) {
@@ -103,7 +105,6 @@ public class ScanAdapter implements ReadOperationAdapter<Scan> {
       }
     }
 
-    chainBuilder.addFilters(createColumnLimitFilter(scan.getMaxVersions()));
 
     if (chainBuilder.getFiltersCount() == 1) {
       return chainBuilder.getFilters(0);


### PR DESCRIPTION
When checking versions, always get the top n versions before the user's filter.  This should fix #1348.