### PR TITLE
Fixing a bug relating to RetryingReadRowsOperation.

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AbstractRetryingOperation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AbstractRetryingOperation.java
@@ -145,7 +145,9 @@ public abstract class AbstractRetryingOperation<RequestT, ResponseT, ResultT>
     Code code = status.getCode();
     // CANCELLED
     if (code == Status.Code.CANCELLED) {
-      completionFuture.cancel(true);
+      if (completionFuture != null && !completionFuture.isDone()) {
+        completionFuture.cancel(true);
+      }
       // An explicit user cancellation is not considered a failure.
       operationTimerContext.close();
       return;

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AbstractRetryingOperation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AbstractRetryingOperation.java
@@ -63,12 +63,12 @@ public abstract class AbstractRetryingOperation<RequestT, ResponseT, ResultT>
     }
 
     @Override
-    protected boolean set(@Nullable RespT resp) {
+    public boolean set(@Nullable RespT resp) {
       return super.set(resp);
     }
 
     @Override
-    protected boolean setException(Throwable throwable) {
+    public boolean setException(Throwable throwable) {
       return super.setException(throwable);
     }
   }
@@ -116,11 +116,7 @@ public abstract class AbstractRetryingOperation<RequestT, ResponseT, ResultT>
     this.callOptions = callOptions;
     this.retryExecutorService = retryExecutorService;
     this.originalMetadata = originalMetadata;
-    this.completionFuture = createCompletionFuture();
-  }
-
-  protected GrpcFuture<ResultT> createCompletionFuture() {
-    return new GrpcFuture<>();
+    this.completionFuture = new GrpcFuture<>();
   }
 
   /** {@inheritDoc} */
@@ -145,9 +141,7 @@ public abstract class AbstractRetryingOperation<RequestT, ResponseT, ResultT>
     Code code = status.getCode();
     // CANCELLED
     if (code == Status.Code.CANCELLED) {
-      if (completionFuture != null && !completionFuture.isDone()) {
-        completionFuture.cancel(true);
-      }
+      completionFuture.cancel(true);
       // An explicit user cancellation is not considered a failure.
       operationTimerContext.close();
       return;


### PR DESCRIPTION
completionFuture is null in RetryingReadRowsOperation, so add some defensive checks in AbstractRetryingOperation onError() for canceled operations.