### PR TITLE
add netty-tcnative as a default dep for all new 1.x artifacts

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/pom.xml
+++ b/bigtable-client-core-parent/bigtable-client-core/pom.xml
@@ -49,6 +49,11 @@ limitations under the License.
             <artifactId>commons-logging</artifactId>
             <version>${commons-logging.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
+        </dependency>
 
         <!-- Auth -->
         <dependency>
@@ -78,12 +83,21 @@ limitations under the License.
                 </exclusion>
             </exclusions>
         </dependency>
-
-        <!-- TODO: group with other general deps -->
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>${guava.version}</version>
+            <groupId>com.google.http-client</groupId>
+            <artifactId>google-http-client</artifactId>
+            <version>${google.http.client.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.api-client</groupId>
+            <artifactId>google-api-client</artifactId>
+            <version>${google.api.client.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava-jdk5</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- GRPC -->
@@ -91,13 +105,6 @@ limitations under the License.
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
             <version>${protobuff-java.version}</version>
-        </dependency>
-
-        <!-- TODO: group with other metrics deps -->
-        <dependency>
-            <groupId>com.google.instrumentation</groupId>
-            <artifactId>instrumentation-api</artifactId>
-            <version>${instrumentation-java.version}</version>
         </dependency>
 
         <dependency>
@@ -150,30 +157,18 @@ limitations under the License.
             <version>${grpc.version}</version>
         </dependency>
 
-        <!-- TODO: group with auth -->
-        <dependency>
-            <groupId>com.google.http-client</groupId>
-            <artifactId>google-http-client</artifactId>
-            <version>${google.http.client.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.google.api-client</groupId>
-            <artifactId>google-api-client</artifactId>
-            <version>${google.api.client.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.google.guava</groupId>
-                    <artifactId>guava-jdk5</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
         <!-- Metrics -->
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-core</artifactId>
             <version>${dropwizard.metrics.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.google.instrumentation</groupId>
+            <artifactId>instrumentation-api</artifactId>
+            <version>${instrumentation-java.version}</version>
+        </dependency>
+
 
         <!-- Test -->
         <dependency>

--- a/bigtable-client-core-parent/bigtable-client-core/pom.xml
+++ b/bigtable-client-core-parent/bigtable-client-core/pom.xml
@@ -122,6 +122,11 @@ limitations under the License.
             <artifactId>netty-handler-proxy</artifactId>
             <version>${netty.version}</version>
         </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-tcnative-boringssl-static</artifactId>
+            <version>${netty-tcnative-boringssl-static.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>io.grpc</groupId>
@@ -193,12 +198,6 @@ limitations under the License.
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-core</artifactId>
             <version>${hamcrest.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-tcnative-boringssl-static</artifactId>
-            <version>${netty-tcnative-boringssl-static.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/bigtable-client-core-parent/bigtable-protos/pom.xml
+++ b/bigtable-client-core-parent/bigtable-protos/pom.xml
@@ -49,11 +49,19 @@ limitations under the License.
     </pluginRepositories>
 
     <dependencies>
+        <!-- Common -->
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
             <version>${jsr305.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
+        </dependency>
+
+        <!-- GRPC -->
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
@@ -88,11 +96,6 @@ limitations under the License.
             <groupId>io.grpc</groupId>
             <artifactId>grpc-protobuf</artifactId>
             <version>${grpc.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>${guava.version}</version>
         </dependency>
     </dependencies>
 

--- a/bigtable-dataflow-parent/bigtable-dataflow-import/pom.xml
+++ b/bigtable-dataflow-parent/bigtable-dataflow-import/pom.xml
@@ -60,12 +60,6 @@ limitations under the License.
             <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-tcnative-boringssl-static</artifactId>
-            <version>${netty-tcnative-boringssl-static.version}</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
 

--- a/bigtable-dataflow-parent/bigtable-hbase-dataflow/pom.xml
+++ b/bigtable-dataflow-parent/bigtable-hbase-dataflow/pom.xml
@@ -60,12 +60,6 @@ limitations under the License.
             <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
-       <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-tcnative-boringssl-static</artifactId>
-           <version>${netty-tcnative-boringssl-static.version}</version>
-           <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>

--- a/bigtable-hbase-parent/bigtable-hbase-1.0/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-1.0/pom.xml
@@ -45,6 +45,10 @@ limitations under the License.
                     <groupId>org.apache.hbase</groupId>
                     <artifactId>hbase-client</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-tcnative-boringssl-static</artifactId>
+                </exclusion>
 
                 <!-- Workaround MNG-5899 & MSHADE-206. Maven >= 3.3.0 doesn't use the dependency reduced
                 pom.xml files when invoking the build from a parent project. So we have to manually exclude

--- a/bigtable-hbase-parent/bigtable-hbase-1.1/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-1.1/pom.xml
@@ -45,6 +45,11 @@ limitations under the License.
                     <groupId>org.apache.hbase</groupId>
                     <artifactId>hbase-client</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-tcnative-boringssl-static</artifactId>
+                </exclusion>
+
 
                 <!-- Workaround MNG-5899 & MSHADE-206. Maven >= 3.3.0 doesn't use the dependency reduced
                 pom.xml files when invoking the build from a parent project. So we have to manually exclude

--- a/bigtable-hbase-parent/bigtable-hbase-1.2/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-1.2/pom.xml
@@ -45,6 +45,11 @@ limitations under the License.
                     <groupId>org.apache.hbase</groupId>
                     <artifactId>hbase-client</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-tcnative-boringssl-static</artifactId>
+                </exclusion>
+
 
                 <!-- Workaround MNG-5899 & MSHADE-206. Maven >= 3.3.0 doesn't use the dependency reduced
                 pom.xml files when invoking the build from a parent project. So we have to manually exclude

--- a/bigtable-hbase-parent/bigtable-hbase-1.3/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-1.3/pom.xml
@@ -45,6 +45,11 @@ limitations under the License.
                     <groupId>org.apache.hbase</groupId>
                     <artifactId>hbase-client</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-tcnative-boringssl-static</artifactId>
+                </exclusion>
+
 
                 <!-- Workaround MNG-5899 & MSHADE-206. Maven >= 3.3.0 doesn't use the dependency reduced
                 pom.xml files when invoking the build from a parent project. So we have to manually exclude

--- a/bigtable-hbase-parent/bigtable-hbase-1.x-hadoop/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-1.x-hadoop/pom.xml
@@ -57,6 +57,12 @@ limitations under the License.
 
     <!-- Manually promote dependencies: This is necessary to avoid flattening hbase-shaded-client's dependency tree -->
     <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-tcnative-boringssl-static</artifactId>
+      <version>${netty-tcnative-boringssl-static.version}</version>
+    </dependency>
+
+    <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
       <version>${jsr305.version}</version>

--- a/bigtable-hbase-parent/bigtable-hbase-1.x-shaded/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-1.x-shaded/pom.xml
@@ -39,6 +39,12 @@ limitations under the License.
 
   <!-- Manually promote dependencies: This is necessary to avoid flattening hbase-shaded-client's dependency tree -->
   <dependency>
+    <groupId>io.netty</groupId>
+    <artifactId>netty-tcnative-boringssl-static</artifactId>
+    <version>${netty-tcnative-boringssl-static.version}</version>
+  </dependency>
+
+  <dependency>
     <groupId>org.apache.hbase</groupId>
     <artifactId>hbase-shaded-client</artifactId>
     <version>${hbase.version}</version>
@@ -82,6 +88,8 @@ limitations under the License.
               <promoteTransitiveDependencies>false</promoteTransitiveDependencies>
               <artifactSet>
                 <excludes>
+                  <!-- exclude jni deps -->
+                  <exclude>io.netty:netty-tcnative-boringssl-static</exclude>
                   <!-- exclude user visible deps -->
                   <exclude>io.dropwizard.metrics:metrics-core</exclude>
                   <exclude>commons-logging:commons-logging</exclude>

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests/pom.xml
@@ -220,12 +220,6 @@ limitations under the License.
             <version>${hbase.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-tcnative-boringssl-static</artifactId>
-            <version>${netty-tcnative-boringssl-static.version}</version>
-            <scope>test</scope>
-        </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/bigtable-hbase-parent/bigtable-hbase-mapreduce/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-mapreduce/pom.xml
@@ -66,13 +66,6 @@ limitations under the License.
             <artifactId>hbase-server</artifactId>
             <version>${hbase.version}</version>
         </dependency>
-
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-tcnative-boringssl-static</artifactId>
-            <version>${netty-tcnative-boringssl-static.version}</version>
-            <scope>compile</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/bigtable-hbase-parent/bigtable-hbase/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase/pom.xml
@@ -89,12 +89,6 @@ limitations under the License.
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-tcnative-boringssl-static</artifactId>
-            <version>${netty-tcnative-boringssl-static.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
             <version>2.6</version>


### PR DESCRIPTION
- cleanup todos in bigtable-client-core pom.xml
- add netty-tcnative-boringssl as a dep to bigtable-client-core
- take care to exclude it from all of the shading
- exclude it from the old transition artifacts