### PR TITLE
Use a new method for Table.get(Get).

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataClient.java
@@ -149,6 +149,14 @@ public interface BigtableDataClient {
   ListenableFuture<List<Row>> readRowsAsync(ReadRowsRequest request);
 
   /**
+   * Returns a list of {@link FlatRow}s, in key order.
+   *
+   * @param request a {@link com.google.bigtable.v2.ReadRowsRequest} object.
+   * @return a List with {@link FlatRow}s.
+   */
+  List<FlatRow> readFlatRowsList(ReadRowsRequest request);
+
+  /**
    * Perform a scan over {@link FlatRow}s, in key order.
    *
    * @param request a {@link com.google.bigtable.v2.ReadRowsRequest} object.

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataGrpcClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataGrpcClient.java
@@ -320,6 +320,13 @@ public class BigtableDataGrpcClient implements BigtableDataClient {
         FLAT_ROW_LIST_TRANSFORMER);
   }
 
+  /** {@inheritDoc} */
+  @Override
+  public List<FlatRow> readFlatRowsList(ReadRowsRequest request) {
+    return FLAT_ROW_LIST_TRANSFORMER.apply(
+      createStreamingListener(request, readRowsAsync, request.getTableName()).getBlockingResult());
+  }
+
   private <ReqT, RespT> RetryingUnaryOperation<ReqT, RespT> createUnaryListener(
       ReqT request, BigtableAsyncRpc<ReqT, RespT> rpc, String tableName) {
     CallOptions callOptions = getCallOptions(rpc.getMethodDescriptor(), request);

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BigtableAsyncRpc.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BigtableAsyncRpc.java
@@ -24,6 +24,7 @@ import io.grpc.CallOptions;
 import io.grpc.ClientCall;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
+import io.grpc.ClientCall.Listener;
 
 /**
  * This interface represents a logical asynchronous RPC end point, including creating a
@@ -82,17 +83,25 @@ public interface BigtableAsyncRpc<REQUEST, RESPONSE> {
   }
 
   /**
-   * Creates a {@link io.grpc.ClientCall} and starts it.
+   * Creates a {@link io.grpc.ClientCall} it.
    *
    * @param callOptions A set of gRPC options to use on this call.
+   *
+   * @return A ClientCall that represents a new request.
+   */
+  ClientCall<REQUEST, RESPONSE> newCall(CallOptions callOptions);
+
+  /**
+   * Starts a {@link io.grpc.ClientCall}.
+   *
    * @param request The request to send.
    * @param listener A listener which handles responses.
    * @param metadata A set of predefined headers to use.
    *
    * @return A ClientCall that represents a new request.
    */
-  ClientCall<REQUEST, RESPONSE> startNewCall(CallOptions callOptions, REQUEST request,
-      ClientCall.Listener<RESPONSE> listener, Metadata metadata);
+  void start(REQUEST request, Listener<RESPONSE> listener, Metadata metadata,
+      ClientCall<REQUEST, RESPONSE> call);
 
   /**
    * Can this request be retried?

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BigtableAsyncUtilities.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BigtableAsyncUtilities.java
@@ -77,9 +77,13 @@ public interface BigtableAsyncUtilities {
         }
 
         @Override
-        public ClientCall<RequestT, ResponseT> startNewCall(CallOptions callOptions,
-            RequestT request, Listener<ResponseT> listener, Metadata metadata) {
-          ClientCall<RequestT, ResponseT> call = channel.newCall(method, callOptions);
+        public ClientCall<RequestT, ResponseT> newCall(CallOptions callOptions) {
+          return channel.newCall(method, callOptions);
+        }
+
+        @Override
+        public void start(RequestT request, Listener<ResponseT> listener, Metadata metadata,
+            ClientCall<RequestT, ResponseT> call) {
           call.start(listener, metadata);
           call.request(1);
           try {
@@ -96,7 +100,6 @@ public interface BigtableAsyncUtilities {
             call.cancel("Exception in halfClose.", t);
             throw Throwables.propagate(t);
           }
-          return call;
         }
       };
     }

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/RetryingMutateRowsOperation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/RetryingMutateRowsOperation.java
@@ -19,7 +19,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 
 import com.google.api.client.util.BackOff;
 import com.google.bigtable.v2.MutateRowsRequest;
@@ -209,14 +208,4 @@ public class RetryingMutateRowsOperation extends
     }
     return MutateRowsResponse.newBuilder().addAllEntries(entries).build();
   }
-
-  @Override
-  protected CallOptions getCallOptions() {
-    CallOptions originalCallOptions = super.getCallOptions();
-    if (originalCallOptions.getDeadline() != null) {
-      return originalCallOptions;
-    }
-    return originalCallOptions.withDeadlineAfter(UNARY_DEADLINE_MINUTES, TimeUnit.MINUTES);
-  }
-
 }

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestBigtableDataGrpcClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestBigtableDataGrpcClient.java
@@ -44,6 +44,7 @@ import com.google.bigtable.v2.MutateRowsRequest.Entry;
 import com.google.bigtable.v2.Mutation;
 import com.google.bigtable.v2.Mutation.SetCell;
 import com.google.bigtable.v2.ReadRowsRequest;
+import com.google.bigtable.v2.ReadRowsResponse;
 import com.google.bigtable.v2.RowRange;
 import com.google.cloud.bigtable.config.BigtableOptions;
 import com.google.cloud.bigtable.config.RetryOptions;
@@ -192,11 +193,19 @@ public class TestBigtableDataGrpcClient {
     verifyRequestCalled(requestBuilder.build());
   }
 
+  @Test
+  public void testListReadRows() {
+    ReadRowsRequest.Builder requestBuilder = ReadRowsRequest.newBuilder().setTableName(TABLE_NAME);
+    requestBuilder.getRowsBuilder().addRowKeys(ByteString.EMPTY);
+    setResponse(ReadRowsResponse.getDefaultInstance());
+    defaultClient.readFlatRowsList(requestBuilder.build());
+    verifyRequestCalled(requestBuilder.build());
+  }
+
   private void setResponse(final Object response) {
     Answer<Void> answer = new Answer<Void>(){
-
       @Override
-      public Void answer(InvocationOnMock invocation) throws Throwable {
+      public Void answer(final InvocationOnMock invocation) throws Throwable {
         checkHeader(invocation.getArgumentAt(1, Metadata.class));
         ClientCall.Listener listener = invocation.getArgumentAt(0, ClientCall.Listener.class);
         listener.onMessage(response);

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestRetryingMutateRowsOperation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestRetryingMutateRowsOperation.java
@@ -128,6 +128,7 @@ public class TestRetryingMutateRowsOperation {
   public void setup() {
     MockitoAnnotations.initMocks(this);
     when(mutateRows.getRpcMetrics()).thenReturn(metrics);
+    when(mutateRows.getMethodDescriptor()).thenReturn(BigtableGrpc.METHOD_MUTATE_ROWS);
     retryOptions = RetryOptionsUtil.createTestRetryOptions(nanoClock);
   }
 

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableTable.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableTable.java
@@ -253,14 +253,16 @@ public class BigtableTable implements Table {
   }
 
   private FlatRow getResults(Get get, String method) throws IOException {
-    try (Timer.Context ignored = metrics.getTimer.time();
-        com.google.cloud.bigtable.grpc.scanner.ResultScanner<FlatRow> scanner =
-            client.readFlatRows(hbaseAdapter.adapt(get))) {
-      FlatRow row = scanner.next();
-      if (scanner.next() != null) {
+    try (Timer.Context ignored = metrics.getTimer.time()) {
+      List<FlatRow> list = client.readFlatRowsList(hbaseAdapter.adapt(get));
+      switch(list.size()) {
+      case 0:
+        return null;
+      case 1:
+        return list.get(0);
+      default:
         throw new IllegalStateException("Multiple responses found for " + method);
       }
-      return row;
     }
   }
 

--- a/bigtable-hbase-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableTable.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableTable.java
@@ -139,7 +139,7 @@ public class TestBigtableTable {
     ArgumentCaptor<ReadRowsRequest> argument =
         ArgumentCaptor.forClass(ReadRowsRequest.class);
 
-    verify(mockClient).readFlatRows(argument.capture());
+    verify(mockClient).readFlatRowsList(argument.capture());
 
     Assert.assertEquals(
         "projects/testproject/instances/testinstance/tables/testtable",


### PR DESCRIPTION
- Adding BigtableDataClient.readFlatRowsList() which will do a synchronous ReadRows request that will return a List<FlatRow>.
- The test for BigtableDataClient.readFlatRowsList() showed a subtle problem that pops up in RetryingStreamOperation unit testing.  That change required a split between creating a new ClientCall and starting that ClientCall.  That change had a ripple effect in tests.
- Adding a default CallOptions to all requests, with the exception of scan ReadRows.  This will ensure that there is a retry in the event of a "lost RPC".

This should be a better solution to #1456 than #1464.