### PR TITLE
Ensuring that scans don't block grpc threads.

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
@@ -121,7 +121,8 @@ public class BigtableSession implements Closeable {
     if (sslBuilder == null) {
       // TODO(igorbernstein2): figure out why .ciphers(null) is necessary
       // Without it, the dataflow-reimport test fails with:
-      // "javax.net.ssl.SSLHandshakeException: No appropriate protocol (protocol is disabled or cipher suites are inappropriate)"
+      // "javax.net.ssl.SSLHandshakeException: No appropriate protocol (protocol is disabled or
+      // cipher suites are inappropriate)"
       sslBuilder = GrpcSslContexts.forClient().ciphers(null);
     }
     return sslBuilder.build();

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ResponseQueueReader.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ResponseQueueReader.java
@@ -20,12 +20,17 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.google.bigtable.v2.ReadRowsRequest;
 import com.google.cloud.bigtable.grpc.BigtableDataGrpcClient;
 import com.google.cloud.bigtable.metrics.BigtableClientMetrics;
 import com.google.cloud.bigtable.metrics.BigtableClientMetrics.MetricLevel;
 import com.google.cloud.bigtable.metrics.Timer;
 import com.google.common.base.Preconditions;
 
+import io.grpc.stub.ClientCallStreamObserver;
+import io.grpc.stub.ClientResponseObserver;
 import io.grpc.stub.StreamObserver;
 
 /**
@@ -36,7 +41,8 @@ import io.grpc.stub.StreamObserver;
  * @see BigtableDataGrpcClient#readFlatRows(com.google.bigtable.v2.ReadRowsRequest) for more
  *     information.
  */
-public class ResponseQueueReader implements StreamObserver<FlatRow> {
+public class ResponseQueueReader
+    implements StreamObserver<FlatRow>, ClientResponseObserver<ReadRowsRequest, FlatRow> {
 
   private static Timer firstResponseTimer;
 
@@ -53,7 +59,8 @@ public class ResponseQueueReader implements StreamObserver<FlatRow> {
   private AtomicBoolean completionMarkerFound = new AtomicBoolean(false);
   private boolean lastResponseProcessed = false;
   private Long startTime;
-  private ScanHandler scanHandler;
+  private ClientCallStreamObserver<ReadRowsRequest> requestStream;
+  private AtomicInteger markerCounter = new AtomicInteger();
 
   /**
    * <p>Constructor for ResponseQueueReader.</p>
@@ -64,8 +71,10 @@ public class ResponseQueueReader implements StreamObserver<FlatRow> {
     }
   }
 
-  public void setScanHandler(ScanHandler scanHandler) {
-    this.scanHandler = scanHandler;
+  @Override
+  public void beforeStart(ClientCallStreamObserver<ReadRowsRequest> requestStream) {
+    requestStream.disableAutoInboundFlowControl();
+    this.requestStream = requestStream;
   }
 
   /**
@@ -84,6 +93,7 @@ public class ResponseQueueReader implements StreamObserver<FlatRow> {
     switch (queueEntry.getType()) {
     case CompletionMarker:
       lastResponseProcessed = true;
+      markerCounter.decrementAndGet();
       break;
     case Data:
       if (startTime != null) {
@@ -92,9 +102,13 @@ public class ResponseQueueReader implements StreamObserver<FlatRow> {
       }
       return queueEntry.getResponseOrThrow();
     case Exception:
+      markerCounter.decrementAndGet();
       return queueEntry.getResponseOrThrow();
     case RequestResultMarker:
-      scanHandler.requestResult();
+      markerCounter.decrementAndGet();
+      if (!completionMarkerFound.get()) {
+        requestStream.request(1);
+      }
       return getNextMergedRow();
     default:
       throw new IllegalStateException("Cannot process type: " + queueEntry.getType());
@@ -132,7 +146,7 @@ public class ResponseQueueReader implements StreamObserver<FlatRow> {
    * @return a int.
    */
   public int available() {
-    return resultQueue.size();
+    return resultQueue.size() - markerCounter.get();
   }
 
   /** {@inheritDoc} */
@@ -145,6 +159,7 @@ public class ResponseQueueReader implements StreamObserver<FlatRow> {
   @Override
   public void onError(Throwable t) {
     addEntry("adding an error ResultQueueEntry", ResultQueueEntry.<FlatRow> fromThrowable(t));
+    markerCounter.incrementAndGet();
   }
 
   /** {@inheritDoc} */
@@ -152,6 +167,7 @@ public class ResponseQueueReader implements StreamObserver<FlatRow> {
   public void onCompleted() {
     completionMarkerFound.set(true);
     addEntry("setting completion", ResultQueueEntry.<FlatRow> completionMarker());
+    markerCounter.incrementAndGet();
   }
 
   /**
@@ -163,6 +179,7 @@ public class ResponseQueueReader implements StreamObserver<FlatRow> {
    */
   public void addRequestResultMarker() {
     addEntry("setting request result marker", ResultQueueEntry.<FlatRow> requestResultMarker());
+    markerCounter.incrementAndGet();
   }
 
   private void addEntry(String message, ResultQueueEntry<FlatRow> entry) {

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ResultQueueEntry.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ResultQueueEntry.java
@@ -34,7 +34,8 @@ abstract class ResultQueueEntry<T> {
   public enum Type {
     Data,
     Exception,
-    CompletionMarker;
+    CompletionMarker,
+    RequestResultMarker;
   }
 
   /**
@@ -70,6 +71,17 @@ abstract class ResultQueueEntry<T> {
   @SuppressWarnings("unchecked")
   public static <T> ResultQueueEntry<T> completionMarker() {
     return COMPLETION_ENTRY;
+  }
+
+  /**
+   * <p>retrieveResultMarker.</p>
+   *
+   * @param <T> a T object.
+   * @return a {@link com.google.cloud.bigtable.grpc.scanner.ResultQueueEntry} object.
+   */
+  @SuppressWarnings("unchecked")
+  public static <T> ResultQueueEntry<T> requestResultMarker() {
+    return REQUEST_RESULT_ENTRY;
   }
 
   private static final class ExceptionResultQueueEntry<T> extends ResultQueueEntry<T> {
@@ -122,6 +134,23 @@ abstract class ResultQueueEntry<T> {
         public Object getResponseOrThrow() throws IOException {
           throw new IOException(
               "Attempt to interpret a result stream completion marker as a result");
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+          // toResultQueueEntry will return null if the type field is different between this and
+          // obj.
+          return toResultQueueEntryForEquals(obj) != null;
+        }
+      };
+
+  @SuppressWarnings("rawtypes")
+  private static final ResultQueueEntry REQUEST_RESULT_ENTRY =
+      new ResultQueueEntry(Type.RequestResultMarker) {
+        @Override
+        public Object getResponseOrThrow() throws IOException {
+          throw new IOException(
+              "Attempt to interpret a result marker as a result");
         }
 
         @Override

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/RetryingReadRowsOperation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/RetryingReadRowsOperation.java
@@ -94,13 +94,6 @@ public class RetryingReadRowsOperation extends
   @Override
   public void onMessage(ReadRowsResponse message) {
     resetStatusBasedBackoff();
-    if (rowObserver instanceof ResponseQueueReader) {
-      // ResponseQueueReader will only read more results if prior FlatRows were retrieved from the
-      // queue.
-      ((ResponseQueueReader) rowObserver).addRequestResultMarker();
-    } else {
-      call.request(1);
-    }
     lastResponseMs = clock.currentTimeMillis();
     // We've had at least one successful RPC, reset the backoff and retry counter
     timeoutRetryCount = 0;
@@ -118,6 +111,13 @@ public class RetryingReadRowsOperation extends
       // The service indicates that it processed rows that did not match the filter, and will not
       // need to be reprocessed.
       updateLastFoundKey(message.getLastScannedRowKey());
+    }
+    if (rowObserver instanceof ResponseQueueReader) {
+      // ResponseQueueReader will only read more results if prior FlatRows were retrieved from the
+      // queue.
+      ((ResponseQueueReader) rowObserver).addRequestResultMarker();
+    } else {
+      call.request(1);
     }
   }
 

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ScanHandler.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ScanHandler.java
@@ -32,9 +32,4 @@ public interface ScanHandler {
    * Perform an rpc cancellation given a client-side request.
    */
   public void cancel();
-
-  /**
-   * Requests the next result from the server-side.
-   */
-  public void requestResult();
 }

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ScanHandler.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ScanHandler.java
@@ -32,4 +32,9 @@ public interface ScanHandler {
    * Perform an rpc cancellation given a client-side request.
    */
   public void cancel();
+
+  /**
+   * Requests the next result from the server-side.
+   */
+  public void requestResult();
 }

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/scanner/ResponseQueueReaderTest.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/scanner/ResponseQueueReaderTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.grpc.scanner;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import com.google.cloud.bigtable.grpc.BigtableSessionSharedThreadPools;
+import com.google.cloud.bigtable.grpc.io.IOExceptionWithStatus;
+import com.google.protobuf.ByteString;
+
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.stub.ClientCallStreamObserver;
+
+@RunWith(JUnit4.class)
+@SuppressWarnings({"rawtypes", "unchecked"})
+public class ResponseQueueReaderTest {
+
+  @Mock
+  private ClientCallStreamObserver mockClientCallStreamObserver;
+
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+
+  private ResponseQueueReader underTest;
+
+  @Before
+  public void setup() {
+    MockitoAnnotations.initMocks(this);
+    underTest = new ResponseQueueReader();
+    underTest.beforeStart(mockClientCallStreamObserver);
+  }
+
+  @Test
+  public void testNone() throws IOException {
+    underTest.onCompleted();
+    assertNull(underTest.getNextMergedRow());
+  }
+
+  @Test
+  public void testSinglePostComplete() throws IOException {
+    FlatRow row = new FlatRow(ByteString.EMPTY, null);
+    underTest.onNext(row);
+    underTest.addRequestResultMarker();
+    underTest.onCompleted();
+    assertSame(row, underTest.getNextMergedRow());
+    verify(mockClientCallStreamObserver, times(0)).request(anyInt());
+  }
+
+  @Test
+  public void testSinglePrecomplete() throws IOException {
+    FlatRow row = new FlatRow(ByteString.EMPTY, null);
+    underTest.onNext(row);
+    underTest.addRequestResultMarker();
+    assertSame(row, underTest.getNextMergedRow());
+    // getNextMergedRow() will block until either a result is present or the operation is complete.
+    BigtableSessionSharedThreadPools.getInstance().getRetryExecutor().schedule(new Runnable() {
+      @Override
+      public void run() {
+        underTest.onCompleted();
+      }
+    }, 50, TimeUnit.MILLISECONDS);
+    assertNull(underTest.getNextMergedRow());
+    verify(mockClientCallStreamObserver, times(1)).request(eq(1));
+  }
+
+  @Test
+  public void testException() throws IOException {
+    StatusRuntimeException exception = Status.DEADLINE_EXCEEDED.asRuntimeException();
+    expectedException.expect(IOExceptionWithStatus.class);
+    underTest.onError(exception);
+    underTest.getNextMergedRow();
+  }
+}

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/scanner/RetryingReadRowsOperationTest.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/scanner/RetryingReadRowsOperationTest.java
@@ -110,8 +110,6 @@ public class RetryingReadRowsOperationTest {
 
   private Metadata metaData;
 
-  private RetryingReadRowsOperation underTest;
-
   @SuppressWarnings({ "rawtypes" })
   @Before
   public void setup() {
@@ -123,10 +121,6 @@ public class RetryingReadRowsOperationTest {
     when(mockRetryableRpc.getMethodDescriptor()).thenReturn(BigtableGrpc.METHOD_READ_ROWS);
     when(mockRpcMetrics.timeOperation()).thenReturn(mockOperationTimerContext);
     when(mockRpcMetrics.timeRpc()).thenReturn(mockRpcTimerContext);
-
-    underTest =
-        new RetryingReadRowsOperation(mockFlatRowObserver, RETRY_OPTIONS, READ_ENTIRE_TABLE_REQUEST,
-            mockRetryableRpc, CallOptions.DEFAULT, mockRetryExecutorService, metaData);
 
     Answer<ScheduledFuture> runAutomatically = new Answer<ScheduledFuture>() {
       @Override
@@ -141,45 +135,56 @@ public class RetryingReadRowsOperationTest {
     doAnswer(runAutomatically).when(mockRetryExecutorService).execute(any(Runnable.class));
   }
 
+  protected RetryingReadRowsOperation createOperation(StreamObserver<FlatRow> observer) {
+    return new RetryingReadRowsOperation(observer, RETRY_OPTIONS, READ_ENTIRE_TABLE_REQUEST,
+        mockRetryableRpc, CallOptions.DEFAULT, mockRetryExecutorService, metaData);
+  }
+
   @Test
   public void testEmptyResponse() {
-    start();
+    RetryingReadRowsOperation underTest = createOperation(mockFlatRowObserver);
+    start(underTest);
     ReadRowsResponse response = ReadRowsResponse.getDefaultInstance();
+
     underTest.onMessage(response);
     verify(mockFlatRowObserver, times(0)).onNext(any(FlatRow.class));
+    verify(mockClientCall, times(2)).request(eq(1));
 
-    finishOK(0);
+    finishOK(underTest, 0);
   }
 
   @Test
   public void testSingleResponse() throws UnsupportedEncodingException {
-    start();
+    RetryingReadRowsOperation underTest = createOperation(mockFlatRowObserver);
+    start(underTest);
     ByteString key = ByteString.copyFrom("SomeKey", "UTF-8");
     ReadRowsResponse response = buildResponse(key);
     underTest.onMessage(response);
     verify(mockFlatRowObserver, times(1)).onNext(any(FlatRow.class));
-    checkRetryRequest(key);
+    checkRetryRequest(underTest, key);
 
-    finishOK(0);
+    finishOK(underTest, 0);
   }
 
   @Test
   public void testMultipleResponses() throws UnsupportedEncodingException {
-    start();
+    RetryingReadRowsOperation underTest = createOperation(mockFlatRowObserver);
+    start(underTest);
 
     ByteString key1 = ByteString.copyFrom("SomeKey1", "UTF-8");
     ByteString key2 = ByteString.copyFrom("SomeKey2", "UTF-8");
     underTest.onMessage(buildResponse(key1));
     underTest.onMessage(buildResponse(key2));
     verify(mockFlatRowObserver, times(2)).onNext(any(FlatRow.class));
-    checkRetryRequest(key2);
+    checkRetryRequest(underTest, key2);
 
-    finishOK(0);
+    finishOK(underTest, 0);
   }
 
   @Test
   public void testMultipleResponsesWithException() throws UnsupportedEncodingException {
-    start();
+    RetryingReadRowsOperation underTest = createOperation(mockFlatRowObserver);
+    start(underTest);
 
     ByteString key1 = ByteString.copyFrom("SomeKey1", "UTF-8");
     ByteString key2 = ByteString.copyFrom("SomeKey2", "UTF-8");
@@ -189,68 +194,71 @@ public class RetryingReadRowsOperationTest {
     Assert.assertNotSame(rw1, underTest.getRowMerger());
     underTest.onMessage(buildResponse(key2));
     verify(mockFlatRowObserver, times(2)).onNext(any(FlatRow.class));
-    checkRetryRequest(key2);
+    checkRetryRequest(underTest, key2);
 
-    finishOK(1);
+    finishOK(underTest, 1);
   }
 
   @Test
   public void testScanTimeoutSucceed() throws UnsupportedEncodingException, BigtableRetriesExhaustedException {
-    start();
+    RetryingReadRowsOperation underTest = createOperation(mockFlatRowObserver);
+    start(underTest);
 
-    final AtomicLong time = setupClock();
+    final AtomicLong time = setupClock(underTest);
     ByteString key1 = ByteString.copyFrom("SomeKey1", "UTF-8");
     ByteString key2 = ByteString.copyFrom("SomeKey2", "UTF-8");
     underTest.onMessage(buildResponse(key1));
 
     // a round of successful retries.
     RowMerger rw1 = underTest.getRowMerger();
-    performSuccessfulScanTimeouts(time);
+    performSuccessfulScanTimeouts(underTest, time);
     Assert.assertNotSame(rw1, underTest.getRowMerger());
     underTest.onClose(Status.ABORTED, new Metadata());
-    checkRetryRequest(key1);
+    checkRetryRequest(underTest, key1);
 
     // a message gets through
     underTest.onMessage(buildResponse(key2));
     verify(mockFlatRowObserver, times(2)).onNext(any(FlatRow.class));
-    checkRetryRequest(key2);
+    checkRetryRequest(underTest, key2);
 
     // more successful retries
-    performSuccessfulScanTimeouts(time);
+    performSuccessfulScanTimeouts(underTest, time);
 
-    checkRetryRequest(key2);
+    checkRetryRequest(underTest, key2);
 
     // a succsesful finish.  There were 2 x RETRY_OPTIONS.getMaxScanTimeoutRetries() timeouts,
     // and 1 ABORTED status.
-    finishOK(RETRY_OPTIONS.getMaxScanTimeoutRetries() * 2 + 1);
+    finishOK(underTest, RETRY_OPTIONS.getMaxScanTimeoutRetries() * 2 + 1);
   }
 
   @Test
   public void testScanTimeoutFail() throws UnsupportedEncodingException, BigtableRetriesExhaustedException {
-    start();
+    RetryingReadRowsOperation underTest = createOperation(mockFlatRowObserver);
+    start(underTest);
 
-    final AtomicLong time = setupClock();
+    final AtomicLong time = setupClock(underTest);
 
     ByteString key = ByteString.copyFrom("SomeKey1", "UTF-8");
     underTest.onMessage(buildResponse(key));
 
     // N successful scan timeout retries
-    performSuccessfulScanTimeouts(time);
+    performSuccessfulScanTimeouts(underTest, time);
 
-    checkRetryRequest(key);
+    checkRetryRequest(underTest, key);
 
     // one last scan timeout that fails.
     thrown.expect(BigtableRetriesExhaustedException.class);
-    performTimeout(time);
+    performTimeout(underTest, time);
   }
 
 
   @Test
   public void testMixScanTimeoutAndStatusExceptions()
       throws UnsupportedEncodingException, BigtableRetriesExhaustedException {
-    start();
+    RetryingReadRowsOperation underTest = createOperation(mockFlatRowObserver);
+    start(underTest);
 
-    final AtomicLong time = setupClock();
+    final AtomicLong time = setupClock(underTest);
     int expectedRetryCount = 0;
 
     ByteString key1 = ByteString.copyFrom("SomeKey1", "UTF-8");
@@ -259,14 +267,14 @@ public class RetryingReadRowsOperationTest {
     underTest.onClose(Status.ABORTED, new Metadata());
     Assert.assertNotNull(underTest.getCurrentBackoff());
     expectedRetryCount++;
-    checkRetryRequest(key1);
+    checkRetryRequest(underTest, key1);
 
     // N successful scan timeout retries
     for (int i = 0; i < 2; i++) {
-      performTimeout(time);
+      performTimeout(underTest, time);
       expectedRetryCount++;
     }
-    checkRetryRequest(key1);
+    checkRetryRequest(underTest, key1);
     Assert.assertNull(underTest.getCurrentBackoff());
     underTest.onMessage(buildResponse(key2));
 
@@ -274,7 +282,7 @@ public class RetryingReadRowsOperationTest {
       underTest.onClose(Status.ABORTED, new Metadata());
       expectedRetryCount++;
 
-      performTimeout(time);
+      performTimeout(underTest, time);
       Assert.assertNull(underTest.getCurrentBackoff());
       expectedRetryCount++;
     }
@@ -283,15 +291,16 @@ public class RetryingReadRowsOperationTest {
     verify(mockRpcTimerContext, times(expectedRetryCount)).close();
 
     thrown.expect(BigtableRetriesExhaustedException.class);
-    performTimeout(time);
+    performTimeout(underTest, time);
   }
 
-  protected void performTimeout(AtomicLong time) throws BigtableRetriesExhaustedException {
+  protected void performTimeout(RetryingReadRowsOperation underTest, AtomicLong time)
+      throws BigtableRetriesExhaustedException {
     time.addAndGet(RETRY_OPTIONS.getReadPartialRowTimeoutMillis() + 1);
     underTest.handleTimeout(new ScanTimeoutException("scan timeout"));
   }
 
-  private AtomicLong setupClock() {
+  private AtomicLong setupClock(RetryingReadRowsOperation underTest) {
     final AtomicLong time = new AtomicLong(0);
     underTest.clock = new Clock() {
       @Override
@@ -302,14 +311,15 @@ public class RetryingReadRowsOperationTest {
     return time;
   }
 
-  private void performSuccessfulScanTimeouts(final AtomicLong time) throws BigtableRetriesExhaustedException {
+  private void performSuccessfulScanTimeouts(RetryingReadRowsOperation underTest, AtomicLong time)
+      throws BigtableRetriesExhaustedException {
     for (int i = 0; i < RETRY_OPTIONS.getMaxScanTimeoutRetries(); i++) {
       Assert.assertEquals(i, underTest.getTimeoutRetryCount());
-      performTimeout(time);
+      performTimeout(underTest, time);
     }
   }
 
-  private void start() {
+  private void start(RetryingReadRowsOperation underTest) {
     underTest.getAsyncResult();
     verify(mockRpcMetrics, times(1)).timeOperation();
     verify(mockRpcMetrics, times(1)).timeRpc();
@@ -321,7 +331,7 @@ public class RetryingReadRowsOperationTest {
       same(mockClientCall));
   }
 
-  private void finishOK(int expectedRetryCount) {
+  private void finishOK(RetryingReadRowsOperation underTest, int expectedRetryCount) {
     underTest.onClose(Status.OK, metaData);
 
     verify(mockOperationTimerContext, times(1)).close();
@@ -329,7 +339,7 @@ public class RetryingReadRowsOperationTest {
     verify(mockRpcTimerContext, times(expectedRetryCount + 1)).close();
   }
 
-  private void checkRetryRequest(ByteString key) {
+  private static void checkRetryRequest(RetryingReadRowsOperation underTest, ByteString key) {
     Assert.assertEquals(key,
       underTest.getRetryRequest().getRows().getRowRanges(0).getStartKeyOpen());
   }


### PR DESCRIPTION
When scan queues are full, the client blocks. That could cause thread leaks, like those in issue #1470. This change will elminiate blocking on the grpc tread, and instead relies on client-side flow control to cache up to 3 responses, and then only request more results when all of the rows returned by a single ReadRowsResponse are removed from the queue.