### PR TITLE
ResourceLimiter is now instance specific.

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
@@ -84,7 +84,8 @@ import io.netty.util.Recycler;
 public class BigtableSession implements Closeable {
 
   private static final Logger LOG = new Logger(BigtableSession.class);
-  private static final Map<String, ChannelPool> cachedDataChannelPoolMap = new HashMap<>();
+  // TODO: Consider caching channel pools per instance.
+  private static ChannelPool cachedDataChannelPool;
   private static final Map<String, ResourceLimiter> resourceLimiterMap = new HashMap<>();
   private static SslContextBuilder sslBuilder;
 
@@ -293,8 +294,6 @@ public class BigtableSession implements Closeable {
     int channelCount = options.getChannelCount();
     if (options.useCachedChannel()) {
       synchronized (BigtableSession.class) {
-        String key = options.getInstanceName().toString();
-        ChannelPool cachedDataChannelPool = cachedDataChannelPoolMap.get(key);
         // TODO: Ensure that the host and channelCount are the same.
         if (cachedDataChannelPool == null) {
           cachedDataChannelPool = createChannelPool(host, channelCount);

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/ResourceLimiter.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/ResourceLimiter.java
@@ -25,17 +25,18 @@ public class ResourceLimiter {
   private static final Logger LOG = new Logger(ResourceLimiter.class);
 
   private static final long REGISTER_WAIT_MILLIS = 5;
-  private static final ResourceLimiterStats stats = ResourceLimiterStats.getInstance();
 
   private final long maxHeapSize;
   private final int absoluteMaxInFlightRpcs;
-  private int currentInFlightMaxRpcs;
+  private final ResourceLimiterStats stats;
   private final AtomicLong operationSequenceGenerator = new AtomicLong();
   private final Map<Long, Long> pendingOperationsWithSize = new HashMap<>();
   private final ConcurrentHashMap<Long, Long> starTimes = new ConcurrentHashMap<>();
   private final LinkedBlockingDeque<Long> completedOperationIds = new LinkedBlockingDeque<>();
+
   private long currentWriteBufferSize;
   private boolean isThrottling = false;
+  private int currentInFlightMaxRpcs;
 
   @VisibleForTesting
   NanoClock clock = NanoClock.SYSTEM;
@@ -46,7 +47,8 @@ public class ResourceLimiter {
    * @param maxHeapSize a long.
    * @param maxInFlightRpcs a int.
    */
-  public ResourceLimiter(long maxHeapSize, int maxInFlightRpcs) {
+  public ResourceLimiter(ResourceLimiterStats stats, long maxHeapSize, int maxInFlightRpcs) {
+    this.stats = stats;
     this.maxHeapSize = maxHeapSize;
     this.absoluteMaxInFlightRpcs = maxInFlightRpcs;
     this.currentInFlightMaxRpcs = maxInFlightRpcs;

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/ResourceLimiterStats.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/ResourceLimiterStats.java
@@ -15,11 +15,14 @@
  */
 package com.google.cloud.bigtable.grpc.async;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
+import com.google.cloud.bigtable.grpc.BigtableInstanceName;
 import com.google.common.annotations.VisibleForTesting;
 
 /**
@@ -28,15 +31,21 @@ import com.google.common.annotations.VisibleForTesting;
  */
 public class ResourceLimiterStats {
 
-  private static ResourceLimiterStats instance = new ResourceLimiterStats();
+  private static Map<String, ResourceLimiterStats> stats = new HashMap<>();
 
-  public static ResourceLimiterStats getInstance() {
+  public static synchronized ResourceLimiterStats getInstance(BigtableInstanceName instanceName) {
+    String key = instanceName.getInstanceName();
+    ResourceLimiterStats instance = stats.get(key);
+    if (instance == null) {
+      instance = new ResourceLimiterStats();
+      stats.put(key, instance);
+    }
     return instance;
   }
 
   @VisibleForTesting
   static void reset(){
-    instance = new ResourceLimiterStats();
+    stats.clear();
   }
 
   private final MetricRegistry registry = new MetricRegistry();

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/ResourceLimiterPerf.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/ResourceLimiterPerf.java
@@ -56,7 +56,8 @@ public class ResourceLimiterPerf {
    */
   private static void test(ListeningExecutorService pool)
       throws InterruptedException, ExecutionException, TimeoutException {
-    final ResourceLimiter underTest = new ResourceLimiter(SIZE, (int) SIZE);
+    final ResourceLimiter underTest =
+        new ResourceLimiter(new ResourceLimiterStats(), SIZE, (int) SIZE);
     final LinkedBlockingQueue<Long> registeredEvents = new LinkedBlockingQueue<>();
 
     final int readerCount = 20;

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestBulkMutation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestBulkMutation.java
@@ -122,7 +122,6 @@ public class TestBulkMutation {
 
   @Test
   public void testAdd() {
-    ResourceLimiterStats.reset();
     MutateRowsRequest.Entry entry = createRequestEntry();
     underTest.add(entry);
     underTest.send();
@@ -132,8 +131,6 @@ public class TestBulkMutation {
         .build();
 
     verify(client, times(1)).mutateRowsAsync(eq(expected));
-    Assert.assertEquals(0, ResourceLimiterStats.getInstance().getMutationTimer().getCount());
-    Assert.assertEquals(0, ResourceLimiterStats.getInstance().getThrottlingTimer().getCount());
   }
 
   public static MutateRowsRequest.Entry createRequestEntry() {

--- a/bigtable-dataflow-parent/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/AbstractCloudBigtableTableDoFn.java
+++ b/bigtable-dataflow-parent/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/AbstractCloudBigtableTableDoFn.java
@@ -113,4 +113,8 @@ public abstract class AbstractCloudBigtableTableDoFn<In, Out> extends DoFn<In, O
     super.populateDisplayData(builder);
     config.populateDisplayData(builder);
   }
+
+  public CloudBigtableConfiguration getConfig() {
+    return config;
+  }
 }


### PR DESCRIPTION
There are cases where multiple projects/instances can be used in the same JVM.  We cache ResourceLimiters and ChannelPools.  Until this PR, the cache was one per JVM; this PR changes the behavior of both ResourceLimiter and the ChannelPool to one per CBT instance per JVM.