### PR TITLE
Shade tcnative & update grpc

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/RetryingReadRowsOperation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/RetryingReadRowsOperation.java
@@ -17,6 +17,7 @@ package com.google.cloud.bigtable.grpc.scanner;
 
 import java.util.concurrent.ScheduledExecutorService;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 
 import com.google.api.client.util.BackOff;
@@ -95,6 +96,11 @@ public class RetryingReadRowsOperation extends
     @Override
     public void setMessageCompression(boolean enable) {
       call.setMessageCompression(enable);
+    }
+
+    @Override
+    public void cancel(@Nullable String s, @Nullable Throwable throwable) {
+      call.cancel(s, throwable);
     }
   }
 

--- a/bigtable-hbase-parent/bigtable-hbase-1.0/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-1.0/pom.xml
@@ -45,10 +45,6 @@ limitations under the License.
                     <groupId>org.apache.hbase</groupId>
                     <artifactId>hbase-client</artifactId>
                 </exclusion>
-                <exclusion>
-                    <groupId>io.netty</groupId>
-                    <artifactId>netty-tcnative-boringssl-static</artifactId>
-                </exclusion>
 
                 <!-- Workaround MNG-5899 & MSHADE-206. Maven >= 3.3.0 doesn't use the dependency reduced
                 pom.xml files when invoking the build from a parent project. So we have to manually exclude

--- a/bigtable-hbase-parent/bigtable-hbase-1.1/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-1.1/pom.xml
@@ -45,11 +45,6 @@ limitations under the License.
                     <groupId>org.apache.hbase</groupId>
                     <artifactId>hbase-client</artifactId>
                 </exclusion>
-                <exclusion>
-                    <groupId>io.netty</groupId>
-                    <artifactId>netty-tcnative-boringssl-static</artifactId>
-                </exclusion>
-
 
                 <!-- Workaround MNG-5899 & MSHADE-206. Maven >= 3.3.0 doesn't use the dependency reduced
                 pom.xml files when invoking the build from a parent project. So we have to manually exclude

--- a/bigtable-hbase-parent/bigtable-hbase-1.2/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-1.2/pom.xml
@@ -45,11 +45,6 @@ limitations under the License.
                     <groupId>org.apache.hbase</groupId>
                     <artifactId>hbase-client</artifactId>
                 </exclusion>
-                <exclusion>
-                    <groupId>io.netty</groupId>
-                    <artifactId>netty-tcnative-boringssl-static</artifactId>
-                </exclusion>
-
 
                 <!-- Workaround MNG-5899 & MSHADE-206. Maven >= 3.3.0 doesn't use the dependency reduced
                 pom.xml files when invoking the build from a parent project. So we have to manually exclude
@@ -145,12 +140,6 @@ limitations under the License.
         </dependency>
 
         <!-- test deps -->
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-tcnative-boringssl-static</artifactId>
-            <version>${netty-tcnative-boringssl-static.version}</version>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-graphite</artifactId>

--- a/bigtable-hbase-parent/bigtable-hbase-1.3/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-1.3/pom.xml
@@ -45,11 +45,6 @@ limitations under the License.
                     <groupId>org.apache.hbase</groupId>
                     <artifactId>hbase-client</artifactId>
                 </exclusion>
-                <exclusion>
-                    <groupId>io.netty</groupId>
-                    <artifactId>netty-tcnative-boringssl-static</artifactId>
-                </exclusion>
-
 
                 <!-- Workaround MNG-5899 & MSHADE-206. Maven >= 3.3.0 doesn't use the dependency reduced
                 pom.xml files when invoking the build from a parent project. So we have to manually exclude

--- a/bigtable-hbase-parent/bigtable-hbase-1.x-hadoop/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-1.x-hadoop/pom.xml
@@ -57,12 +57,6 @@ limitations under the License.
 
     <!-- Manually promote dependencies: This is necessary to avoid flattening hbase-shaded-client's dependency tree -->
     <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-tcnative-boringssl-static</artifactId>
-      <version>${netty-tcnative-boringssl-static.version}</version>
-    </dependency>
-
-    <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
       <version>${jsr305.version}</version>

--- a/bigtable-hbase-parent/bigtable-hbase-1.x-shaded/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-1.x-shaded/pom.xml
@@ -140,6 +140,9 @@ limitations under the License.
                 <relocation>
                   <pattern>io.netty</pattern>
                   <shadedPattern>com.google.bigtable.repackaged.io.netty</shadedPattern>
+                  <excludes>
+                    <exclude>io.netty.internal.tcnative.**</exclude>
+                  </excludes>
                 </relocation>
                 <relocation>
                   <pattern>org.joda</pattern>

--- a/bigtable-hbase-parent/bigtable-hbase-1.x-shaded/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-1.x-shaded/pom.xml
@@ -39,12 +39,6 @@ limitations under the License.
 
   <!-- Manually promote dependencies: This is necessary to avoid flattening hbase-shaded-client's dependency tree -->
   <dependency>
-    <groupId>io.netty</groupId>
-    <artifactId>netty-tcnative-boringssl-static</artifactId>
-    <version>${netty-tcnative-boringssl-static.version}</version>
-  </dependency>
-
-  <dependency>
     <groupId>org.apache.hbase</groupId>
     <artifactId>hbase-shaded-client</artifactId>
     <version>${hbase.version}</version>
@@ -88,8 +82,6 @@ limitations under the License.
               <promoteTransitiveDependencies>false</promoteTransitiveDependencies>
               <artifactSet>
                 <excludes>
-                  <!-- exclude jni deps -->
-                  <exclude>io.netty:netty-tcnative-boringssl-static</exclude>
                   <!-- exclude user visible deps -->
                   <exclude>io.dropwizard.metrics:metrics-core</exclude>
                   <exclude>commons-logging:commons-logging</exclude>
@@ -137,13 +129,25 @@ limitations under the License.
                   <pattern>io.grpc</pattern>
                   <shadedPattern>com.google.bigtable.repackaged.io.grpc</shadedPattern>
                 </relocation>
+
+                <!-- Relocate netty, taking care to keep the prefix consistent for native tcnative
+                  libs. For details see:
+                    https://github.com/netty/netty/pull/6995
+                    https://github.com/grpc/grpc-java/pull/2485
+                -->
                 <relocation>
                   <pattern>io.netty</pattern>
                   <shadedPattern>com.google.bigtable.repackaged.io.netty</shadedPattern>
-                  <excludes>
-                    <exclude>io.netty.internal.tcnative.**</exclude>
-                  </excludes>
                 </relocation>
+                <relocation>
+                  <pattern>META-INF/native/libnetty</pattern>
+                  <shadedPattern>META-INF/native/libcom-google-bigtable-repackaged-netty</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>META-INF/native/netty</pattern>
+                  <shadedPattern>META-INFO/native/com-google-bigtable-repackaged-netty</shadedPattern>
+                </relocation>
+
                 <relocation>
                   <pattern>org.joda</pattern>
                   <shadedPattern>com.google.bigtable.repackaged.org.joda</shadedPattern>

--- a/bigtable-hbase-parent/bigtable-hbase-1.x-shaded/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-1.x-shaded/pom.xml
@@ -80,6 +80,9 @@ limitations under the License.
                Also, this is needed to workaround maven reactor not using dependency-reduced-pom.xml
                files. See note in bigtable-1.x-hadoop .-->
               <promoteTransitiveDependencies>false</promoteTransitiveDependencies>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+              </transformers>
               <artifactSet>
                 <excludes>
                   <!-- exclude user visible deps -->

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/resources/log4j.properties
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/resources/log4j.properties
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Root logger option
-log4j.rootLogger=WARN, stdout
+log4j.rootLogger=ERROR, stdout
 
 # Direct log messages to stdout
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/resources/log4j.properties
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/resources/log4j.properties
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Root logger option
-log4j.rootLogger=ERROR, stdout
+log4j.rootLogger=WARN, stdout
 
 # Direct log messages to stdout
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@ limitations under the License.
         <compat.module>hbase-hadoop2-compat</compat.module>
         <junit.version>4.12</junit.version>
         <mockito.version>1.10.19</mockito.version>
-        <grpc.version>1.5.0</grpc.version>
+        <grpc.version>1.6.0</grpc.version>
         <!--NOTE: 4.1.14.Final is the first version that support shading -->
         <netty.version>4.1.14.Final</netty.version>
         <netty-tcnative-boringssl-static.version>2.0.5.Final</netty-tcnative-boringssl-static.version>

--- a/pom.xml
+++ b/pom.xml
@@ -170,7 +170,7 @@ limitations under the License.
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
-                    <version>2.4.3</version>
+                    <version>3.1.0</version>
                 </plugin>
                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,8 @@ limitations under the License.
         <junit.version>4.12</junit.version>
         <mockito.version>1.10.19</mockito.version>
         <grpc.version>1.5.0</grpc.version>
-        <netty.version>4.1.8.Final</netty.version>
+        <netty.version>4.1.12.Final</netty.version>
+        <netty-tcnative-boringssl-static.version>2.0.5.Final</netty-tcnative-boringssl-static.version>
         <protobuff-java.version>3.3.1</protobuff-java.version>
         <protoc.version>3.3.0</protoc.version>
         <google.api.client.version>1.22.0</google.api.client.version>
@@ -67,7 +68,7 @@ limitations under the License.
         <guava.version>19.0</guava.version>
         <google.auth.library.version>0.7.0</google.auth.library.version>
         <dropwizard.metrics.version>3.1.2</dropwizard.metrics.version>
-        <netty-tcnative-boringssl-static.version>1.1.33.Fork26</netty-tcnative-boringssl-static.version>
+
 
         <jsr305.version>3.0.2</jsr305.version>
         <commons-logging.version>1.2</commons-logging.version>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,8 @@ limitations under the License.
         <junit.version>4.12</junit.version>
         <mockito.version>1.10.19</mockito.version>
         <grpc.version>1.5.0</grpc.version>
-        <netty.version>4.1.12.Final</netty.version>
+        <!--NOTE: 4.1.14.Final is the first version that support shading -->
+        <netty.version>4.1.14.Final</netty.version>
         <netty-tcnative-boringssl-static.version>2.0.5.Final</netty-tcnative-boringssl-static.version>
         <protobuff-java.version>3.3.1</protobuff-java.version>
         <protoc.version>3.3.0</protoc.version>


### PR DESCRIPTION
This PR is based on https://github.com/grpc/grpc-java/pull/2485. However, since bigtable-hbase-1.x-shaded shades grpc we should not depend on grpc-netty-shaded: this will cause conflicts when the end user has both bigtable-hbase-1.x-shaded and grpc-netty-shaded on the classpath.

This requires netty 4.1.14 & grpc 1.6.0

As a bonus this fixes relocation of service files so ManagedChannelBuilder should work now