### PR TITLE
Namespace operations are warnings only if a flag is set

### DIFF
--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableOptionsFactory.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableOptionsFactory.java
@@ -267,6 +267,11 @@ public class BigtableOptionsFactory {
   public static final String BIGTABLE_LONG_RPC_TIMEOUT_MS_KEY = "google.bigtable.long.rpc.timeout.ms";
 
   /**
+   * Allow namespace methods to be no-ops
+   */
+  public static final String BIGTABLE_NAMESAPCE_WARNING_KEY = "google.bigtable.namespace.warnings";
+
+  /**
    * <p>fromConfiguration.</p>
    *
    * @param configuration a {@link org.apache.hadoop.conf.Configuration} object.

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableAdmin.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableAdmin.java
@@ -69,6 +69,7 @@ import com.google.cloud.bigtable.config.BigtableOptions;
 import com.google.cloud.bigtable.config.Logger;
 import com.google.cloud.bigtable.grpc.BigtableInstanceName;
 import com.google.cloud.bigtable.grpc.BigtableTableAdminClient;
+import com.google.cloud.bigtable.hbase.BigtableOptionsFactory;
 import com.google.cloud.bigtable.hbase.adapters.admin.ColumnDescriptorAdapter;
 import com.google.cloud.bigtable.hbase.adapters.admin.TableAdapter;
 import com.google.common.base.MoreObjects;
@@ -1253,47 +1254,79 @@ public abstract class AbstractBigtableAdmin implements Admin {
   /** {@inheritDoc} */
   @Override
   public void createNamespace(NamespaceDescriptor descriptor) throws IOException {
-    LOG.warn("createNamespace is a no-op");
+    if (provideWarningsForNamespaces()) {
+      LOG.warn("createNamespace is a no-op");
+    } else {
+      throw new UnsupportedOperationException("createNamespace"); // TODO
+    }
   }
 
   /** {@inheritDoc} */
   @Override
   public void modifyNamespace(NamespaceDescriptor descriptor) throws IOException {
-    LOG.warn("modifyNamespace is a no-op");
+    if (provideWarningsForNamespaces()) {
+      LOG.warn("modifyNamespace is a no-op");
+    } else {
+      throw new UnsupportedOperationException("modifyNamespace");  // TODO
+    }
   }
 
   /** {@inheritDoc} */
   @Override
   public void deleteNamespace(String name) throws IOException {
-    LOG.warn("deleteNamespace is a no-op");
+    if (provideWarningsForNamespaces()) {
+      LOG.warn("deleteNamespace is a no-op");
+    } else {
+      throw new UnsupportedOperationException("deleteNamespace");  // TODO
+    }
   }
 
   /** {@inheritDoc} */
   @Override
   public NamespaceDescriptor getNamespaceDescriptor(String name) throws IOException {
-    LOG.warn("getNamespaceDescriptor is a no-op");
-    return null;
+    if (provideWarningsForNamespaces()) {
+      LOG.warn("getNamespaceDescriptor is a no-op");
+      return null;
+    } else {
+      throw new UnsupportedOperationException("getNamespaceDescriptor");  // TODO
+    }
   }
 
   /** {@inheritDoc} */
   @Override
   public NamespaceDescriptor[] listNamespaceDescriptors() throws IOException {
-    LOG.warn("listNamespaceDescriptors is a no-op");
-    return new NamespaceDescriptor[0];
+    if (provideWarningsForNamespaces()) {
+      LOG.warn("listNamespaceDescriptors is a no-op");
+      return new NamespaceDescriptor[0];
+    } else {
+      throw new UnsupportedOperationException("listNamespaceDescriptors");  // TODO
+    }
   }
 
   /** {@inheritDoc} */
   @Override
   public HTableDescriptor[] listTableDescriptorsByNamespace(String name) throws IOException {
-    LOG.warn("listTableDescriptorsByNamespace is a no-op");
-    return new HTableDescriptor[0];
+    if (provideWarningsForNamespaces()) {
+      LOG.warn("listTableDescriptorsByNamespace is a no-op");
+      return new HTableDescriptor[0];
+    } else {
+      throw new UnsupportedOperationException("listTableDescriptorsByNamespace");  // TODO
+    }
   }
 
   /** {@inheritDoc} */
   @Override
   public TableName[] listTableNamesByNamespace(String name) throws IOException {
-    LOG.warn("listTableNamesByNamespace is a no-op");
-    return new TableName[0];
+    if (provideWarningsForNamespaces()) {
+      LOG.warn("listTableNamesByNamespace is a no-op");
+      return new TableName[0];
+    } else {
+      throw new UnsupportedOperationException("listTableNamesByNamespace");  // TODO
+    }
+  }
+
+  private boolean provideWarningsForNamespaces() {
+    return configuration.getBoolean(BigtableOptionsFactory.BIGTABLE_NAMESAPCE_WARNING_KEY, false);
   }
 
   /** {@inheritDoc} */


### PR DESCRIPTION
Users need to set "google.bigtable.namespace.warnings" = true if they want namespace methods to log warnings instead of throw exceptions.