### PR TITLE
Upgrading to grpc 1.6.1

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/pom.xml
+++ b/bigtable-client-core-parent/bigtable-client-core/pom.xml
@@ -109,21 +109,6 @@ limitations under the License.
 
         <dependency>
             <groupId>io.netty</groupId>
-            <artifactId>netty-handler</artifactId>
-            <version>${netty.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-codec-http2</artifactId>
-            <version>${netty.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-handler-proxy</artifactId>
-            <version>${netty.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
             <artifactId>netty-tcnative-boringssl-static</artifactId>
             <version>${netty-tcnative-boringssl-static.version}</version>
         </dependency>
@@ -142,19 +127,6 @@ limitations under the License.
             <groupId>io.grpc</groupId>
             <artifactId>grpc-netty</artifactId>
             <version>${grpc.version}</version>
-            <!-- Override grpc's version on netty.
-                Netty upgraded its version of netty-tcnative to 2.x, and since users are currently responsible for
-                adding their own netty-tcnative dep, its a backward incompatible change. For now, we need to hold back
-                the version of netty.
-                Once we catch up to grpc's netty version, this, netty-codec-http2 &  netty-handler-proxy deps should be
-                removed.
-            -->
-            <exclusions>
-                <exclusion>
-                    <groupId>io.netty</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -58,12 +58,12 @@ limitations under the License.
         <compat.module>hbase-hadoop2-compat</compat.module>
         <junit.version>4.12</junit.version>
         <mockito.version>1.10.19</mockito.version>
-        <grpc.version>1.6.0</grpc.version>
+        <grpc.version>1.6.1</grpc.version>
         <!--NOTE: 4.1.14.Final is the first version that support shading -->
         <netty.version>4.1.14.Final</netty.version>
         <netty-tcnative-boringssl-static.version>2.0.5.Final</netty-tcnative-boringssl-static.version>
         <protobuff-java.version>3.3.1</protobuff-java.version>
-        <protoc.version>3.3.0</protoc.version>
+        <protoc.version>3.4.0</protoc.version>
         <google.api.client.version>1.22.0</google.api.client.version>
         <google.http.client.version>1.22.0</google.http.client.version>
         <guava.version>19.0</guava.version>

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@ limitations under the License.
         <netty.version>4.1.14.Final</netty.version>
         <netty-tcnative-boringssl-static.version>2.0.5.Final</netty-tcnative-boringssl-static.version>
         <protobuff-java.version>3.3.1</protobuff-java.version>
-        <protoc.version>3.4.0</protoc.version>
+        <protoc.version>3.3.0</protoc.version>
         <google.api.client.version>1.22.0</google.api.client.version>
         <google.http.client.version>1.22.0</google.http.client.version>
         <guava.version>19.0</guava.version>


### PR DESCRIPTION
Also using the default io.netty dependencies from grpc now that we're using newer tcnative jars.