### PR TITLE
Enabling tracing in grpc versions that have tracing turned off.

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
@@ -182,21 +182,20 @@ public class BigtableSession implements Closeable {
     connectionStartupExecutor.shutdown();
   }
 
+  // TODO: remove this method once grpc 1.7 is released.
   private static void enableTracing(AbstractManagedChannelImplBuilder<?> builder) {
-    Method setEnableTracingMethod = null;
     try {
-      setEnableTracingMethod =
+      Method setEnableTracingMethod =
           AbstractManagedChannelImplBuilder.class.getMethod("setEnableTracing", boolean.class);
+      if (setEnableTracingMethod != null) {
+        try {
+          setEnableTracingMethod.invoke(builder, true);
+        } catch (Exception e) {
+          LOG.warn("Could not enable tracing", e);
+        }
+      }
     } catch (NoSuchMethodException | SecurityException e1) {
       return;
-    }
-    if (setEnableTracingMethod != null) {
-      try {
-        setEnableTracingMethod.invoke(builder, true);
-        System.out.println("ENABLING TRACING!!!!");
-      } catch (Exception e) {
-        LOG.warn("Could not enable tracing", e);
-      }
     }
   }
 


### PR DESCRIPTION
Early versions of grpc don't have this setEnabled() API, and future versions won't either.  This change leverages reflection to allow us to trace with grpc 1.6, and will future-proof and past-proof the client.