### PR TITLE
Adding a TimeStamp Range Filter.

### DIFF
--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestFilters.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestFilters.java
@@ -1465,9 +1465,6 @@ public class TestFilters extends AbstractTest {
   }
 
   @Test
-  @Ignore("This test does not work in HBase mode")
-  // TODO: add a HBaseKnownDifference.class Category so that HBase tests won't run this, but CBT
-  // tests will.
   public void testTimestampRangeFilter() throws IOException {
     // Initialize
     int numCols = 10;
@@ -1486,13 +1483,13 @@ public class TestFilters extends AbstractTest {
     Get get = new Get(rowKey).setFilter(filter);
     Result result = table.get(get);
     Cell[] cells = result.rawCells();
-    Assert.assertEquals("Should have three cells, timestamps 4, 5 and 6.", 3, cells.length);
+    Assert.assertEquals("Should have three cells, timestamps 4 and 5.", 2, cells.length);
 
     // Since the qualifiers are random, ignore the order of the returned cells.
     long[] timestamps =
-        new long[] { cells[0].getTimestamp(), cells[1].getTimestamp(), cells[2].getTimestamp() };
+        new long[] { cells[0].getTimestamp(), cells[1].getTimestamp() };
     Arrays.sort(timestamps);
-    Assert.assertArrayEquals(new long[] { 4L, 5L, 6L }, timestamps);
+    Assert.assertArrayEquals(new long[] { 4L, 5L }, timestamps);
 
     table.close();
   }

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestFilters.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestFilters.java
@@ -18,6 +18,7 @@ package com.google.cloud.bigtable.hbase;
 import static com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule.COLUMN_FAMILY;
 import static com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule.COLUMN_FAMILY2;
 
+import com.google.cloud.bigtable.hbase.filter.TimestampRangeFilter;
 import com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterators;
@@ -67,6 +68,7 @@ import org.apache.hadoop.hbase.filter.WhileMatchFilter;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.Pair;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -1458,6 +1460,39 @@ public class TestFilters extends AbstractTest {
     long[] timestamps = new long[]{cells[0].getTimestamp(), cells[1].getTimestamp()};
     Arrays.sort(timestamps);
     Assert.assertArrayEquals(new long[]{0L, 1L}, timestamps);
+
+    table.close();
+  }
+
+  @Test
+  @Ignore("This test does not work in HBase mode")
+  // TODO: add a HBaseKnownDifference.class Category so that HBase tests won't run this, but CBT
+  // tests will.
+  public void testTimestampRangeFilter() throws IOException {
+    // Initialize
+    int numCols = 10;
+    String goodValue = "includeThisValue";
+    Table table = getTable();
+    byte[] rowKey = dataHelper.randomData("testRow-TimestampRange-");
+    Put put = new Put(rowKey);
+    for (int i = 0; i < numCols; ++i) {
+      put.addColumn(COLUMN_FAMILY, dataHelper.randomData(""), i, Bytes.toBytes(goodValue));
+    }
+    table.put(put);
+
+    // Filter for results
+    Filter filter = new TimestampRangeFilter(4, 6);
+
+    Get get = new Get(rowKey).setFilter(filter);
+    Result result = table.get(get);
+    Cell[] cells = result.rawCells();
+    Assert.assertEquals("Should have three cells, timestamps 4, 5 and 6.", 3, cells.length);
+
+    // Since the qualifiers are random, ignore the order of the returned cells.
+    long[] timestamps =
+        new long[] { cells[0].getTimestamp(), cells[1].getTimestamp(), cells[2].getTimestamp() };
+    Arrays.sort(timestamps);
+    Assert.assertArrayEquals(new long[] { 4L, 5L, 6L }, timestamps);
 
     table.close();
   }

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/FilterAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/FilterAdapter.java
@@ -16,6 +16,7 @@
 package com.google.cloud.bigtable.hbase.adapters.filters;
 
 import com.google.bigtable.v2.RowFilter;
+import com.google.cloud.bigtable.hbase.filter.TimestampRangeFilter;
 import com.google.cloud.bigtable.util.RowKeyWrapper;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
@@ -74,6 +75,8 @@ public class FilterAdapter {
         MultipleColumnPrefixFilter.class, new MultipleColumnPrefixFilterAdapter());
     adapter.addFilterAdapter(
         TimestampsFilter.class, new TimestampsFilterAdapter());
+    adapter.addFilterAdapter(
+      TimestampRangeFilter.class, new TimestampRangeFilterAdapter());
     ValueFilterAdapter valueFilterAdapter = new ValueFilterAdapter();
     adapter.addFilterAdapter(
         ValueFilter.class, valueFilterAdapter);

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/TimestampFilterUtil.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/TimestampFilterUtil.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.adapters.filters;
+
+import com.google.bigtable.v2.RowFilter;
+import com.google.bigtable.v2.TimestampRange;
+import com.google.cloud.bigtable.hbase.BigtableConstants;
+
+/**
+ * Common utilities for Timestamp filters.
+ */
+public class TimestampFilterUtil {
+
+
+  public static long hbaseToBigtableTimeUnit(long timestamp) {
+    return BigtableConstants.BIGTABLE_TIMEUNIT.convert(
+        timestamp, BigtableConstants.HBASE_TIMEUNIT);
+  }
+
+  // HBase TimestampsFilters are of the form: [N, M], however; bigtable
+  // uses [N, M) to express timestamp ranges. In order to express an HBase
+  // single point timestamp [M, M], we need to specify [M, M+1) to bigtable.
+  public static RowFilter hbaseToTimestampRangeFilter(long hbaseStartTimestamp,
+      long hbaseEndTimestamp) {
+    return toTimestampRangeFilter(hbaseToBigtableTimeUnit(hbaseStartTimestamp),
+      hbaseToBigtableTimeUnit(hbaseEndTimestamp + 1));
+  }
+
+  public static RowFilter toTimestampRangeFilter(long bigtableStartTimestamp,
+      long bigtableEndTimestamp) {
+    return RowFilter.newBuilder()
+        .setTimestampRangeFilter(
+            TimestampRange.newBuilder()
+                .setStartTimestampMicros(bigtableStartTimestamp)
+                .setEndTimestampMicros(bigtableEndTimestamp))
+        .build();
+  }
+}

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/TimestampFilterUtil.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/TimestampFilterUtil.java
@@ -24,21 +24,27 @@ import com.google.cloud.bigtable.hbase.BigtableConstants;
  */
 public class TimestampFilterUtil {
 
-
+  /**
+   * Converts an HBase timestamp in milliseconds to a Cloud Bigtable timestamp in Microseconds.
+   */
   public static long hbaseToBigtableTimeUnit(long timestamp) {
     return BigtableConstants.BIGTABLE_TIMEUNIT.convert(
         timestamp, BigtableConstants.HBASE_TIMEUNIT);
   }
 
-  // HBase TimestampsFilters are of the form: [N, M], however; bigtable
-  // uses [N, M) to express timestamp ranges. In order to express an HBase
-  // single point timestamp [M, M], we need to specify [M, M+1) to bigtable.
+  /**
+   * Converts a [startMs, endMs) timestamps to a Cloud Bigtable [startMicros, endMicros) filter.
+   */
   public static RowFilter hbaseToTimestampRangeFilter(long hbaseStartTimestamp,
       long hbaseEndTimestamp) {
     return toTimestampRangeFilter(hbaseToBigtableTimeUnit(hbaseStartTimestamp),
-      hbaseToBigtableTimeUnit(hbaseEndTimestamp + 1));
+      hbaseToBigtableTimeUnit(hbaseEndTimestamp));
   }
 
+  /**
+   * Converts a [startMicros, endNons) timestamps to a Cloud Bigtable [startMicros, endMicros)
+   * filter.
+   */
   public static RowFilter toTimestampRangeFilter(long bigtableStartTimestamp,
       long bigtableEndTimestamp) {
     return RowFilter.newBuilder()

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/TimestampRangeFilterAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/TimestampRangeFilterAdapter.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.adapters.filters;
+
+import com.google.bigtable.v2.RowFilter;
+import com.google.cloud.bigtable.hbase.filter.TimestampRangeFilter;
+
+/**
+ * Converts a {@link TimestampRangeFilter} into a Cloud Bigtable {@link RowFilter}.
+ */
+public class TimestampRangeFilterAdapter extends TypedFilterAdapterBase<TimestampRangeFilter> {
+
+  @Override
+  public RowFilter adapt(FilterAdapterContext context, TimestampRangeFilter filter) {
+    RowFilter rangeFilter = TimestampFilterUtil.hbaseToTimestampRangeFilter(
+        filter.getStartTimestampInclusive(),
+        filter.getEndTimestampInclusive());
+    System.out.println(rangeFilter);
+    return rangeFilter;
+  }
+
+  @Override
+  public FilterSupportStatus isFilterSupported(FilterAdapterContext context,
+      TimestampRangeFilter filter) {
+    return FilterSupportStatus.SUPPORTED;
+  }
+
+}

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/TimestampRangeFilterAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/TimestampRangeFilterAdapter.java
@@ -25,11 +25,9 @@ public class TimestampRangeFilterAdapter extends TypedFilterAdapterBase<Timestam
 
   @Override
   public RowFilter adapt(FilterAdapterContext context, TimestampRangeFilter filter) {
-    RowFilter rangeFilter = TimestampFilterUtil.hbaseToTimestampRangeFilter(
+    return TimestampFilterUtil.hbaseToTimestampRangeFilter(
         filter.getStartTimestampInclusive(),
-        filter.getEndTimestampInclusive());
-    System.out.println(rangeFilter);
-    return rangeFilter;
+        filter.getEndTimestampExclusive());
   }
 
   @Override
@@ -37,5 +35,4 @@ public class TimestampRangeFilterAdapter extends TypedFilterAdapterBase<Timestam
       TimestampRangeFilter filter) {
     return FilterSupportStatus.SUPPORTED;
   }
-
 }

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/TimestampsFilterAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/TimestampsFilterAdapter.java
@@ -17,8 +17,6 @@ package com.google.cloud.bigtable.hbase.adapters.filters;
 
 import com.google.bigtable.v2.RowFilter;
 import com.google.bigtable.v2.RowFilter.Interleave;
-import com.google.bigtable.v2.TimestampRange;
-import com.google.cloud.bigtable.hbase.BigtableConstants;
 
 import org.apache.hadoop.hbase.filter.TimestampsFilter;
 
@@ -38,21 +36,8 @@ public class TimestampsFilterAdapter
     Interleave.Builder interleaveBuilder =
         RowFilter.Interleave.newBuilder();
     for (long timestamp : filter.getTimestamps()) {
-      // HBase TimestampsFilters are of the form: [N, M], however; bigtable
-      // uses [N, M) to express timestamp ranges. In order to express an HBase
-      // single point timestamp [M, M], we need to specify [M, M+1) to bigtable.
-      long bigtableStartTimestamp =
-          BigtableConstants.BIGTABLE_TIMEUNIT.convert(
-              timestamp, BigtableConstants.HBASE_TIMEUNIT);
-      long bigtableEndTimestamp =
-          BigtableConstants.BIGTABLE_TIMEUNIT.convert(
-              timestamp + 1, BigtableConstants.HBASE_TIMEUNIT);
-      interleaveBuilder.addFilters(
-          RowFilter.newBuilder()
-              .setTimestampRangeFilter(
-                  TimestampRange.newBuilder()
-                      .setStartTimestampMicros(bigtableStartTimestamp)
-                      .setEndTimestampMicros(bigtableEndTimestamp)));
+      interleaveBuilder
+          .addFilters(TimestampFilterUtil.hbaseToTimestampRangeFilter(timestamp, timestamp));
     }
     return RowFilter.newBuilder().setInterleave(interleaveBuilder).build();
   }

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/TimestampsFilterAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/TimestampsFilterAdapter.java
@@ -37,7 +37,7 @@ public class TimestampsFilterAdapter
         RowFilter.Interleave.newBuilder();
     for (long timestamp : filter.getTimestamps()) {
       interleaveBuilder
-          .addFilters(TimestampFilterUtil.hbaseToTimestampRangeFilter(timestamp, timestamp));
+          .addFilters(TimestampFilterUtil.hbaseToTimestampRangeFilter(timestamp, timestamp + 1));
     }
     return RowFilter.newBuilder().setInterleave(interleaveBuilder).build();
   }

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/filter/TimestampRangeFilter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/filter/TimestampRangeFilter.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.filter;
+
+import java.io.IOException;
+
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.filter.FilterBase;
+
+/**
+ * Defines a filter that only returns cells whose version matches a start and end (both are
+ * inclusive)
+ */
+public class TimestampRangeFilter extends FilterBase {
+
+  private final long startTimestampInclusive;
+  private final long endTimestampInclusive;
+
+  public TimestampRangeFilter(long startTimestamp, long endTimestamp) {
+    this.startTimestampInclusive = startTimestamp;
+    this.endTimestampInclusive = endTimestamp;
+  }
+
+  public long getStartTimestampInclusive() {
+    return startTimestampInclusive;
+  }
+
+  public long getEndTimestampInclusive() {
+    return endTimestampInclusive;
+  }
+
+  @Override
+  /**
+   * This is for HBase compatibility, and will not be used for Cloud Bigtable
+   */
+  public ReturnCode filterKeyValue(Cell cell) throws IOException {
+    long timestamp = cell.getTimestamp();
+    if (this.startTimestampInclusive <= timestamp && timestamp <= endTimestampInclusive) {
+      return ReturnCode.INCLUDE;
+    }
+    return ReturnCode.SKIP;
+  }
+}

--- a/bigtable-hbase-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestTimestampRangeFilterAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestTimestampRangeFilterAdapter.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.adapters.filters;
+
+import org.apache.hadoop.hbase.client.Scan;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import com.google.bigtable.v2.RowFilter;
+import com.google.cloud.bigtable.hbase.filter.TimestampRangeFilter;
+
+@RunWith(JUnit4.class)
+public class TestTimestampRangeFilterAdapter {
+
+  TimestampRangeFilterAdapter filterAdapter = new TimestampRangeFilterAdapter();
+  Scan emptyScan = new Scan();
+  FilterAdapterContext emptyScanContext = new FilterAdapterContext(emptyScan, null);
+
+  @Test
+  public void timestampFiltersAreAdapted() {
+    TimestampRangeFilter filter = new TimestampRangeFilter(10L, 20L);
+    RowFilter rowFilter = filterAdapter.adapt(emptyScanContext, filter);
+    Assert.assertEquals(10000L, rowFilter.getTimestampRangeFilter().getStartTimestampMicros());
+    Assert.assertEquals(21000L, rowFilter.getTimestampRangeFilter().getEndTimestampMicros());
+  }
+}

--- a/bigtable-hbase-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestTimestampRangeFilterAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestTimestampRangeFilterAdapter.java
@@ -36,6 +36,6 @@ public class TestTimestampRangeFilterAdapter {
     TimestampRangeFilter filter = new TimestampRangeFilter(10L, 20L);
     RowFilter rowFilter = filterAdapter.adapt(emptyScanContext, filter);
     Assert.assertEquals(10000L, rowFilter.getTimestampRangeFilter().getStartTimestampMicros());
-    Assert.assertEquals(21000L, rowFilter.getTimestampRangeFilter().getEndTimestampMicros());
+    Assert.assertEquals(20000L, rowFilter.getTimestampRangeFilter().getEndTimestampMicros());
   }
 }

--- a/bigtable-hbase-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestTimestampRangeFilterAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestTimestampRangeFilterAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Google Inc. All Rights Reserved.
+ * Copyright 2017 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This allows similar functionality to HBase's `Get/Scan.setTimeRange(start, end)`, but as a Filter.  This works well with Cloud Bigtable, but will not work with HBase.  HBase requires an HBase Protobuf equivalent to any filter, which does not exist for TimestampRangeFilter.

This PR works towards issue #1510.