### PR TITLE
Use non-deprecated Futures.addCallback function

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BulkMutation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BulkMutation.java
@@ -34,6 +34,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
 import com.google.protobuf.Any;
 import com.google.rpc.Status;
@@ -174,7 +175,7 @@ public class BulkMutation {
         public void onFailure(Throwable t) {
           setFailure(t);
         }
-      });
+      }, MoreExecutors.directExecutor());
     }
 
     @VisibleForTesting

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/OperationAccountant.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/OperationAccountant.java
@@ -22,6 +22,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -84,7 +85,7 @@ public class OperationAccountant {
       public void onFailure(Throwable t) {
         onOperationCompletion();
       }
-    });
+    }, MoreExecutors.directExecutor());
   }
 
   /**

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BatchExecutor.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BatchExecutor.java
@@ -51,6 +51,7 @@ import com.google.cloud.bigtable.metrics.BigtableClientMetrics.MetricLevel;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
 import org.apache.hadoop.hbase.util.Bytes;
 
@@ -192,7 +193,8 @@ public class BatchExecutor {
     RpcResultFutureCallback<T> futureCallback =
         new RpcResultFutureCallback<T>(row, callback, index, results, resultFuture);
     results[index] = null;
-    Futures.addCallback(issueAsyncRequest(bulkOperation, row), futureCallback);
+    Futures.addCallback(issueAsyncRequest(bulkOperation, row),
+        futureCallback, MoreExecutors.directExecutor());
     return resultFuture;
   }
 

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutator.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutator.java
@@ -44,6 +44,7 @@ import com.google.cloud.bigtable.hbase.adapters.HBaseRequestAdapter;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
 
 /**
  * Bigtable's {@link org.apache.hadoop.hbase.client.BufferedMutator} implementation.
@@ -231,7 +232,7 @@ public class BigtableBufferedMutator implements BufferedMutator {
       // and inflight rpc count.
       future = Futures.immediateFailedFuture(e);
     }
-    Futures.addCallback(future, new ExceptionCallback(mutation));
+    Futures.addCallback(future, new ExceptionCallback(mutation), MoreExecutors.directExecutor());
   }
 
   private void addGlobalException(Row mutation, Throwable t) {


### PR DESCRIPTION
This PR changes which Futures.addCallback() overload we call. This is because the overload we're using is being deprecated.