### PR TITLE
Improving tracing spans

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AbstractRetryingOperation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AbstractRetryingOperation.java
@@ -57,6 +57,7 @@ import io.opencensus.trace.Tracing;
 /**
  * A {@link ClientCall.Listener} that retries a {@link BigtableAsyncRpc} request.
  */
+@SuppressWarnings("deprecation")
 public abstract class AbstractRetryingOperation<RequestT, ResponseT, ResultT>
     extends ClientCall.Listener<ResponseT>  {
 

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/RowMerger.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/RowMerger.java
@@ -37,13 +37,13 @@ import io.grpc.stub.StreamObserver;
 
 /**
  * <p>
- * Builds a complete {@link FlatRow} from {@link com.google.bigtable.v2.ReadRowsResponse} objects. A {@link com.google.bigtable.v2.ReadRowsResponse}
- * may contain a single {@link FlatRow}, multiple {@link FlatRow}s, or even a part of a {@link com.google.bigtable.v2.Cell} if the
- * cell is
+ * Builds a complete {@link FlatRow} from {@link com.google.bigtable.v2.ReadRowsResponse} objects. A
+ * {@link com.google.bigtable.v2.ReadRowsResponse} may contain a single {@link FlatRow}, multiple
+ * {@link FlatRow}s, or even a part of a {@link com.google.bigtable.v2.Cell} if the cell is
  * </p>
  * <p>
- * Each RowMerger object is valid only for building a single FlatRow. Expected usage is along the lines
- * of:
+ * Each RowMerger object is valid only for building a single FlatRow. Expected usage is along the
+ * lines of:
  * </p>
  *
  * <pre>
@@ -58,7 +58,9 @@ import io.grpc.stub.StreamObserver;
  * When a complete row is found, {@link io.grpc.stub.StreamObserver#onNext(Object)} will be called.
  * {@link io.grpc.stub.StreamObserver#onError(Throwable)} will be called for
  * </p>
- *
+ * <p>
+ * <b>NOTE: RowMerger is not threadsafe.</b>
+ * </p>
  * @author sduskis
  * @version $Id: $Id
  */
@@ -424,9 +426,13 @@ public class RowMerger implements StreamObserver<ReadRowsResponse> {
     }
   }
 
+  /**
+   * @return the number of rows processed in the previous call to {@link #onNext(ReadRowsResponse)}.
+   */
   public int getRowCountInLastMessage() {
     return rowCountInLastMessage;
   }
+
 
   /** {@inheritDoc} */
   @Override

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/RowMerger.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/RowMerger.java
@@ -364,6 +364,7 @@ public class RowMerger implements StreamObserver<ReadRowsResponse> {
   private ByteString lastCompletedRowKey = null;
   private RowInProgress rowInProgress;
   private boolean complete;
+  private int rowCountInLastMessage = -1;
 
   /**
    * <p>Constructor for RowMerger.</p>
@@ -381,6 +382,7 @@ public class RowMerger implements StreamObserver<ReadRowsResponse> {
       onError(new IllegalStateException("Adding partialRow after completion"));
       return;
     }
+    rowCountInLastMessage = 0;
     for (int i = 0; i < readRowsResponse.getChunksCount(); i++) {
       try {
         CellChunk chunk = readRowsResponse.getChunks(i);
@@ -413,12 +415,17 @@ public class RowMerger implements StreamObserver<ReadRowsResponse> {
           lastCompletedRowKey = rowInProgress.getRowKey();
           rowInProgress = null;
           state = RowMergerState.NewRow;
+          rowCountInLastMessage++;
         }
       } catch (Throwable e) {
         onError(e);
         return;
       }
     }
+  }
+
+  public int getRowCountInLastMessage() {
+    return rowCountInLastMessage;
   }
 
   /** {@inheritDoc} */

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestBigtableDataGrpcClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestBigtableDataGrpcClient.java
@@ -18,7 +18,6 @@ package com.google.cloud.bigtable.grpc;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.times;
@@ -26,11 +25,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 import org.junit.Assert;
 import org.junit.Before;

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/BigtableWhileMatchResultScannerAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/BigtableWhileMatchResultScannerAdapter.java
@@ -59,8 +59,9 @@ public class BigtableWhileMatchResultScannerAdapter {
    * </p>
    * @param bigtableResultScanner a {@link com.google.cloud.bigtable.grpc.scanner.ResultScanner}
    *          object.
-   * @param span A parent span for the scan that needs to be closed when the scanning is complete.
-   *          The span has an HBase specific tag, which needs to be handled by the adapter.
+   * @param span A parent {@link Span} for the scan that needs to be closed when the scanning is
+   *          complete. The span has an HBase specific tag, which needs to be handled by the
+   *          adapter.
    * @return a {@link org.apache.hadoop.hbase.client.ResultScanner} object.
    */
   public ResultScanner adapt(


### PR DESCRIPTION
- Using Closable where possible
- BulkMutations now report number of mutations
- Scans now report the number of rows per response and processing time.