### PR TITLE
Adding BigtableBufferedMutator stack traces.

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/Logger.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/Logger.java
@@ -64,6 +64,20 @@ public class Logger {
   }
 
   /**
+   * <p>debug</p>
+   *
+   * @see Log#debug
+   * @param message Format string.
+   * @param t a {@link java.lang.Throwable} object.
+   * @param args Arguments for format string.
+   */
+  public void debug(String message, Throwable t, Object ... args) {
+    if (log.isDebugEnabled()) {
+      log.debug(String.format(message, args), t);
+    }
+  }
+
+  /**
    * <p>info</p>
    *
    * @see Log#info

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutator.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutator.java
@@ -263,14 +263,19 @@ public class BigtableBufferedMutator implements BufferedMutator {
       ArrayList<String> hostnames = new ArrayList<>(mutationExceptions.size());
       List<Row> failedMutations = new ArrayList<>(mutationExceptions.size());
 
+      if (!mutationExceptions.isEmpty()) {
+        LOG.warn("Exception occurred in BufferedMutator", mutationExceptions.get(0).throwable);
+      }
       for (MutationException mutationException : mutationExceptions) {
         problems.add(mutationException.throwable);
         failedMutations.add(mutationException.mutation);
         hostnames.add(host);
+        LOG.debug("Exception occurred in BufferedMutator", mutationException.throwable);
       }
 
       RetriesExhaustedWithDetailsException exception = new RetriesExhaustedWithDetailsException(
           problems, failedMutations, hostnames);
+
       exceptionListener.onException(exception, this);
     }
   }


### PR DESCRIPTION
The first exception is printed out to the log as a warning.
More exceptions have debug level.