### PR TITLE
Fix for randomly failing testcase due to randomly generated table name.

### DIFF
--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/TestCreateTable.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/TestCreateTable.java
@@ -106,8 +106,8 @@ public class TestCreateTable extends AbstractTest {
       try {
         admin.createTable(new HTableDescriptor(TableName.valueOf(badName))
             .addFamily(new HColumnDescriptor(COLUMN_FAMILY)));
-      } catch (IllegalArgumentException RuntimeException) {
-        //added RuntimeException check as RandomStringUtils seems to be generating a string server side doesn't like 
+      } catch (RuntimeException ex) {
+        //TODO verify - added RuntimeException check as RandomStringUtils seems to be generating a string server side doesn't like 
         failed = true;
       }
       Assert.assertTrue("Should fail as table name: '" + badName + "'", failed);


### PR DESCRIPTION
Not sure why this case - client side validates fine, but server doesn't like it - is only happening. Added a TODO to investigate further. 