### PR TITLE
Slight ReadRowsAcceptanceTest change

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/scanner/ReadRowsAcceptanceTest.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/scanner/ReadRowsAcceptanceTest.java
@@ -184,13 +184,14 @@ public class ReadRowsAcceptanceTest {
   private void addResponses(List<FlatRow> responses, List<Throwable> exceptions)
       throws IOException {
     RowMerger rowMerger = createRowMerger(responses, exceptions);
-    ReadRowsResponse.Builder responseBuilder = ReadRowsResponse.newBuilder();
+
     for (String chunkStr : testCase.chunks) {
+      ReadRowsResponse.Builder responseBuilder = ReadRowsResponse.newBuilder();
       CellChunk.Builder ccBuilder = CellChunk.newBuilder();
       TextFormat.merge(new StringReader(chunkStr), ccBuilder);
       responseBuilder.addChunks(ccBuilder.build());
+      rowMerger.onNext(responseBuilder.build());
     }
-    rowMerger.onNext(responseBuilder.build());
     if (exceptions.isEmpty()) {
       rowMerger.onCompleted();
     }


### PR DESCRIPTION
ReadRowsAcceptanceTest now creates a new ReadRowsResponse per chunk.  This is useful to ensure that RowMerger does the right thing across ReadRowsResponses.