### PR TITLE
Adding grpc and tcnative to bigtable-hbase-[12].x

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/pom.xml
+++ b/bigtable-client-core-parent/bigtable-client-core/pom.xml
@@ -169,17 +169,19 @@ limitations under the License.
             </exclusions>
         </dependency>
 
-        <!-- GRPC -->
+        <!-- GRPC and tcnative -->
+        <!-- 
+            These dependencies are copied to bigtable-hbase-1.x and bigtable-hbase-2.x.
+
+            The copy has to happen to ensure consistency of all io.netty and io.grpc versions
+            even if there is a different transitive dependency of grpc from other clients.
+            Specifically this should avoid problems when stackdriver tracing is used in
+            conjunction with Cloud Bigtable.
+        -->
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
             <version>${protobuff-java.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-tcnative-boringssl-static</artifactId>
-            <version>${netty-tcnative-boringssl-static.version}</version>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>
@@ -205,6 +207,12 @@ limitations under the License.
             <groupId>io.grpc</groupId>
             <artifactId>grpc-stub</artifactId>
             <version>${grpc.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-tcnative-boringssl-static</artifactId>
+            <version>${netty-tcnative-boringssl-static.version}</version>
         </dependency>
 
         <!-- Metrics -->

--- a/bigtable-hbase-parent/bigtable-hbase-1.x/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-1.x/pom.xml
@@ -39,6 +39,51 @@ limitations under the License.
       <version>${project.version}</version>
     </dependency>
 
+    <!-- GRPC and tcnative -->
+    <!-- 
+        These dependencies are copied to bigtable-hbase-1.x and bigtable-hbase-2.x.
+
+        The copy has to happen to ensure consistency of all io.netty and io.grpc versions
+        even if there is a different transitive dependency of grpc from other clients.
+        Specifically this should avoid problems when stackdriver tracing is used in
+        conjunction with Cloud Bigtable.
+    -->
+    <dependency>
+        <groupId>com.google.protobuf</groupId>
+        <artifactId>protobuf-java</artifactId>
+        <version>${protobuff-java.version}</version>
+    </dependency>
+    <dependency>
+        <groupId>io.grpc</groupId>
+        <artifactId>grpc-protobuf</artifactId>
+        <version>${grpc.version}</version>
+    </dependency>
+    <dependency>
+        <groupId>io.grpc</groupId>
+        <artifactId>grpc-auth</artifactId>
+        <version>${grpc.version}</version>
+    </dependency>
+    <dependency>
+        <groupId>io.grpc</groupId>
+        <artifactId>grpc-core</artifactId>
+        <version>${grpc.version}</version>
+    </dependency>
+    <dependency>
+        <groupId>io.grpc</groupId>
+        <artifactId>grpc-netty</artifactId>
+        <version>${grpc.version}</version>
+    </dependency>
+    <dependency>
+        <groupId>io.grpc</groupId>
+        <artifactId>grpc-stub</artifactId>
+        <version>${grpc.version}</version>
+    </dependency>
+
+    <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-tcnative-boringssl-static</artifactId>
+        <version>${netty-tcnative-boringssl-static.version}</version>
+    </dependency>
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-graphite</artifactId>

--- a/bigtable-hbase-parent/bigtable-hbase-1.x/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-1.x/pom.xml
@@ -84,6 +84,9 @@ limitations under the License.
         <artifactId>netty-tcnative-boringssl-static</artifactId>
         <version>${netty-tcnative-boringssl-static.version}</version>
     </dependency>
+
+    <!-- END GRPC and tcnative -->
+
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-graphite</artifactId>

--- a/bigtable-hbase-parent/bigtable-hbase-2.x/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-2.x/pom.xml
@@ -55,6 +55,52 @@ limitations under the License.
        </exclusions>
    </dependency>
 
+    <!-- GRPC and tcnative -->
+    <!-- 
+        These dependencies are copied to bigtable-hbase-1.x and bigtable-hbase-2.x.
+
+        The copy has to happen to ensure consistency of all io.netty and io.grpc versions
+        even if there is a different transitive dependency of grpc from other clients.
+        Specifically this should avoid problems when stackdriver tracing is used in
+        conjunction with Cloud Bigtable.
+    -->
+    <dependency>
+        <groupId>com.google.protobuf</groupId>
+        <artifactId>protobuf-java</artifactId>
+        <version>${protobuff-java.version}</version>
+    </dependency>
+    <dependency>
+        <groupId>io.grpc</groupId>
+        <artifactId>grpc-protobuf</artifactId>
+        <version>${grpc.version}</version>
+    </dependency>
+    <dependency>
+        <groupId>io.grpc</groupId>
+        <artifactId>grpc-auth</artifactId>
+        <version>${grpc.version}</version>
+    </dependency>
+    <dependency>
+        <groupId>io.grpc</groupId>
+        <artifactId>grpc-core</artifactId>
+        <version>${grpc.version}</version>
+    </dependency>
+    <dependency>
+        <groupId>io.grpc</groupId>
+        <artifactId>grpc-netty</artifactId>
+        <version>${grpc.version}</version>
+    </dependency>
+    <dependency>
+        <groupId>io.grpc</groupId>
+        <artifactId>grpc-stub</artifactId>
+        <version>${grpc.version}</version>
+    </dependency>
+
+    <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-tcnative-boringssl-static</artifactId>
+        <version>${netty-tcnative-boringssl-static.version}</version>
+    </dependency>
+
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-graphite</artifactId>

--- a/bigtable-hbase-parent/bigtable-hbase-2.x/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-2.x/pom.xml
@@ -101,6 +101,8 @@ limitations under the License.
         <version>${netty-tcnative-boringssl-static.version}</version>
     </dependency>
 
+    <!-- END GRPC and tcnative -->
+
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-graphite</artifactId>


### PR DESCRIPTION
The additional copies of grpc and tcnative should help solve some cases of diamond dependency problems we found with stackdriver tracing integration.