### PR TITLE
Common component changes and utilities for Hbase2 async.

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableTableAdminClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableTableAdminClient.java
@@ -42,6 +42,14 @@ public interface BigtableTableAdminClient {
   void createTable(CreateTableRequest request);
 
   /**
+   * Creates a new table asynchronously. The table can be created with a full set of initial column
+   * families, specified in the request.
+   * 
+   * @param request a {@link CreateTableRequest} object.
+   */
+  ListenableFuture<Table> createTableAsync(CreateTableRequest request);
+
+  /**
    * Gets the details of a table.
    *
    * @param request a {@link GetTableRequest} object.

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableTableAdminGrpcClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableTableAdminGrpcClient.java
@@ -118,6 +118,13 @@ public class BigtableTableAdminGrpcClient implements BigtableTableAdminClient {
     createUnaryListener(request, createTableRpc, request.getParent()).getBlockingResult();
   }
 
+  /** {@inheritDoc} 
+   * @return */
+  @Override
+  public ListenableFuture<Table> createTableAsync(CreateTableRequest request) {
+    return createUnaryListener(request, createTableRpc, request.getParent()).getAsyncResult();
+  }
+
   /** {@inheritDoc} */
   @Override
   public Table modifyColumnFamily(ModifyColumnFamiliesRequest request) {

--- a/bigtable-hbase-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/FutureUtils.java
+++ b/bigtable-hbase-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/FutureUtils.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase2_x;
+
+import java.util.concurrent.CompletableFuture;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+
+/**
+ * Utility methods for converting Future types 
+ * @author spollapally
+ */
+public class FutureUtils {
+
+  public static <T> CompletableFuture<T> toCompletableFuture(
+      final ListenableFuture<T> listenableFuture) {
+    final CompletableFuture<T> completableFuture = new CompletableFuture<T>() {
+      @Override
+      public boolean cancel(boolean mayInterruptIfRunning) {
+        boolean result = listenableFuture.cancel(mayInterruptIfRunning);
+        super.cancel(mayInterruptIfRunning);
+        return result;
+      }
+    };
+
+    Futures.addCallback(listenableFuture, new FutureCallback<T>() {
+      public void onFailure(Throwable throwable) {
+        completableFuture.completeExceptionally(throwable);
+      }
+
+      public void onSuccess(T t) {
+        completableFuture.complete(t);
+      }
+    });
+    return completableFuture;
+  }
+
+  public static <T> CompletableFuture<T> failedFuture(Throwable error) {
+    CompletableFuture<T> future = new CompletableFuture<>();
+    future.completeExceptionally(error);
+    return future;
+  }
+
+}

--- a/bigtable-hbase-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/FutureUtils.java
+++ b/bigtable-hbase-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/FutureUtils.java
@@ -21,7 +21,10 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 
 /**
- * Utility methods for converting Future types 
+ * Utility methods for converting guava {@link ListenableFuture} Future to
+ * {@link CompletableFuture}. Useful to convert the ListenableFuture types used by
+ * bigtable-client-core component to Java 8 CompletableFuture types used in Hbase 2
+ * 
  * @author spollapally
  */
 public class FutureUtils {

--- a/bigtable-hbase-parent/bigtable-hbase-2.x/src/main/java/org/apache/hadoop/hbase/client/BigtableAsyncRegistry.java
+++ b/bigtable-hbase-parent/bigtable-hbase-2.x/src/main/java/org/apache/hadoop/hbase/client/BigtableAsyncRegistry.java
@@ -21,8 +21,12 @@ import org.apache.hadoop.hbase.RegionLocations;
 import org.apache.hadoop.hbase.ServerName;
 
 /**
- * Bigtable implementation of {@link AsyncRegistry}}. Hard codes required values as corresponding Bigtable
- * components do not exist
+ * Bigtable implementation of {@link AsyncRegistry}. The default Habse 2 implementation provided by
+ * {@link ZKAsyncRegistry} assumes a ZooKeeper environment, which is not the case for Bigtable.
+ * 
+ * This class is injected via the system property: "hbase.client.registry.impl" For further details
+ * See {@link AsyncRegistryFactory#REGISTRY_IMPL_CONF_KEY}, and
+ * {@link ConnectionFactory#createAsyncConnection()}
  * 
  * @author spollapally
  */
@@ -34,7 +38,7 @@ public class BigtableAsyncRegistry implements AsyncRegistry {
   public void close() {}
 
   /**
-   * getClusterId() is required for creating and asyncConnection successfully. see
+   * A non null return value is required for successful creation of asyncConnection. see
    * {@link ConnectionFactory#createAsyncConnection()}
    */
   @Override

--- a/bigtable-hbase-parent/bigtable-hbase-2.x/src/main/java/org/apache/hadoop/hbase/client/BigtableAsyncRegistry.java
+++ b/bigtable-hbase-parent/bigtable-hbase-2.x/src/main/java/org/apache/hadoop/hbase/client/BigtableAsyncRegistry.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.client;
+
+import java.util.concurrent.CompletableFuture;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.RegionLocations;
+import org.apache.hadoop.hbase.ServerName;
+
+/**
+ * Bigtable implementation of {@link AsyncRegistry}}. Hard codes required values as corresponding Bigtable
+ * components do not exist
+ * 
+ * @author spollapally
+ */
+public class BigtableAsyncRegistry implements AsyncRegistry {
+
+  public BigtableAsyncRegistry(Configuration conf) {}
+
+  @Override
+  public void close() {}
+
+  /**
+   * getClusterId() is required for creating and asyncConnection successfully. see
+   * {@link ConnectionFactory#createAsyncConnection()}
+   */
+  @Override
+  public CompletableFuture<String> getClusterId() {
+    return CompletableFuture.completedFuture("TestClusterID");
+  }
+
+  @Override
+  public CompletableFuture<Integer> getCurrentNrHRS() {
+    throw new UnsupportedOperationException("getCurrentNrHRS");
+  }
+
+  @Override
+  public CompletableFuture<ServerName> getMasterAddress() {
+    throw new UnsupportedOperationException("getMasterAddress");
+  }
+
+  @Override
+  public CompletableFuture<Integer> getMasterInfoPort() {
+    throw new UnsupportedOperationException("getMasterInfoPort");
+  }
+
+  @Override
+  public CompletableFuture<RegionLocations> getMetaRegionLocation() {
+    throw new UnsupportedOperationException("getMetaRegionLocation");
+  }
+
+}

--- a/bigtable-hbase-parent/bigtable-hbase-2.x/src/test/java/com/google/cloud/bigtable/hbase2_x/FutureUtilsTest.java
+++ b/bigtable-hbase-parent/bigtable-hbase-2.x/src/test/java/com/google/cloud/bigtable/hbase2_x/FutureUtilsTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase2_x;
+
+import static org.junit.Assert.*;
+import static org.hamcrest.core.StringContains.containsString;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.hamcrest.core.IsInstanceOf;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
+
+public class FutureUtilsTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void testFailedFuture() throws Exception {
+    CompletableFuture<Object> asyncFuture =
+        FutureUtils.failedFuture(new IllegalStateException("Test failed feature"));
+
+    assertTrue("future should be complete", asyncFuture.isDone());
+    assertTrue("Should complete with exception", asyncFuture.isCompletedExceptionally());
+
+    thrown.expect(ExecutionException.class);
+    thrown.expectCause(IsInstanceOf.<Throwable>instanceOf(IllegalStateException.class));
+    thrown.expectMessage(containsString("Test failed feature"));
+    asyncFuture.get();
+  }
+
+  @Test
+  public void testToCompletableFuture() throws Exception {
+    String result = "Result";
+
+    ListeningExecutorService service =
+        MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(1));
+
+    ListenableFuture<String> listenableFuture = service.submit(new Callable<String>() {
+      public String call() throws Exception {
+        Thread.sleep(1000);
+        return result;
+      }
+    });
+
+    CompletableFuture<String> completableFuture = FutureUtils.toCompletableFuture(listenableFuture);
+    assertFalse("Should be in progress", completableFuture.isDone());
+
+    Throwable t = null;
+    try {
+      completableFuture.get(500, TimeUnit.MILLISECONDS);
+    } catch (TimeoutException e) {
+      t = e;
+    }
+    assertNotNull("TimeoutException is expected", t);
+    assertEquals(result, completableFuture.get());
+  }
+
+  @Test
+  public void testToCompletableFuture_exception() throws Exception {
+    ListeningExecutorService service =
+        MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(1));
+
+    ListenableFuture<String> listenableFuture = service.submit(new Callable<String>() {
+      public String call() throws Exception {
+        throw new IllegalStateException("Test failed feature");
+      }
+    });
+
+    CompletableFuture<String> completableFuture = FutureUtils.toCompletableFuture(listenableFuture);
+    assertTrue("future should be complete", completableFuture.isDone());
+    assertTrue("Should complete with exception", completableFuture.isCompletedExceptionally());
+
+    thrown.expect(ExecutionException.class);
+    thrown.expectCause(IsInstanceOf.<Throwable>instanceOf(IllegalStateException.class));
+    thrown.expectMessage(containsString("Test failed feature"));
+    completableFuture.get();
+  }
+}

--- a/bigtable-hbase-parent/bigtable-hbase-2.x/src/test/java/com/google/cloud/bigtable/hbase2_x/FutureUtilsTest.java
+++ b/bigtable-hbase-parent/bigtable-hbase-2.x/src/test/java/com/google/cloud/bigtable/hbase2_x/FutureUtilsTest.java
@@ -31,6 +31,11 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 
+/**
+ * Unit tests for {@link FutureUtils}
+ * 
+ * @author spollapally
+ */
 public class FutureUtilsTest {
 
   @Rule

--- a/bigtable-hbase-parent/bigtable-hbase-2.x/src/test/java/com/google/cloud/bigtable/hbase2_x/FutureUtilsTest.java
+++ b/bigtable-hbase-parent/bigtable-hbase-2.x/src/test/java/com/google/cloud/bigtable/hbase2_x/FutureUtilsTest.java
@@ -89,12 +89,13 @@ public class FutureUtilsTest {
     });
 
     CompletableFuture<String> completableFuture = FutureUtils.toCompletableFuture(listenableFuture);
-    assertTrue("future should be complete", completableFuture.isDone());
-    assertTrue("Should complete with exception", completableFuture.isCompletedExceptionally());
 
     thrown.expect(ExecutionException.class);
     thrown.expectCause(IsInstanceOf.<Throwable>instanceOf(IllegalStateException.class));
     thrown.expectMessage(containsString("Test failed feature"));
     completableFuture.get();
+    
+    assertTrue("future should be complete", completableFuture.isDone());
+    assertTrue("Should complete with exception", completableFuture.isCompletedExceptionally());
   }
 }

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/admin/TableAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/admin/TableAdapter.java
@@ -35,8 +35,8 @@ import java.util.Map.Entry;
  * @version $Id: $Id
  */
 public class TableAdapter {
-  private final BigtableInstanceName bigtableInstanceName;
-  private final ColumnDescriptorAdapter columnDescriptorAdapter;
+  protected final BigtableInstanceName bigtableInstanceName;
+  protected final ColumnDescriptorAdapter columnDescriptorAdapter;
 
   /**
    * <p>Constructor for TableAdapter.</p>


### PR DESCRIPTION
Changes in TableAdapter are to allow extensions to work-around hbase-2 binary compatibility issues.
 