### PR TITLE
fix dep

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/pom.xml
+++ b/bigtable-client-core-parent/bigtable-client-core/pom.xml
@@ -56,10 +56,6 @@ limitations under the License.
                     <groupId>io.grpc</groupId>
                     <artifactId>grpc-all</artifactId>
                 </exclusion>
-                <exclusion>
-                    <groupId>com.google.api</groupId>
-                    <artifactId>api-common</artifactId>
-                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -70,10 +66,6 @@ limitations under the License.
                 <exclusion>
                     <groupId>io.grpc</groupId>
                     <artifactId>grpc-all</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.google.api</groupId>
-                    <artifactId>api-common</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -86,10 +78,6 @@ limitations under the License.
                     <groupId>io.grpc</groupId>
                     <artifactId>grpc-all</artifactId>
                 </exclusion>
-                <exclusion>
-                    <groupId>com.google.api</groupId>
-                    <artifactId>api-common</artifactId>
-                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -100,10 +88,6 @@ limitations under the License.
                 <exclusion>
                     <groupId>io.grpc</groupId>
                     <artifactId>grpc-all</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.google.api</groupId>
-                    <artifactId>api-common</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>


### PR DESCRIPTION
When a Mockito mock fails to verify a BigtableDataClient mock, it blows up with a class not found error for ResourceName (which is a class that resides in api-common)