### PR TITLE
Fixing ReadRowsRequestManager row limits.

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
@@ -62,7 +62,6 @@ import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.internal.DnsNameResolverProvider;
 import io.grpc.internal.GrpcUtil;
-import io.netty.util.Recycler;
 
 /**
  * <p>Encapsulates the creation of Bigtable Grpc services.</p>

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ReadRowsRequestManager.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ReadRowsRequestManager.java
@@ -54,7 +54,10 @@ class ReadRowsRequestManager {
 
   void updateLastFoundKey(ByteString key) {
     this.lastFoundKey = key;
-    rowCount++;
+  }
+
+  void incrementRowCount(int count) {
+    rowCount += count;
   }
 
   ReadRowsRequest buildUpdatedRequest() {

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/RetryingReadRowsOperation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/RetryingReadRowsOperation.java
@@ -182,6 +182,7 @@ public class RetryingReadRowsOperation extends
       AttributeValue.longAttributeValue(rowCountInLastMessage)));
 
     totalRowsProcessed += rowCountInLastMessage;
+    requestManager.incrementRowCount(rowCountInLastMessage);
 
     ByteString lastProcessedKey = rowMerger.getLastCompletedRowKey();
     if (previouslyProcessedKey != lastProcessedKey) {


### PR DESCRIPTION
Row limits were not handled well with ReadRowsRequestManager.  ReadRowsRequestManager gets last found row key at the end of processing a ReadRowsResponse.
Row limits need to be tracked in a different method.