### PR TITLE
Adding a MutateRowsRequestManager

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/MutateRowsRequestManager.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/MutateRowsRequestManager.java
@@ -46,18 +46,18 @@ public class MutateRowsRequestManager  {
     /* All responses produced OK */
     SUCCESS,
     /* All responses produced OK or a retryable code */
-    RETYABLE,
+    RETRYABLE,
     /* Some responses a non-retryable code */
     NOT_RETRYABLE,
-    /* Some responses a non-retryable code */
-    INLALID;
+    /* The response was invalid - missing indexes and etc. */
+    INVALID;
   }
 
   /**
    * The current request to send. This starts as the original request. If retries occur, this
    * request will contain the subset of Mutations that need to be retried.
    */
-  private MutateRowsRequest currentRequest;
+  private volatile MutateRowsRequest currentRequest;
 
   /**
    * When doing retries, the retry sends a partial set of the original mutations that failed with a
@@ -124,7 +124,7 @@ public class MutateRowsRequestManager  {
 
     // There was a problem in the data found in onMessage(), so fail the RPC.
     if (messageIsInvalid) {
-      return ProcessingStatus.INLALID;
+      return ProcessingStatus.INVALID;
     }
 
     List<Integer> toRetry = new ArrayList<>();
@@ -150,7 +150,7 @@ public class MutateRowsRequestManager  {
     if (!toRetry.isEmpty()) {
       currentRequest = createRetryRequest(toRetry);
       if (processingStatus == ProcessingStatus.SUCCESS) {
-        processingStatus = ProcessingStatus.RETYABLE;
+        processingStatus = ProcessingStatus.RETRYABLE;
       }
     }
     return processingStatus;

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/MutateRowsRequestManager.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/MutateRowsRequestManager.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.grpc.async;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.google.bigtable.v2.MutateRowsRequest;
+import com.google.bigtable.v2.MutateRowsResponse;
+import com.google.bigtable.v2.MutateRowsResponse.Entry;
+import com.google.cloud.bigtable.config.RetryOptions;
+import com.google.cloud.bigtable.grpc.BigtableDataClient;
+import com.google.rpc.Status;
+
+import io.grpc.Status.Code;
+
+/**
+ * Performs retries for {@link BigtableDataClient#mutateRows(MutateRowsRequest)} operations.
+ */
+public class MutateRowsRequestManager  {
+  private final static Status STATUS_INTERNAL =
+      Status.newBuilder().setCode(io.grpc.Status.Code.INTERNAL.value()).build();
+
+  private static Code getGrpcCode(Status status) {
+    return status == null ? null : io.grpc.Status.fromCodeValue(status.getCode()).getCode();
+  }
+
+  private static Entry createEntry(int i, Status status) {
+    return MutateRowsResponse.Entry.newBuilder().setIndex(i).setStatus(status).build();
+  }
+
+
+  /**
+   * The current request to send. This starts as the original request. If retries occur, this
+   * request will contain the subset of Mutations that need to be retried.
+   */
+  private MutateRowsRequest currentRequest;
+
+  /**
+   * When doing retries, the retry sends a partial set of the original mutations that failed with a
+   * retryable status. This array contains a mapping of indices from the {@link #getRetryRequest()}
+   * to {@link #getOriginalRequest()}.
+   */
+  private int[] mapToOriginalIndex;
+
+  /**
+   * This array tracks the cumulative set of results across all RPC requests.
+   */
+  private final Status[] results;
+  private final RetryOptions retryOptions;
+  private final MutateRowsRequest originalRequest;
+
+  private boolean messageIsInvalid;
+  private boolean retryable;
+
+  public MutateRowsRequestManager(RetryOptions retryOptions, MutateRowsRequest originalRequest) {
+    this.currentRequest = originalRequest;
+    this.originalRequest = originalRequest;
+    this.retryOptions = retryOptions;
+    results = new Status[originalRequest.getEntriesCount()];
+
+    // This map should is a map between currentRequest and originalRquest. For now, currentRequest
+    // == originalRquest, but they could diverge if a retry occurs.
+    mapToOriginalIndex = new int[originalRequest.getEntriesCount()];
+    for (int i = 0; i < mapToOriginalIndex.length; i++) {
+      mapToOriginalIndex[i] = i;
+    }
+  }
+
+  /**
+   * Adds the content of the message to the {@link #results}.
+   */
+  public void onMessage(MutateRowsResponse message) {
+    for (Entry entry : message.getEntriesList()) {
+      int index = (int) entry.getIndex();
+
+      // Sanity check to make sure that the index returned from the server is valid.
+      if (index >= mapToOriginalIndex.length || index < 0) {
+        messageIsInvalid = true;
+        break;
+      }
+
+      // Set the result.
+      results[mapToOriginalIndex[index]] = entry.getStatus();
+    }
+  }
+
+  public MutateRowsRequest getRetryRequest() {
+    return currentRequest;
+  }
+
+  public boolean onOK() {
+    retryable = true;
+    // Sanity check to make sure that every mutation received a response.
+    for (int i = 0; i < results.length; i++) {
+      if (results[i] == null) {
+        messageIsInvalid = true;
+        break;
+      }
+    }
+
+    // There was a problem in the data found in onMessage(), so fail the RPC.
+    if (messageIsInvalid) {
+      retryable = false;
+      return false;
+    }
+
+    List<Integer> toRetry = new ArrayList<>();
+    boolean success = true;
+
+    // Check the current state to determine the state of the results.
+    // There are three states: OK, Fail, or Partial Retry.
+    for (int i = 0; i < results.length; i++) {
+      Status status = results[i];
+      if (status.getCode() == io.grpc.Status.Code.OK.value()) {
+        continue;
+      }
+
+      success = false;
+      if (retryOptions.isRetryable(getGrpcCode(status))) {
+        // An individual mutation failed with a retryable code, usually DEADLINE_EXCEEDED.
+        toRetry.add(i);
+      } else {
+        // Don't retry if even a single response is not retryable.
+        retryable = false;
+      }
+    }
+
+    if (!toRetry.isEmpty()) {
+      currentRequest = createRetryRequest(toRetry);
+    }
+    return success;
+  }
+
+  public boolean isMessageInvalid() {
+    return messageIsInvalid;
+  }
+
+  public boolean isRetryable() {
+    return retryable;
+  }
+
+  /**
+   * Creates a new {@link MutateRowsRequest} that's a subset of the original request that
+   * corresponds to a set of indices.
+   *
+   * @param indiciesToRetry
+   * @return the new {@link MutateRowsRequest}.
+   */
+  private MutateRowsRequest createRetryRequest(List<Integer> indiciesToRetry) {
+    MutateRowsRequest.Builder updatedRequest = MutateRowsRequest.newBuilder()
+        .setTableName(originalRequest.getTableName());
+
+    mapToOriginalIndex = toIntArray(indiciesToRetry);
+    for (int i = 0; i < indiciesToRetry.size(); i++) {
+      updatedRequest.addEntries(originalRequest.getEntries(indiciesToRetry.get(i)));
+    }
+
+    return updatedRequest.build();
+  }
+
+  public MutateRowsResponse buildResponse() {
+    List<MutateRowsResponse.Entry> entries = new ArrayList<>();
+    for (int i = 0; i < results.length; i++) {
+      Status status = (results[i] == null) ? STATUS_INTERNAL : results[i];
+      entries.add(createEntry(i, status));
+    }
+    return MutateRowsResponse.newBuilder().addAllEntries(entries).build();
+  }
+
+  /**
+   * Converts the List<Integer> to int[].
+   */
+  private int[] toIntArray(List<Integer> list) {
+    int[] array = new int[list.size()];
+    for (int i = 0; i < list.size(); i++) {
+      array[i] = list.get(i);
+    }
+    return array;
+  }
+}

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/RetryingMutateRowsOperation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/RetryingMutateRowsOperation.java
@@ -15,7 +15,6 @@
  */
 package com.google.cloud.bigtable.grpc.async;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
@@ -23,15 +22,12 @@ import java.util.concurrent.ScheduledExecutorService;
 import com.google.api.client.util.BackOff;
 import com.google.bigtable.v2.MutateRowsRequest;
 import com.google.bigtable.v2.MutateRowsResponse;
-import com.google.bigtable.v2.MutateRowsResponse.Entry;
 import com.google.cloud.bigtable.config.RetryOptions;
 import com.google.cloud.bigtable.grpc.BigtableDataClient;
 import com.google.common.collect.ImmutableMap;
-import com.google.rpc.Status;
 
 import io.grpc.CallOptions;
 import io.grpc.Metadata;
-import io.grpc.Status.Code;
 import io.opencensus.trace.AttributeValue;
 
 /**
@@ -41,50 +37,14 @@ public class RetryingMutateRowsOperation extends
     AbstractRetryingOperation<MutateRowsRequest, MutateRowsResponse, List<MutateRowsResponse>> {
   private final static io.grpc.Status INVALID_RESPONSE =
       io.grpc.Status.INTERNAL.withDescription("The server returned an invalid response");
-  private final static Status STATUS_INTERNAL =
-      Status.newBuilder().setCode(io.grpc.Status.Code.INTERNAL.value()).build();
 
-  private static Code getGrpcCode(Status status) {
-    return status == null ? null : io.grpc.Status.fromCodeValue(status.getCode()).getCode();
-  }
-
-  private static Entry createEntry(int i, Status status) {
-    return MutateRowsResponse.Entry.newBuilder().setIndex(i).setStatus(status).build();
-  }
-
-
-  /**
-   * The current request to send. This starts as the original request. If retries occur, this
-   * request will contain the subset of Mutations that need to be retried.
-   */
-  private MutateRowsRequest currentRequest;
-
-  /**
-   * When doing retries, the retry sends a partial set of the original mutations that failed with a
-   * retryable status. This array contains a mapping of indices from the {@link #getRetryRequest()}
-   * to {@link #getOriginalRequest()}.
-   */
-  private int[] mapToOriginalIndex;
-
-  /**
-   * This array tracks the cumulative set of results across all RPC requests.
-   */
-  private final Status[] results;
-  private boolean messageIsInvalid;
+  private final MutateRowsRequestManager requestManager;
 
   public RetryingMutateRowsOperation(RetryOptions retryOptions, MutateRowsRequest originalRquest,
       BigtableAsyncRpc<MutateRowsRequest, MutateRowsResponse> retryableRpc, CallOptions callOptions,
       ScheduledExecutorService retryExecutorService, Metadata originalMetadata) {
     super(retryOptions, originalRquest, retryableRpc, callOptions, retryExecutorService, originalMetadata);
-    this.currentRequest = originalRquest;
-    results = new Status[originalRquest.getEntriesCount()];
-
-    // This map should is a map between currentRequest and originalRquest. For now, currentRequest
-    // == originalRquest, but they could diverge if a retry occurs.
-    mapToOriginalIndex = new int[originalRquest.getEntriesCount()];
-    for (int i = 0; i < mapToOriginalIndex.length; i++) {
-      mapToOriginalIndex[i] = i;
-    }
+    requestManager = new MutateRowsRequestManager(retryOptions, originalRquest);
     operationSpan.addAnnotation("MutationCount", ImmutableMap.of("count",
       AttributeValue.longAttributeValue(originalRquest.getEntriesCount())));
   }
@@ -94,127 +54,46 @@ public class RetryingMutateRowsOperation extends
    */
   @Override
   public void onMessage(MutateRowsResponse message) {
-    for (Entry entry : message.getEntriesList()) {
-      int index = (int) entry.getIndex();
-
-      // Sanity check to make sure that the index returned from the server is valid.
-      if (index >= mapToOriginalIndex.length || index < 0) {
-        messageIsInvalid = true;
-        break;
-      }
-
-      // Set the result.
-      results[mapToOriginalIndex[index]] = entry.getStatus();
-    }
+    requestManager.onMessage(message);
   }
 
   @Override
   protected MutateRowsRequest getRetryRequest() {
-    return currentRequest;
+    return requestManager.getRetryRequest();
   }
 
   @Override
   protected boolean onOK(Metadata trailers) {
-    // Sanity check to make sure that every mutation received a response.
-    for (int i = 0; i < results.length; i++) {
-      if (results[i] == null) {
-        messageIsInvalid = true;
-        break;
-      }
+    boolean success = requestManager.onOK();
+
+    if (requestManager.isMessageInvalid()) {
+      // Set an exception.
+      onError(INVALID_RESPONSE, trailers);
+      return true;
     }
 
     // There was a problem in the data found in onMessage(), so fail the RPC.
-    if (messageIsInvalid) {
-      onError(INVALID_RESPONSE, trailers);
-      return false;
-    }
-
-    boolean fail = false;
-    List<Integer> toRetry = new ArrayList<>();
-
-    // Check the current state to determine the state of the results.
-    // There are three states: OK, Fail, or Partial Retry.
-    for (int i = 0; i < results.length; i++) {
-      Status status = results[i];
-      if (status.getCode() == io.grpc.Status.Code.OK.value()) {
-        continue;
-      }
-
-      if (retryOptions.isRetryable(getGrpcCode(status))) {
-        // An individual mutation failed with a retryable code, usually DEADLINE_EXCEEDED.
-        toRetry.add(i);
-      } else {
-        // Don't retry if even a single response is not retryable.
-        fail = true;
-      }
-    }
-
-    if (fail) {
-      rpc.getRpcMetrics().markFailure();
-    }
-
-    if (!toRetry.isEmpty()) {
-      operationSpan.addAnnotation("MutationCount", ImmutableMap.of("retryCount",
-        AttributeValue.longAttributeValue(toRetry.size())));
-    }
-
-    // OK or Fail should set the future, and end the operation.
-    // The caller should handle the processing of the failed mutations.
-    if (toRetry.isEmpty() || fail) {
-      completionFuture.set(Arrays.asList(buildResponse()));
+    if (success || !requestManager.isRetryable()) {
+      // Set the response, with either success, or non-retryable responses.
+      completionFuture.set(Arrays.asList(requestManager.buildResponse()));
       return true;
     }
 
     // Perform a partial retry, if the backoff policy allows it.
     long nextBackOff = getNextBackoff();
     if (nextBackOff == BackOff.STOP) {
+      // Return the response as is, and don't retry;
       rpc.getRpcMetrics().markRetriesExhasted();
-      completionFuture.set(Arrays.asList(buildResponse()));
+      completionFuture.set(Arrays.asList(requestManager.buildResponse()));
+      operationSpan.addAnnotation("MutationCount", ImmutableMap.of("failureCount",
+        AttributeValue.longAttributeValue(requestManager.getRetryRequest().getEntriesCount())));
       return true;
-    } else {
-      currentRequest = createRetryRequest(toRetry);
-      mapToOriginalIndex = toIntArray(toRetry);
-      performRetry(nextBackOff);
-      return false;
-    }
-  }
-
-  /**
-   * Creates a new {@link MutateRowsRequest} that's a subset of the original request that
-   * corresponds to a set of indices.
-   *
-   * @param indiciesToRetry
-   * @return the new {@link MutateRowsRequest}.
-   */
-  private MutateRowsRequest createRetryRequest(List<Integer> indiciesToRetry) {
-    MutateRowsRequest originalRequest = getOriginalRequest();
-    MutateRowsRequest.Builder updatedRequest = MutateRowsRequest.newBuilder()
-        .setTableName(originalRequest.getTableName());
-
-    for (int i = 0; i < indiciesToRetry.size(); i++) {
-      updatedRequest.addEntries(originalRequest.getEntries(indiciesToRetry.get(i)));
     }
 
-    return updatedRequest.build();
+    performRetry(nextBackOff);
+    operationSpan.addAnnotation("MutationCount", ImmutableMap.of("retryCount",
+      AttributeValue.longAttributeValue(requestManager.getRetryRequest().getEntriesCount())));
+    return false;
   }
 
-  /**
-   * Converts the List<Integer> to int[].
-   */
-  private int[] toIntArray(List<Integer> list) {
-    int[] array = new int[list.size()];
-    for (int i = 0; i < list.size(); i++) {
-      array[i] = list.get(i);
-    }
-    return array;
-  }
-
-  private MutateRowsResponse buildResponse() {
-    List<MutateRowsResponse.Entry> entries = new ArrayList<>();
-    for (int i = 0; i < results.length; i++) {
-      Status status = (results[i] == null) ? STATUS_INTERNAL : results[i];
-      entries.add(createEntry(i, status));
-    }
-    return MutateRowsResponse.newBuilder().addAllEntries(entries).build();
-  }
 }

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/RetryingMutateRowsOperation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/RetryingMutateRowsOperation.java
@@ -50,9 +50,6 @@ public class RetryingMutateRowsOperation extends
       AttributeValue.longAttributeValue(originalRquest.getEntriesCount())));
   }
 
-  /**
-   * Adds the content of the message to the {@link #results}.
-   */
   @Override
   public void onMessage(MutateRowsResponse message) {
     requestManager.onMessage(message);

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/RetryingMutateRowsOperation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/RetryingMutateRowsOperation.java
@@ -67,7 +67,7 @@ public class RetryingMutateRowsOperation extends
   protected boolean onOK(Metadata trailers) {
     ProcessingStatus status = requestManager.onOK();
 
-    if (status == ProcessingStatus.INLALID) {
+    if (status == ProcessingStatus.INVALID) {
       // Set an exception.
       onError(INVALID_RESPONSE, trailers);
       return true;

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ReadRowsRequestManager.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ReadRowsRequestManager.java
@@ -38,9 +38,9 @@ class ReadRowsRequestManager {
   private final ReadRowsRequest originalRequest;
 
   // The number of rows read so far.
-  private long rowCount = 0;
+  private volatile long rowCount = 0;
 
-  private ByteString lastFoundKey;
+  private volatile ByteString lastFoundKey;
 
   /**
    * <p>

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/RetryingReadRowsOperation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/RetryingReadRowsOperation.java
@@ -310,8 +310,13 @@ public class RetryingReadRowsOperation extends
 
   @Override
   protected void performRetry(long nextBackOff) {
-    nextRequest = requestManager.buildUpdatedRequest();
+    buildUpdatedRequst();
     super.performRetry(nextBackOff);
+  }
+
+  @VisibleForTesting
+  ReadRowsRequest buildUpdatedRequst() {
+    return nextRequest = requestManager.buildUpdatedRequest();
   }
 
   @VisibleForTesting

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/RetryingReadRowsOperation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/RetryingReadRowsOperation.java
@@ -118,6 +118,7 @@ public class RetryingReadRowsOperation extends
   private CallToStreamObserverAdapter<ReadRowsRequest> adapter;
   private StreamObserver<ReadRowsResponse> resultObserver;
   private int totalRowsProcessed = 0;
+  private volatile ReadRowsRequest nextRequest;
 
   public RetryingReadRowsOperation(
       StreamObserver<FlatRow> observer,
@@ -130,6 +131,7 @@ public class RetryingReadRowsOperation extends
     super(retryOptions, request, retryableRpc, callOptions, retryExecutorService, originalMetadata);
     this.rowObserver = observer;
     this.requestManager = new ReadRowsRequestManager(request);
+    this.nextRequest = request;
   }
 
   // This observer will be notified after ReadRowsResponse have been fully processed.
@@ -142,7 +144,7 @@ public class RetryingReadRowsOperation extends
    */
   @Override
   protected ReadRowsRequest getRetryRequest() {
-    return requestManager.buildUpdatedRequest();
+    return nextRequest;
   }
 
   @SuppressWarnings("unchecked")
@@ -303,6 +305,12 @@ public class RetryingReadRowsOperation extends
     } else {
       throw getExhaustedRetriesException(Status.ABORTED);
     }
+  }
+
+  @Override
+  protected void performRetry(long nextBackOff) {
+    nextRequest = requestManager.buildUpdatedRequest();
+    super.performRetry(nextBackOff);
   }
 
   @VisibleForTesting

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestMutateRowsRequestManager.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestMutateRowsRequestManager.java
@@ -150,7 +150,7 @@ public class TestMutateRowsRequestManager {
       for (int j = 1; j < i; j++) {
         statuses[j] = DEADLINE_EXCEEDED;
       }
-      Assert.assertEquals(ProcessingStatus.RETYABLE, send(underTest, createResponse(statuses)));
+      Assert.assertEquals(ProcessingStatus.RETRYABLE, send(underTest, createResponse(statuses)));
     }
     Assert.assertEquals(createResponse(OK, OK, OK, OK, OK, OK, OK, OK, OK, DEADLINE_EXCEEDED),
       underTest.buildResponse());
@@ -167,7 +167,7 @@ public class TestMutateRowsRequestManager {
   @Test
   public void testInvalid() {
     MutateRowsRequestManager underTest = createRequestManager(createRequest(3));
-    Assert.assertEquals(ProcessingStatus.INLALID, send(underTest, createResponse(OK, OK)));
+    Assert.assertEquals(ProcessingStatus.INVALID, send(underTest, createResponse(OK, OK)));
   }
 
   private MutateRowsRequestManager createRequestManager(MutateRowsRequest request) {

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestMutateRowsRequestManager.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestMutateRowsRequestManager.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.grpc.async;
+
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.MockitoAnnotations;
+
+import com.google.api.client.util.NanoClock;
+import com.google.bigtable.v2.MutateRowsRequest;
+import com.google.bigtable.v2.MutateRowsRequest.Entry;
+import com.google.bigtable.v2.MutateRowsResponse;
+import com.google.bigtable.v2.Mutation;
+import com.google.bigtable.v2.Mutation.SetCell;
+import com.google.cloud.bigtable.config.RetryOptions;
+import com.google.cloud.bigtable.config.RetryOptionsUtil;
+import com.google.rpc.Status;
+
+import io.grpc.Deadline;
+import io.grpc.Status.Code;
+
+/**
+ * Tests for {@link MutateRowsRequestManager}
+ *
+ */
+@RunWith(JUnit4.class)
+public class TestMutateRowsRequestManager {
+
+  private static Status OK = statusOf(io.grpc.Status.Code.OK);
+  private static Status DEADLINE_EXCEEDED = statusOf(io.grpc.Status.Code.DEADLINE_EXCEEDED);
+  private static Status NOT_FOUND = statusOf(io.grpc.Status.Code.NOT_FOUND);
+
+  private static MutateRowsRequest createRequest(int entryCount) {
+    MutateRowsRequest.Builder builder = MutateRowsRequest.newBuilder();
+    for (int i = 0; i < entryCount; i++) {
+      Mutation mutation = Mutation.newBuilder()
+          .setSetCell(SetCell.newBuilder().setFamilyName("Family" + i).build()).build();
+      builder.addEntries(Entry.newBuilder().addMutations(mutation));
+    }
+    return builder.build();
+  }
+
+  private static MutateRowsResponse createResponse(Status... statuses) {
+    MutateRowsResponse.Builder builder = MutateRowsResponse.newBuilder();
+    for (int i = 0; i < statuses.length; i++) {
+      builder.addEntries(toEntry(i, statuses[i]));
+    }
+    return builder.build();
+  }
+
+  private static com.google.bigtable.v2.MutateRowsResponse.Entry toEntry(int i, Status status) {
+    return MutateRowsResponse.Entry.newBuilder().setIndex(i).setStatus(status).build();
+  }
+
+  private static Status statusOf(Code code) {
+    return Status.newBuilder().setCode(code.value()).build();
+  }
+
+  private static boolean send(MutateRowsRequestManager underTest, MutateRowsResponse response) {
+    underTest.onMessage(response);
+    return underTest.onOK();
+  }
+
+  private AtomicLong time = new AtomicLong();
+  private NanoClock nanoClock = new NanoClock() {
+    @Override
+    public long nanoTime() {
+      return time.get();
+    }
+  };
+
+  private RetryOptions retryOptions;
+
+  @Before
+  public void setup() {
+    MockitoAnnotations.initMocks(this);
+    retryOptions = RetryOptionsUtil.createTestRetryOptions(nanoClock);
+  }
+
+  @Test
+  public void testEmptySuccess() throws Exception {
+    MutateRowsRequestManager underTest = createRequestManager(createRequest(0));
+    send(underTest, createResponse());
+    Assert.assertEquals(createResponse(), underTest.buildResponse());
+  }
+
+  @Test
+  public void testSingleSuccess() throws Exception {
+    MutateRowsRequestManager underTest = createRequestManager(createRequest(1));
+    send(underTest, createResponse(OK));
+    Assert.assertEquals(createResponse(OK),underTest.buildResponse());
+  }
+
+  @Test
+  public void testMultiSuccess() throws Exception {
+    MutateRowsRequestManager underTest = createRequestManager(createRequest(10));
+    send(underTest, createResponse(OK, OK, OK, OK, OK, DEADLINE_EXCEEDED, DEADLINE_EXCEEDED,
+      DEADLINE_EXCEEDED, DEADLINE_EXCEEDED));
+    send(underTest, createResponse(OK, OK, OK, OK, OK));
+    Assert.assertEquals(createResponse(OK, OK, OK, OK, OK, OK, OK, OK, OK, OK),
+      underTest.buildResponse());
+  }
+
+  @Test
+  public void testMultiAttempt() throws Exception {
+    MutateRowsRequestManager underTest = createRequestManager(createRequest(10));
+    for (int i = 10; i > 1; i--) {
+      Status statuses[] = new Status[i];
+      statuses[0] = OK;
+      for (int j = 1; j < i; j++) {
+        statuses[j] = DEADLINE_EXCEEDED;
+      }
+      Assert.assertFalse(send(underTest, createResponse(statuses)));
+      Assert.assertTrue(underTest.isRetryable());
+      Assert.assertFalse(underTest.isMessageInvalid());
+    }
+    Assert.assertEquals(createResponse(OK, OK, OK, OK, OK, OK, OK, OK, OK, DEADLINE_EXCEEDED),
+      underTest.buildResponse());
+  }
+
+  @Test
+  public void testNotRetryable() throws Exception {
+    MutateRowsRequestManager underTest = createRequestManager(createRequest(3));
+    Assert.assertFalse(send(underTest, createResponse(OK, OK, NOT_FOUND)));
+    Assert.assertFalse(underTest.isRetryable());
+    Assert.assertFalse(underTest.isMessageInvalid());
+    Assert.assertEquals(createResponse(OK, OK, NOT_FOUND), underTest.buildResponse());
+  }
+
+  @Test
+  public void testInvalid() throws Exception {
+    MutateRowsRequestManager underTest = createRequestManager(createRequest(3));
+    Assert.assertFalse(send(underTest, createResponse(OK, OK)));
+    Assert.assertFalse(underTest.isRetryable());
+    Assert.assertTrue(underTest.isMessageInvalid());
+  }
+
+  private MutateRowsRequestManager createRequestManager(MutateRowsRequest request) {
+    return new MutateRowsRequestManager(retryOptions, request);
+  }
+}

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/scanner/RetryingReadRowsOperationTest.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/scanner/RetryingReadRowsOperationTest.java
@@ -381,8 +381,9 @@ public class RetryingReadRowsOperationTest {
     verify(mockRpcTimerContext, times(expectedRetryCount + 1)).close();
   }
 
-  private static void checkRetryRequest(RetryingReadRowsOperation underTest, ByteString key, int rowCount) {
-    ReadRowsRequest request = underTest.getRetryRequest();
+  private static void checkRetryRequest(RetryingReadRowsOperation underTest, ByteString key,
+      int rowCount) {
+    ReadRowsRequest request = underTest.buildUpdatedRequst();
     Assert.assertEquals(key, request.getRows().getRowRanges(0).getStartKeyOpen());
     Assert.assertEquals(rowCount, request.getRowsLimit());
   }


### PR DESCRIPTION
This new class encapsulates the logic of handling the MutateRowsRequest/Response interaction across retries.  This change is very similar to the structure of ReadRowsRequestManager / RetryingReadRowsOperation.