### PR TITLE
Javadoc fix for HBase 2.x BigtableConnection

### DIFF
--- a/bigtable-hbase-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableConnection.java
+++ b/bigtable-hbase-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableConnection.java
@@ -53,9 +53,10 @@ public class BigtableConnection extends AbstractBigtableConnection {
   }
 
   /**
-   * Due to hbase 1.x to 2.x binary incompatibilities. {@link HRegionLocation(HRegionInfo
-   * hRegionInfo)} will fail with NoSuchMethodException if not recompiled with hbase 2.0
-   * dependencies. Hence the override. See {@link SampledRowKeysAdapter} for more details.
+   * Due to hbase 1.x to 2.x binary incompatibilities.
+   * {@link HRegionLocation#HRegionLocation(org.apache.hadoop.hbase.client.RegionInfo, ServerName)}
+   * will fail with NoSuchMethodException if not recompiled with hbase 2.0 dependencies. Hence the
+   * override. See {@link SampledRowKeysAdapter} for more details.
    */
   @Override
   protected SampledRowKeysAdapter createSampledRowKeysAdapter(TableName tableName,


### PR DESCRIPTION
Running `mvn -Ddoclint javadoc:javadoc` was broken.