### PR TITLE
Adding .build() for protobuf adapters.

### DIFF
--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/AppendAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/AppendAdapter.java
@@ -47,7 +47,7 @@ public class AppendAdapter implements OperationAdapter<Append, ReadModifyWriteRo
       List<Cell> cells = CellDeduplicationHelper.deduplicateFamily(operation, entry.getKey());
 
       for (Cell cell : cells) {
-        ReadModifyWriteRule.Builder rule = result.addRulesBuilder();
+        ReadModifyWriteRule.Builder rule = ReadModifyWriteRule.newBuilder();
         rule.setFamilyName(familyName);
         rule.setColumnQualifier(
             ByteString.copyFrom(
@@ -59,6 +59,7 @@ public class AppendAdapter implements OperationAdapter<Append, ReadModifyWriteRo
                 cell.getValueArray(),
                 cell.getValueOffset(),
                 cell.getValueLength()));
+        result.addRules(rule.build());
       }
     }
     return result;

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/DeleteAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/DeleteAdapter.java
@@ -62,7 +62,7 @@ public class DeleteAdapter extends MutationAdapter<Delete> {
         String.format("Cell type %s is unsupported.", cell.getTypeByte()));
   }
 
-  static void throwOnUnsupportedDeleteFamilyVersion(@SuppressWarnings("unused") Cell cell) {
+  static void throwOnUnsupportedDeleteFamilyVersion(Cell cell) {
     throw new UnsupportedOperationException(
         "Cannot perform column family deletion at timestamp.");
   }
@@ -113,9 +113,10 @@ public class DeleteAdapter extends MutationAdapter<Delete> {
         cell.getTimestamp(),
         BigtableConstants.HBASE_TIMEUNIT);
 
-      deleteBuilder.getTimeRangeBuilder()
+      deleteBuilder.setTimeRange(TimestampRange.newBuilder()
           .setStartTimestampMicros(startTimestamp)
-          .setEndTimestampMicros(endTimestamp);
+          .setEndTimestampMicros(endTimestamp)
+          .build());
     } else {
       // Delete all cells before a timestamp
       if (cell.getTimestamp() != HConstants.LATEST_TIMESTAMP) {
@@ -152,7 +153,8 @@ public class DeleteAdapter extends MutationAdapter<Delete> {
 
             mutations.add(Mutation.newBuilder()
               .setDeleteFromFamily(DeleteFromFamily.newBuilder()
-                  .setFamilyNameBytes(familyByteString).build())
+                  .setFamilyNameBytes(familyByteString)
+                  .build())
               .build());
           } else if (isFamilyVersionDelete(cell)) {
             throwOnUnsupportedDeleteFamilyVersion(cell);

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/IncrementAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/IncrementAdapter.java
@@ -59,7 +59,7 @@ public class IncrementAdapter
           CellDeduplicationHelper.deduplicateFamily(operation, familyEntry.getKey());
 
       for (Cell cell : mutationCells){
-        ReadModifyWriteRule.Builder rule = result.addRulesBuilder();
+        ReadModifyWriteRule.Builder rule = ReadModifyWriteRule.newBuilder();
         rule.setIncrementAmount(
             Bytes.toLong(cell.getValueArray(), cell.getValueOffset(), cell.getValueLength()));
         rule.setFamilyName(familyName);
@@ -68,6 +68,7 @@ public class IncrementAdapter
                 cell.getQualifierArray(),
                 cell.getQualifierOffset(),
                 cell.getQualifierLength()));
+        result.addRules(rule.build());
       }
     }
     return result;

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/PutAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/PutAdapter.java
@@ -118,7 +118,8 @@ public class PutAdapter extends MutationAdapter<Put> {
                 .setFamilyNameBytes(familyString)
                 .setColumnQualifier(cellQualifierByteString)
                 .setValue(value)
-                .setTimestampMicros(timestampMicros))
+                .setTimestampMicros(timestampMicros)
+                .build())
             .build());
       }
     }

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/GetAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/GetAdapter.java
@@ -17,7 +17,6 @@ package com.google.cloud.bigtable.hbase.adapters.read;
 
 import com.google.bigtable.v2.ReadRowsRequest;
 import com.google.bigtable.v2.RowSet;
-import com.google.bigtable.v2.ReadRowsRequest.Builder;
 import com.google.protobuf.ByteString;
 
 import org.apache.hadoop.hbase.client.Get;
@@ -44,7 +43,7 @@ public class GetAdapter implements ReadOperationAdapter<Get> {
 
   /** {@inheritDoc} */
   @Override
-  public Builder adapt(Get operation, ReadHooks readHooks) {
+  public ReadRowsRequest.Builder adapt(Get operation, ReadHooks readHooks) {
     Scan operationAsScan = new Scan(operation);
     scanAdapter.throwIfUnsupportedScan(operationAsScan);
     return ReadRowsRequest.newBuilder()


### PR DESCRIPTION
I had to refactor `ColumnDescriptorAdapter` a bit so that I could add `.build()`s in a not-too-ugly way.