### PR TITLE
Fixing a subtle issue in RefreshingOAuth2CredentialsInterceptor

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptor.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptor.java
@@ -326,13 +326,8 @@ public class RefreshingOAuth2CredentialsInterceptor implements ClientInterceptor
         this.futureToken = executor.submit(new Callable<HeaderCacheElement>() {
           @Override
           public HeaderCacheElement call() throws Exception {
-            try {
-              HeaderCacheElement newToken = refreshCredentials();
-              return updateToken(newToken);
-            } finally {
-              futureToken = null;
-              isRefreshing = false;
-            }
+            HeaderCacheElement newToken = refreshCredentials();
+            return updateToken(newToken);
           }
         });
       } catch (RuntimeException e) {
@@ -358,6 +353,8 @@ public class RefreshingOAuth2CredentialsInterceptor implements ClientInterceptor
         LOG.warn("Failed to refresh the access token. Falling back to existing token. "
             + "New token state: {}, status: {}", newState, newToken.status);
       }
+      futureToken = null;
+      isRefreshing = false;
 
       return headerCache;
     }


### PR DESCRIPTION
The current rate limiter approach masks any legitimate unauthenticated status codes and instead replaces the legit message with the rate limiting error message. Changing the logic to rate limit the revocations rather than the token lookups, which should be a more efficient approach.