### PR TITLE
Increase junit timeout for IntegrationTests

### DIFF
--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/IntegrationTests.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/IntegrationTests.java
@@ -52,7 +52,7 @@ import org.junit.runners.Suite;
 public class IntegrationTests {
 
   @ClassRule
-  public static Timeout timeoutRule = new Timeout(10, TimeUnit.MINUTES);
+  public static Timeout timeoutRule = new Timeout(30, TimeUnit.MINUTES);
 
   @ClassRule
   public static SharedTestEnvRule sharedTestEnvRule = new SharedTestEnvRule();

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/IntegrationTests.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/IntegrationTests.java
@@ -50,7 +50,7 @@ import org.junit.runners.Suite;
 public class IntegrationTests {
 
   @ClassRule
-  public static Timeout timeoutRule = new Timeout(10, TimeUnit.MINUTES);
+  public static Timeout timeoutRule = new Timeout(30, TimeUnit.MINUTES);
 
   @ClassRule
   public static SharedTestEnvRule sharedTestEnvRule = new SharedTestEnvRule();


### PR DESCRIPTION
Increase junit timeout for IntegrationTests from 10 minutes to 30.