### PR TITLE
Integration test time-out is now configuration driven.

### DIFF
--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/IntegrationTests.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/IntegrationTests.java
@@ -51,8 +51,11 @@ import org.junit.runners.Suite;
 })
 public class IntegrationTests {
 
+  public static final int TIME_OUT_MINUTES =
+      Integer.getInteger("integration.test.timeout.minutes", 10);
+
   @ClassRule
-  public static Timeout timeoutRule = new Timeout(30, TimeUnit.MINUTES);
+  public static Timeout timeoutRule = new Timeout(TIME_OUT_MINUTES, TimeUnit.MINUTES);
 
   @ClassRule
   public static SharedTestEnvRule sharedTestEnvRule = new SharedTestEnvRule();

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/IntegrationTests.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/IntegrationTests.java
@@ -52,7 +52,7 @@ import org.junit.runners.Suite;
 public class IntegrationTests {
 
   public static final int TIME_OUT_MINUTES =
-      Integer.getInteger("integration.test.timeout.minutes", 10);
+      Integer.getInteger("integration.test.timeout.minutes", 3);
 
   @ClassRule
   public static Timeout timeoutRule = new Timeout(TIME_OUT_MINUTES, TimeUnit.MINUTES);

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/IntegrationTests.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/IntegrationTests.java
@@ -51,7 +51,7 @@ import org.junit.runners.Suite;
 })
 public class IntegrationTests {
 
-  public static final int TIME_OUT_MINUTES =
+  private static final int TIME_OUT_MINUTES =
       Integer.getInteger("integration.test.timeout.minutes", 3);
 
   @ClassRule

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/IntegrationTests.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/IntegrationTests.java
@@ -49,8 +49,11 @@ import org.junit.runners.Suite;
 })
 public class IntegrationTests {
 
+  public static final int TIME_OUT_MINUTES =
+      Integer.getInteger("integration.test.timeout.minutes", 10);
+
   @ClassRule
-  public static Timeout timeoutRule = new Timeout(30, TimeUnit.MINUTES);
+  public static Timeout timeoutRule = new Timeout(TIME_OUT_MINUTES, TimeUnit.MINUTES);
 
   @ClassRule
   public static SharedTestEnvRule sharedTestEnvRule = new SharedTestEnvRule();

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/IntegrationTests.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/IntegrationTests.java
@@ -49,7 +49,7 @@ import org.junit.runners.Suite;
 })
 public class IntegrationTests {
 
-  public static final int TIME_OUT_MINUTES =
+  private static final int TIME_OUT_MINUTES =
       Integer.getInteger("integration.test.timeout.minutes", 3);
 
   @ClassRule

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/IntegrationTests.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/IntegrationTests.java
@@ -50,7 +50,7 @@ import org.junit.runners.Suite;
 public class IntegrationTests {
 
   public static final int TIME_OUT_MINUTES =
-      Integer.getInteger("integration.test.timeout.minutes", 10);
+      Integer.getInteger("integration.test.timeout.minutes", 3);
 
   @ClassRule
   public static Timeout timeoutRule = new Timeout(TIME_OUT_MINUTES, TimeUnit.MINUTES);


### PR DESCRIPTION
The default timeout for integration tests is now 3 minutes.  Use `-Dintegration.test.timeout.minutes=XX` for any other configuration.