### PR TITLE
Allow users to set snapshot cluster for integration tests

### DIFF
--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/test_env/BigtableEnv.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/test_env/BigtableEnv.java
@@ -50,7 +50,8 @@ class BigtableEnv extends SharedTestEnv {
       BigtableOptionsFactory.PROJECT_ID_KEY,
       BigtableOptionsFactory.INSTANCE_ID_KEY,
       BigtableOptionsFactory.BIGTABLE_USE_BULK_API,
-      BigtableOptionsFactory.BIGTABLE_USE_PLAINTEXT_NEGOTIATION
+      BigtableOptionsFactory.BIGTABLE_USE_PLAINTEXT_NEGOTIATION,
+      BigtableOptionsFactory.BIGTABLE_SNAPSHOT_CLUSTER_ID_KEY
   );
   private Configuration configuration;
 

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/test_env/BigtableEnv.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/test_env/BigtableEnv.java
@@ -44,7 +44,8 @@ class BigtableEnv extends SharedTestEnv {
       BigtableOptionsFactory.PROJECT_ID_KEY,
       BigtableOptionsFactory.INSTANCE_ID_KEY,
       BigtableOptionsFactory.BIGTABLE_USE_BULK_API,
-      BigtableOptionsFactory.BIGTABLE_USE_PLAINTEXT_NEGOTIATION
+      BigtableOptionsFactory.BIGTABLE_USE_PLAINTEXT_NEGOTIATION,
+      BigtableOptionsFactory.BIGTABLE_SNAPSHOT_CLUSTER_ID_KEY
   );
   private Configuration configuration;
 


### PR DESCRIPTION
Users should be able to explicitly set `-Dgoogle.bigtable.snapshot.cluster.id=XXXXX` for the snapshot test.