### PR TITLE
AbstractTests should re-use the IntegrationTest env

### DIFF
--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/AbstractTest.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/AbstractTest.java
@@ -17,9 +17,12 @@ package com.google.cloud.bigtable.hbase;
 
 import com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule;
 import java.io.IOException;
+
+import org.apache.hadoop.hbase.client.Admin;
 import org.apache.hadoop.hbase.client.AsyncConnection;
 import org.apache.hadoop.hbase.client.Connection;
 import org.apache.hadoop.hbase.util.Bytes;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.rules.TestRule;
 import org.junit.rules.TestWatcher;
@@ -46,6 +49,16 @@ public abstract class AbstractTest {
         System.currentTimeMillis() - start);
     };
   };
+
+  @BeforeClass
+  public static void truncate() {
+    try(Admin admin = sharedTestEnv.getConnection().getAdmin()) {
+      admin.truncateTable(sharedTestEnv.getDefaultTableName(), true);
+    } catch (IOException e) {
+      new Logger(AbstractTest.class).warn("Cloud not truncate Table");
+    };
+  }
+
 
   // This is for when we need to look at the results outside of the current connection
   public Connection createNewConnection() throws IOException {

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/AbstractTest.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/AbstractTest.java
@@ -20,25 +20,31 @@ import java.io.IOException;
 import org.apache.hadoop.hbase.client.AsyncConnection;
 import org.apache.hadoop.hbase.client.Connection;
 import org.apache.hadoop.hbase.util.Bytes;
-import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.rules.TestRule;
+import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
-import org.junit.runners.model.Statement;
 
 public abstract class AbstractTest {
 
-  @ClassRule
-  public static SharedTestEnvRule sharedTestEnv = new SharedTestEnvRule();
-  protected DataGenerationHelper dataHelper = new DataGenerationHelper();
+  public static SharedTestEnvRule sharedTestEnv = IntegrationTests.sharedTestEnvRule;
+
+  protected static DataGenerationHelper dataHelper = new DataGenerationHelper();
   protected Logger logger = new Logger(this.getClass());
   @Rule
-  public TestRule loggingRule = new TestRule() {
+  public TestRule loggingRule = new TestWatcher() {
+    private long start;
+
     @Override
-    public Statement apply(Statement base, Description description) {
-      logger.info("Running: %s", description.getDisplayName());
-      return base;
+    public void starting(Description description) {
+      this.start = System.currentTimeMillis();
+      logger.info("Starting: %s", description.getDisplayName());
     }
+
+    protected void finished(Description description) {
+      logger.info("Finished: %s in %d ms.", description.getDisplayName(),
+        System.currentTimeMillis() - start);
+    };
   };
 
   // This is for when we need to look at the results outside of the current connection

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/test_env/SharedTestEnvRule.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/test_env/SharedTestEnvRule.java
@@ -64,7 +64,7 @@ public class SharedTestEnvRule extends ExternalResource {
   @Override
   protected void after() {
     try (Admin admin = connection.getAdmin()) {
-
+      LOG.info("Deleting table " + defaultTableName.getNameAsString());
       admin.disableTable(defaultTableName);
       admin.deleteTable(defaultTableName);
     } catch (Exception e) {
@@ -79,7 +79,7 @@ public class SharedTestEnvRule extends ExternalResource {
     connection = null;
 
     try {
-      asyncConnection.close();;
+      asyncConnection.close();
     } catch (Exception e) {
       LOG.error("Failed to close asyncConnection after test", e);
     }
@@ -139,6 +139,7 @@ public class SharedTestEnvRule extends ExternalResource {
 //          .addColumnFamily(hcd).addColumnFamily(hcdfamily2).build();
 //
 //      admin.createTable(tableDescriptor);
+      LOG.info("Creating table " + defaultTableName.getNameAsString());
       HColumnDescriptor hcd = new HColumnDescriptor(COLUMN_FAMILY).setMaxVersions(MAX_VERSIONS);
       HColumnDescriptor family2 = new HColumnDescriptor(COLUMN_FAMILY2).setMaxVersions(MAX_VERSIONS);
       admin.createTable(

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/AbstractTest.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/AbstractTest.java
@@ -15,14 +15,17 @@
  */
 package com.google.cloud.bigtable.hbase;
 
-import com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule;
 import java.io.IOException;
 
+import org.apache.hadoop.hbase.client.Admin;
 import org.apache.hadoop.hbase.client.Connection;
 import org.apache.hadoop.hbase.util.Bytes;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
+
+import com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule;
 
 public abstract class AbstractTest {
 
@@ -45,6 +48,15 @@ public abstract class AbstractTest {
         System.currentTimeMillis() - start);
     };
   };
+
+  @BeforeClass
+  public static void truncate() {
+    try(Admin admin = sharedTestEnv.getConnection().getAdmin()) {
+      admin.truncateTable(sharedTestEnv.getDefaultTableName(), true);
+    } catch (IOException e) {
+      new Logger(AbstractTest.class).warn("Cloud not truncate Table");
+    };
+  }
 
   // This is for when we need to look at the results outside of the current connection
   public Connection createNewConnection() throws IOException {

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/AbstractTest.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/AbstractTest.java
@@ -17,27 +17,33 @@ package com.google.cloud.bigtable.hbase;
 
 import com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule;
 import java.io.IOException;
+
 import org.apache.hadoop.hbase.client.Connection;
 import org.apache.hadoop.hbase.util.Bytes;
-import org.junit.ClassRule;
 import org.junit.Rule;
-import org.junit.rules.TestRule;
+import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
-import org.junit.runners.model.Statement;
 
 public abstract class AbstractTest {
 
-  @ClassRule
-  public static SharedTestEnvRule sharedTestEnv = new SharedTestEnvRule();
-  protected DataGenerationHelper dataHelper = new DataGenerationHelper();
+  public static SharedTestEnvRule sharedTestEnv = IntegrationTests.sharedTestEnvRule;
+
+  protected static DataGenerationHelper dataHelper = new DataGenerationHelper();
   protected Logger logger = new Logger(this.getClass());
   @Rule
-  public TestRule loggingRule = new TestRule() {
+  public TestWatcher loggingRule = new TestWatcher() {
+    private long start;
+
     @Override
-    public Statement apply(Statement base, Description description) {
-      logger.info("Running: %s", description.getDisplayName());
-      return base;
+    public void starting(Description description) {
+      this.start = System.currentTimeMillis();
+      logger.info("Starting: %s", description.getDisplayName());
     }
+
+    protected void finished(Description description) {
+      logger.info("Test: %s finished in %d ms.", description.getDisplayName(),
+        System.currentTimeMillis() - start);
+    };
   };
 
   // This is for when we need to look at the results outside of the current connection

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/test_env/SharedTestEnvRule.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/test_env/SharedTestEnvRule.java
@@ -60,7 +60,7 @@ public class SharedTestEnvRule extends ExternalResource {
   @Override
   protected void after() {
     try (Admin admin = connection.getAdmin()) {
-
+      LOG.info("Deleting table " + defaultTableName.getNameAsString());
       admin.disableTable(defaultTableName);
       admin.deleteTable(defaultTableName);
     } catch (Exception e) {
@@ -111,6 +111,7 @@ public class SharedTestEnvRule extends ExternalResource {
 
   public void createTable(TableName tableName) throws IOException {
     try (Admin admin = connection.getAdmin();) {
+      LOG.info("Creating table " + defaultTableName.getNameAsString());
       HColumnDescriptor hcd = new HColumnDescriptor(COLUMN_FAMILY).setMaxVersions(MAX_VERSIONS);
       HColumnDescriptor family2 = new HColumnDescriptor(COLUMN_FAMILY2).setMaxVersions(MAX_VERSIONS);
       admin.createTable(


### PR DESCRIPTION
Before this change, every test class would create its own table.  This change creates a single table for all tests.