### PR TITLE
Remove some superfluous calls to create/modify table.

### DIFF
--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/TestColumnFamilyAdmin.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/TestColumnFamilyAdmin.java
@@ -59,12 +59,6 @@ public class TestColumnFamilyAdmin extends AbstractTest {
   }
 
   @Test
-  public void testCreateTable() throws IOException {
-    HTableDescriptor retrievedDescriptor = admin.getTableDescriptor(tableName);
-    Assert.assertEquals(descriptor.getTableName(), retrievedDescriptor.getTableName());
-  }
-
-  @Test
   public void testCreateTableFull() throws IOException {
     HTableDescriptor retrievedDescriptor = admin.getTableDescriptor(tableName);
     Assert.assertEquals(descriptor, retrievedDescriptor);

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/TestCreateTable.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/TestCreateTable.java
@@ -48,6 +48,8 @@ public class TestCreateTable extends AbstractTest {
 
   private static final Logger LOG = new Logger(TestCreateTable.class);
 
+  private static boolean shouldTest = "true".equals(ystem.getProperty("bigtable.test.create.table", "true"));
+
   @Rule
   public ExpectedException thrown = ExpectedException.none();
 
@@ -349,26 +351,12 @@ public class TestCreateTable extends AbstractTest {
     }
   }
 
+
   @Test
   public void testAlreadyExists() throws IOException {
     thrown.expect(TableExistsException.class);
     Admin admin = getConnection().getAdmin();
-    TableName tableName = TableName.valueOf("TestTable" +
-        UUID.randomUUID().toString());
-    HTableDescriptor descriptor = new HTableDescriptor(tableName);
-    descriptor.addFamily(new HColumnDescriptor(COLUMN_FAMILY));
-
-    try {
-      admin.createTable(descriptor);
-      admin.createTable(descriptor);
-    } finally {
-      try {
-        admin.disableTable(tableName);
-        admin.deleteTable(tableName);
-      } catch (Throwable t) {
-        // Log the error and ignore it.
-        LOG.warn("Error cleaning up the table", t);
-      }
-    }
+    TableName tableName = sharedTestEnv.getDefaultTableName();
+    admin.createTable(admin.getTableDescriptor(tableName));
   }
 }

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestColumnFamilyAdmin.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestColumnFamilyAdmin.java
@@ -59,75 +59,41 @@ public class TestColumnFamilyAdmin extends AbstractTest {
   }
 
   @Test
-  public void testCreateTable() throws IOException {
-    HTableDescriptor retrievedDescriptor = admin.getTableDescriptor(tableName);
-    Assert.assertEquals(descriptor.getTableName(), retrievedDescriptor.getTableName());
-  }
-
-  @Test
-  public void testCreateTableFull() throws IOException {
-    HTableDescriptor retrievedDescriptor = admin.getTableDescriptor(tableName);
-    Assert.assertEquals(descriptor, retrievedDescriptor);
+  public void testCreate() throws IOException {
+    Assert.assertEquals(descriptor, admin.getTableDescriptor(tableName));
   }
 
   @Test
   public void testAddColumn() throws IOException {
     HColumnDescriptor newColumn = new HColumnDescriptor("NEW_COLUMN");
     admin.addColumn(tableName, newColumn);
-    
-    // Make sure this call doesn't fail, but don't actually check the results yet, since Bigtable
-    // backend doesn't return column families yet.
-    admin.getTableDescriptor(tableName);
-    
-    HTableDescriptor expectedDescriptor = new HTableDescriptor(descriptor);
-    expectedDescriptor.addFamily(newColumn);
 
-    admin.getTableDescriptor(tableName);
+    Assert.assertEquals(new HTableDescriptor(descriptor).addFamily(newColumn),
+      admin.getTableDescriptor(tableName));
   }
 
   @Test
-  public void testAddAndCompareColumn() throws IOException {
-    HColumnDescriptor newColumn = new HColumnDescriptor("NEW_COLUMN");
-    admin.addColumn(tableName, newColumn);
-
-    HTableDescriptor expectedDescriptor = new HTableDescriptor(descriptor);
-    expectedDescriptor.addFamily(newColumn);
-
-    HTableDescriptor retrievedDescriptor = admin.getTableDescriptor(tableName);
-    Assert.assertEquals(expectedDescriptor, retrievedDescriptor);
-  }
-
-  @Test
-  public void testModifyColumnFamily() throws IOException {
+  public void testModifyColumn() throws IOException {
     HColumnDescriptor newColumn = new HColumnDescriptor("MODIFY_COLUMN");
     newColumn.setMaxVersions(2);
     admin.addColumn(tableName, newColumn);
 
-    HTableDescriptor expectedDescriptor = new HTableDescriptor(descriptor);
-    expectedDescriptor.addFamily(newColumn);
-
-    HTableDescriptor retrievedDescriptor = admin.getTableDescriptor(tableName);
-    Assert.assertEquals(expectedDescriptor, retrievedDescriptor);
+    Assert.assertEquals(new HTableDescriptor(descriptor).addFamily(newColumn),
+      admin.getTableDescriptor(tableName));
 
     newColumn.setMaxVersions(100);
     admin.modifyColumn(tableName, newColumn);
 
-    expectedDescriptor = new HTableDescriptor(descriptor);
-    expectedDescriptor.addFamily(newColumn);
-
-    retrievedDescriptor = admin.getTableDescriptor(tableName);
-    Assert.assertEquals(expectedDescriptor, retrievedDescriptor);
-
+    Assert.assertEquals(new HTableDescriptor(descriptor).addFamily(newColumn),
+      admin.getTableDescriptor(tableName));
   }
 
   @Test
   public void testRemoveColumn() throws IOException {
     admin.deleteColumn(tableName, DELETE_COLUMN_FAMILY);
-    HTableDescriptor retrievedDescriptor = admin.getTableDescriptor(tableName);
+    HTableDescriptor expectedDescriptor = new HTableDescriptor(tableName)
+        .addFamily(new HColumnDescriptor(COLUMN_FAMILY));
 
-    HTableDescriptor expectedDescriptor = new HTableDescriptor(tableName);
-    expectedDescriptor.addFamily(new HColumnDescriptor(COLUMN_FAMILY));
-
-    Assert.assertEquals(expectedDescriptor, retrievedDescriptor);
+    Assert.assertEquals(expectedDescriptor, admin.getTableDescriptor(tableName));
   }
 }

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestCreateTable.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestCreateTable.java
@@ -253,8 +253,8 @@ public class TestCreateTable extends AbstractTest {
 
     Admin admin = getConnection().getAdmin();
 
-    TableName tableName = TableName.valueOf("TestTable" +
-        UUID.randomUUID().toString());
+    TableName tableName = sharedTestEnv.newTestTableName();
+
     HTableDescriptor descriptor = new HTableDescriptor(tableName);
     descriptor.addFamily(new HColumnDescriptor(COLUMN_FAMILY));
     byte[] startKey = Bytes.toBytes("AAA");
@@ -300,8 +300,7 @@ public class TestCreateTable extends AbstractTest {
 
     Admin admin = getConnection().getAdmin();
 
-    TableName tableName = TableName.valueOf("TestTable" +
-        UUID.randomUUID().toString());
+    TableName tableName = sharedTestEnv.newTestTableName();
     HTableDescriptor descriptor = new HTableDescriptor(tableName);
     descriptor.addFamily(new HColumnDescriptor(COLUMN_FAMILY));
     byte[] startKey = Bytes.toBytes("AAA");
@@ -352,22 +351,7 @@ public class TestCreateTable extends AbstractTest {
   public void testAlreadyExists() throws IOException {
     thrown.expect(TableExistsException.class);
     Admin admin = getConnection().getAdmin();
-    TableName tableName = TableName.valueOf("TestTable" +
-        UUID.randomUUID().toString());
-    HTableDescriptor descriptor = new HTableDescriptor(tableName);
-    descriptor.addFamily(new HColumnDescriptor(COLUMN_FAMILY));
-
-    try {
-      admin.createTable(descriptor);
-      admin.createTable(descriptor);
-    } finally {
-      try {
-        admin.disableTable(tableName);
-        admin.deleteTable(tableName);
-      } catch (Throwable t) {
-        // Log the error and ignore it.
-        LOG.warn("Error cleaning up the table", t);
-      }
-    }
+    TableName tableName = sharedTestEnv.getDefaultTableName();
+    admin.createTable(admin.getTableDescriptor(tableName));
   }
 }


### PR DESCRIPTION
This should improve the runtime of our integration tests.