### PR TITLE
SingleColumnValueFilterAdapter now uses an interleave.

### DIFF
--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/TestSnapshots.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/TestSnapshots.java
@@ -42,7 +42,7 @@ import org.junit.experimental.categories.Category;
 @SuppressWarnings("deprecation")
 public class TestSnapshots extends AbstractTest {
 
-  final byte[] QUALIFIER = dataHelper.randomData("TestSingleColumnValueFilter");
+  final byte[] QUALIFIER = dataHelper.randomData("TestSnapshots");
 
   private final TableName tableName = sharedTestEnv.newTestTableName();
   // The maximum size of a table id or snapshot id is 50. newTestTableName().size() can approach 50.

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestSnapshots.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestSnapshots.java
@@ -39,7 +39,7 @@ import org.junit.Test;
 
 public class TestSnapshots extends AbstractTest {
 
-  final byte[] QUALIFIER = dataHelper.randomData("TestSingleColumnValueFilter");
+  final byte[] QUALIFIER = dataHelper.randomData("TestSnapshots");
 
   private final TableName tableName = sharedTestEnv.newTestTableName();
   // The maximum size of a table id or snapshot id is 50. newTestTableName().size() can approach 50.

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/SingleColumnValueFilterAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/SingleColumnValueFilterAdapter.java
@@ -4,9 +4,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -26,7 +26,10 @@ import org.apache.hadoop.hbase.util.Bytes;
 import com.google.bigtable.v2.RowFilter;
 import com.google.bigtable.v2.RowFilter.Chain;
 import com.google.bigtable.v2.RowFilter.Condition;
+import com.google.bigtable.v2.RowFilter.Interleave;
 import com.google.cloud.bigtable.util.ByteStringer;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.protobuf.ByteString;
 
 /**
  * Adapt SingleColumnValueFilter instances into bigtable RowFilters.
@@ -37,11 +40,14 @@ import com.google.cloud.bigtable.util.ByteStringer;
 public class SingleColumnValueFilterAdapter
     extends TypedFilterAdapterBase<SingleColumnValueFilter> {
 
-  private static final RowFilter ALL_VALUES_FILTER =
-      RowFilter.newBuilder()
-          .setCellsPerColumnLimitFilter(Integer.MAX_VALUE)
-          .build();
+  @VisibleForTesting
+  static final RowFilter ALL_VALUES_FILTER =
+      RowFilter.newBuilder().setPassAllFilter(true).build();
+  @VisibleForTesting
+  static final RowFilter LATEST_ONLY_FILTER =
+      RowFilter.newBuilder().setCellsPerColumnLimitFilter(1).build();
   private final ValueFilterAdapter delegateAdapter;
+
   /**
    * <p>Constructor for SingleColumnValueFilterAdapter.</p>
    *
@@ -51,54 +57,155 @@ public class SingleColumnValueFilterAdapter
     this.delegateAdapter = delegateAdapter;
   }
 
-  /** {@inheritDoc} */
+  /**
+   * {@link SingleColumnValueFilter} is a filter that will return a row if a family/qualifier
+   * value matches some condition. Optionally,  if
+   * {@link SingleColumnValueFilter#getFilterIfMissing()} is set to false, then also return
+   * the row if the family/column is not present on the row.  There's a
+   *
+   * <p> Here's a rough translation of {@link SingleColumnValueFilter#getFilterIfMissing()} == true.
+   *
+   * <pre>
+   * IF a single family/column exists AND
+   *    the value of the family/column meets some condition THEN
+   *       return the ROW
+   * END
+   * </pre>
+   *
+   * Here's a rough translation of {@link SingleColumnValueFilter#getFilterIfMissing()} == false.
+   *
+   * <pre>
+   * IF a single family/column exists THEN
+   *   IF the value of the family/column meets some condition THEN
+   *     return the ROW
+   *   END
+   * ELSE IF filter.filter_if_missing == false THEN
+   *   return the ROW
+   * END
+   * </pre>
+   * 
+   * The Cloud Bigtable filter translation for the
+   * {@link SingleColumnValueFilter#getFilterIfMissing()} true case here's the resulting filter is
+   * as follows:
+   *
+   * <pre>
+   *   condition: {
+   *      predicate: {
+   *        chain: {
+   *           family: [filter.family]
+   *           qualifier: [filter.qualifier],
+   *           value: // something interesting
+   *           // if filter.latestOnly, then add
+   *           // cells_per_column: 1
+   *        }
+   *      }
+   *      true_filter: {
+   *         pass_all: true
+   *      }
+   *   }
+   * </pre>
+   *
+   * In addition to the default filter, there's a bit more if
+   * {@link SingleColumnValueFilter#getFilterIfMissing()} is false.  Here's what the filter would
+   * look like:
+   *
+   * <pre>
+   *   interleave: [ // either
+   *     {
+   *       // If the family/qualifer exists and matches a value
+   *       // Then return the row
+   *       // Else return nothing
+   *       condition: {
+   *         predicate: {
+   *           chain: {
+   *             family: [filter.family]
+   *             qualifier: [filter.qualifier],
+   *             // if filter.latestOnly, then add
+   *             // cells_per_column: 1
+   *             value: // something interesting
+   *           }
+   *         },
+   *         true_filter: { pass_all: true }
+   *       }
+   *     }, {
+   *       // If the family/qualifer exists
+   *       // Then return nothing
+   *       // Else return row
+   *       condition: {
+   *         predicate: {
+   *           chain: {
+   *             family: [filter.family]
+   *             qualifier: [filter.qualifier],
+   *           }
+   *         },
+   *         false_filter: { pass_all: true }
+   *       }
+   *     }
+   *   ]
+   * </pre>
+   *
+   * NOTE: This logic can also be expressed as nested predicates, but that approach creates really poor
+   * performance on the server side.
+   * <p>
+   */
   @Override
   public RowFilter adapt(FilterAdapterContext context, SingleColumnValueFilter filter)
       throws IOException {
+
+    // filter to check if the column exists
+    RowFilter columnSpecFilter = getColumnSpecFilter(
+      filter.getFamily(),
+      filter.getQualifier(),
+      filter.getLatestVersionOnly());
+
+    // filter to return the row if the condition is met
+    RowFilter emitRowsWithValueFilter = RowFilter.newBuilder()
+      .setCondition(
+          Condition.newBuilder()
+              .setPredicateFilter(
+                  RowFilter.newBuilder()
+                      .setChain(
+                          columnSpecFilter.getChain().toBuilder()
+                              .addFilters(createValueMatchFilter(context, filter))
+                              .build()))
+              .setTrueFilter(ALL_VALUES_FILTER))
+      .build();
+
     if (filter.getFilterIfMissing()) {
-      return createEmitRowsWithValueFilter(context, filter);
+      return emitRowsWithValueFilter;
     } else {
-      return RowFilter.newBuilder()
-          .setCondition(
-              Condition.newBuilder()
-                  .setPredicateFilter(createColumnSpecFilter(filter))
-                  .setTrueFilter(createEmitRowsWithValueFilter(context, filter))
-                  .setFalseFilter(ALL_VALUES_FILTER))
-          .build();
+      return RowFilter.newBuilder().setInterleave(
+        Interleave.newBuilder()
+          .addFilters(emitRowsWithValueFilter)
+          .addFilters(RowFilter.newBuilder()
+            .setCondition(
+                Condition.newBuilder()
+                    .setPredicateFilter(columnSpecFilter)
+                    .setFalseFilter(ALL_VALUES_FILTER))
+            .build())
+          .build()
+      ).build();
     }
   }
 
-  /**
-   * Create a filter that will match a given family, qualifier, and cells per qualifier.
-   */
-  private RowFilter createColumnSpecFilter(SingleColumnValueFilter filter) throws IOException {
-    return RowFilter.newBuilder()
-        .setChain(Chain.newBuilder()
-            .addFilters(RowFilter.newBuilder()
-                .setFamilyNameRegexFilter(
-                    Bytes.toString(quoteRegularExpression(filter.getFamily()))))
-            .addFilters(RowFilter.newBuilder()
-                .setColumnQualifierRegexFilter(
-                    ByteStringer.wrap(quoteRegularExpression(filter.getQualifier()))))
-            .addFilters(createVersionLimitFilter(filter)))
-        .build();
-  }
+  @VisibleForTesting
+  static RowFilter getColumnSpecFilter(byte[] family, byte[] qualifier, boolean latestVersionOnly)
+      throws IOException {
+    ByteString wrappedQual = ByteStringer.wrap(quoteRegularExpression(qualifier));
+    String wrappedFamily = Bytes.toString(quoteRegularExpression(family));
+    Chain.Builder chainBuilder = Chain.newBuilder()
+        .addFilters(RowFilter.newBuilder()
+            .setFamilyNameRegexFilter(wrappedFamily)
+            .build())
+        .addFilters(RowFilter.newBuilder()
+            .setColumnQualifierRegexFilter(wrappedQual)
+            .build());
 
-  /**
-   * Emit a filter that will limit the number of cell versions that will be emitted.
-   */
-  private RowFilter createVersionLimitFilter(SingleColumnValueFilter filter) {
-    return RowFilter.newBuilder()
-        .setCellsPerColumnLimitFilter(
-            filter.getLatestVersionOnly() ? 1 : Integer.MAX_VALUE)
-        .build();
-  }
+    if (latestVersionOnly) {
+      chainBuilder.addFilters(LATEST_ONLY_FILTER);
+    }
 
-  /**
-   * Construct a ValueFilter for a SingleColumnValueFilter.
-   */
-  private ValueFilter createValueFilter(SingleColumnValueFilter filter) {
-    return new ValueFilter(filter.getOperator(), filter.getComparator());
+    return RowFilter.newBuilder().setChain(chainBuilder.build()).build();
   }
 
   /**
@@ -106,28 +213,8 @@ public class SingleColumnValueFilterAdapter
    */
   private RowFilter createValueMatchFilter(
       FilterAdapterContext context, SingleColumnValueFilter filter) throws IOException {
-    ValueFilter valueFilter = createValueFilter(filter);
+    ValueFilter valueFilter = new ValueFilter(filter.getOperator(), filter.getComparator());
     return delegateAdapter.adapt(context, valueFilter);
-  }
-
-  /**
-   * Create a filter that will emit all cells in a row if a given qualifier
-   * has a given value.
-   */
-  private RowFilter createEmitRowsWithValueFilter(
-      FilterAdapterContext context, SingleColumnValueFilter filter)
-      throws IOException {
-    return RowFilter.newBuilder()
-        .setCondition(
-            Condition.newBuilder()
-                .setPredicateFilter(
-                    RowFilter.newBuilder()
-                        .setChain(
-                            Chain.newBuilder()
-                                .addFilters(createColumnSpecFilter(filter))
-                                .addFilters(createValueMatchFilter(context, filter))))
-                .setTrueFilter(ALL_VALUES_FILTER))
-        .build();
   }
 
   /** {@inheritDoc} */
@@ -135,6 +222,6 @@ public class SingleColumnValueFilterAdapter
   public FilterSupportStatus isFilterSupported(
       FilterAdapterContext context, SingleColumnValueFilter filter) {
       return delegateAdapter.isFilterSupported(
-          context, createValueFilter(filter));
+          context, new ValueFilter(filter.getOperator(), filter.getComparator()));
   }
 }

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/SingleColumnValueFilterAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/SingleColumnValueFilterAdapter.java
@@ -94,9 +94,9 @@ public class SingleColumnValueFilterAdapter
    *        chain: {
    *           family: [filter.family]
    *           qualifier: [filter.qualifier],
-   *           value: // something interesting
    *           // if filter.latestOnly, then add
    *           // cells_per_column: 1
+   *           value: // something interesting
    *        }
    *      }
    *      true_filter: {
@@ -181,7 +181,8 @@ public class SingleColumnValueFilterAdapter
             .setCondition(
                 Condition.newBuilder()
                     .setPredicateFilter(columnSpecFilter)
-                    .setFalseFilter(ALL_VALUES_FILTER))
+                    .setFalseFilter(ALL_VALUES_FILTER)
+                    .build())
             .build())
           .build()
       ).build();

--- a/bigtable-hbase-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/RowMergerPerf.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/RowMergerPerf.java
@@ -29,11 +29,15 @@ public class RowMergerPerf {
 
   public static void main(String[] args) {
 //     warm up
-    for (int i = 0; i < 3; i++) {
+    for (int i = 0; i < 2; i++) {
       System.out.println("===================");
       System.out.println("testing 1 Cell");
       rowMergerPerf(1);
     }
+
+      System.out.println("===================");
+      System.out.println("testing " + 10 + " Cells");
+      rowMergerPerf(10);
 
     for (int i = 5; i <= 105; i += 10) {
       System.out.println("===================");


### PR DESCRIPTION
`SingleColumnValueFilterAdapter` is a relatively complex HBase filter.  There were circumstances where it creates nested `Condition`s, which is problematic on the server-side.  A user used multiple `SingleColumnValueFilterAdapter`s which in turn caused severe problems.  @dmmcerlean suggested an alternative that would use `Interleave`d `Condition`s instead of nested `Condition`s.  This PR implements the suggestion.  In addition to the implementation itself, this PR attempts to document the intent of `SingleColumnValueFilterAdapter` as well as how to convert the options therein to a Cloud Bigtable `RowFilter`.

In addition, `TestSingleColumnValueFilter` was updated to test new conditions, and all `Scan`s were constrained to only the range of rows created by the test.

Also, TestSnapshots used keys that contained `TestSingleColumnValueFilter`.  The keys were updated to use a prefix of `TestSnapshots` instead.