### PR TITLE
Removing use of DnsNameResolverProvider from BigtableSession

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
@@ -60,7 +60,6 @@ import io.grpc.ClientInterceptor;
 import io.grpc.ClientInterceptors;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
-import io.grpc.internal.DnsNameResolverProvider;
 import io.grpc.internal.GrpcUtil;
 
 /**
@@ -451,7 +450,6 @@ public class BigtableSession implements Closeable {
     }
 
     return builder
-        .nameResolverFactory(new DnsNameResolverProvider())
         .idleTimeout(Long.MAX_VALUE, TimeUnit.SECONDS)
         .maxInboundMessageSize(MAX_MESSAGE_SIZE)
         .userAgent(BigtableVersionInfo.CORE_UESR_AGENT + "," + options.getUserAgent())


### PR DESCRIPTION
DnsNameResolverProvider is used by default in ManagedChannelBuilder.  We
had some problems relating to shading at one point which broke the
default ManagedChannelBuilder configuration.  Those problems have been
resolved, so this PR removes the explicit use of DnsNameResolverProvider.