### PR TITLE
Upgrading grpc, netty, and com.google.api.grpc.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,12 +54,12 @@ limitations under the License.
         <compat.module>hbase-hadoop2-compat</compat.module>
         <junit.version>4.12</junit.version>
         <mockito.version>1.10.19</mockito.version>
-        <com.google.api.grpc.version>0.1.26</com.google.api.grpc.version>
-        <grpc.version>1.8.0</grpc.version>
-        <opencensus.version>0.9.0</opencensus.version>
-        <netty.version>4.1.16.Final</netty.version>
-        <netty-tcnative-boringssl-static.version>2.0.6.Final</netty-tcnative-boringssl-static.version>
-        <protobuff-java.version>3.4.0</protobuff-java.version>
+        <com.google.api.grpc.version>0.1.28</com.google.api.grpc.version>
+        <grpc.version>1.9.0</grpc.version>
+        <opencensus.version>0.10.1</opencensus.version>
+        <netty.version>4.1.17.Final</netty.version>
+        <netty-tcnative-boringssl-static.version>2.0.7.Final</netty-tcnative-boringssl-static.version>
+        <protobuff-java.version>3.5.1</protobuff-java.version>
         <protoc.version>3.4.0</protoc.version>
         <google.api.client.version>1.23.0</google.api.client.version>
         <google.http.client.version>1.23.0</google.http.client.version>


### PR DESCRIPTION
I tried updating Beam and hbase2, but they had backwards incompatible changes.