### PR TITLE
Removing table truncation in AbstractTest

### DIFF
--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/AbstractTest.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/AbstractTest.java
@@ -18,12 +18,9 @@ package com.google.cloud.bigtable.hbase;
 import com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule;
 import java.io.IOException;
 
-import org.apache.hadoop.hbase.TableName;
-import org.apache.hadoop.hbase.client.Admin;
 import org.apache.hadoop.hbase.client.AsyncConnection;
 import org.apache.hadoop.hbase.client.Connection;
 import org.apache.hadoop.hbase.util.Bytes;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.rules.TestRule;
 import org.junit.rules.TestWatcher;
@@ -48,26 +45,8 @@ public abstract class AbstractTest {
     protected void finished(Description description) {
       logger.info("Finished: %s in %d ms.", description.getDisplayName(),
         System.currentTimeMillis() - start);
-    };
-  };
-
-  @BeforeClass
-  public static void truncate() throws IOException {
-    Admin admin = sharedTestEnv.getConnection().getAdmin();
-    TableName tableName = sharedTestEnv.getDefaultTableName();
-    try {
-      if (admin.isTableEnabled(tableName)) {
-        admin.disableTable(tableName);
-      }
-      admin.truncateTable(tableName, true);
-    } catch (IOException e) {
-      new Logger(AbstractTest.class).warn("Cloud not truncate Table");
-    } finally {
-      if (admin.isTableDisabled(tableName)) {
-        admin.enableTable(tableName);
-      }
     }
-  }
+  };
 
   // This is for when we need to look at the results outside of the current connection
   public Connection createNewConnection() throws IOException {

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/AbstractTest.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/AbstractTest.java
@@ -17,11 +17,8 @@ package com.google.cloud.bigtable.hbase;
 
 import java.io.IOException;
 
-import org.apache.hadoop.hbase.TableName;
-import org.apache.hadoop.hbase.client.Admin;
 import org.apache.hadoop.hbase.client.Connection;
 import org.apache.hadoop.hbase.util.Bytes;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
@@ -47,26 +44,8 @@ public abstract class AbstractTest {
     protected void finished(Description description) {
       logger.info("Test: %s finished in %d ms.", description.getDisplayName(),
         System.currentTimeMillis() - start);
-    };
-  };
-
-  @BeforeClass
-  public static void truncate() throws IOException {
-    Admin admin = sharedTestEnv.getConnection().getAdmin();
-    TableName tableName = sharedTestEnv.getDefaultTableName();
-    try {
-      if (admin.isTableEnabled(tableName)) {
-        admin.disableTable(tableName);
-      }
-      admin.truncateTable(tableName, true);
-    } catch (IOException e) {
-      new Logger(AbstractTest.class).warn("Cloud not truncate Table");
-    } finally {
-      if (admin.isTableDisabled(tableName)) {
-        admin.enableTable(tableName);
-      }
     }
-  }
+  };
 
   // This is for when we need to look at the results outside of the current connection
   public Connection createNewConnection() throws IOException {


### PR DESCRIPTION
The HBase minicluster test fails in a weird way.  Disabling the table times out at the end of the test.  The current tests don't require truncation.  Truncation is a future proofing mechanism which is slowing down tests and causing HBase minicluster to fail.  We can remove the truncation now, and figure out better alternatives in the future... YAGNI.