### PR TITLE
Adding an HBase Filter that wraps a Bigtable RowFilter.

### DIFF
--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/BigtableFilterAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/BigtableFilterAdapter.java
@@ -20,6 +20,9 @@ import java.io.IOException;
 import com.google.bigtable.v2.RowFilter;
 import com.google.cloud.bigtable.hbase.filter.BigtableFilter;
 
+/**
+ * Converts a {@link BigtableFilter} to a {@link RowFilter}.
+ */
 public class BigtableFilterAdapter extends TypedFilterAdapterBase<BigtableFilter> {
 
   @Override

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/BigtableFilterAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/BigtableFilterAdapter.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.adapters.filters;
+
+import java.io.IOException;
+
+import com.google.bigtable.v2.RowFilter;
+import com.google.cloud.bigtable.hbase.filter.BigtableFilter;
+
+public class BigtableFilterAdapter extends TypedFilterAdapterBase<BigtableFilter> {
+
+  @Override
+  public RowFilter adapt(FilterAdapterContext context, BigtableFilter filter) throws IOException {
+    return filter.getRowFilter();
+  }
+
+  @Override
+  public FilterSupportStatus isFilterSupported(FilterAdapterContext context,
+      BigtableFilter filter) {
+    return FilterSupportStatus.SUPPORTED;
+  }
+}

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/FilterAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/FilterAdapter.java
@@ -16,6 +16,7 @@
 package com.google.cloud.bigtable.hbase.adapters.filters;
 
 import com.google.bigtable.v2.RowFilter;
+import com.google.cloud.bigtable.hbase.filter.BigtableFilter;
 import com.google.cloud.bigtable.hbase.filter.TimestampRangeFilter;
 import com.google.cloud.bigtable.util.RowKeyWrapper;
 import com.google.common.base.Optional;
@@ -107,6 +108,7 @@ public class FilterAdapter {
         org.apache.hadoop.hbase.filter.RowFilter.class, new RowFilterAdapter());
     adapter.addFilterAdapter(FuzzyRowFilter.class, new FuzzyRowFilterAdapter());
     adapter.addFilterAdapter(FamilyFilter.class, new FamilyFilterAdapter());
+    adapter.addFilterAdapter(BigtableFilter.class, new BigtableFilterAdapter());
 
     // MultiRowRangeFilter only exists in hbase >= 1.1
     try {

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/filter/BigtableFilter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/filter/BigtableFilter.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.filter;
+
+import java.io.IOException;
+import java.io.Serializable;
+
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.exceptions.DeserializationException;
+import org.apache.hadoop.hbase.filter.Filter;
+import org.apache.hadoop.hbase.filter.FilterBase;
+import org.apache.hadoop.hbase.filter.FilterList;
+
+import com.google.bigtable.v2.RowFilter;
+import com.google.cloud.bigtable.data.v2.wrappers.Filters;
+import com.google.protobuf.InvalidProtocolBufferException;
+
+/**
+ * An HBase {@link Filter} that wraps a Cloud Bigtable {@link Filters.Filter}. Generally, users
+ * should opt for a pure HBase {@link Filter}.  There are complex cases where a Cloud Bigtable 
+ * {@link Filters.Filter} can express a more robust expression than the HBase semantics, or can
+ * be used to express an expression that's more performant than a translation of a complex
+ * HBase {@link FilterList}.
+ */
+public class BigtableFilter extends FilterBase implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  private final RowFilter rowFilter;
+
+  public BigtableFilter(Filters.Filter filter) {
+    this.rowFilter = filter.toProto();
+  }
+
+  private BigtableFilter(RowFilter rowFilter) {
+    this.rowFilter = rowFilter;
+  }
+
+  @Override
+  public ReturnCode filterKeyValue(Cell arg0) throws IOException {
+    return ReturnCode.SKIP;
+  }
+
+  public RowFilter getRowFilter() {
+    return rowFilter;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == null || !(obj instanceof BigtableFilter)) {
+      return false;
+    }
+    BigtableFilter other = (BigtableFilter) obj;
+    return rowFilter.equals(other.rowFilter);
+  }
+
+  @Override
+  public byte[] toByteArray() throws IOException {
+    return rowFilter.toByteArray();
+  }
+
+  public static BigtableFilter parseFrom(final byte[] bytes) throws DeserializationException {
+    try {
+      return new BigtableFilter(RowFilter.parseFrom(bytes));
+    } catch (InvalidProtocolBufferException e) {
+      throw new DeserializationException(e);
+    }
+  }
+}

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/filter/TimestampRangeFilter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/filter/TimestampRangeFilter.java
@@ -63,6 +63,16 @@ public class TimestampRangeFilter extends FilterBase implements Serializable {
   }
 
   @Override
+  public boolean equals(Object obj) {
+    if (obj == null || !(obj instanceof TimestampRangeFilter)) {
+      return false;
+    }
+    TimestampRangeFilter other = (TimestampRangeFilter) obj;
+    return startTimestampInclusive == other.startTimestampInclusive
+        && endTimestampExclusive == other.endTimestampExclusive;
+  }
+
+  @Override
   public byte[] toByteArray() throws IOException {
     try (ByteArrayOutputStream bos = new ByteArrayOutputStream();
         ObjectOutput out = new ObjectOutputStream(bos)) {

--- a/bigtable-hbase-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/filter/TestBigtableFilter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/filter/TestBigtableFilter.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.filter;
+
+import java.io.IOException;
+
+import org.apache.hadoop.hbase.protobuf.ProtobufUtil;
+import org.apache.hadoop.hbase.protobuf.generated.FilterProtos;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import com.google.cloud.bigtable.data.v2.wrappers.Filters;
+
+/**
+ * Tests for {@link BigtableFilter}
+ */
+@RunWith(JUnit4.class)
+public class TestBigtableFilter {
+  @Test
+  public void testSerialization() throws IOException {
+    BigtableFilter original = new BigtableFilter(Filters.F.pass());
+    FilterProtos.Filter proto = ProtobufUtil.toFilter(original);
+    Assert.assertEquals(original, ProtobufUtil.toFilter(proto));
+  }
+
+}

--- a/bigtable-hbase-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/filter/TestTimestampRangeFilter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/filter/TestTimestampRangeFilter.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.filter;
+
+import java.io.IOException;
+
+import org.apache.hadoop.hbase.protobuf.ProtobufUtil;
+import org.apache.hadoop.hbase.protobuf.generated.FilterProtos;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Tests for {@link TimestampRangeFilter}
+ */
+@RunWith(JUnit4.class)
+public class TestTimestampRangeFilter {
+
+  @Test
+  public void testSerialization() throws IOException {
+    TimestampRangeFilter original = new TimestampRangeFilter(10L, 20L);
+    FilterProtos.Filter proto = ProtobufUtil.toFilter(original);
+    Assert.assertEquals(original, ProtobufUtil.toFilter(proto));
+  }
+
+}


### PR DESCRIPTION
This powertool can be used to create filters that work well in Bigtable's dialect that cannot be expressed easily in HBase's dialect.

Also, created unit tests for serialization of BigtableFilter and TimestampRangeFilter.