### PR TITLE
Removing SLF4JBridgeHandler from SharedTestEnvRule

### DIFF
--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/pom.xml
@@ -298,13 +298,6 @@ limitations under the License.
         </dependency>
 
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jul-to-slf4j</artifactId>
-            <version>1.7.7</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>${junit.version}</version>

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/test_env/SharedTestEnvRule.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/test_env/SharedTestEnvRule.java
@@ -17,7 +17,6 @@ package com.google.cloud.bigtable.hbase.test_env;
 
 import java.io.IOException;
 import java.util.UUID;
-import java.util.logging.Handler;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -29,7 +28,6 @@ import org.apache.hadoop.hbase.client.AsyncConnection;
 import org.apache.hadoop.hbase.client.Connection;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.rules.ExternalResource;
-import org.slf4j.bridge.SLF4JBridgeHandler;
 
 public class SharedTestEnvRule extends ExternalResource {
 
@@ -41,17 +39,9 @@ public class SharedTestEnvRule extends ExternalResource {
   private SharedTestEnv sharedTestEnv;
   private Connection connection;
   private AsyncConnection asyncConnection;
-  private java.util.logging.Logger julLogger;
-  private java.util.logging.Handler[] savedJulHandlers;
 
   @Override
   protected void before() throws Throwable {
-    julLogger = java.util.logging.LogManager.getLogManager().getLogger("");
-    savedJulHandlers = julLogger.getHandlers();
-    for (Handler h : savedJulHandlers) {
-      julLogger.removeHandler(h);
-    }
-    SLF4JBridgeHandler.install();
 
     sharedTestEnv = SharedTestEnv.get();
     connection = createConnection();
@@ -91,13 +81,6 @@ public class SharedTestEnvRule extends ExternalResource {
       LOG.error("Failed to release the environment after test", e);
     }
     sharedTestEnv = null;
-
-    SLF4JBridgeHandler.uninstall();
-    for (Handler handler : savedJulHandlers) {
-      julLogger.addHandler(handler);
-    }
-    julLogger = null;
-    savedJulHandlers = null;
   }
 
   public Connection getConnection() {

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests/pom.xml
@@ -284,13 +284,6 @@ limitations under the License.
         </dependency>
 
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jul-to-slf4j</artifactId>
-            <version>1.7.7</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>${junit.version}</version>

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/test_env/SharedTestEnvRule.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/test_env/SharedTestEnvRule.java
@@ -17,7 +17,6 @@ package com.google.cloud.bigtable.hbase.test_env;
 
 import java.io.IOException;
 import java.util.UUID;
-import java.util.logging.Handler;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.hbase.HColumnDescriptor;
@@ -27,7 +26,6 @@ import org.apache.hadoop.hbase.client.Admin;
 import org.apache.hadoop.hbase.client.Connection;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.rules.ExternalResource;
-import org.slf4j.bridge.SLF4JBridgeHandler;
 
 public class SharedTestEnvRule extends ExternalResource {
 
@@ -38,18 +36,9 @@ public class SharedTestEnvRule extends ExternalResource {
   private TableName defaultTableName;
   private SharedTestEnv sharedTestEnv;
   private Connection connection;
-  private java.util.logging.Logger julLogger;
-  private java.util.logging.Handler[] savedJulHandlers;
 
   @Override
   protected void before() throws Throwable {
-    julLogger = java.util.logging.LogManager.getLogManager().getLogger("");
-    savedJulHandlers = julLogger.getHandlers();
-    for (Handler h : savedJulHandlers) {
-      julLogger.removeHandler(h);
-    }
-    SLF4JBridgeHandler.install();
-
     sharedTestEnv = SharedTestEnv.get();
     connection = createConnection();
 
@@ -79,13 +68,6 @@ public class SharedTestEnvRule extends ExternalResource {
       LOG.error("Failed to release the environment after test", e);
     }
     sharedTestEnv = null;
-
-    SLF4JBridgeHandler.uninstall();
-    for (Handler handler : savedJulHandlers) {
-      julLogger.addHandler(handler);
-    }
-    julLogger = null;
-    savedJulHandlers = null;
   }
 
   public Connection getConnection() {


### PR DESCRIPTION
I'm not sure what this does for us.  It's likely an artifact of a historical problem that was resolved.