### PR TITLE
Simplifying creation of Table objects in integration tests.

### DIFF
--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/AbstractTest.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/AbstractTest.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 
 import org.apache.hadoop.hbase.client.AsyncConnection;
 import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.Table;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.Rule;
 import org.junit.rules.TestRule;
@@ -59,6 +60,10 @@ public abstract class AbstractTest {
 
   protected AsyncConnection getAsyncConnection() throws Exception {
     return sharedTestEnv.getAsynConnection();
+  }
+
+  protected Table getDefaultTable() throws IOException {
+    return getConnection().getTable(sharedTestEnv.getDefaultTableName());
   }
 
   protected static class QualifierValue implements Comparable<QualifierValue> {

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/TestAppend.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/TestAppend.java
@@ -37,7 +37,7 @@ public class TestAppend extends AbstractTest {
   @Test
   public void testAppend() throws Exception {
     // Initialize
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("rowKey-");
     byte[] qualifier = dataHelper.randomData("qualifier-");
     byte[] value1 = dataHelper.randomData("value1-");
@@ -72,7 +72,7 @@ public class TestAppend extends AbstractTest {
   @Test
   public void testAppendToEmptyCell() throws Exception {
     // Initialize
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("rowKey-");
     byte[] qualifier = dataHelper.randomData("qualifier-");
     byte[] value = dataHelper.randomData("value1-");
@@ -93,7 +93,7 @@ public class TestAppend extends AbstractTest {
   @Test
   public void testAppendNoResult() throws Exception {
     // Initialize
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("rowKey-");
     byte[] qual = dataHelper.randomData("qualifier-");
     byte[] value1 = dataHelper.randomData("value-");
@@ -115,7 +115,7 @@ public class TestAppend extends AbstractTest {
   @Test
   public void testAppendToMultipleColumns() throws Exception {
     // Initialize
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("rowKey-");
     byte[] qualifier1 = dataHelper.randomData("qualifier1-");
     byte[] qualifier2 = dataHelper.randomData("qualifier2-");
@@ -148,7 +148,7 @@ public class TestAppend extends AbstractTest {
   @Test
   public void testAppendToMultipleFamilies() throws Exception {
     // Initialize
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("rowKey-");
     byte[] qualifier1 = dataHelper.randomData("qualifier1-");
     byte[] value1 = dataHelper.randomData("value1-");
@@ -183,7 +183,7 @@ public class TestAppend extends AbstractTest {
   @Test
   public void testAppendMultiFamilyEmptyQualifier() throws Exception {
     // Initialize
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("rowKey-");
     byte[] qualifier1 = new byte[0];
     byte[] value1 = dataHelper.randomData("value1-");

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/TestBasicOps.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/TestBasicOps.java
@@ -75,7 +75,7 @@ public class TestBasicOps extends AbstractTest {
   @Test
   public void testNullQualifier() throws IOException {
     // Initialize values
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("testrow-");
     byte[] testValue = dataHelper.randomData("testValue-");
 
@@ -199,7 +199,7 @@ public class TestBasicOps extends AbstractTest {
   private void
       testPutGetDelete(boolean doGet, byte[] rowKey, byte[] testQualifier, byte[] testValue)
           throws IOException {
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
 
     Stopwatch stopwatch = new Stopwatch();
     stopwatch.start();

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/TestBatch.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/TestBatch.java
@@ -66,7 +66,7 @@ public class TestBatch extends AbstractTest {
 
   private void testGetPutDelete(int count, boolean sameQualifier)
       throws IOException, InterruptedException, ArrayComparisonFailure {
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     // Initialize data
     byte[][] rowKeys = new byte[count][];
     byte[][] quals = new byte[count][];
@@ -129,7 +129,7 @@ public class TestBatch extends AbstractTest {
   @Test
   public void testBatchIncrement() throws IOException, InterruptedException {
     // Initialize data
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey1 = dataHelper.randomData("testrow-");
     byte[] qual1 = dataHelper.randomData("qual-");
     Random random = new Random();
@@ -168,7 +168,7 @@ public class TestBatch extends AbstractTest {
   @Test
   public void testBatchAppend() throws IOException, InterruptedException {
     // Initialize data
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey1 = dataHelper.randomData("testrow-");
     byte[] qual1 = dataHelper.randomData("qual-");
     byte[] value1_1 = dataHelper.randomData("value-");
@@ -215,7 +215,7 @@ public class TestBatch extends AbstractTest {
   // INVALID_ARGUMENT for all 5 puts.
   public void testBatchWithException() throws IOException, InterruptedException {
     // Initialize data
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[][] rowKeys = dataHelper.randomData("testrow-", 5);
     byte[][] quals = dataHelper.randomData("qual-", 5);
     byte[][] values = dataHelper.randomData("value-", 5);
@@ -280,7 +280,7 @@ public class TestBatch extends AbstractTest {
   @Test
   public void testRowMutations() throws IOException {
     // Initialize data
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("testrow-");
     byte[][] quals = dataHelper.randomData("qual-", 3);
     byte[][] values = dataHelper.randomData("value-", 3);
@@ -323,7 +323,7 @@ public class TestBatch extends AbstractTest {
   @Test
   public void testBatchGets() throws Exception {
     // Initialize data
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey1 = dataHelper.randomData("testrow-");
     byte[] qual1 = dataHelper.randomData("qual-");
     byte[] value1 = dataHelper.randomData("value-");

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/TestBufferedMutator.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/TestBufferedMutator.java
@@ -55,7 +55,7 @@ public class TestBufferedMutator extends AbstractTest {
 
   @Test
   public void testAutoFlushOn() throws Exception {
-    try (Table mutator = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    try (Table mutator = getDefaultTable();
         Connection c = createNewConnection();
         Table tableForRead = c.getTable(sharedTestEnv.getDefaultTableName());) {
       mutator.put(getPut());

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/TestCheckAndMutate.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/TestCheckAndMutate.java
@@ -52,7 +52,7 @@ public class TestCheckAndMutate extends AbstractTest {
   @Test
   public void testCheckAndPutSameQual() throws IOException {
     // Initialize
-    try (Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName())) {
+    try (Table table = getDefaultTable()) {
       testCheckAndMutate(dataHelper, table);
     }
   }
@@ -95,7 +95,7 @@ public class TestCheckAndMutate extends AbstractTest {
   @Test
   public void testCheckAndDeleteSameQual() throws IOException {
     // Initialize
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("rowKey-");
     byte[] qual = dataHelper.randomData("qualifier-");
     byte[] value1 = dataHelper.randomData("value-");
@@ -125,7 +125,7 @@ public class TestCheckAndMutate extends AbstractTest {
   @Test
   public void testCheckAndPutDiffQual() throws IOException {
     // Initialize
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("rowKey-");
     byte[] qual1 = dataHelper.randomData("qualifier-");
     byte[] qual2 = dataHelper.randomData("qualifier-");
@@ -166,7 +166,7 @@ public class TestCheckAndMutate extends AbstractTest {
   @Test
   public void testCheckAndDeleteDiffQual() throws IOException {
     // Initialize
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("rowKey-");
     byte[] qual1 = dataHelper.randomData("qualifier-");
     byte[] qual2 = dataHelper.randomData("qualifier-");
@@ -208,7 +208,7 @@ public class TestCheckAndMutate extends AbstractTest {
   @Test
   public void testCheckAndPutDiffRow() throws IOException {
     // Initialize
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey1 = dataHelper.randomData("rowKey-");
     byte[] rowKey2 = dataHelper.randomData("rowKey-");
     byte[] qual = dataHelper.randomData("qualifier-");
@@ -228,7 +228,7 @@ public class TestCheckAndMutate extends AbstractTest {
   @Test
   public void testCheckAndDeleteDiffRow() throws IOException {
     // Initialize
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey1 = dataHelper.randomData("rowKey-");
     byte[] rowKey2 = dataHelper.randomData("rowKey-");
     byte[] qual = dataHelper.randomData("qualifier-");
@@ -246,7 +246,7 @@ public class TestCheckAndMutate extends AbstractTest {
   @Test
   public void testCheckAndMutate() throws IOException {
     // Initialize
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("rowKey-");
     byte[] qualCheck = dataHelper.randomData("qualifier-");
     byte[] qualPut = dataHelper.randomData("qualifier-");
@@ -300,7 +300,7 @@ public class TestCheckAndMutate extends AbstractTest {
     byte[] otherQual = dataHelper.randomData("other-");
     boolean success;
 
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
 
     table.put(new Put(rowKey).addColumn(SharedTestEnvRule.COLUMN_FAMILY, qualToCheck,
       Bytes.toBytes(2000l)));
@@ -364,7 +364,7 @@ public class TestCheckAndMutate extends AbstractTest {
     byte[] otherQual = dataHelper.randomData("other-");
     boolean success;
 
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     Put someRandomPut =
         new Put(rowKey).addColumn(SharedTestEnvRule.COLUMN_FAMILY, otherQual, Bytes.toBytes(1l));
 

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/TestDelete.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/TestDelete.java
@@ -37,7 +37,7 @@ public class TestDelete extends AbstractTest {
   @Test
   public void testDeleteRow() throws IOException {
     // Initialize data
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("testrow-");
     byte[] qual1 = dataHelper.randomData("qual-");
     byte[] qual2 = dataHelper.randomData("qual-");
@@ -64,7 +64,7 @@ public class TestDelete extends AbstractTest {
   @Test
   public void testDeleteEmptyRow() throws IOException {
     // Initialize data
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("testrow-");
 
     Delete delete = new Delete(rowKey);
@@ -80,7 +80,7 @@ public class TestDelete extends AbstractTest {
   @Category(KnownGap.class)
   public void testDeleteLatestColumnVersion() throws IOException {
     // Initialize data
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("testrow-");
     byte[] qual = dataHelper.randomData("qual-");
     byte[] value = dataHelper.randomData("value-");
@@ -115,7 +115,7 @@ public class TestDelete extends AbstractTest {
   @Test
   public void testDeleteSpecificColumnVersion() throws IOException {
     // Initialize data
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("testrow-");
     byte[] qual = dataHelper.randomData("qual-");
     byte[] value = dataHelper.randomData("value-");
@@ -152,7 +152,7 @@ public class TestDelete extends AbstractTest {
   @Test
   public void testDeleteAllColumnVersions() throws IOException {
     // Initialize data
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("testrow-");
     byte[] qual1 = dataHelper.randomData("qual-");
     byte[] qual2 = dataHelper.randomData("qual-");
@@ -191,7 +191,7 @@ public class TestDelete extends AbstractTest {
   @Test
   public void testDeleteOlderColumnVersions() throws IOException {
     // Initialize data
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("testrow-");
     byte[] qual = dataHelper.randomData("qual-");
     byte[] value = dataHelper.randomData("value-");
@@ -227,7 +227,7 @@ public class TestDelete extends AbstractTest {
   @Test
   public void testDeleteFamily() throws IOException {
     // Initialize data
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("testrow-");
     byte[] qual1 = dataHelper.randomData("qual-");
     byte[] qual2 = dataHelper.randomData("qual-");
@@ -263,7 +263,7 @@ public class TestDelete extends AbstractTest {
   @Category(KnownGap.class)
   public void testDeleteOlderFamilyColumns() throws IOException {
     // Initialize data
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("testrow-");
     byte[] qual1 = dataHelper.randomData("qual-");
     byte[] qual2 = dataHelper.randomData("qual-");
@@ -305,7 +305,7 @@ public class TestDelete extends AbstractTest {
   @Category(KnownGap.class)
   public void testDeleteFamilyWithSpecificTimestamp() throws IOException {
     // Initialize data
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("testrow-");
     byte[] qual1 = dataHelper.randomData("qual-");
     byte[] qual2 = dataHelper.randomData("qual-");

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/TestDurability.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/TestDurability.java
@@ -55,7 +55,7 @@ public class TestDurability extends AbstractTest {
     Put put = new Put(rowKey);
     put.setDurability(durability);
     put.addColumn(SharedTestEnvRule.COLUMN_FAMILY, testQualifier, testValue);
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     table.put(put);
 
     // Get

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/TestFilters.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/TestFilters.java
@@ -122,7 +122,7 @@ public class TestFilters extends AbstractTest {
   }
 
   private Table getTable() throws IOException {
-    return getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    return getDefaultTable();
   }
 
   /**
@@ -1610,7 +1610,7 @@ public class TestFilters extends AbstractTest {
     byte[] rowKey = dataHelper.randomData("rowKeyNumeric-");
     byte[] qualToCheck = dataHelper.randomData("toCheckNumeric-");
 
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
 
     table.put(new Put(rowKey).addColumn(SharedTestEnvRule.COLUMN_FAMILY, qualToCheck,
       Bytes.toBytes(2000l)));

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/TestGet.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/TestGet.java
@@ -52,7 +52,7 @@ public class TestGet extends AbstractTest {
   @Test
   public void testNoQualifier() throws IOException {
     // Initialize variables
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("testrow-");
     int numValues = 3;
     byte[][] quals = dataHelper.randomData("qual-", numValues);
@@ -88,7 +88,7 @@ public class TestGet extends AbstractTest {
   @Test
   public void testMultipleQualifiers() throws IOException {
     // Initialize variables
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("testrow-");
     int numValues = 3;
     byte[][] quals = dataHelper.randomData("qual-", numValues);
@@ -128,7 +128,7 @@ public class TestGet extends AbstractTest {
   @Test
   public void testTimeRange() throws IOException {
     // Initialize variables
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("testrow-");
     byte[] qual = dataHelper.randomData("qual-");
     int numVersions = 5;
@@ -173,7 +173,7 @@ public class TestGet extends AbstractTest {
   @Test
   public void testSingleTimestamp() throws IOException {
     // Initialize variables
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("testrow-");
     byte[] qual = dataHelper.randomData("qual-");
     int numVersions = 5;
@@ -213,7 +213,7 @@ public class TestGet extends AbstractTest {
   @Test
   public void testMaxVersions() throws IOException {
     // Initialize data
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("testrow-");
     byte[] qual = dataHelper.randomData("qual-");
     int totalVersions = 5;
@@ -259,7 +259,7 @@ public class TestGet extends AbstractTest {
   @Category(KnownGap.class)
   public void testMaxResultsPerColumnFamily() throws IOException {
     // Initialize data
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("testrow-");
     int totalColumns = 10;
     int offsetColumn = 3;
@@ -309,7 +309,7 @@ public class TestGet extends AbstractTest {
   @Test
   public void testEmptyValues() throws IOException {
     // Initialize data
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     int numValues = 10;
     byte[] rowKey = dataHelper.randomData("testrow-");
     byte[][] quals = dataHelper.randomData("qual-", numValues);
@@ -346,7 +346,7 @@ public class TestGet extends AbstractTest {
   @Category(KnownGap.class)
   public void testExists() throws IOException {
     // Initialize data
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     int numValues = 10;
     byte[][] rowKeys = dataHelper.randomData("testrow-", numValues);
     byte[][] quals = dataHelper.randomData("qual-", numValues);
@@ -474,7 +474,7 @@ public class TestGet extends AbstractTest {
   @Test
   public void testOneBadApple() throws IOException {
     // Initialize data
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     int numValues = 10;
 
     // Run a control test.
@@ -517,7 +517,7 @@ public class TestGet extends AbstractTest {
     };
     byte[][] values = dataHelper.randomData("value-", qualifiers.length);
     byte[] rowKey = dataHelper.randomData("rowKey");
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     Put put = new Put(rowKey);
 
     for (int i = 0; i < qualifiers.length; i++) {

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/TestGetTable.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/TestGetTable.java
@@ -27,7 +27,7 @@ import java.util.concurrent.Executors;
 public class TestGetTable extends AbstractTest {
   @Test
   public void testGetTable1() throws Exception {
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     Assert.assertEquals(sharedTestEnv.getDefaultTableName(), table.getName());
     table.close();
   }

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/TestIncrement.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/TestIncrement.java
@@ -56,7 +56,7 @@ public class TestIncrement extends AbstractTest {
   @Test
   public void testIncrement() throws IOException {
     // Initialize data
-    try (Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName())){
+    try (Table table = getDefaultTable()){
       testIncrement(dataHelper, table);
     }
   }
@@ -119,7 +119,7 @@ public class TestIncrement extends AbstractTest {
   @Category(KnownGap.class)
   public void testIncrementWithTimerange() throws IOException {
     // Initialize data
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("testrow-");
     byte[] qual = dataHelper.randomData("qual-");
 
@@ -187,7 +187,7 @@ public class TestIncrement extends AbstractTest {
     long oneMinute = 60 * 1000;
     long fifteenMinutes = 15 * 60 * 1000;
 
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = Bytes.toBytes("testrow-" + RandomStringUtils.randomAlphanumeric(8));
     byte[] qualifier = Bytes.toBytes("testQualifier-" + RandomStringUtils.randomAlphanumeric(8));
     Put put = new Put(rowKey);
@@ -223,7 +223,7 @@ public class TestIncrement extends AbstractTest {
   @Category(KnownGap.class)
   public void testFailOnIncrementInt() throws IOException {
     // Initialize
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("testrow-");
     byte[] qual = dataHelper.randomData("qual-");
     int value = new Random().nextInt();
@@ -250,7 +250,7 @@ public class TestIncrement extends AbstractTest {
   @Category(KnownGap.class)
   public void testFailOnIncrementString() throws IOException {
     // Initialize
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("testrow-");
     byte[] qual = dataHelper.randomData("qual-");
     byte[] value = dataHelper.randomData("value-");
@@ -275,7 +275,7 @@ public class TestIncrement extends AbstractTest {
   @Test
   public void testIncrementEightBytes() throws IOException {
     // Initialize
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("testrow-");
     byte[] qual = dataHelper.randomData("qual-");
     byte[] value = new byte[8];

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/TestPut.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/TestPut.java
@@ -55,7 +55,7 @@ public class TestPut extends AbstractTest {
   @Test
   public void testPutMultipleCellsOneRow() throws IOException {
     // Initialize variables
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("testrow-");
     byte[][] quals = dataHelper.randomData("testQualifier-", NUM_CELLS);
     byte[][] values = dataHelper.randomData("testValue-", NUM_CELLS);
@@ -98,7 +98,7 @@ public class TestPut extends AbstractTest {
    */
   public void testPutGetDeleteMultipleRows() throws IOException {
     // Initialize interface
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[][] rowKeys = dataHelper.randomData("testrow-", NUM_ROWS);
     byte[][] qualifiers = dataHelper.randomData("testQualifier-", NUM_ROWS);
     byte[][] values = dataHelper.randomData("testValue-", NUM_ROWS);
@@ -163,7 +163,7 @@ public class TestPut extends AbstractTest {
     long oneMinute = 60 * 1000;
     long fifteenMinutes = 15 * 60 * 1000;
 
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = Bytes.toBytes("testrow-" + RandomStringUtils.randomAlphanumeric(8));
     byte[] qualifier = Bytes.toBytes("testQualifier-" + RandomStringUtils.randomAlphanumeric(8));
     byte[] value = Bytes.toBytes("testValue-" + RandomStringUtils.randomAlphanumeric(8));
@@ -196,7 +196,7 @@ public class TestPut extends AbstractTest {
   @Test(expected = NoSuchColumnFamilyException.class)
   @Category(KnownGap.class)
   public void testIOExceptionOnFailedPut() throws Exception {
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = Bytes.toBytes("testrow-" + RandomStringUtils.randomAlphanumeric(8));
     byte[] badfamily = Bytes.toBytes("badcolumnfamily-" + RandomStringUtils.randomAlphanumeric(8));
     byte[] qualifier = Bytes.toBytes("testQualifier-" + RandomStringUtils.randomAlphanumeric(8));
@@ -209,7 +209,7 @@ public class TestPut extends AbstractTest {
   @Test
   @Category(KnownGap.class)
   public void testAtomicPut() throws Exception {
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = Bytes.toBytes("testrow-" + RandomStringUtils.randomAlphanumeric(8));
     byte[] goodQual = Bytes.toBytes("testQualifier-" + RandomStringUtils.randomAlphanumeric(8));
     byte[] goodValue = Bytes.toBytes("testValue-" + RandomStringUtils.randomAlphanumeric(8));
@@ -247,7 +247,7 @@ public class TestPut extends AbstractTest {
     byte[] value1 = Bytes.toBytes("testvalue-" + RandomStringUtils.randomAlphanumeric(8));
     byte[] value2 = Bytes.toBytes("testvalue-" + RandomStringUtils.randomAlphanumeric(8));
     long timestamp = System.currentTimeMillis();
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     Put put = new Put(rowKey);
     put.addColumn(COLUMN_FAMILY, qualifier, timestamp, value1);
     table.put(put);
@@ -278,7 +278,7 @@ public class TestPut extends AbstractTest {
     }
     multiplePutsOneBad(numberOfGoodPuts, goodkeys, rowKey);
     Get get = new Get(rowKey);
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     Result whatsLeft = table.get(get);
     Assert.assertEquals("Same row, all other puts accepted", numberOfGoodPuts, whatsLeft.size());
     table.close();
@@ -301,7 +301,7 @@ public class TestPut extends AbstractTest {
       Get get = new Get(goodkeys[i]);
       gets.add(get);
     }
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     Result[] whatsLeft = table.get(gets);
     int cellCount = 0;
     for (Result result : whatsLeft) {
@@ -314,7 +314,7 @@ public class TestPut extends AbstractTest {
   @Test
   public void testMultipleFamilies() throws IOException {
     // Initialize variables
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("multiFamRow-");
     byte[][] quals = dataHelper.randomData("testQualifier-", NUM_CELLS);
     byte[][] values = dataHelper.randomData("testValue-", NUM_CELLS * 2);
@@ -368,7 +368,7 @@ public class TestPut extends AbstractTest {
 
   private void multiplePutsOneBad(int numberOfGoodPuts, byte[][] goodkeys, byte[] badkey)
       throws IOException {
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     List<Put> puts = new ArrayList<Put>();
     for (int i = 0; i < numberOfGoodPuts; ++i) {
       byte[] qualifier = Bytes.toBytes("testQualifier-" + RandomStringUtils.randomAlphanumeric(8));

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/TestPutGetDelete.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/TestPutGetDelete.java
@@ -42,7 +42,7 @@ public class TestPutGetDelete extends AbstractTest {
     byte[] testQualifier = dataHelper.randomData("testQualifier-");
     byte[] testValue = dataHelper.randomData("testValue-");
 
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
 
     // Put
     Put put = new Put(rowKey);

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/TestScan.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/TestScan.java
@@ -69,7 +69,7 @@ public class TestScan extends AbstractTest {
 
   @Test
   public void testGetScannerBeforeTimestamp() throws IOException {
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("testrow-");
     byte[] qual = dataHelper.randomData("qual-");
     byte[][] values = dataHelper.randomData("value-", 2);
@@ -105,7 +105,7 @@ public class TestScan extends AbstractTest {
   @Test
   public void testGetScannerNoQualifiers() throws IOException {
     // Initialize variables
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("testrow-");
     int numValues = 3;
     byte[][] quals = dataHelper.randomData("qual-", numValues);
@@ -147,7 +147,7 @@ public class TestScan extends AbstractTest {
     int rowsToWrite = 100;
 
     // Initialize variables
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
 
     byte[][] rowKeys = new byte[rowsToWrite][];
     rowKeys[0] = dataHelper.randomData(prefix);
@@ -213,7 +213,7 @@ public class TestScan extends AbstractTest {
     int rowsToWrite = 100;
 
     // Initialize variables
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
 
     byte[][] rowKeys = new byte[rowsToWrite][];
     rowKeys[0] = dataHelper.randomData(prefix);
@@ -257,7 +257,7 @@ public class TestScan extends AbstractTest {
   @Test
   public void testStartEndEquals() throws IOException {
     // Initialize variables
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("start_end_equals");
     byte[] qualifier = dataHelper.randomData("qual-");
     byte[] value = dataHelper.randomData("value-");

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/TestSingleColumnValueFilter.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/TestSingleColumnValueFilter.java
@@ -55,7 +55,7 @@ public class TestSingleColumnValueFilter extends AbstractTest {
 
   @BeforeClass
   public static void fillTable() throws IOException {
-    table = sharedTestEnv.getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    table = sharedTestEnv.getDefaultTable();
 
     List<Put> puts = new ArrayList<>();
     ImmutableSet.Builder<String> keyBuilder = ImmutableSet.builder();

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/TestTimestamp.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/TestTimestamp.java
@@ -39,7 +39,7 @@ public class TestTimestamp extends AbstractTest {
   @Test
   public void testArbitraryTimestamp() throws IOException {
     // Initialize
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("testrow-");
     byte[] testQualifier = dataHelper.randomData("testQual-");
     int numVersions = 4;

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/test_env/SharedTestEnvRule.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/test_env/SharedTestEnvRule.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Admin;
 import org.apache.hadoop.hbase.client.AsyncConnection;
 import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.Table;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.rules.ExternalResource;
 import org.slf4j.bridge.SLF4JBridgeHandler;
@@ -114,6 +115,10 @@ public class SharedTestEnvRule extends ExternalResource {
 
   public AsyncConnection getAsynConnection() {
     return asyncConnection;
+  }
+
+  public Table getDefaultTable() throws IOException {
+    return getConnection().getTable(defaultTableName);
   }
 
   public boolean isBigtable() {

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/AbstractTest.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/AbstractTest.java
@@ -18,6 +18,7 @@ package com.google.cloud.bigtable.hbase;
 import java.io.IOException;
 
 import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.Table;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.Rule;
 import org.junit.rules.TestWatcher;
@@ -48,12 +49,16 @@ public abstract class AbstractTest {
   };
 
   // This is for when we need to look at the results outside of the current connection
-  public Connection createNewConnection() throws IOException {
+  protected Connection createNewConnection() throws IOException {
     return sharedTestEnv.createConnection();
   }
 
   protected Connection getConnection() {
     return sharedTestEnv.getConnection();
+  }
+
+  protected Table getDefaultTable() throws IOException {
+    return sharedTestEnv.getDefaultTable();
   }
 
   protected static class QualifierValue implements Comparable<QualifierValue> {

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestAppend.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestAppend.java
@@ -37,7 +37,7 @@ public class TestAppend extends AbstractTest {
   @Test
   public void testAppend() throws Exception {
     // Initialize
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("rowKey-");
     byte[] qualifier = dataHelper.randomData("qualifier-");
     byte[] value1 = dataHelper.randomData("value1-");
@@ -71,7 +71,7 @@ public class TestAppend extends AbstractTest {
   @Test
   public void testAppendToEmptyCell() throws Exception {
     // Initialize
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("rowKey-");
     byte[] qualifier = dataHelper.randomData("qualifier-");
     byte[] value = dataHelper.randomData("value1-");
@@ -92,7 +92,7 @@ public class TestAppend extends AbstractTest {
   @Test
   public void testAppendNoResult() throws Exception {
     // Initialize
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("rowKey-");
     byte[] qual = dataHelper.randomData("qualifier-");
     byte[] value1 = dataHelper.randomData("value-");
@@ -110,7 +110,7 @@ public class TestAppend extends AbstractTest {
   @Test
   public void testAppendToMultipleColumns() throws Exception {
     // Initialize
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("rowKey-");
     byte[] qualifier1 = dataHelper.randomData("qualifier1-");
     byte[] qualifier2 = dataHelper.randomData("qualifier2-");
@@ -143,7 +143,7 @@ public class TestAppend extends AbstractTest {
   @Test
   public void testAppendToMultipleFamilies() throws Exception {
     // Initialize
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("rowKey-");
     byte[] qualifier1 = dataHelper.randomData("qualifier1-");
     byte[] value1 = dataHelper.randomData("value1-");
@@ -178,7 +178,7 @@ public class TestAppend extends AbstractTest {
   @Test
   public void testAppendMultiFamilyEmptyQualifier() throws Exception {
     // Initialize
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("rowKey-");
     byte[] qualifier1 = new byte[0];
     byte[] value1 = dataHelper.randomData("value1-");

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestBasicOps.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestBasicOps.java
@@ -75,7 +75,7 @@ public class TestBasicOps extends AbstractTest {
   @Test
   public void testNullQualifier() throws IOException {
     // Initialize values
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("testrow-");
     byte[] testValue = dataHelper.randomData("testValue-");
 
@@ -198,7 +198,7 @@ public class TestBasicOps extends AbstractTest {
   private void
       testPutGetDelete(boolean doGet, byte[] rowKey, byte[] testQualifier, byte[] testValue)
           throws IOException {
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
 
     Stopwatch stopwatch = new Stopwatch();
     stopwatch.start();

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestBatch.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestBatch.java
@@ -66,7 +66,7 @@ public class TestBatch extends AbstractTest {
 
   private void testGetPutDelete(int count, boolean sameQualifier)
       throws IOException, InterruptedException, ArrayComparisonFailure {
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     // Initialize data
     byte[][] rowKeys = new byte[count][];
     byte[][] quals = new byte[count][];
@@ -129,7 +129,7 @@ public class TestBatch extends AbstractTest {
   @Test
   public void testBatchIncrement() throws IOException, InterruptedException {
     // Initialize data
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey1 = dataHelper.randomData("testrow-");
     byte[] qual1 = dataHelper.randomData("qual-");
     Random random = new Random();
@@ -168,7 +168,7 @@ public class TestBatch extends AbstractTest {
   @Test
   public void testBatchAppend() throws IOException, InterruptedException {
     // Initialize data
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey1 = dataHelper.randomData("testrow-");
     byte[] qual1 = dataHelper.randomData("qual-");
     byte[] value1_1 = dataHelper.randomData("value-");
@@ -215,7 +215,7 @@ public class TestBatch extends AbstractTest {
   // INVALID_ARGUMENT for all 5 puts.
   public void testBatchWithException() throws IOException, InterruptedException {
     // Initialize data
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[][] rowKeys = dataHelper.randomData("testrow-", 5);
     byte[][] quals = dataHelper.randomData("qual-", 5);
     byte[][] values = dataHelper.randomData("value-", 5);
@@ -280,7 +280,7 @@ public class TestBatch extends AbstractTest {
   @Test
   public void testRowMutations() throws IOException {
     // Initialize data
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("testrow-");
     byte[][] quals = dataHelper.randomData("qual-", 3);
     byte[][] values = dataHelper.randomData("value-", 3);
@@ -323,7 +323,7 @@ public class TestBatch extends AbstractTest {
   @Test
   public void testBatchGets() throws Exception {
     // Initialize data
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey1 = dataHelper.randomData("testrow-");
     byte[] qual1 = dataHelper.randomData("qual-");
     byte[] value1 = dataHelper.randomData("value-");

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestBufferedMutator.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestBufferedMutator.java
@@ -39,7 +39,9 @@ public class TestBufferedMutator extends AbstractTest {
 
   @Test
   public void testAutoFlushOff() throws Exception {
-    try (BufferedMutator mutator = getConnection().getBufferedMutator(sharedTestEnv.getDefaultTableName());
+    try (
+        BufferedMutator mutator =
+            getConnection().getBufferedMutator(sharedTestEnv.getDefaultTableName());
         Connection c = createNewConnection();
         Table tableForRead = c.getTable(sharedTestEnv.getDefaultTableName());) {
       // Set up the tiny write and read
@@ -55,7 +57,7 @@ public class TestBufferedMutator extends AbstractTest {
 
   @Test
   public void testAutoFlushOn() throws Exception {
-    try (Table mutator = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    try (Table mutator = getDefaultTable();
         Connection c = createNewConnection();
         Table tableForRead = c.getTable(sharedTestEnv.getDefaultTableName());) {
       mutator.put(getPut());
@@ -67,8 +69,8 @@ public class TestBufferedMutator extends AbstractTest {
   @Ignore(value="We need a better test now that BigtableBufferedMutator has different logic")
   public void testBufferSizeFlush() throws Exception {
     int maxSize = 1024;
-    BufferedMutatorParams params = new BufferedMutatorParams(sharedTestEnv.getDefaultTableName())
-        .writeBufferSize(maxSize);
+    BufferedMutatorParams params =
+        new BufferedMutatorParams(sharedTestEnv.getDefaultTableName()).writeBufferSize(maxSize);
     try (BufferedMutator mutator = getConnection().getBufferedMutator(params)) {
       // HBase 1.0.0 has a bug in it. It returns maxSize instead of the buffer size for
       // getWriteBufferSize.  https://issues.apache.org/jira/browse/HBASE-13113

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestCheckAndMutate.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestCheckAndMutate.java
@@ -51,7 +51,7 @@ public class TestCheckAndMutate extends AbstractTest {
   @Test
   public void testCheckAndPutSameQual() throws IOException {
     // Initialize
-    try (Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName())) {
+    try (Table table = getDefaultTable()) {
       testCheckAndMutate(dataHelper, table);
     }
   }
@@ -94,7 +94,7 @@ public class TestCheckAndMutate extends AbstractTest {
   @Test
   public void testCheckAndDeleteSameQual() throws IOException {
     // Initialize
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("rowKey-");
     byte[] qual = dataHelper.randomData("qualifier-");
     byte[] value1 = dataHelper.randomData("value-");
@@ -124,7 +124,7 @@ public class TestCheckAndMutate extends AbstractTest {
   @Test
   public void testCheckAndPutDiffQual() throws IOException {
     // Initialize
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("rowKey-");
     byte[] qual1 = dataHelper.randomData("qualifier-");
     byte[] qual2 = dataHelper.randomData("qualifier-");
@@ -165,7 +165,7 @@ public class TestCheckAndMutate extends AbstractTest {
   @Test
   public void testCheckAndDeleteDiffQual() throws IOException {
     // Initialize
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("rowKey-");
     byte[] qual1 = dataHelper.randomData("qualifier-");
     byte[] qual2 = dataHelper.randomData("qualifier-");
@@ -207,7 +207,7 @@ public class TestCheckAndMutate extends AbstractTest {
   @Test
   public void testCheckAndPutDiffRow() throws IOException {
     // Initialize
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey1 = dataHelper.randomData("rowKey-");
     byte[] rowKey2 = dataHelper.randomData("rowKey-");
     byte[] qual = dataHelper.randomData("qualifier-");
@@ -225,7 +225,7 @@ public class TestCheckAndMutate extends AbstractTest {
   @Test
   public void testCheckAndDeleteDiffRow() throws IOException {
     // Initialize
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey1 = dataHelper.randomData("rowKey-");
     byte[] rowKey2 = dataHelper.randomData("rowKey-");
     byte[] qual = dataHelper.randomData("qualifier-");
@@ -242,7 +242,7 @@ public class TestCheckAndMutate extends AbstractTest {
   @Test
   public void testCheckAndMutate() throws IOException {
     // Initialize
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("rowKey-");
     byte[] qualCheck = dataHelper.randomData("qualifier-");
     byte[] qualPut = dataHelper.randomData("qualifier-");
@@ -296,7 +296,7 @@ public class TestCheckAndMutate extends AbstractTest {
     byte[] otherQual = dataHelper.randomData("other-");
     boolean success;
 
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
 
     table.put(new Put(rowKey).addColumn(SharedTestEnvRule.COLUMN_FAMILY, qualToCheck,
       Bytes.toBytes(2000l)));
@@ -360,7 +360,7 @@ public class TestCheckAndMutate extends AbstractTest {
     byte[] otherQual = dataHelper.randomData("other-");
     boolean success;
 
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     Put someRandomPut =
         new Put(rowKey).addColumn(SharedTestEnvRule.COLUMN_FAMILY, otherQual, Bytes.toBytes(1l));
 

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestDelete.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestDelete.java
@@ -37,7 +37,7 @@ public class TestDelete extends AbstractTest {
   @Test
   public void testDeleteRow() throws IOException {
     // Initialize data
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("testrow-");
     byte[] qual1 = dataHelper.randomData("qual-");
     byte[] qual2 = dataHelper.randomData("qual-");
@@ -64,7 +64,7 @@ public class TestDelete extends AbstractTest {
   @Test
   public void testDeleteEmptyRow() throws IOException {
     // Initialize data
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("testrow-");
 
     Delete delete = new Delete(rowKey);
@@ -80,7 +80,7 @@ public class TestDelete extends AbstractTest {
   @Category(KnownGap.class)
   public void testDeleteLatestColumnVersion() throws IOException {
     // Initialize data
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("testrow-");
     byte[] qual = dataHelper.randomData("qual-");
     byte[] value = dataHelper.randomData("value-");
@@ -115,7 +115,7 @@ public class TestDelete extends AbstractTest {
   @Test
   public void testDeleteSpecificColumnVersion() throws IOException {
     // Initialize data
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("testrow-");
     byte[] qual = dataHelper.randomData("qual-");
     byte[] value = dataHelper.randomData("value-");
@@ -152,7 +152,7 @@ public class TestDelete extends AbstractTest {
   @Test
   public void testDeleteAllColumnVersions() throws IOException {
     // Initialize data
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("testrow-");
     byte[] qual1 = dataHelper.randomData("qual-");
     byte[] qual2 = dataHelper.randomData("qual-");
@@ -191,7 +191,7 @@ public class TestDelete extends AbstractTest {
   @Test
   public void testDeleteOlderColumnVersions() throws IOException {
     // Initialize data
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("testrow-");
     byte[] qual = dataHelper.randomData("qual-");
     byte[] value = dataHelper.randomData("value-");
@@ -227,7 +227,7 @@ public class TestDelete extends AbstractTest {
   @Test
   public void testDeleteFamily() throws IOException {
     // Initialize data
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("testrow-");
     byte[] qual1 = dataHelper.randomData("qual-");
     byte[] qual2 = dataHelper.randomData("qual-");
@@ -263,7 +263,7 @@ public class TestDelete extends AbstractTest {
   @Category(KnownGap.class)
   public void testDeleteOlderFamilyColumns() throws IOException {
     // Initialize data
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("testrow-");
     byte[] qual1 = dataHelper.randomData("qual-");
     byte[] qual2 = dataHelper.randomData("qual-");
@@ -305,7 +305,7 @@ public class TestDelete extends AbstractTest {
   @Category(KnownGap.class)
   public void testDeleteFamilyWithSpecificTimestamp() throws IOException {
     // Initialize data
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("testrow-");
     byte[] qual1 = dataHelper.randomData("qual-");
     byte[] qual2 = dataHelper.randomData("qual-");

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestDurability.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestDurability.java
@@ -55,7 +55,7 @@ public class TestDurability extends AbstractTest {
     Put put = new Put(rowKey);
     put.setDurability(durability);
     put.addColumn(SharedTestEnvRule.COLUMN_FAMILY, testQualifier, testValue);
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     table.put(put);
 
     // Get

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestFilters.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestFilters.java
@@ -123,7 +123,7 @@ public class TestFilters extends AbstractTest {
   }
 
   private Table getTable() throws IOException {
-    return getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    return getDefaultTable();
   }
 
   /**
@@ -1611,7 +1611,7 @@ public class TestFilters extends AbstractTest {
     byte[] rowKey = dataHelper.randomData("rowKeyNumeric-");
     byte[] qualToCheck = dataHelper.randomData("toCheckNumeric-");
 
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
 
     table.put(new Put(rowKey).addColumn(SharedTestEnvRule.COLUMN_FAMILY, qualToCheck,
       Bytes.toBytes(2000l)));

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestGet.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestGet.java
@@ -52,7 +52,7 @@ public class TestGet extends AbstractTest {
   @Test
   public void testNoQualifier() throws IOException {
     // Initialize variables
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("testrow-");
     int numValues = 3;
     byte[][] quals = dataHelper.randomData("qual-", numValues);
@@ -88,7 +88,7 @@ public class TestGet extends AbstractTest {
   @Test
   public void testMultipleQualifiers() throws IOException {
     // Initialize variables
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("testrow-");
     int numValues = 3;
     byte[][] quals = dataHelper.randomData("qual-", numValues);
@@ -128,7 +128,7 @@ public class TestGet extends AbstractTest {
   @Test
   public void testTimeRange() throws IOException {
     // Initialize variables
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("testrow-");
     byte[] qual = dataHelper.randomData("qual-");
     int numVersions = 5;
@@ -173,7 +173,7 @@ public class TestGet extends AbstractTest {
   @Test
   public void testSingleTimestamp() throws IOException {
     // Initialize variables
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("testrow-");
     byte[] qual = dataHelper.randomData("qual-");
     int numVersions = 5;
@@ -213,7 +213,7 @@ public class TestGet extends AbstractTest {
   @Test
   public void testMaxVersions() throws IOException {
     // Initialize data
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("testrow-");
     byte[] qual = dataHelper.randomData("qual-");
     int totalVersions = 5;
@@ -259,7 +259,7 @@ public class TestGet extends AbstractTest {
   @Category(KnownGap.class)
   public void testMaxResultsPerColumnFamily() throws IOException {
     // Initialize data
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("testrow-");
     int totalColumns = 10;
     int offsetColumn = 3;
@@ -309,7 +309,7 @@ public class TestGet extends AbstractTest {
   @Test
   public void testEmptyValues() throws IOException {
     // Initialize data
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     int numValues = 10;
     byte[] rowKey = dataHelper.randomData("testrow-");
     byte[][] quals = dataHelper.randomData("qual-", numValues);
@@ -346,7 +346,7 @@ public class TestGet extends AbstractTest {
   @Category(KnownGap.class)
   public void testExists() throws IOException {
     // Initialize data
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     int numValues = 10;
     byte[][] rowKeys = dataHelper.randomData("testrow-", numValues);
     byte[][] quals = dataHelper.randomData("qual-", numValues);
@@ -474,7 +474,7 @@ public class TestGet extends AbstractTest {
   @Test
   public void testOneBadApple() throws IOException {
     // Initialize data
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     int numValues = 10;
 
     // Run a control test.
@@ -517,7 +517,7 @@ public class TestGet extends AbstractTest {
     };
     byte[][] values = dataHelper.randomData("value-", qualifiers.length);
     byte[] rowKey = dataHelper.randomData("rowKey");
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     Put put = new Put(rowKey);
 
     for (int i = 0; i < qualifiers.length; i++) {

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestGetTable.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestGetTable.java
@@ -27,14 +27,15 @@ import java.util.concurrent.Executors;
 public class TestGetTable extends AbstractTest {
   @Test
   public void testGetTable1() throws Exception {
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     Assert.assertEquals(sharedTestEnv.getDefaultTableName(), table.getName());
     table.close();
   }
 
   @Test
   public void testGetTable2() throws Exception {
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName(), Executors.newFixedThreadPool(1));
+    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName(),
+      Executors.newFixedThreadPool(1));
     Assert.assertEquals(sharedTestEnv.getDefaultTableName(), table.getName());
     table.close();
   }

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestIncrement.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestIncrement.java
@@ -56,7 +56,7 @@ public class TestIncrement extends AbstractTest {
   @Test
   public void testIncrement() throws IOException {
     // Initialize data
-    try (Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName())){
+    try (Table table = getDefaultTable()){
       testIncrement(dataHelper, table);
     }
   }
@@ -119,7 +119,7 @@ public class TestIncrement extends AbstractTest {
   @Category(KnownGap.class)
   public void testIncrementWithTimerange() throws IOException {
     // Initialize data
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("testrow-");
     byte[] qual = dataHelper.randomData("qual-");
 
@@ -187,7 +187,7 @@ public class TestIncrement extends AbstractTest {
     long oneMinute = 60 * 1000;
     long fifteenMinutes = 15 * 60 * 1000;
 
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = Bytes.toBytes("testrow-" + RandomStringUtils.randomAlphanumeric(8));
     byte[] qualifier = Bytes.toBytes("testQualifier-" + RandomStringUtils.randomAlphanumeric(8));
     Put put = new Put(rowKey);
@@ -223,7 +223,7 @@ public class TestIncrement extends AbstractTest {
   @Category(KnownGap.class)
   public void testFailOnIncrementInt() throws IOException {
     // Initialize
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("testrow-");
     byte[] qual = dataHelper.randomData("qual-");
     int value = new Random().nextInt();
@@ -250,7 +250,7 @@ public class TestIncrement extends AbstractTest {
   @Category(KnownGap.class)
   public void testFailOnIncrementString() throws IOException {
     // Initialize
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("testrow-");
     byte[] qual = dataHelper.randomData("qual-");
     byte[] value = dataHelper.randomData("value-");
@@ -275,7 +275,7 @@ public class TestIncrement extends AbstractTest {
   @Test
   public void testIncrementEightBytes() throws IOException {
     // Initialize
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("testrow-");
     byte[] qual = dataHelper.randomData("qual-");
     byte[] value = new byte[8];

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestPut.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestPut.java
@@ -55,7 +55,7 @@ public class TestPut extends AbstractTest {
   @Test
   public void testPutMultipleCellsOneRow() throws IOException {
     // Initialize variables
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("testrow-");
     byte[][] quals = dataHelper.randomData("testQualifier-", NUM_CELLS);
     byte[][] values = dataHelper.randomData("testValue-", NUM_CELLS);
@@ -98,7 +98,7 @@ public class TestPut extends AbstractTest {
    */
   public void testPutGetDeleteMultipleRows() throws IOException {
     // Initialize interface
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[][] rowKeys = dataHelper.randomData("testrow-", NUM_ROWS);
     byte[][] qualifiers = dataHelper.randomData("testQualifier-", NUM_ROWS);
     byte[][] values = dataHelper.randomData("testValue-", NUM_ROWS);
@@ -163,7 +163,7 @@ public class TestPut extends AbstractTest {
     long oneMinute = 60 * 1000;
     long fifteenMinutes = 15 * 60 * 1000;
 
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = Bytes.toBytes("testrow-" + RandomStringUtils.randomAlphanumeric(8));
     byte[] qualifier = Bytes.toBytes("testQualifier-" + RandomStringUtils.randomAlphanumeric(8));
     byte[] value = Bytes.toBytes("testValue-" + RandomStringUtils.randomAlphanumeric(8));
@@ -196,7 +196,7 @@ public class TestPut extends AbstractTest {
   @Test(expected = RetriesExhaustedWithDetailsException.class)
   @Category(KnownGap.class)
   public void testIOExceptionOnFailedPut() throws Exception {
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = Bytes.toBytes("testrow-" + RandomStringUtils.randomAlphanumeric(8));
     byte[] badfamily = Bytes.toBytes("badcolumnfamily-" + RandomStringUtils.randomAlphanumeric(8));
     byte[] qualifier = Bytes.toBytes("testQualifier-" + RandomStringUtils.randomAlphanumeric(8));
@@ -209,7 +209,7 @@ public class TestPut extends AbstractTest {
   @Test
   @Category(KnownGap.class)
   public void testAtomicPut() throws Exception {
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = Bytes.toBytes("testrow-" + RandomStringUtils.randomAlphanumeric(8));
     byte[] goodQual = Bytes.toBytes("testQualifier-" + RandomStringUtils.randomAlphanumeric(8));
     byte[] goodValue = Bytes.toBytes("testValue-" + RandomStringUtils.randomAlphanumeric(8));
@@ -244,7 +244,7 @@ public class TestPut extends AbstractTest {
     byte[] value1 = Bytes.toBytes("testvalue-" + RandomStringUtils.randomAlphanumeric(8));
     byte[] value2 = Bytes.toBytes("testvalue-" + RandomStringUtils.randomAlphanumeric(8));
     long timestamp = System.currentTimeMillis();
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     Put put = new Put(rowKey);
     put.addColumn(COLUMN_FAMILY, qualifier, timestamp, value1);
     table.put(put);
@@ -275,7 +275,7 @@ public class TestPut extends AbstractTest {
     }
     multiplePutsOneBad(numberOfGoodPuts, goodkeys, rowKey);
     Get get = new Get(rowKey);
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     Result whatsLeft = table.get(get);
     Assert.assertEquals("Same row, all other puts accepted", numberOfGoodPuts, whatsLeft.size());
     table.close();
@@ -298,7 +298,7 @@ public class TestPut extends AbstractTest {
       Get get = new Get(goodkeys[i]);
       gets.add(get);
     }
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     Result[] whatsLeft = table.get(gets);
     int cellCount = 0;
     for (Result result : whatsLeft) {
@@ -311,7 +311,7 @@ public class TestPut extends AbstractTest {
   @Test
   public void testMultipleFamilies() throws IOException {
     // Initialize variables
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("multiFamRow-");
     byte[][] quals = dataHelper.randomData("testQualifier-", NUM_CELLS);
     byte[][] values = dataHelper.randomData("testValue-", NUM_CELLS * 2);
@@ -365,7 +365,7 @@ public class TestPut extends AbstractTest {
 
   private void multiplePutsOneBad(int numberOfGoodPuts, byte[][] goodkeys, byte[] badkey)
       throws IOException {
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     List<Put> puts = new ArrayList<Put>();
     for (int i = 0; i < numberOfGoodPuts; ++i) {
       byte[] qualifier = Bytes.toBytes("testQualifier-" + RandomStringUtils.randomAlphanumeric(8));

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestPutGetDelete.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestPutGetDelete.java
@@ -42,7 +42,7 @@ public class TestPutGetDelete extends AbstractTest {
     byte[] testQualifier = dataHelper.randomData("testQualifier-");
     byte[] testValue = dataHelper.randomData("testValue-");
 
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
 
     // Put
     Put put = new Put(rowKey);

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestScan.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestScan.java
@@ -69,7 +69,7 @@ public class TestScan extends AbstractTest {
 
   @Test
   public void testGetScannerBeforeTimestamp() throws IOException {
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("testrow-");
     byte[] qual = dataHelper.randomData("qual-");
     byte[][] values = dataHelper.randomData("value-", 2);
@@ -105,7 +105,7 @@ public class TestScan extends AbstractTest {
   @Test
   public void testGetScannerNoQualifiers() throws IOException {
     // Initialize variables
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("testrow-");
     int numValues = 3;
     byte[][] quals = dataHelper.randomData("qual-", numValues);
@@ -147,7 +147,7 @@ public class TestScan extends AbstractTest {
     int rowsToWrite = 100;
 
     // Initialize variables
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
 
     byte[][] rowKeys = new byte[rowsToWrite][];
     rowKeys[0] = dataHelper.randomData(prefix);
@@ -213,7 +213,7 @@ public class TestScan extends AbstractTest {
     int rowsToWrite = 100;
 
     // Initialize variables
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
 
     byte[][] rowKeys = new byte[rowsToWrite][];
     rowKeys[0] = dataHelper.randomData(prefix);
@@ -257,7 +257,7 @@ public class TestScan extends AbstractTest {
   @Test
   public void testStartEndEquals() throws IOException {
     // Initialize variables
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("start_end_equals");
     byte[] qualifier = dataHelper.randomData("qual-");
     byte[] value = dataHelper.randomData("value-");

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestSingleColumnValueFilter.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestSingleColumnValueFilter.java
@@ -55,7 +55,7 @@ public class TestSingleColumnValueFilter extends AbstractTest {
 
   @BeforeClass
   public static void fillTable() throws IOException {
-    table = sharedTestEnv.getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    table = sharedTestEnv.getDefaultTable();
 
     List<Put> puts = new ArrayList<>();
     ImmutableSet.Builder<String> keyBuilder = ImmutableSet.builder();

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestTimestamp.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestTimestamp.java
@@ -39,7 +39,7 @@ public class TestTimestamp extends AbstractTest {
   @Test
   public void testArbitraryTimestamp() throws IOException {
     // Initialize
-    Table table = getConnection().getTable(sharedTestEnv.getDefaultTableName());
+    Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("testrow-");
     byte[] testQualifier = dataHelper.randomData("testQual-");
     int numVersions = 4;

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/test_env/SharedTestEnvRule.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/test_env/SharedTestEnvRule.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Admin;
 import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.Table;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.rules.ExternalResource;
 import org.slf4j.bridge.SLF4JBridgeHandler;
@@ -103,6 +104,10 @@ public class SharedTestEnvRule extends ExternalResource {
 
   public TableName getDefaultTableName() {
     return defaultTableName;
+  }
+
+  public Table getDefaultTable() throws IOException {
+    return getConnection().getTable(defaultTableName);
   }
 
   public TableName newTestTableName() {


### PR DESCRIPTION
- Adding a getDefaultTable() method that returns the default table
- TestImport truncates the default table, so creating a new table table for it instead.