### PR TITLE
Fixing a broken build.

### DIFF
--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/TestFilters.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/TestFilters.java
@@ -2033,7 +2033,7 @@ public class TestFilters extends AbstractTest {
         .addColumn(COLUMN_FAMILY, qualB, valB));
 
       Filters.Filter qualAFilter =
-          Filters.F.qualifier().exactMatch(ByteString.copyFrom(qualA));
+          Filters.FILTERS.qualifier().exactMatch(ByteString.copyFrom(qualA));
       BigtableFilter bigtableFilter = new BigtableFilter(qualAFilter);
       Result result = table.get(new Get(rowKey).setFilter(bigtableFilter));
 

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestFilters.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestFilters.java
@@ -2034,7 +2034,7 @@ public class TestFilters extends AbstractTest {
         .addColumn(COLUMN_FAMILY, qualB, valB));
 
       Filters.Filter qualAFilter =
-          Filters.F.qualifier().exactMatch(ByteString.copyFrom(qualA));
+          Filters.FILTERS.qualifier().exactMatch(ByteString.copyFrom(qualA));
       BigtableFilter bigtableFilter = new BigtableFilter(qualAFilter);
       Result result = table.get(new Get(rowKey).setFilter(bigtableFilter));
 


### PR DESCRIPTION
`TestFilters` used `Filters.F` instead of the new `Filters.FILTER` that was introduced in #1635.