### PR TITLE
Decoupling AbstractTest and IntegrationTests.

### DIFF
--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/AbstractTest.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/AbstractTest.java
@@ -29,7 +29,7 @@ import org.junit.runner.Description;
 
 public abstract class AbstractTest {
 
-  public static SharedTestEnvRule sharedTestEnv = IntegrationTests.sharedTestEnvRule;
+  public SharedTestEnvRule sharedTestEnv = SharedTestEnvRule.getInstance();
 
   protected static DataGenerationHelper dataHelper = new DataGenerationHelper();
   protected Logger logger = new Logger(this.getClass());

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/IntegrationTests.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/IntegrationTests.java
@@ -58,6 +58,27 @@ import org.junit.runners.Suite;
 })
 public class IntegrationTests {
 
+  static {
+    SharedTestEnvRule.setInstance(new SharedTestEnvRule() {
+      @Override
+      /*
+       * NOTE: This code is identical to the hbase 2.x code, but this produces binary incompatible
+       * results.  This code has to remain in the 1.x integration testing code-base.
+       */
+      public void createTable(TableName tableName) throws IOException {
+        try (Admin admin = getConnection().getAdmin()) {
+          LOG.info("Creating table " + tableName.getNameAsString());
+          HColumnDescriptor hcd = new HColumnDescriptor(COLUMN_FAMILY).setMaxVersions(MAX_VERSIONS);
+          HColumnDescriptor family2 = new HColumnDescriptor(COLUMN_FAMILY2).setMaxVersions(MAX_VERSIONS);
+          admin.createTable(
+              new HTableDescriptor(tableName)
+                  .addFamily(hcd)
+                  .addFamily(family2));
+        }
+      }
+    });
+  }
+
   private static final int TIME_OUT_MINUTES =
       Integer.getInteger("integration.test.timeout.minutes", 3);
 
@@ -65,23 +86,6 @@ public class IntegrationTests {
   public static Timeout timeoutRule = new Timeout(TIME_OUT_MINUTES, TimeUnit.MINUTES);
 
   @ClassRule
-  public static SharedTestEnvRule sharedTestEnvRule = new SharedTestEnvRule() {
-    @Override
-    /*
-     * NOTE: This code is identical to the hbase 1.x code, but this produces binary incompatible
-     * results.  This code has to remain in the 2.x integration testing code-base.
-     */
-    public void createTable(TableName tableName) throws IOException {
-      try (Admin admin = getConnection().getAdmin()) {
-        LOG.info("Creating table " + tableName.getNameAsString());
-        HColumnDescriptor hcd = new HColumnDescriptor(COLUMN_FAMILY).setMaxVersions(MAX_VERSIONS);
-        HColumnDescriptor family2 = new HColumnDescriptor(COLUMN_FAMILY2).setMaxVersions(MAX_VERSIONS);
-        admin.createTable(
-            new HTableDescriptor(tableName)
-                .addFamily(hcd)
-                .addFamily(family2));
-      }
-    }
-  };
+  public static SharedTestEnvRule sharedTestEnvRule = SharedTestEnvRule.getInstance();
 
 }

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/TestSingleColumnValueFilter.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/TestSingleColumnValueFilter.java
@@ -40,6 +40,7 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule;
 import com.google.common.collect.ImmutableSet;
 
 public class TestSingleColumnValueFilter extends AbstractTest {
@@ -55,7 +56,7 @@ public class TestSingleColumnValueFilter extends AbstractTest {
 
   @BeforeClass
   public static void fillTable() throws IOException {
-    table = sharedTestEnv.getDefaultTable();
+    table = SharedTestEnvRule.getInstance().getDefaultTable();
 
     List<Put> puts = new ArrayList<>();
     ImmutableSet.Builder<String> keyBuilder = ImmutableSet.builder();

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/async/TestAsyncAdmin.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests-2.x/src/test/java/com/google/cloud/bigtable/hbase/async/TestAsyncAdmin.java
@@ -45,6 +45,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import com.google.cloud.bigtable.hbase.AbstractTest;
+import com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule;
 
 /**
  * Integration tests for BigtableAsyncConnection
@@ -57,7 +58,8 @@ public class TestAsyncAdmin extends AbstractTest {
 
   @BeforeClass
   public static void setupAsyncCon() throws InterruptedException, ExecutionException {
-    asyncCon = ConnectionFactory.createAsyncConnection(sharedTestEnv.getConfiguration()).get();
+    asyncCon = ConnectionFactory
+        .createAsyncConnection(SharedTestEnvRule.getInstance().getConfiguration()).get();
   }
 
   @AfterClass

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests-common/src/main/java/com/google/cloud/bigtable/hbase/test_env/SharedTestEnvRule.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests-common/src/main/java/com/google/cloud/bigtable/hbase/test_env/SharedTestEnvRule.java
@@ -34,6 +34,20 @@ public abstract class SharedTestEnvRule extends ExternalResource {
   public static final int MAX_VERSIONS = 6;
   public static final byte[] COLUMN_FAMILY = Bytes.toBytes("test_family");
   public static final byte[] COLUMN_FAMILY2 = Bytes.toBytes("test_family2");
+  private static SharedTestEnvRule instance;
+
+  /**
+   * This class is generally a singleton, where implementation can change.  Some startup utility
+   * will set this instance.
+   */
+  public static void setInstance(SharedTestEnvRule instance) {
+    SharedTestEnvRule.instance = instance;
+  }
+
+  public static SharedTestEnvRule getInstance() {
+    return instance;
+  }
+
   protected static final Log LOG = LogFactory.getLog(SharedTestEnvRule.class);
   private TableName defaultTableName;
   private SharedTestEnv sharedTestEnv;

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/AbstractTest.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/AbstractTest.java
@@ -29,7 +29,7 @@ import com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule;
 
 public abstract class AbstractTest {
 
-  public static SharedTestEnvRule sharedTestEnv = IntegrationTests.sharedTestEnvRule;
+  public SharedTestEnvRule sharedTestEnv = SharedTestEnvRule.getInstance();
 
   protected static DataGenerationHelper dataHelper = new DataGenerationHelper();
   protected Logger logger = new Logger(this.getClass());
@@ -50,15 +50,15 @@ public abstract class AbstractTest {
   };
 
   // This is for when we need to look at the results outside of the current connection
-  protected static Connection createNewConnection() throws IOException {
+  protected Connection createNewConnection() throws IOException {
     return sharedTestEnv.createConnection();
   }
 
-  protected static Connection getConnection() {
+  protected Connection getConnection() {
     return sharedTestEnv.getConnection();
   }
 
-  protected static Table getDefaultTable() throws IOException {
+  protected Table getDefaultTable() throws IOException {
     return sharedTestEnv.getDefaultTable();
   }
 

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestSingleColumnValueFilter.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestSingleColumnValueFilter.java
@@ -40,6 +40,7 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule;
 import com.google.common.collect.ImmutableSet;
 
 public class TestSingleColumnValueFilter extends AbstractTest {
@@ -55,7 +56,7 @@ public class TestSingleColumnValueFilter extends AbstractTest {
 
   @BeforeClass
   public static void fillTable() throws IOException {
-    table = sharedTestEnv.getDefaultTable();
+    table = SharedTestEnvRule.getInstance().getDefaultTable();
 
     List<Put> puts = new ArrayList<>();
     ImmutableSet.Builder<String> keyBuilder = ImmutableSet.builder();


### PR DESCRIPTION
`IntegrationTets` needs to set up the shared test environment, and `AbstractTest` and its subclasses need to use that environment.  This PR adds a level of indirection for the shared test environment by adding a singleton for the shared test environment.  IntegrationTests will set up the singleton, and `AbstractTest` will get that singleton.

The goal is to keep `IntegrationTests` where they are, and move `AbstractTest` and common subclasses to bigtable-hbase-integration-tests-common.