### PR TITLE
Fixing a broken filter test

### DIFF
--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestFilters.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestFilters.java
@@ -1716,9 +1716,10 @@ public class TestFilters extends AbstractTest {
       Assert.assertArrayEquals(rowKeys[i+1], boundedResults[i].getRow());
     }
   }
+
   @Test
   public void testMultiRangeFilter() throws IOException {
-    String prefix = "testMultiRangeFilter";
+    String prefix = "testMultiRangeFilter_";
     int rowCount = 10;
     byte[][] rowKeys = dataHelper.randomData(prefix, rowCount);
     Arrays.sort(rowKeys, Bytes.BYTES_COMPARATOR);
@@ -1752,9 +1753,8 @@ public class TestFilters extends AbstractTest {
   }
 
   @Test
-  @Category(KnownGap.class)
   public void testMultiRangeFilterOrList() throws IOException {
-    String prefix = "testMultiRangeFilterOrList";
+    String prefix = "testMultiRangeFilterOrList_";
     int rowCount = 10;
     byte[][] rowKeys = dataHelper.randomData(prefix, rowCount);
     Arrays.sort(rowKeys, Bytes.BYTES_COMPARATOR);

--- a/bigtable-hbase-parent/bigtable-hbase-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestFilters.java
+++ b/bigtable-hbase-parent/bigtable-hbase-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestFilters.java
@@ -1717,9 +1717,10 @@ public class TestFilters extends AbstractTest {
       Assert.assertArrayEquals(rowKeys[i+1], boundedResults[i].getRow());
     }
   }
+
   @Test
   public void testMultiRangeFilter() throws IOException {
-    String prefix = "testMultiRangeFilter";
+    String prefix = "testMultiRangeFilter_";
     int rowCount = 10;
     byte[][] rowKeys = dataHelper.randomData(prefix, rowCount);
     Arrays.sort(rowKeys, Bytes.BYTES_COMPARATOR);
@@ -1753,9 +1754,8 @@ public class TestFilters extends AbstractTest {
   }
 
   @Test
-  @Category(KnownGap.class)
   public void testMultiRangeFilterOrList() throws IOException {
-    String prefix = "testMultiRangeFilterOrList";
+    String prefix = "testMultiRangeFilterOrList_";
     int rowCount = 10;
     byte[][] rowKeys = dataHelper.randomData(prefix, rowCount);
     Arrays.sort(rowKeys, Bytes.BYTES_COMPARATOR);


### PR DESCRIPTION
Our hbase tests are failing on TestFilters.testMultiRangeFilter().  There is a potential conflict between testMultiRangeFilterOrList() and testMultiRangeFilter() in terms of key space, which may be the root of the problem.  I could not reporoduce the problem myself, but as part of my investigation I found that testMultiRangeFilterOrList() no longer needs @Category(KnownGap.class).