### PR TITLE
Improving RefreshingOAuth2CredentialsInterceptor

### DIFF
--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableAdmin.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableAdmin.java
@@ -52,7 +52,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 import java.util.regex.Pattern;
 import org.apache.hadoop.conf.Configuration;


### PR DESCRIPTION
- Adding additional exception logging for unexpected cases
- Timeout is now 15 seconds, and configurable by a user
- Reduced visibility of package private variables in favor of new methods meant for testing
- Added handling for directExecutor()