### PR TITLE
Auth interceptor future doesn't throw exceptions

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptor.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptor.java
@@ -21,6 +21,7 @@ import com.google.auth.oauth2.OAuth2Credentials;
 import com.google.cloud.bigtable.config.Logger;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.RateLimiter;
 import io.grpc.CallOptions;
 import io.grpc.Channel;
@@ -328,7 +329,11 @@ public class RefreshingOAuth2CredentialsInterceptor implements ClientInterceptor
         }
       } catch (RuntimeException e) {
         futureToken = null;
-        throw e;
+        LOG.warn("Got an unexpected exception while trying to refresh google credentials.", e);
+        return Futures.immediateFuture(new HeaderCacheElement(
+          Status.UNAUTHENTICATED
+              .withDescription("Unexpected error trying to authenticate")
+              .withCause(e)));
       }
 
       return future;

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptorTest.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptorTest.java
@@ -104,9 +104,9 @@ public class RefreshingOAuth2CredentialsInterceptorTest {
 
   @SuppressWarnings("unchecked")
   @Test
-  public void testBadExecutor() throws IOException {
+  public void testExecutorProblem() throws IOException {
     ExecutorService mockExecutor = Mockito.mock(ExecutorService.class);
-    when(mockExecutor.submit(any(Callable.class))).thenThrow(new RuntimeException(""));
+    when(mockExecutor.submit(any(Callable.class))).thenThrow(new TimeoutException(""));
     underTest = new RefreshingOAuth2CredentialsInterceptor(mockExecutor, credentials);
     Assert.assertEquals(CacheState.Exception, underTest.getHeaderSafe().getCacheState());
   }

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptorTest.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptorTest.java
@@ -106,7 +106,7 @@ public class RefreshingOAuth2CredentialsInterceptorTest {
   @Test
   public void testExecutorProblem() throws IOException {
     ExecutorService mockExecutor = Mockito.mock(ExecutorService.class);
-    when(mockExecutor.submit(any(Callable.class))).thenThrow(new TimeoutException(""));
+    when(mockExecutor.submit(any(Callable.class))).thenThrow(new RuntimeException(""));
     underTest = new RefreshingOAuth2CredentialsInterceptor(mockExecutor, credentials);
     Assert.assertEquals(CacheState.Exception, underTest.getHeaderSafe().getCacheState());
   }


### PR DESCRIPTION
Instead of throwing an exception, a problem with the executor should
log and return an UNAUTHENTICATED cache element.