### PR TITLE
Release scheduledFlush under a synchronized block

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BulkMutation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BulkMutation.java
@@ -426,8 +426,10 @@ public class BulkMutation {
         scheduledFlush = retryExecutorService.schedule(new Runnable() {
           @Override
           public void run() {
-            scheduledFlush = null;
-            send();
+            synchronized (BulkMutation.this) {
+              scheduledFlush = null;
+              send();
+            }
           }
         }, autoflushMs, TimeUnit.MILLISECONDS);
       }


### PR DESCRIPTION
Since the write to `scheduledFlush` is neither volatile nor written under a synchronized block I don't believe it is guaranteed to be visible to all threads.

This could have the following effects:

* Automatic flushing for `BulkMutation` is stuck, no more writes get scheduled since no threads observe a `null` value for `scheduledFlush`.
* Another flush could be scheduled before `send` has returned.