### PR TITLE
BigtableAsyncConnection should return async object implementations.

### DIFF
--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/IntegrationTests.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/IntegrationTests.java
@@ -16,6 +16,7 @@
 package com.google.cloud.bigtable.hbase;
 
 import com.google.cloud.bigtable.hbase.async.TestAsyncAdmin;
+import com.google.cloud.bigtable.hbase.async.TestAsyncConnection;
 import com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule;
 
 import java.io.IOException;
@@ -53,7 +54,8 @@ import org.junit.runners.Suite;
     TestPut.class,
     TestTimestamp.class,
     TestTruncateTable.class,
-    TestAsyncAdmin.class
+    TestAsyncAdmin.class,
+    TestAsyncConnection.class
 })
 public class IntegrationTests {
 

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/async/AbstractAsyncTest.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/async/AbstractAsyncTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.async;
+
+import java.util.concurrent.ExecutionException;
+
+import org.apache.hadoop.hbase.client.AsyncConnection;
+import org.apache.hadoop.hbase.client.ConnectionFactory;
+
+import com.google.cloud.bigtable.hbase.AbstractTest;
+import com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule;
+
+public abstract class AbstractAsyncTest extends AbstractTest {
+
+  private static final String CONN_KEY = AbstractAsyncTest.class.getName() + "_asyncCon";
+
+  public static AsyncConnection getAsyncConnection()
+      throws InterruptedException, ExecutionException {
+    SharedTestEnvRule sharedEnv = SharedTestEnvRule.getInstance();
+    AsyncConnection conn = (AsyncConnection) sharedEnv.getClosable(CONN_KEY);
+    if (conn == null) {
+      conn = ConnectionFactory.createAsyncConnection(sharedEnv.getConfiguration()).get();
+      sharedEnv.registerClosable(CONN_KEY, conn);
+    }
+    return conn;
+  }
+
+}

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/async/TestAsyncAdmin.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/async/TestAsyncAdmin.java
@@ -20,74 +20,55 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.regex.Pattern;
+
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.TableNotEnabledException;
 import org.apache.hadoop.hbase.TableNotFoundException;
 import org.apache.hadoop.hbase.client.Admin;
 import org.apache.hadoop.hbase.client.AsyncAdmin;
-import org.apache.hadoop.hbase.client.AsyncConnection;
 import org.apache.hadoop.hbase.client.ColumnFamilyDescriptorBuilder;
-import org.apache.hadoop.hbase.client.ConnectionFactory;
 import org.apache.hadoop.hbase.client.TableDescriptor;
 import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.hamcrest.core.IsInstanceOf;
-import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import com.google.cloud.bigtable.hbase.AbstractTest;
-import com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule;
 
 /**
  * Integration tests for BigtableAsyncConnection
  * 
  * @author spollapally
  */
-public class TestAsyncAdmin extends AbstractTest {
-
-  private static AsyncConnection asyncCon;
-
-  @BeforeClass
-  public static void setupAsyncCon() throws InterruptedException, ExecutionException {
-    asyncCon = ConnectionFactory
-        .createAsyncConnection(SharedTestEnvRule.getInstance().getConfiguration()).get();
-  }
-
-  @AfterClass
-  public static void closeAsyncCon() throws IOException {
-    asyncCon.close();
-  }
+public class TestAsyncAdmin extends AbstractAsyncTest {
 
   @Rule
   public ExpectedException thrown = ExpectedException.none();
 
   @Test
   public void testAsyncConnection() throws Exception {
-    Assert.assertNotNull("async connection should not be null", asyncCon);
-    AsyncAdmin asycAdmin = asyncCon.getAdmin();
+    Assert.assertNotNull("async connection should not be null", getAsyncConnection());
+    AsyncAdmin asycAdmin = getAsyncConnection().getAdmin();
     Assert.assertNotNull("asycAdmin should not be null", asycAdmin);
   }
 
   @Test
   public void testCreateTable_exception() throws Exception {
-    AsyncAdmin asyncAdmin = asyncCon.getAdmin();
+    AsyncAdmin asyncAdmin = getAsyncConnection().getAdmin();
     thrown.expect(NullPointerException.class);
     asyncAdmin.createTable(null).get();
   }
 
   @Test
   public void testCreateTable_harness() throws Exception {
-    AsyncAdmin asyncAdmin = asyncCon.getAdmin();
-    TableName tableName = TableName.valueOf("TestTable" + UUID.randomUUID().toString());
+    AsyncAdmin asyncAdmin = getAsyncConnection().getAdmin();
+    TableName tableName = sharedTestEnv.newTestTableName();
 
     try {
       // test exists
@@ -153,7 +134,7 @@ public class TestAsyncAdmin extends AbstractTest {
 
   @Test
   public void testCreateTableWithNumRegions_exception() throws Exception {
-    AsyncAdmin asyncAdmin = asyncCon.getAdmin();
+    AsyncAdmin asyncAdmin = getAsyncConnection().getAdmin();
     TableName tableName = TableName.valueOf("TestTable" + UUID.randomUUID().toString());
     thrown.expect(ExecutionException.class);
     thrown.expectCause(IsInstanceOf.<Throwable>instanceOf(IllegalArgumentException.class));
@@ -163,7 +144,7 @@ public class TestAsyncAdmin extends AbstractTest {
 
   @Test
   public void testCreateTableWithSplits() throws Exception {
-    AsyncAdmin asyncAdmin = asyncCon.getAdmin();
+    AsyncAdmin asyncAdmin = getAsyncConnection().getAdmin();
     TableName tableName1 = TableName.valueOf("TestTable" + UUID.randomUUID().toString());
     TableName tableName2 = TableName.valueOf("TestTable" + UUID.randomUUID().toString());
 
@@ -192,7 +173,7 @@ public class TestAsyncAdmin extends AbstractTest {
 
   @Test
   public void testDisbleTable_exceptions() throws Exception {
-    AsyncAdmin asyncAdmin = asyncCon.getAdmin();
+    AsyncAdmin asyncAdmin = getAsyncConnection().getAdmin();
     TableName tableName = TableName.valueOf("TestTable" + UUID.randomUUID().toString());
 
     // test non existing table

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/async/TestAsyncConnection.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/async/TestAsyncConnection.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.async;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
+
+import com.google.cloud.bigtable.hbase.KnownGap;
+import com.google.common.util.concurrent.MoreExecutors;
+
+/**
+ * Integration tests to make sure that AsyncConnection methods do not throw exceptions.
+ * @author sduskis
+ */
+public class TestAsyncConnection extends AbstractAsyncTest {
+
+  private static final ExecutorService directExecutorService = MoreExecutors.sameThreadExecutor();
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void testAdmin() throws InterruptedException, ExecutionException {
+    Assert.assertNotNull(getAsyncConnection().getAdmin());
+    Assert.assertNotNull(getAsyncConnection().getAdmin(directExecutorService));
+  }
+
+  @Test
+  public void testRegionLocator() throws InterruptedException, ExecutionException {
+    Assert
+        .assertNotNull(getAsyncConnection().getRegionLocator(sharedTestEnv.getDefaultTableName()));
+  }
+
+  @Test
+  public void testTable() throws InterruptedException, ExecutionException {
+    Assert.assertNotNull(
+      getAsyncConnection().getTable(sharedTestEnv.getDefaultTableName(), directExecutorService));
+    Assert.assertNotNull(getAsyncConnection()
+        .getTableBuilder(sharedTestEnv.getDefaultTableName(), directExecutorService).build());
+  }
+
+  @Test
+  @Category(KnownGap.class)
+  public void testRawTable() throws InterruptedException, ExecutionException {
+    Assert.assertNotNull(getAsyncConnection().getRawTable(sharedTestEnv.getDefaultTableName()));
+    Assert.assertNotNull(
+      getAsyncConnection().getRawTableBuilder(sharedTestEnv.getDefaultTableName()).build());
+  }
+
+  @Test
+  public void testBufferedMutator() throws InterruptedException, ExecutionException {
+    Assert.assertNotNull(
+      getAsyncConnection().getBufferedMutator(sharedTestEnv.getDefaultTableName()));
+    Assert.assertNotNull(
+      getAsyncConnection().getBufferedMutatorBuilder(sharedTestEnv.getDefaultTableName()).build());
+    Assert.assertNotNull(getAsyncConnection()
+        .getBufferedMutatorBuilder(sharedTestEnv.getDefaultTableName(), directExecutorService)
+        .build());
+  }
+}

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/org/apache/hadoop/hbase/client/BigtableAsyncConnection.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/org/apache/hadoop/hbase/client/BigtableAsyncConnection.java
@@ -33,15 +33,18 @@ import com.google.cloud.bigtable.hbase.adapters.Adapters;
 import com.google.cloud.bigtable.hbase.adapters.HBaseRequestAdapter;
 import com.google.cloud.bigtable.hbase.adapters.HBaseRequestAdapter.MutationAdapters;
 import com.google.cloud.bigtable.hbase2_x.BigtableAsyncAdmin;
+import com.google.cloud.bigtable.hbase2_x.BigtableAsyncBufferedMutator;
+import com.google.cloud.bigtable.hbase2_x.BigtableAsyncTable;
+import com.google.cloud.bigtable.hbase2_x.BigtableAsyncTableRegionLocator;
 
 /**
  * Bigtable implementation of {@link AsyncConnection}
- * 
+ *
  * @author spollapally
  */
 public class BigtableAsyncConnection implements AsyncConnection, Closeable {
   private final Logger LOG = new Logger(getClass());
-  
+
   private final Configuration conf;
   private BigtableSession session;
   private BigtableOptions options;
@@ -55,13 +58,13 @@ public class BigtableAsyncConnection implements AsyncConnection, Closeable {
     // with a whole bunch of other classes.
     Adapters.class.getName();
   }
-  
+
   public BigtableAsyncConnection(Configuration conf) throws IOException {
     this(conf, null, null, null);
   }
 
-  public BigtableAsyncConnection(Configuration conf, AsyncRegistry registry, String clusterId,
-      User user) throws IOException {
+  public BigtableAsyncConnection(Configuration conf, AsyncRegistry ignoredRegistry,
+      String ignoredClusterId, User ignoredUser) throws IOException {
     LOG.debug("Creating BigtableAsyncConnection");
     this.conf = conf;
 
@@ -72,7 +75,7 @@ public class BigtableAsyncConnection implements AsyncConnection, Closeable {
       LOG.error("Error loading BigtableOptions from Configuration.", ioe);
       throw ioe;
     }
-    
+
     this.closed = false;
     this.session = new BigtableSession(opts);
     this.options = this.session.getOptions();
@@ -96,11 +99,11 @@ public class BigtableAsyncConnection implements AsyncConnection, Closeable {
   public BigtableOptions getOptions() {
     return this.options;
   }
-  
+
   public Set<TableName> getDisabledTables() {
     return disabledTables;
   }
-  
+
   @Override
   public void close() throws IOException {
     LOG.debug("closeing BigtableAsyncConnection");
@@ -118,32 +121,32 @@ public class BigtableAsyncConnection implements AsyncConnection, Closeable {
   @Override
   public AsyncAdminBuilder getAdminBuilder() {
     return new AsyncAdminBuilder() {
-      
+
       @Override
       public AsyncAdminBuilder setStartLogErrorsCnt(int arg0) {
-        throw new UnsupportedOperationException("setStartLogErrorsCnt");
+        return this;
       }
-      
+
       @Override
       public AsyncAdminBuilder setRpcTimeout(long arg0, TimeUnit arg1) {
-        throw new UnsupportedOperationException("setRpcTimeout");
+        return this;
       }
-      
+
       @Override
       public AsyncAdminBuilder setRetryPause(long arg0, TimeUnit arg1) {
-        throw new UnsupportedOperationException("setRetryPause");
+        return this;
       }
-      
+
       @Override
       public AsyncAdminBuilder setOperationTimeout(long arg0, TimeUnit arg1) {
-        throw new UnsupportedOperationException("setOperationTimeout");
+        return this;
       }
-      
+
       @Override
       public AsyncAdminBuilder setMaxAttempts(int arg0) {
-        throw new UnsupportedOperationException("setMaxAttempts");
+        return this;
       }
-      
+
       @Override
       public AsyncAdmin build() {
         try {
@@ -158,33 +161,159 @@ public class BigtableAsyncConnection implements AsyncConnection, Closeable {
 
   @Override
   public AsyncAdminBuilder getAdminBuilder(ExecutorService arg0) {
-    throw new UnsupportedOperationException("getAdminBuilder ExecutorService"); // TODO
+    return getAdminBuilder();
   }
 
   @Override
-  public AsyncBufferedMutatorBuilder getBufferedMutatorBuilder(TableName arg0) {
-    throw new UnsupportedOperationException("getBufferedMutatorBuilder"); // TODO
+  public AsyncBufferedMutatorBuilder getBufferedMutatorBuilder(final TableName tableName) {
+    return new AsyncBufferedMutatorBuilder() {
+
+      @Override
+      public AsyncBufferedMutatorBuilder setWriteBufferSize(long arg0) {
+        return this;
+      }
+
+      @Override
+      public AsyncBufferedMutatorBuilder setStartLogErrorsCnt(int arg0) {
+        return this;
+      }
+
+      @Override
+      public AsyncBufferedMutatorBuilder setRpcTimeout(long arg0, TimeUnit arg1) {
+        return this;
+      }
+
+      @Override
+      public AsyncBufferedMutatorBuilder setRetryPause(long arg0, TimeUnit arg1) {
+        return this;
+      }
+
+      @Override
+      public AsyncBufferedMutatorBuilder setOperationTimeout(long arg0, TimeUnit arg1) {
+        return this;
+      }
+
+      @Override
+      public AsyncBufferedMutatorBuilder setMaxAttempts(int arg0) {
+        return this;
+      }
+
+      @Override
+      public AsyncBufferedMutator build() {
+        return new BigtableAsyncBufferedMutator();
+      }
+    };
   }
 
   @Override
-  public AsyncBufferedMutatorBuilder getBufferedMutatorBuilder(TableName arg0,
+  public AsyncBufferedMutatorBuilder getBufferedMutatorBuilder(TableName tableName,
       ExecutorService arg1) {
-    throw new UnsupportedOperationException("getBufferedMutatorBuilder"); // TODO
+    return getBufferedMutatorBuilder(tableName);
   }
 
   @Override
-  public AsyncTableBuilder<RawAsyncTable> getRawTableBuilder(TableName arg0) {
-    throw new UnsupportedOperationException("getRawTableBuilder"); // TODO
+  public AsyncTableBuilder<RawAsyncTable> getRawTableBuilder(TableName tableName) {
+    return new AsyncTableBuilder<RawAsyncTable>() {
+      @Override
+      public RawAsyncTable build() {
+      throw new UnsupportedOperationException("getRawTableBuilder"); // TODO
+      }
+
+      @Override
+      public AsyncTableBuilder<RawAsyncTable> setMaxAttempts(int arg0) {
+        return this;
+      }
+
+      @Override
+      public AsyncTableBuilder<RawAsyncTable> setOperationTimeout(long arg0, TimeUnit arg1) {
+        return this;
+      }
+
+      @Override
+      public AsyncTableBuilder<RawAsyncTable> setReadRpcTimeout(long arg0, TimeUnit arg1) {
+        return this;
+      }
+
+      @Override
+      public AsyncTableBuilder<RawAsyncTable> setRetryPause(long arg0, TimeUnit arg1) {
+        return this;
+      }
+
+      @Override
+      public AsyncTableBuilder<RawAsyncTable> setRpcTimeout(long arg0, TimeUnit arg1) {
+        return this;
+      }
+
+      @Override
+      public AsyncTableBuilder<RawAsyncTable> setScanTimeout(long arg0, TimeUnit arg1) {
+        return this;
+      }
+
+      @Override
+      public AsyncTableBuilder<RawAsyncTable> setStartLogErrorsCnt(int arg0) {
+        return this;
+      }
+
+      @Override
+      public AsyncTableBuilder<RawAsyncTable> setWriteRpcTimeout(long arg0, TimeUnit arg1) {
+        return this;
+      }
+    };
   }
 
   @Override
   public AsyncTableRegionLocator getRegionLocator(TableName tableName) {
-    throw new UnsupportedOperationException("getRegionLocator"); // TODO
+    return new BigtableAsyncTableRegionLocator(tableName, options, this.session.getDataClient());
   }
 
   @Override
   public AsyncTableBuilder<AsyncTable> getTableBuilder(TableName tableName,
       ExecutorService executorService) {
-    throw new UnsupportedOperationException("getTableBuilder"); // TODO
+    return new AsyncTableBuilder<AsyncTable>() {
+      @Override
+      public AsyncTable build() {
+        return new BigtableAsyncTable(BigtableAsyncConnection.this, createAdapter(tableName));
+      }
+
+      @Override
+      public AsyncTableBuilder<AsyncTable> setMaxAttempts(int arg0) {
+        return this;
+      }
+
+      @Override
+      public AsyncTableBuilder<AsyncTable> setOperationTimeout(long arg0, TimeUnit arg1) {
+        return this;
+      }
+
+      @Override
+      public AsyncTableBuilder<AsyncTable> setReadRpcTimeout(long arg0, TimeUnit arg1) {
+        return this;
+      }
+
+      @Override
+      public AsyncTableBuilder<AsyncTable> setRetryPause(long arg0, TimeUnit arg1) {
+        return this;
+      }
+
+      @Override
+      public AsyncTableBuilder<AsyncTable> setRpcTimeout(long arg0, TimeUnit arg1) {
+        return this;
+      }
+
+      @Override
+      public AsyncTableBuilder<AsyncTable> setScanTimeout(long arg0, TimeUnit arg1) {
+        return this;
+      }
+
+      @Override
+      public AsyncTableBuilder<AsyncTable> setStartLogErrorsCnt(int arg0) {
+        return this;
+      }
+
+      @Override
+      public AsyncTableBuilder<AsyncTable> setWriteRpcTimeout(long arg0, TimeUnit arg1) {
+        return this;
+      }
+    };
   }
 }


### PR DESCRIPTION
I cache AsyncConnection in SharedTestEnvRule, and reuse it across async tests.
Added builders to TestAsyncConnection.