### PR TITLE
Implement BigtableAsyncBufferedMutator.

### DIFF
--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/IntegrationTests.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/IntegrationTests.java
@@ -17,6 +17,7 @@ package com.google.cloud.bigtable.hbase;
 
 import com.google.cloud.bigtable.hbase.async.TestAsyncAdmin;
 import com.google.cloud.bigtable.hbase.async.TestAsyncBatch;
+import com.google.cloud.bigtable.hbase.async.TestAsyncBufferedMutator;
 import com.google.cloud.bigtable.hbase.async.TestAsyncConnection;
 import com.google.cloud.bigtable.hbase.async.TestAsyncScan;
 import com.google.cloud.bigtable.hbase.async.TestBasicAsyncOps;
@@ -59,9 +60,10 @@ import org.junit.runners.Suite;
     TestTruncateTable.class,
     TestAsyncAdmin.class,
     TestAsyncBatch.class,
+    TestAsyncBufferedMutator.class,
     TestAsyncConnection.class,
     TestAsyncScan.class,
-    TestBasicAsyncOps.class
+    TestBasicAsyncOps.class,
 })
 public class IntegrationTests {
 

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/async/TestAsyncBufferedMutator.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/async/TestAsyncBufferedMutator.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.async;
+
+import static com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule.COLUMN_FAMILY;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.hadoop.hbase.CellUtil;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.AsyncBufferedMutator;
+import org.apache.hadoop.hbase.client.Get;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.Table;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Requirement 1.1 - Writes are buffered in the client by default (can be disabled).  Buffer size
+ * can be defined programmatically or configuring the hbase.client.write.buffer property.
+ */
+public class TestAsyncBufferedMutator extends AbstractAsyncTest {
+
+  @Test
+  public void testBufferdMutatorMulti() throws Exception {
+    TableName defaultTableName = sharedTestEnv.getDefaultTableName();
+
+    final byte[] rowKey = dataHelper.randomData("TestAsyncBufferedMutator-");
+    final byte[] qualifier = dataHelper.randomData("testQualifier-");
+    final byte[] value = dataHelper.randomData("testValue-");
+
+    try (AsyncBufferedMutator mutator = getAsyncConnection().getBufferedMutator(defaultTableName);
+        Table tableForRead = getDefaultTable();) {
+      Put put = new Put(rowKey).addColumn(COLUMN_FAMILY, qualifier, value);
+      Get get = new Get(rowKey).addColumn(COLUMN_FAMILY, qualifier);
+      CompletableFuture<Void> future = mutator.mutate(put);
+      mutator.flush();
+      future.get(30, TimeUnit.SECONDS);
+      Assert.assertEquals("Expecting one result", 1, tableForRead.get(get).size());
+    }
+  }
+
+  @Test
+  public void testBufferdMutator() throws Exception {
+    final byte[] rowKey1 = dataHelper.randomData("TestAsyncBufferedMutator-");
+    final byte[] rowKey2 = dataHelper.randomData("TestAsyncBufferedMutator-");
+    final byte[] qualifier = dataHelper.randomData("testQualifier-");
+    final byte[] value = dataHelper.randomData("testValue-");
+
+    Put put1 = new Put(rowKey1).addColumn(COLUMN_FAMILY, qualifier, value);
+    Put put2 = new Put(rowKey2).addColumn(COLUMN_FAMILY, qualifier, value);
+    Get get1 = new Get(rowKey1);
+    Get get2 = new Get(rowKey2);
+
+    
+    TableName defaultTableName = sharedTestEnv.getDefaultTableName();
+    try (AsyncBufferedMutator mutator = getAsyncConnection().getBufferedMutator(defaultTableName);
+        Table tableForRead = getDefaultTable();) {
+      List<CompletableFuture<Void>> futures = mutator.mutate(Arrays.asList(put1, put2));
+      mutator.flush();
+      for (CompletableFuture<Void> f : futures) {
+        f.get(30, TimeUnit.SECONDS);
+      }
+      Result[] results = tableForRead.get(Arrays.asList(get1, get2));
+      Assert.assertEquals("Expecting one result", 2, results.length);
+      Assert.assertTrue(CellUtil.matchingValue(results[0].rawCells()[0], value));
+      Assert.assertTrue(CellUtil.matchingValue(results[1].rawCells()[0], value));
+    }
+  }
+}

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/async/TestAsyncBufferedMutator.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/async/TestAsyncBufferedMutator.java
@@ -39,7 +39,7 @@ import org.junit.Test;
 public class TestAsyncBufferedMutator extends AbstractAsyncTest {
 
   @Test
-  public void testBufferdMutatorMulti() throws Exception {
+  public void testBufferdMutator() throws Exception {
     TableName defaultTableName = sharedTestEnv.getDefaultTableName();
 
     final byte[] rowKey = dataHelper.randomData("TestAsyncBufferedMutator-");
@@ -58,7 +58,7 @@ public class TestAsyncBufferedMutator extends AbstractAsyncTest {
   }
 
   @Test
-  public void testBufferdMutator() throws Exception {
+  public void testBufferdMutatorMulti() throws Exception {
     final byte[] rowKey1 = dataHelper.randomData("TestAsyncBufferedMutator-");
     final byte[] rowKey2 = dataHelper.randomData("TestAsyncBufferedMutator-");
     final byte[] qualifier = dataHelper.randomData("testQualifier-");

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableConnection.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableConnection.java
@@ -87,22 +87,22 @@ public class BigtableConnection extends AbstractBigtableConnection {
 
       @Override
       public TableBuilder setWriteRpcTimeout(int arg0) {
-        return null;
+        return this;
       }
 
       @Override
       public TableBuilder setRpcTimeout(int arg0) {
-        return null;
+        return this;
       }
 
       @Override
       public TableBuilder setReadRpcTimeout(int arg0) {
-        return null;
+        return this;
       }
 
       @Override
       public TableBuilder setOperationTimeout(int arg0) {
-        return null;
+        return this;
       }
 
       @Override
@@ -118,7 +118,7 @@ public class BigtableConnection extends AbstractBigtableConnection {
 
   /** {@inheritDoc} */
   @Override
-  public Table getTable(TableName tableName, ExecutorService pool) throws IOException {
+  public Table getTable(TableName tableName, ExecutorService ignored) throws IOException {
     return new BigtableTable(this, createAdapter(tableName));
   }
 

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableConnection.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableConnection.java
@@ -82,8 +82,38 @@ public class BigtableConnection extends AbstractBigtableConnection {
 
   /** {@inheritDoc} */
   @Override
-  public TableBuilder getTableBuilder(TableName arg0, ExecutorService arg1) {
-    throw new UnsupportedOperationException("getTableBuilder"); // TODO
+  public TableBuilder getTableBuilder(final TableName tableName, final ExecutorService pool) {
+    return new TableBuilder() {
+
+      @Override
+      public TableBuilder setWriteRpcTimeout(int arg0) {
+        return null;
+      }
+
+      @Override
+      public TableBuilder setRpcTimeout(int arg0) {
+        return null;
+      }
+
+      @Override
+      public TableBuilder setReadRpcTimeout(int arg0) {
+        return null;
+      }
+
+      @Override
+      public TableBuilder setOperationTimeout(int arg0) {
+        return null;
+      }
+
+      @Override
+      public Table build() {
+        try {
+          return getTable(tableName, pool);
+        } catch (IOException e) {
+          throw new RuntimeException("Could not create the table", e);
+        }
+      }
+    };
   }
 
   /** {@inheritDoc} */

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/FutureUtils.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/FutureUtils.java
@@ -34,7 +34,7 @@ import com.google.common.util.concurrent.MoreExecutors;
  */
 public class FutureUtils {
 
-  private static final ExecutorService DIRECT_EXECUTOR = MoreExecutors.newDirectExecutorService();
+  public static final ExecutorService DIRECT_EXECUTOR = MoreExecutors.newDirectExecutorService();
   static Logger logger = new Logger(FutureUtils.class);
 
   public static <T> CompletableFuture<T> toCompletableFuture(ListenableFuture<T> listenableFuture) {

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/org/apache/hadoop/hbase/client/BigtableAsyncConnection.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/org/apache/hadoop/hbase/client/BigtableAsyncConnection.java
@@ -200,7 +200,8 @@ public class BigtableAsyncConnection implements AsyncConnection, Closeable {
 
       @Override
       public AsyncBufferedMutator build() {
-        return new BigtableAsyncBufferedMutator();
+        return new BigtableAsyncBufferedMutator(createAdapter(tableName), getConfiguration(),
+            session);
       }
     };
   }

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutator.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutator.java
@@ -19,27 +19,16 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock.ReadLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock.WriteLock;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.TableName;
-import org.apache.hadoop.hbase.client.Append;
 import org.apache.hadoop.hbase.client.BufferedMutator;
-import org.apache.hadoop.hbase.client.Delete;
-import org.apache.hadoop.hbase.client.Increment;
 import org.apache.hadoop.hbase.client.Mutation;
-import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.RetriesExhaustedWithDetailsException;
 import org.apache.hadoop.hbase.client.Row;
 
-import com.google.cloud.bigtable.config.BigtableOptions;
 import com.google.cloud.bigtable.config.Logger;
 import com.google.cloud.bigtable.grpc.BigtableSession;
-import com.google.cloud.bigtable.grpc.BigtableTableName;
-import com.google.cloud.bigtable.grpc.async.AsyncExecutor;
-import com.google.cloud.bigtable.grpc.async.BulkMutation;
 import com.google.cloud.bigtable.hbase.adapters.HBaseRequestAdapter;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
@@ -53,8 +42,6 @@ import com.google.common.util.concurrent.MoreExecutors;
  * @version $Id: $Id
  */
 public class BigtableBufferedMutator implements BufferedMutator {
-
-  /** Constant <code>LOG</code> */
   protected static final Logger LOG = new Logger(BigtableBufferedMutator.class);
 
   private static class MutationException {
@@ -67,31 +54,12 @@ public class BigtableBufferedMutator implements BufferedMutator {
     }
   }
 
-  private final Configuration configuration;
-
-  /**
-   * Makes sure that mutations and flushes are safe to proceed.  Ensures that while the mutator
-   * is closing, there will be no additional writes.
-   */
-  private final ReentrantReadWriteLock isClosedLock = new ReentrantReadWriteLock();
-  private final ReadLock closedReadLock = isClosedLock.readLock();
-  private final WriteLock closedWriteLock = isClosedLock.writeLock();
-
-  private boolean closed = false;
-
-  private final HBaseRequestAdapter adapter;
-  private final ExceptionListener exceptionListener;
+  private final BigtableBufferedMutatorHelper helper;
+  private final ExceptionListener listener;
 
   private final AtomicBoolean hasExceptions = new AtomicBoolean(false);
   private final List<MutationException> globalExceptions = new ArrayList<MutationException>();
-
   private final String host;
-
-  private final AsyncExecutor asyncExecutor;
-
-  private BulkMutation bulkMutation = null;
-
-  private BigtableOptions options;
 
   /**
    * <p>Constructor for BigtableBufferedMutator.</p>
@@ -108,77 +76,50 @@ public class BigtableBufferedMutator implements BufferedMutator {
       Configuration configuration,
       BigtableSession session,
       BufferedMutator.ExceptionListener listener) {
-    this.adapter = adapter;
-    this.configuration = configuration;
-    this.exceptionListener = listener;
-    this.options = session.getOptions();
-    this.host = options.getDataHost().toString();
-    this.asyncExecutor = session.createAsyncExecutor();
-    BigtableTableName tableName = this.adapter.getBigtableTableName();
-    this.bulkMutation = session.createBulkMutation(tableName);
+    helper = new BigtableBufferedMutatorHelper(adapter, configuration, session);
+    this.listener = listener;
+    this.host = session.getOptions().getDataHost().toString();
   }
 
   /** {@inheritDoc} */
   @Override
   public void close() throws IOException {
-    closedWriteLock.lock();
-    try {
-      flush();
-      asyncExecutor.flush();
-      closed = true;
-    } finally {
-      closedWriteLock.unlock();
-    }
+    helper.close();
+    handleExceptions();
   }
 
   /** {@inheritDoc} */
   @Override
   public void flush() throws IOException {
-    // If there is a bulk mutation in progress, then send it.
-    if (bulkMutation != null) {
-      try {
-        bulkMutation.flush();
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
-        throw new IOException("flush() was interrupted", e);
-      }
-    }
-    asyncExecutor.flush();
+    helper.flush();
     handleExceptions();
   }
 
   /** {@inheritDoc} */
   @Override
   public Configuration getConfiguration() {
-    return this.configuration;
+    return helper.getConfiguration();
   }
 
   /** {@inheritDoc} */
   @Override
   public TableName getName() {
-    return this.adapter.getTableName();
+    return helper.getName();
   }
 
   /** {@inheritDoc} */
   @Override
   public long getWriteBufferSize() {
-    return this.options.getBulkOptions().getMaxMemory();
+    return helper.getWriteBufferSize();
   }
 
   /** {@inheritDoc} */
   @Override
   public void mutate(List<? extends Mutation> mutations) throws IOException {
-    closedReadLock.lock();
-    try {
-      if (closed) {
-        throw new IllegalStateException("Cannot mutate when the BufferedMutator is closed.");
-      }
-      handleExceptions();
-      for (Mutation mutation : mutations) {
-        offer(mutation);
-      }
-    } finally {
-      closedReadLock.unlock();
+    handleExceptions();
+    List<ListenableFuture<?>> futures = helper.mutate(mutations);
+    for (int i = 0; i < mutations.size(); i++) {
+      addCallback(futures.get(i), mutations.get(i));
     }
   }
 
@@ -190,56 +131,9 @@ public class BigtableBufferedMutator implements BufferedMutator {
    * 2) There are more than {@link #getWriteBufferSize()} bytes pending
    */
   @Override
-  public void mutate(final Mutation mutation) throws IOException {
-    closedReadLock.lock();
-    try {
-      if (closed) {
-        throw new IllegalStateException("Cannot mutate when the BufferedMutator is closed.");
-      }
-      handleExceptions();
-      offer(mutation);
-    } finally {
-      closedReadLock.unlock();
-    }
-  }
-
-  /**
-   * Send the operations to the async executor asynchronously.  The conversion from hbase
-   * object to cloud bigtable proto and the async call both take time (microseconds worth) that
-   * could be parallelized, or at least removed from the user's thread.
-   */
-  @SuppressWarnings("unchecked")
-  private void offer(Mutation mutation) {
-    ListenableFuture<?> future = null;
-    try {
-      if (mutation == null) {
-        future = Futures.immediateFailedFuture(
-          new IllegalArgumentException("Cannot perform a mutation on a null object."));
-      } else if (mutation instanceof Put) {
-        future = bulkMutation.add(adapter.adaptEntry((Put) mutation));
-      } else if (mutation instanceof Delete) {
-        future = bulkMutation.add(adapter.adaptEntry((Delete) mutation));
-      } else if (mutation instanceof Increment) {
-        future = asyncExecutor.readModifyWriteRowAsync(adapter.adapt((Increment) mutation));
-      } else if (mutation instanceof Append) {
-        future = asyncExecutor.readModifyWriteRowAsync(adapter.adapt((Append) mutation));
-      } else {
-        future = Futures.immediateFailedFuture(new IllegalArgumentException(
-            "Encountered unknown mutation type: " + mutation.getClass()));
-      }
-    } catch (Exception e) {
-      // issueRequest(mutation) could throw an Exception for validation issues. Remove the heapsize
-      // and inflight rpc count.
-      future = Futures.immediateFailedFuture(e);
-    }
-    Futures.addCallback(future, new ExceptionCallback(mutation), MoreExecutors.directExecutor());
-  }
-
-  private void addGlobalException(Row mutation, Throwable t) {
-    synchronized (globalExceptions) {
-      globalExceptions.add(new MutationException(mutation, t));
-      hasExceptions.set(true);
-    }
+  public void mutate(Mutation mutation) throws IOException {
+    handleExceptions();
+    addCallback(helper.mutate(mutation), mutation);
   }
 
   /**
@@ -247,37 +141,62 @@ public class BigtableBufferedMutator implements BufferedMutator {
    * send it to the {@link org.apache.hadoop.hbase.client.BufferedMutator.ExceptionListener}.
    */
   private void handleExceptions() throws RetriesExhaustedWithDetailsException {
-    if (hasExceptions.get()) {
-      ArrayList<MutationException> mutationExceptions = null;
-      synchronized (globalExceptions) {
-        hasExceptions.set(false);
-        if (globalExceptions.isEmpty()) {
-          return;
-        }
-
-        mutationExceptions = new ArrayList<>(globalExceptions);
-        globalExceptions.clear();
-      }
-
-      List<Throwable> problems = new ArrayList<>(mutationExceptions.size());
-      ArrayList<String> hostnames = new ArrayList<>(mutationExceptions.size());
-      List<Row> failedMutations = new ArrayList<>(mutationExceptions.size());
-
-      if (!mutationExceptions.isEmpty()) {
-        LOG.warn("Exception occurred in BufferedMutator", mutationExceptions.get(0).throwable);
-      }
-      for (MutationException mutationException : mutationExceptions) {
-        problems.add(mutationException.throwable);
-        failedMutations.add(mutationException.mutation);
-        hostnames.add(host);
-        LOG.debug("Exception occurred in BufferedMutator", mutationException.throwable);
-      }
-
-      RetriesExhaustedWithDetailsException exception = new RetriesExhaustedWithDetailsException(
-          problems, failedMutations, hostnames);
-
-      exceptionListener.onException(exception, this);
+    RetriesExhaustedWithDetailsException exceptions = getExceptions();
+    if (exceptions != null) {
+      listener.onException(exceptions, this);
     }
+  }
+
+  @SuppressWarnings("unchecked")
+  private void addCallback(ListenableFuture<?> future, Mutation mutation) {
+    Futures.addCallback(future, new ExceptionCallback(mutation), MoreExecutors.directExecutor());
+  }
+
+  /**
+   * <p>hasInflightRequests.</p>
+   *
+   * @return a boolean.
+   */
+  public boolean hasInflightRequests() {
+    return helper.hasInflightRequests();
+  }
+  
+  /**
+   * Create a {@link RetriesExhaustedWithDetailsException} if there were any async exceptions and
+   * send it to the {@link org.apache.hadoop.hbase.client.BufferedMutator.ExceptionListener}.
+   */
+  private RetriesExhaustedWithDetailsException getExceptions()
+      throws RetriesExhaustedWithDetailsException {
+    if (!hasExceptions.get()) {
+      return null;
+    }
+
+    ArrayList<MutationException> mutationExceptions = null;
+    synchronized (globalExceptions) {
+      hasExceptions.set(false);
+      if (globalExceptions.isEmpty()) {
+        return null;
+      }
+
+      mutationExceptions = new ArrayList<>(globalExceptions);
+      globalExceptions.clear();
+    }
+
+    List<Throwable> problems = new ArrayList<>(mutationExceptions.size());
+    ArrayList<String> hostnames = new ArrayList<>(mutationExceptions.size());
+    List<Row> failedMutations = new ArrayList<>(mutationExceptions.size());
+
+    if (!mutationExceptions.isEmpty()) {
+      LOG.warn("Exception occurred in BufferedMutator", mutationExceptions.get(0).throwable);
+    }
+    for (MutationException mutationException : mutationExceptions) {
+      problems.add(mutationException.throwable);
+      failedMutations.add(mutationException.mutation);
+      hostnames.add(host);
+      LOG.debug("Exception occurred in BufferedMutator", mutationException.throwable);
+    }
+
+    return new RetriesExhaustedWithDetailsException(problems, failedMutations, hostnames);
   }
 
   @SuppressWarnings("rawtypes")
@@ -298,13 +217,10 @@ public class BigtableBufferedMutator implements BufferedMutator {
     }
   }
 
-  /**
-   * <p>hasInflightRequests.</p>
-   *
-   * @return a boolean.
-   */
-  public boolean hasInflightRequests() {
-    return this.asyncExecutor.hasInflightRequests()
-        || (bulkMutation != null && !bulkMutation.isFlushed());
+  private void addGlobalException(Row mutation, Throwable t) {
+    synchronized (globalExceptions) {
+      globalExceptions.add(new MutationException(mutation, t));
+      hasExceptions.set(true);
+    }
   }
 }

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutatorHelper.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutatorHelper.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock.ReadLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock.WriteLock;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Append;
+import org.apache.hadoop.hbase.client.Delete;
+import org.apache.hadoop.hbase.client.Increment;
+import org.apache.hadoop.hbase.client.Mutation;
+import org.apache.hadoop.hbase.client.Put;
+
+import com.google.cloud.bigtable.config.BigtableOptions;
+import com.google.cloud.bigtable.config.Logger;
+import com.google.cloud.bigtable.grpc.BigtableSession;
+import com.google.cloud.bigtable.grpc.BigtableTableName;
+import com.google.cloud.bigtable.grpc.async.AsyncExecutor;
+import com.google.cloud.bigtable.grpc.async.BulkMutation;
+import com.google.cloud.bigtable.hbase.adapters.HBaseRequestAdapter;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+
+/**
+ * A helper for Bigtable's {@link org.apache.hadoop.hbase.client.BufferedMutator} implementations.
+ * @author sduskis
+ * @version $Id: $Id
+ */
+public class BigtableBufferedMutatorHelper {
+
+  /** Constant <code>LOG</code> */
+  protected static final Logger LOG = new Logger(BigtableBufferedMutatorHelper.class);
+
+  private final Configuration configuration;
+
+  /**
+   * Makes sure that mutations and flushes are safe to proceed.  Ensures that while the mutator
+   * is closing, there will be no additional writes.
+   */
+  private final ReentrantReadWriteLock isClosedLock = new ReentrantReadWriteLock();
+  private final ReadLock closedReadLock = isClosedLock.readLock();
+  private final WriteLock closedWriteLock = isClosedLock.writeLock();
+
+  private boolean closed = false;
+
+  private final HBaseRequestAdapter adapter;
+  private final AsyncExecutor asyncExecutor;
+
+  private BulkMutation bulkMutation = null;
+
+  private BigtableOptions options;
+
+  /**
+   * <p>
+   * Constructor for BigtableBufferedMutator.
+   * </p>
+   * @param adapter Converts HBase objects to Bigtable protos
+   * @param configuration For Additional configuration. TODO: move this to options
+   * @param listener Handles exceptions. By default, it just throws the exception.
+   * @param session a {@link com.google.cloud.bigtable.grpc.BigtableSession} to get
+   *          {@link com.google.cloud.bigtable.config.BigtableOptions},
+   *          {@link com.google.cloud.bigtable.grpc.async.AsyncExecutor} and
+   *          {@link com.google.cloud.bigtable.grpc.async.BulkMutation} objects from starting the
+   *          async operations on the BigtableDataClient.
+   */
+  public BigtableBufferedMutatorHelper(
+      HBaseRequestAdapter adapter,
+      Configuration configuration,
+      BigtableSession session) {
+    this.adapter = adapter;
+    this.configuration = configuration;
+    this.options = session.getOptions();
+    this.asyncExecutor = session.createAsyncExecutor();
+    BigtableTableName tableName = this.adapter.getBigtableTableName();
+    this.bulkMutation = session.createBulkMutation(tableName);
+  }
+
+  public void close() throws IOException {
+    closedWriteLock.lock();
+    try {
+      flush();
+      asyncExecutor.flush();
+      closed = true;
+    } finally {
+      closedWriteLock.unlock();
+    }
+  }
+
+  public void flush() throws IOException {
+    // If there is a bulk mutation in progress, then send it.
+    if (bulkMutation != null) {
+      try {
+        bulkMutation.flush();
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new IOException("flush() was interrupted", e);
+      }
+    }
+    asyncExecutor.flush();
+  }
+
+  public void sendUnsent() {
+    if (bulkMutation != null) {
+      bulkMutation.sendUnsent();
+    }
+  }
+
+  public Configuration getConfiguration() {
+    return this.configuration;
+  }
+
+  public TableName getName() {
+    return this.adapter.getTableName();
+  }
+
+  public long getWriteBufferSize() {
+    return this.options.getBulkOptions().getMaxMemory();
+  }
+
+  public List<ListenableFuture<?>> mutate(List<? extends Mutation> mutations) {
+    closedReadLock.lock();
+    try {
+      List<ListenableFuture<?>> futures = new ArrayList<>(mutations.size());
+      for (Mutation mutation : mutations) {
+        futures.add(offer(mutation));
+      }
+      return futures;
+    } finally {
+      closedReadLock.unlock();
+    }
+  }
+
+  /**
+   * Being a Mutation. This method will block if either of the following are true:
+   * 1) There are more than {@code maxInflightRpcs} RPCs in flight
+   * 2) There are more than {@link #getWriteBufferSize()} bytes pending
+   * @return 
+   */
+  public ListenableFuture<?> mutate(final Mutation mutation) {
+    closedReadLock.lock();
+    try {
+      if (closed) {
+        throw new IllegalStateException("Cannot mutate when the BufferedMutator is closed.");
+      }
+      return offer(mutation);
+    } finally {
+      closedReadLock.unlock();
+    }
+  }
+
+  /**
+   * Send the operations to the async executor asynchronously.  The conversion from hbase
+   * object to cloud bigtable proto and the async call both take time (microseconds worth) that
+   * could be parallelized, or at least removed from the user's thread.
+   */
+  private ListenableFuture<?> offer(Mutation mutation) {
+    if (closed) {
+      Futures.immediateFailedFuture(
+        new IllegalStateException("Cannot mutate when the BufferedMutator is closed."));
+    }
+    ListenableFuture<?> future = null;
+    try {
+      if (mutation == null) {
+        future = Futures.immediateFailedFuture(
+          new IllegalArgumentException("Cannot perform a mutation on a null object."));
+      } else if (mutation instanceof Put) {
+        future = bulkMutation.add(adapter.adaptEntry((Put) mutation));
+      } else if (mutation instanceof Delete) {
+        future = bulkMutation.add(adapter.adaptEntry((Delete) mutation));
+      } else if (mutation instanceof Increment) {
+        future = asyncExecutor.readModifyWriteRowAsync(adapter.adapt((Increment) mutation));
+      } else if (mutation instanceof Append) {
+        future = asyncExecutor.readModifyWriteRowAsync(adapter.adapt((Append) mutation));
+      } else {
+        future = Futures.immediateFailedFuture(new IllegalArgumentException(
+            "Encountered unknown mutation type: " + mutation.getClass()));
+      }
+    } catch (Exception e) {
+      // issueRequest(mutation) could throw an Exception for validation issues. Remove the heapsize
+      // and inflight rpc count.
+      future = Futures.immediateFailedFuture(e);
+    }
+    return future;
+  }
+
+
+  /**
+   * <p>hasInflightRequests.</p>
+   *
+   * @return a boolean.
+   */
+  public boolean hasInflightRequests() {
+    return this.asyncExecutor.hasInflightRequests()
+        || (bulkMutation != null && !bulkMutation.isFlushed());
+  }
+}


### PR DESCRIPTION
I moved most of the code from BigtableBufferedMutator to a class called BigtableBufferedMutatorHelper.  BigtableBufferedMutatorHelper returns futures, and does all of the thigns both BigtableBufferedMutator and BigtableAsyncBufferedMutator need.  BigtableBufferedMutator deferes to BigtableBufferedMutatorHelper for everything but exception management.

BigtableAsyncBufferedMutator turned out to be simpler than BigtableBufferedMutator, but has some behavior changes for flush() and close().  Users need to wait for individual CompletableFutures to complete.