### PR TITLE
Filter sync

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/data/v2/wrappers/Filters.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/data/v2/wrappers/Filters.java
@@ -492,16 +492,6 @@ public final class Filters {
     public TimestampRangeFilter range() {
       return new TimestampRangeFilter();
     }
-
-    /**
-     * Matches only cells with timestamps within the given range.
-     *
-     * @param startMicros Inclusive start of the range in microseconds.
-     * @param endMicros Exclusive end of the range in microseconds.
-     */
-    public Filter range(long startMicros, long endMicros) {
-      return range().startClosed(startMicros).endOpen(endMicros);
-    }
   }
 
   /**

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/data/v2/wrappers/Filters.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/data/v2/wrappers/Filters.java
@@ -191,15 +191,11 @@ public final class Filters {
 
   // Implementations of target specific filters.
   /** DSL for adding filters to a chain. */
-  public static final class ChainFilter implements Filter, Cloneable {
-    private final RowFilter.Chain.Builder builder;
+  public static final class ChainFilter implements Filter {
+    private RowFilter.Chain.Builder builder;
 
     private ChainFilter() {
-      this(RowFilter.Chain.newBuilder());
-    }
-
-    private ChainFilter(RowFilter.Chain.Builder builder) {
-      this.builder = builder;
+      this.builder = RowFilter.Chain.newBuilder();
     }
 
     /** Add a filter to chain. */
@@ -222,7 +218,13 @@ public final class Filters {
     /** Makes a deep copy of the Chain. */
     @Override
     public ChainFilter clone() {
-      return new ChainFilter(builder.build().toBuilder());
+      try {
+        ChainFilter clone = (ChainFilter) super.clone();
+        clone.builder = builder.clone();
+        return clone;
+      } catch (CloneNotSupportedException | ClassCastException e) {
+        throw new RuntimeException("should never happen");
+      }
     }
   }
 
@@ -248,6 +250,17 @@ public final class Filters {
         return builder.getFilters(0);
       } else {
         return RowFilter.newBuilder().setInterleave(builder.build()).build();
+      }
+    }
+
+    @Override
+    public InterleaveFilter clone() {
+      try {
+        InterleaveFilter clone = (InterleaveFilter) super.clone();
+        clone.builder = builder.clone();
+        return clone;
+      } catch (CloneNotSupportedException | ClassCastException e) {
+        throw new RuntimeException("should never happen");
       }
     }
   }
@@ -282,6 +295,17 @@ public final class Filters {
           builder.hasTrueFilter() || builder.hasFalseFilter(),
           "ConditionFilter must have either a then or otherwise filter.");
       return RowFilter.newBuilder().setCondition(builder.build()).build();
+    }
+
+    @Override
+    public ConditionFilter clone() {
+      try {
+        ConditionFilter clone = (ConditionFilter) super.clone();
+        clone.builder = builder.clone();
+        return clone;
+      } catch (CloneNotSupportedException | ClassCastException e) {
+        throw new RuntimeException("should never happen");
+      }
     }
   }
 
@@ -450,6 +474,11 @@ public final class Filters {
 
       return RowFilter.newBuilder().setColumnRangeFilter(builder.build()).build();
     }
+
+    @Override
+    public QualifierRangeFilter clone() {
+      return super.clone();
+    }
   }
 
   public static final class TimestampFilter {
@@ -513,6 +542,11 @@ public final class Filters {
           throw new IllegalStateException("Unknown end bound: " + getEndBound());
       }
       return RowFilter.newBuilder().setTimestampRangeFilter(builder.build()).build();
+    }
+
+    @Override
+    public TimestampRangeFilter clone() {
+      return super.clone();
     }
   }
 
@@ -600,6 +634,11 @@ public final class Filters {
       }
       return RowFilter.newBuilder().setValueRangeFilter(builder.build()).build();
     }
+
+    @Override
+    public ValueRangeFilter clone() {
+      return super.clone();
+    }
   }
 
   public static final class OffsetFilter {
@@ -651,9 +690,18 @@ public final class Filters {
     public RowFilter toProto() {
       return proto;
     }
+
+    @Override
+    public SimpleFilter clone() {
+      try {
+        return (SimpleFilter) super.clone();
+      } catch (CloneNotSupportedException e) {
+        throw new RuntimeException("should never happen", e);
+      }
+    }
   }
 
-  public interface Filter {
+  public interface Filter extends Cloneable {
     @InternalApi
     RowFilter toProto();
   }

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/data/v2/wrappers/Filters.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/data/v2/wrappers/Filters.java
@@ -375,11 +375,6 @@ public final class Filters {
       return new SimpleFilter(RowFilter.newBuilder().setFamilyNameRegexFilter(regex).build());
     }
 
-    public Filter regex(@Nonnull ByteString regex) {
-      Preconditions.checkNotNull(regex);
-      return new SimpleFilter(RowFilter.newBuilder().setFamilyNameRegexFilterBytes(regex).build());
-    }
-
     /** Matches only cells from columns whose families match the value. */
     public Filter exactMatch(@Nonnull String value) {
       Preconditions.checkNotNull(value);

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/data/v2/wrappers/Range.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/data/v2/wrappers/Range.java
@@ -1,0 +1,267 @@
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.data.v2.wrappers;
+
+import com.google.common.base.Preconditions;
+import com.google.protobuf.ByteString;
+import javax.annotation.Nonnull;
+
+/**
+ * Range API.
+ *
+ * <p>This base class represents the API for all ranges in the Cloud Bigtable client. Please note
+ * this mutable type. It's intended to support fluent DSLs.For example:
+ *
+ * <pre>{@code
+ * // A Range that encloses all strings
+ * ByteStringRange.unbounded();
+ *
+ * // Range that includes all strings including "begin" up until "end"
+ * ByteStringRange.unbounded().of("start", "end");
+ *
+ * // Create a Bytestring range with an unbounded start and the inclusive end "end"
+ * ByteStringRange.unbounded().endClosed("end");
+ *
+ * // Ranges are mutable, so take care to clone them to get a new instance
+ * ByteStringRange r1 = ByteStringRange.of("a", "z");
+ * ByteStringRange r2 = r1.clone().endUnbounded();
+ * }</pre>
+ */
+abstract class Range<T, R extends Range<T, R>> {
+  public enum BoundType {
+    OPEN,
+    CLOSED,
+    UNBOUNDED
+  }
+
+  private BoundType startBound;
+  private T start;
+  private BoundType endBound;
+  private T end;
+
+  Range() {
+    this(BoundType.UNBOUNDED, null, BoundType.UNBOUNDED, null);
+  }
+
+  Range(BoundType startBound, T start, BoundType endBound, T end) {
+    this.startBound = startBound;
+    this.start = start;
+    this.endBound = endBound;
+    this.end = end;
+  }
+
+  /**
+   * Creates a new {@link Range} with the specified inclusive start and the specified exclusive end.
+   */
+  public R of(@Nonnull T startClosed, @Nonnull T endOpen) {
+    return startClosed(startClosed).endOpen(endOpen);
+  }
+
+  /** Creates a new {@link Range} with an unbounded start and the current end. */
+  public R startUnbounded() {
+    this.start = null;
+    this.startBound = BoundType.UNBOUNDED;
+    return thisT();
+  }
+
+  /** Creates a new {@link Range} with the specified exclusive start and the current end. */
+  public R startOpen(@Nonnull T start) {
+    this.start = Preconditions.checkNotNull(start, "Start can't be null");
+    this.startBound = BoundType.OPEN;
+    return thisT();
+  }
+
+  /** Creates a new {@link Range} with the specified inclusive start and the current end. */
+  public R startClosed(@Nonnull T start) {
+    this.start = Preconditions.checkNotNull(start, "Start can't be null");
+    this.startBound = BoundType.CLOSED;
+    return thisT();
+  }
+
+  /** Creates a new {@link Range} with the current start and an unbounded end. */
+  public R endUnbounded() {
+    this.end = null;
+    this.endBound = BoundType.UNBOUNDED;
+    return thisT();
+  }
+
+  /** Creates a new {@link Range} with the specified exclusive end and the current start. */
+  public R endOpen(@Nonnull T end) {
+    this.end = Preconditions.checkNotNull(end, "End can't be null");
+    this.endBound = BoundType.OPEN;
+    return thisT();
+  }
+
+  /** Creates a new {@link Range} with the specified inclusive end and the current start. */
+  public R endClosed(@Nonnull T end) {
+    this.end = Preconditions.checkNotNull(end, "End can't be null");
+    this.endBound = BoundType.CLOSED;
+    return thisT();
+  }
+
+  /** Gets the current start {@link BoundType}. */
+  public BoundType getStartBound() {
+    return startBound;
+  }
+
+  /**
+   * Gets the current start value.
+   *
+   * @throws IllegalStateException If the current {@link #getStartBound()} is {@link
+   *     BoundType#UNBOUNDED}.
+   */
+  public T getStart() {
+    Preconditions.checkState(startBound != BoundType.UNBOUNDED, "Start is unbounded");
+    return start;
+  }
+
+  /** Gets the current end {@link BoundType}. */
+  public BoundType getEndBound() {
+    return endBound;
+  }
+
+  /**
+   * Gets the current end value.
+   *
+   * @throws IllegalStateException If the current {@link #getEndBound()} is {@link
+   *     BoundType#UNBOUNDED}.
+   */
+  public T getEnd() {
+    Preconditions.checkState(endBound != BoundType.UNBOUNDED, "End is unbounded");
+    return end;
+  }
+
+  @SuppressWarnings("unchecked")
+  private R thisT() {
+    return (R) this;
+  }
+
+  /** Abstract specialization of a {@link Range} for timestamps. */
+  abstract static class AbstractTimestampRange<R extends AbstractTimestampRange<R>>
+      extends Range<Long, R> implements Cloneable {
+    AbstractTimestampRange() {
+      super();
+    }
+
+    AbstractTimestampRange(BoundType startBound, Long start, BoundType endBound, Long end) {
+      super(startBound, start, endBound, end);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    protected R clone() {
+      try {
+        return (R) super.clone();
+      } catch (CloneNotSupportedException e) {
+        throw new RuntimeException("should never happen", e);
+      }
+    }
+  }
+
+  /**
+   * Abstract specialization of a {@link Range} for {@link ByteString}s. Allows for easy interop
+   * with simple Strings.
+   */
+  abstract static class AbstractByteStringRange<R extends AbstractByteStringRange<R>>
+      extends Range<ByteString, R> implements Cloneable {
+    AbstractByteStringRange() {
+      this(BoundType.UNBOUNDED, null, BoundType.UNBOUNDED, null);
+    }
+
+    AbstractByteStringRange(
+        BoundType startBound, ByteString start, BoundType endBound, ByteString end) {
+      super(startBound, start, endBound, end);
+    }
+
+    /**
+     * Creates a new {@link Range} with the specified inclusive start and the specified exclusive
+     * end.
+     */
+    public R of(String startClosed, String endOpen) {
+      return of(wrap(startClosed), wrap(endOpen));
+    }
+
+    /** Creates a new {@link Range} with the specified exclusive start and the current end. */
+    public R startOpen(String start) {
+      return startOpen(wrap(start));
+    }
+
+    /** Creates a new {@link Range} with the specified inclusive start and the current end. */
+    public R startClosed(String start) {
+      return startClosed(wrap(start));
+    }
+
+    /** Creates a new {@link Range} with the specified exclusive end and the current start. */
+    public R endOpen(String end) {
+      return endOpen(wrap(end));
+    }
+
+    /** Creates a new {@link Range} with the specified inclusive end and the current start. */
+    public R endClosed(String end) {
+      return endClosed(wrap(end));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    protected R clone() {
+      try {
+        return (R) super.clone();
+      } catch (CloneNotSupportedException e) {
+        throw new RuntimeException("should never happen", e);
+      }
+    }
+
+    static ByteString wrap(String str) {
+      return ByteString.copyFromUtf8(str);
+    }
+  }
+
+  /** Concrete Range for timestamps */
+  public static final class TimestampRange extends AbstractTimestampRange<TimestampRange> {
+    public static TimestampRange unbounded() {
+      return new TimestampRange(BoundType.UNBOUNDED, null, BoundType.UNBOUNDED, null);
+    }
+
+    public static TimestampRange create(long closedStart, long openEnd) {
+      return new TimestampRange(BoundType.CLOSED, closedStart, BoundType.OPEN, openEnd);
+    }
+
+    private TimestampRange(BoundType startBound, Long start, BoundType endBound, Long end) {
+      super(startBound, start, endBound, end);
+    }
+  }
+
+  /** Concrete Range for ByteStrings */
+  public static final class ByteStringRange extends AbstractByteStringRange<ByteStringRange> {
+    public static ByteStringRange unbounded() {
+      return new ByteStringRange(BoundType.UNBOUNDED, null, BoundType.UNBOUNDED, null);
+    }
+
+    public static ByteStringRange create(ByteString closedStart, ByteString openEnd) {
+      return new ByteStringRange(BoundType.CLOSED, closedStart, BoundType.OPEN, openEnd);
+    }
+
+    public static ByteStringRange create(String closedStart, String openEnd) {
+      return new ByteStringRange(
+          BoundType.CLOSED, wrap(closedStart), BoundType.OPEN, wrap(openEnd));
+    }
+
+    private ByteStringRange(
+        BoundType startBound, ByteString start, BoundType endBound, ByteString end) {
+      super(startBound, start, endBound, end);
+    }
+  }
+}

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/data/v2/wrappers/FiltersTest.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/data/v2/wrappers/FiltersTest.java
@@ -17,16 +17,14 @@ package com.google.cloud.bigtable.data.v2.wrappers;
 
 import static com.google.cloud.bigtable.data.v2.wrappers.Filters.FILTERS;
 
-import java.util.concurrent.TimeUnit;
-
 import com.google.bigtable.v2.ColumnRange;
 import com.google.bigtable.v2.RowFilter;
 import com.google.bigtable.v2.RowFilter.Chain;
 import com.google.bigtable.v2.RowFilter.Condition;
 import com.google.bigtable.v2.RowFilter.Interleave;
+import com.google.bigtable.v2.TimestampRange;
 import com.google.bigtable.v2.ValueRange;
 import com.google.protobuf.ByteString;
-
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -37,12 +35,11 @@ public class FiltersTest {
   @Test
   public void chainTest() {
     RowFilter actualProto =
-        FILTERS.chain()
+        FILTERS
+            .chain()
             .filter(FILTERS.key().regex(".*"))
             .filter(FILTERS.key().sample(0.5))
-            .filter(FILTERS.chain()
-                .filter(FILTERS.family().regex("hi$"))
-                .filter(FILTERS.qualifier().regex("^q")))
+            .filter(FILTERS.chain().filter(FILTERS.family().regex("hi$")).filter(FILTERS.pass()))
             .toProto();
 
     RowFilter expectedFilter =
@@ -58,9 +55,7 @@ public class FiltersTest {
                                 Chain.newBuilder()
                                     .addFilters(
                                         RowFilter.newBuilder().setFamilyNameRegexFilter("hi$"))
-                                    .addFilters(
-                                        RowFilter.newBuilder().setColumnQualifierRegexFilter(
-                                            ByteString.copyFromUtf8("^q"))))))
+                                    .addFilters(RowFilter.newBuilder().setPassAllFilter(true)))))
             .build();
 
     Assert.assertEquals(expectedFilter, actualProto);
@@ -69,12 +64,12 @@ public class FiltersTest {
   @Test
   public void interleaveTest() {
     RowFilter actualProto =
-        FILTERS.interleave()
+        FILTERS
+            .interleave()
             .filter(FILTERS.key().regex(".*"))
             .filter(FILTERS.key().sample(0.5))
-            .filter(FILTERS.interleave()
-                .filter(FILTERS.family().regex("hi$"))
-                .filter(FILTERS.qualifier().regex("^q")))
+            .filter(
+                FILTERS.interleave().filter(FILTERS.family().regex("hi$")).filter(FILTERS.pass()))
             .toProto();
 
     RowFilter expectedFilter =
@@ -91,8 +86,7 @@ public class FiltersTest {
                                     .addFilters(
                                         RowFilter.newBuilder().setFamilyNameRegexFilter("hi$"))
                                     .addFilters(
-                                        RowFilter.newBuilder().setColumnQualifierRegexFilter(
-                                            ByteString.copyFromUtf8("^q"))))))
+                                        RowFilter.newBuilder().setPassAllFilter(true).build()))))
             .build();
 
     Assert.assertEquals(expectedFilter, actualProto);
@@ -100,8 +94,9 @@ public class FiltersTest {
 
   @Test
   public void conditionTest() {
-    RowFilter actualProto =
-        FILTERS.condition(FILTERS.key().regex(".*"))
+    RowFilter actualFilter =
+        FILTERS
+            .condition(FILTERS.key().regex(".*"))
             .then(FILTERS.label("true"))
             .otherwise(FILTERS.label("false"))
             .toProto();
@@ -116,173 +111,217 @@ public class FiltersTest {
                     .setFalseFilter(RowFilter.newBuilder().setApplyLabelTransformer("false")))
             .build();
 
-    Assert.assertEquals(expectedFilter, actualProto);
-  }
-
-  @Test
-  public void passTest() {
-    RowFilter actualProto = FILTERS.pass().toProto();
-
-    RowFilter expectedFilter = RowFilter.newBuilder().setPassAllFilter(true).build();
-
-    Assert.assertEquals(expectedFilter, actualProto);
-  }
-
-  @Test
-  public void blockTest() {
-    RowFilter actualProto = FILTERS.block().toProto();
-
-    RowFilter expectedFilter = RowFilter.newBuilder().setBlockAllFilter(true).build();
-
-    Assert.assertEquals(expectedFilter, actualProto);
-  }
-
-  @Test
-  public void sinkTest() {
-    RowFilter actualProto = FILTERS.sink().toProto();
-
-    RowFilter expectedFilter = RowFilter.newBuilder().setSink(true).build();
-
-    Assert.assertEquals(expectedFilter, actualProto);
-  }
-
-  @Test
-  public void labelTest() {
-    RowFilter actualProto = FILTERS.label("my-label").toProto();
-
-    RowFilter expectedFilter = RowFilter.newBuilder().setApplyLabelTransformer("my-label").build();
-
-    Assert.assertEquals(expectedFilter, actualProto);
+    Assert.assertEquals(expectedFilter, actualFilter);
   }
 
   @Test
   public void keyRegexTest() {
-    RowFilter actualProto = FILTERS.key().regex(".*").toProto();
+    RowFilter actualFilter = FILTERS.key().regex(ByteString.copyFromUtf8(".*")).toProto();
 
     RowFilter expectedFilter =
         RowFilter.newBuilder().setRowKeyRegexFilter(ByteString.copyFromUtf8(".*")).build();
 
-    Assert.assertEquals(expectedFilter, actualProto);
+    Assert.assertEquals(expectedFilter, actualFilter);
+  }
+
+  @Test
+  public void keyRegexStringTest() {
+    RowFilter actualFilter = FILTERS.key().regex(".*").toProto();
+
+    RowFilter expectedFilter =
+        RowFilter.newBuilder().setRowKeyRegexFilter(ByteString.copyFromUtf8(".*")).build();
+
+    Assert.assertEquals(expectedFilter, actualFilter);
   }
 
   @Test
   public void keyExactMatchTest() {
-    RowFilter actualProto = FILTERS.key().exactMatch(ByteString.copyFromUtf8(".*")).toProto();
+    RowFilter actualFilter = FILTERS.key().exactMatch(ByteString.copyFromUtf8(".*")).toProto();
 
     RowFilter expectedFilter =
         RowFilter.newBuilder().setRowKeyRegexFilter(ByteString.copyFromUtf8("\\.\\*")).build();
 
-    Assert.assertEquals(expectedFilter, actualProto);
+    Assert.assertEquals(expectedFilter, actualFilter);
   }
 
   @Test
   public void keySampleTest() {
-    RowFilter actualProto = FILTERS.key().sample(0.3).toProto();
+    RowFilter actualFilter = FILTERS.key().sample(0.3).toProto();
 
     RowFilter expectedFilter = RowFilter.newBuilder().setRowSampleFilter(0.3).build();
 
-    Assert.assertEquals(expectedFilter, actualProto);
+    Assert.assertEquals(expectedFilter, actualFilter);
   }
 
   @Test
   public void familyRegexTest() {
-    RowFilter actualProto = FILTERS.family().regex("^hi").toProto();
+    RowFilter actualFilter = FILTERS.family().regex("^hi").toProto();
 
     RowFilter expectedFilter = RowFilter.newBuilder().setFamilyNameRegexFilter("^hi").build();
 
-    Assert.assertEquals(expectedFilter, actualProto);
+    Assert.assertEquals(expectedFilter, actualFilter);
   }
 
   @Test
   public void familyExactMatchTest() {
-    RowFilter actualProto = FILTERS.family().exactMatch("^hi").toProto();
+    RowFilter actualFilter = FILTERS.family().exactMatch("^hi").toProto();
 
     RowFilter expectedFilter = RowFilter.newBuilder().setFamilyNameRegexFilter("\\^hi").build();
 
-    Assert.assertEquals(expectedFilter, actualProto);
+    Assert.assertEquals(expectedFilter, actualFilter);
   }
 
   @Test
   public void qualifierRegexTest() {
-    RowFilter actualProto = FILTERS.qualifier().regex("^hi").toProto();
+    RowFilter actualFilter = FILTERS.qualifier().regex(ByteString.copyFromUtf8("^hi")).toProto();
 
     RowFilter expectedFilter =
         RowFilter.newBuilder()
             .setColumnQualifierRegexFilter(ByteString.copyFromUtf8("^hi"))
             .build();
 
-    Assert.assertEquals(expectedFilter, actualProto);
+    Assert.assertEquals(expectedFilter, actualFilter);
+  }
+
+  @Test
+  public void qualifierRegexStringTest() {
+    RowFilter actualFilter = FILTERS.qualifier().regex("^hi").toProto();
+
+    RowFilter expectedFilter =
+        RowFilter.newBuilder()
+            .setColumnQualifierRegexFilter(ByteString.copyFromUtf8("^hi"))
+            .build();
+
+    Assert.assertEquals(expectedFilter, actualFilter);
   }
 
   @Test
   public void qualifierExactMatchTest() {
-    RowFilter actualProto = FILTERS.qualifier().exactMatch(ByteString.copyFromUtf8("^hi")).toProto();
+    RowFilter actualFilter =
+        FILTERS.qualifier().exactMatch(ByteString.copyFromUtf8("^hi")).toProto();
 
     RowFilter expectedFilter =
         RowFilter.newBuilder()
             .setColumnQualifierRegexFilter(ByteString.copyFromUtf8("\\^hi"))
             .build();
 
-    Assert.assertEquals(expectedFilter, actualProto);
+    Assert.assertEquals(expectedFilter, actualFilter);
   }
 
   @Test
-  public void qualifierRangeOpenClosed() {
-    String family = "family";
-    ByteString begin = ByteString.copyFromUtf8("begin");
-    ByteString end = ByteString.copyFromUtf8("end");
-    RowFilter actualProto = FILTERS.qualifier().rangeWithinFamily(family)
-        .startOpen(begin)
-        .endClosed(end)
-        .toProto();
+  public void qualifierRangeInFamilyClosedOpen() {
+    RowFilter actualFilter =
+        FILTERS
+            .qualifier()
+            .rangeWithinFamily("family")
+            .startClosed("begin")
+            .endOpen("end")
+            .toProto();
+
     RowFilter expectedFilter =
         RowFilter.newBuilder()
             .setColumnRangeFilter(
                 ColumnRange.newBuilder()
-                    .setFamilyName(family)
-                    .setStartQualifierOpen(begin)
-                    .setEndQualifierClosed(end))
+                    .setFamilyName("family")
+                    .setStartQualifierClosed(ByteString.copyFromUtf8("begin"))
+                    .setEndQualifierOpen(ByteString.copyFromUtf8("end")))
             .build();
 
-    Assert.assertEquals(expectedFilter, actualProto);
+    Assert.assertEquals(expectedFilter, actualFilter);
   }
 
   @Test
-  public void qualifierRangeClosedOpen() {
-    String family = "family";
-    ByteString begin = ByteString.copyFromUtf8("begin");
-    ByteString end = ByteString.copyFromUtf8("end");
-    RowFilter actualProto = FILTERS.qualifier().rangeWithinFamily(family)
-        .startClosed(begin)
-        .endOpen(end)
-        .toProto();
+  public void qualifierRangeInFamilyOpenClosed() {
+    RowFilter actualFilter =
+        FILTERS
+            .qualifier()
+            .rangeWithinFamily("family")
+            .startOpen("begin")
+            .endClosed("end")
+            .toProto();
+
     RowFilter expectedFilter =
         RowFilter.newBuilder()
             .setColumnRangeFilter(
                 ColumnRange.newBuilder()
-                    .setFamilyName(family)
-                    .setStartQualifierClosed(begin)
-                    .setEndQualifierOpen(end))
+                    .setFamilyName("family")
+                    .setStartQualifierOpen(ByteString.copyFromUtf8("begin"))
+                    .setEndQualifierClosed(ByteString.copyFromUtf8("end")))
             .build();
 
-    Assert.assertEquals(expectedFilter, actualProto);
+    Assert.assertEquals(expectedFilter, actualFilter);
+  }
+
+  @Test
+  public void qualifierRangeRange() {
+    RowFilter actualFilter =
+        FILTERS
+            .qualifier()
+            .rangeWithinFamily("family")
+            .startClosed("begin")
+            .endOpen("end")
+            .toProto();
+
+    RowFilter expectedFilter =
+        RowFilter.newBuilder()
+            .setColumnRangeFilter(
+                ColumnRange.newBuilder()
+                    .setFamilyName("family")
+                    .setStartQualifierClosed(ByteString.copyFromUtf8("begin"))
+                    .setEndQualifierOpen(ByteString.copyFromUtf8("end")))
+            .build();
+
+    Assert.assertEquals(expectedFilter, actualFilter);
+  }
+
+  @Test
+  public void timestampRange() {
+    RowFilter actualFilter =
+        FILTERS.timestamp().range().startClosed(1_000L).endOpen(30_000L).toProto();
+
+    RowFilter expectedFilter =
+        RowFilter.newBuilder()
+            .setTimestampRangeFilter(
+                TimestampRange.newBuilder()
+                    .setStartTimestampMicros(1_000L)
+                    .setEndTimestampMicros(30_000L))
+            .build();
+
+    Assert.assertEquals(expectedFilter, actualFilter);
+  }
+
+  @Test
+  public void timestampOpenClosedFakeRange() {
+    RowFilter actualFilter =
+        FILTERS.timestamp().range().startOpen(1_000L).endClosed(30_000L).toProto();
+
+    // open start & closed end are faked in the client by incrementing the query
+    RowFilter expectedFilter =
+        RowFilter.newBuilder()
+            .setTimestampRangeFilter(
+                TimestampRange.newBuilder()
+                    .setStartTimestampMicros(1_000L + 1)
+                    .setEndTimestampMicros(30_000L + 1))
+            .build();
+
+    Assert.assertEquals(expectedFilter, actualFilter);
   }
 
   @Test
   public void valueRegex() {
-    RowFilter actualProto = FILTERS.value().regex("some[0-9]regex").toProto();
+    RowFilter actualFilter = FILTERS.value().regex("some[0-9]regex").toProto();
 
     RowFilter expectedFilter =
         RowFilter.newBuilder()
             .setValueRegexFilter(ByteString.copyFromUtf8("some[0-9]regex"))
             .build();
 
-    Assert.assertEquals(expectedFilter, actualProto);
+    Assert.assertEquals(expectedFilter, actualFilter);
   }
 
   @Test
   public void valueExactMatch() {
-    RowFilter actualProto =
+    RowFilter actualFilter =
         FILTERS.value().exactMatch(ByteString.copyFromUtf8("some[0-9]regex")).toProto();
 
     RowFilter expectedFilter =
@@ -290,122 +329,108 @@ public class FiltersTest {
             .setValueRegexFilter(ByteString.copyFromUtf8("some\\[0\\-9\\]regex"))
             .build();
 
-    Assert.assertEquals(expectedFilter, actualProto);
+    Assert.assertEquals(expectedFilter, actualFilter);
   }
 
   @Test
   public void valueRangeClosedOpen() {
-    ByteString begin = ByteString.copyFromUtf8("begin");
-    ByteString end = ByteString.copyFromUtf8("end");
-
-    RowFilter actualProto = FILTERS.value().range()
-        .startOpen(begin)
-        .endClosed(end)
-        .toProto();
+    RowFilter actualFilter = FILTERS.value().range().startClosed("begin").endOpen("end").toProto();
 
     RowFilter expectedFilter =
         RowFilter.newBuilder()
             .setValueRangeFilter(
                 ValueRange.newBuilder()
-                    .setStartValueOpen(begin)
-                    .setEndValueClosed(end))
+                    .setStartValueClosed(ByteString.copyFromUtf8("begin"))
+                    .setEndValueOpen(ByteString.copyFromUtf8("end")))
             .build();
 
-    Assert.assertEquals(expectedFilter, actualProto);
+    Assert.assertEquals(expectedFilter, actualFilter);
   }
 
   @Test
   public void valueRangeOpenClosed() {
-    ByteString begin = ByteString.copyFromUtf8("begin");
-    ByteString end = ByteString.copyFromUtf8("end");
-
-    RowFilter actualProto = FILTERS.value().range()
-        .startClosed(begin)
-        .endOpen(end)
-        .toProto();
+    RowFilter actualFilter = FILTERS.value().range().startOpen("begin").endClosed("end").toProto();
 
     RowFilter expectedFilter =
         RowFilter.newBuilder()
             .setValueRangeFilter(
                 ValueRange.newBuilder()
-                    .setStartValueClosed(begin)
-                    .setEndValueOpen(end))
+                    .setStartValueOpen(ByteString.copyFromUtf8("begin"))
+                    .setEndValueClosed(ByteString.copyFromUtf8("end")))
             .build();
 
-    Assert.assertEquals(expectedFilter, actualProto);
+    Assert.assertEquals(expectedFilter, actualFilter);
   }
 
   @Test
   public void valueStripTest() {
-    RowFilter actualProto = FILTERS.value().strip().toProto();
+    RowFilter actualFilter = FILTERS.value().strip().toProto();
 
     RowFilter expectedFilter = RowFilter.newBuilder().setStripValueTransformer(true).build();
 
-    Assert.assertEquals(expectedFilter, actualProto);
+    Assert.assertEquals(expectedFilter, actualFilter);
   }
 
   @Test
   public void offsetCellsPerRowTest() {
-    RowFilter actualProto = FILTERS.offset().cellsPerRow(10).toProto();
+    RowFilter actualFilter = FILTERS.offset().cellsPerRow(10).toProto();
 
     RowFilter expectedFilter = RowFilter.newBuilder().setCellsPerRowOffsetFilter(10).build();
 
-    Assert.assertEquals(expectedFilter, actualProto);
+    Assert.assertEquals(expectedFilter, actualFilter);
   }
 
   @Test
   public void limitCellsPerRowTest() {
-    RowFilter actualProto = FILTERS.limit().cellsPerRow(10).toProto();
+    RowFilter actualFilter = FILTERS.limit().cellsPerRow(10).toProto();
 
     RowFilter expectedFilter = RowFilter.newBuilder().setCellsPerRowLimitFilter(10).build();
 
-    Assert.assertEquals(expectedFilter, actualProto);
+    Assert.assertEquals(expectedFilter, actualFilter);
   }
 
   @Test
   public void limitCellsPerColumnTest() {
-    RowFilter actualProto = FILTERS.limit().cellsPerColumn(10).toProto();
+    RowFilter actualFilter = FILTERS.limit().cellsPerColumn(10).toProto();
 
     RowFilter expectedFilter = RowFilter.newBuilder().setCellsPerColumnLimitFilter(10).build();
 
-    Assert.assertEquals(expectedFilter, actualProto);
+    Assert.assertEquals(expectedFilter, actualFilter);
   }
 
   @Test
-  public void timestampFullRangeTest() {
-    long start = TimeUnit.MILLISECONDS.toMicros(System.currentTimeMillis() - 10000000);
-    long end = TimeUnit.MILLISECONDS.toMicros(System.currentTimeMillis());
-    RowFilter actualProto = FILTERS.timestamp().range(start, end).toProto();
+  public void passTest() {
+    RowFilter actualFilter = FILTERS.pass().toProto();
 
-    RowFilter.Builder expected = RowFilter.newBuilder();
-    expected.getTimestampRangeFilterBuilder()
-      .setStartTimestampMicros(start)
-      .setEndTimestampMicros(end);
+    RowFilter expectedFilter = RowFilter.newBuilder().setPassAllFilter(true).build();
 
-    Assert.assertEquals(expected.build(), actualProto);
+    Assert.assertEquals(expectedFilter, actualFilter);
   }
 
   @Test
-  public void timestampStartTest() {
-    long start = TimeUnit.MILLISECONDS.toMicros(System.currentTimeMillis() - 10000000);
-    RowFilter actualProto = FILTERS.timestamp().range().startClosed(start).toProto();
+  public void blockTest() {
+    RowFilter actualFilter = FILTERS.block().toProto();
 
-    RowFilter.Builder expected = RowFilter.newBuilder();
-    expected.getTimestampRangeFilterBuilder()
-      .setStartTimestampMicros(start);
+    RowFilter expectedFilter = RowFilter.newBuilder().setBlockAllFilter(true).build();
 
-    Assert.assertEquals(expected.build(), actualProto);
+    Assert.assertEquals(expectedFilter, actualFilter);
   }
 
   @Test
-  public void timestampEndTest() {
-    long end = TimeUnit.MILLISECONDS.toMicros(System.currentTimeMillis());
-    RowFilter actualProto = FILTERS.timestamp().range().endOpen(end).toProto();
+  public void sinkTest() {
+    RowFilter actualFilter = FILTERS.sink().toProto();
 
-    RowFilter.Builder expected = RowFilter.newBuilder();
-    expected.getTimestampRangeFilterBuilder()
-      .setEndTimestampMicros(end);
+    RowFilter expectedFilter = RowFilter.newBuilder().setSink(true).build();
 
-    Assert.assertEquals(expected.build(), actualProto);
+    Assert.assertEquals(expectedFilter, actualFilter);
+  }
+
+  @Test
+  public void labelTest() {
+    RowFilter actualFilter = FILTERS.label("my-label").toProto();
+
+    RowFilter expectedFilter = RowFilter.newBuilder().setApplyLabelTransformer("my-label").build();
+
+    Assert.assertEquals(expectedFilter, actualFilter);
   }
 }

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/data/v2/wrappers/RangeTest.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/data/v2/wrappers/RangeTest.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.data.v2.wrappers;
+
+import com.google.cloud.bigtable.data.v2.wrappers.Range.BoundType;
+import com.google.cloud.bigtable.data.v2.wrappers.Range.ByteStringRange;
+import com.google.cloud.bigtable.data.v2.wrappers.Range.TimestampRange;
+import com.google.protobuf.ByteString;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class RangeTest {
+  @Test
+  public void timestampUnboundedTest() {
+    TimestampRange range = TimestampRange.unbounded();
+    Assert.assertEquals(BoundType.UNBOUNDED, range.getStartBound());
+    Assert.assertEquals(BoundType.UNBOUNDED, range.getEndBound());
+
+    Throwable actualError = null;
+    try {
+      //noinspection ResultOfMethodCallIgnored
+      range.getStart();
+    } catch (Throwable e) {
+      actualError = e;
+    }
+    Assert.assertTrue(actualError instanceof IllegalStateException);
+
+    try {
+      //noinspection ResultOfMethodCallIgnored
+      range.getEnd();
+    } catch (Throwable e) {
+      actualError = e;
+    }
+    Assert.assertTrue(actualError instanceof IllegalStateException);
+  }
+
+  @Test
+  public void timestampOfTest() {
+    TimestampRange range = TimestampRange.create(10, 2_000);
+    Assert.assertEquals(BoundType.CLOSED, range.getStartBound());
+    Assert.assertEquals(10, range.getStart().longValue());
+    Assert.assertEquals(BoundType.OPEN, range.getEndBound());
+    Assert.assertEquals(2_000, range.getEnd().longValue());
+  }
+
+  @Test
+  public void timestampChangeStartTest() {
+    TimestampRange range = TimestampRange.create(10, 2_000).startOpen(20L);
+
+    Assert.assertEquals(BoundType.OPEN, range.getEndBound());
+    Assert.assertEquals(2_000, range.getEnd().longValue());
+
+    Assert.assertEquals(BoundType.OPEN, range.getStartBound());
+    Assert.assertEquals(20, range.getStart().longValue());
+
+    range = range.startClosed(30L);
+    Assert.assertEquals(BoundType.CLOSED, range.getStartBound());
+    Assert.assertEquals(30, range.getStart().longValue());
+  }
+
+  @Test
+  public void timestampChangeEndTest() {
+    TimestampRange range = TimestampRange.create(10, 2_000).endClosed(1_000L);
+
+    Assert.assertEquals(BoundType.CLOSED, range.getStartBound());
+    Assert.assertEquals(10, range.getStart().longValue());
+
+    Assert.assertEquals(BoundType.CLOSED, range.getEndBound());
+    Assert.assertEquals(1_000, range.getEnd().longValue());
+
+    range = range.endOpen(3_000L);
+    Assert.assertEquals(BoundType.OPEN, range.getEndBound());
+    Assert.assertEquals(3_000, range.getEnd().longValue());
+  }
+
+  @Test
+  public void byteStringUnboundedTest() {
+    ByteStringRange range = ByteStringRange.unbounded();
+    Assert.assertEquals(BoundType.UNBOUNDED, range.getStartBound());
+    Assert.assertEquals(BoundType.UNBOUNDED, range.getEndBound());
+
+    Throwable actualError = null;
+    try {
+      range.getStart();
+    } catch (Throwable e) {
+      actualError = e;
+    }
+    Assert.assertTrue(actualError instanceof IllegalStateException);
+
+    try {
+      range.getEnd();
+    } catch (Throwable e) {
+      actualError = e;
+    }
+    Assert.assertTrue(actualError instanceof IllegalStateException);
+  }
+
+  @Test
+  public void byteStringOfTest() {
+    ByteStringRange range =
+        ByteStringRange.create(ByteString.copyFromUtf8("a"), ByteString.copyFromUtf8("b"));
+
+    Assert.assertEquals(BoundType.CLOSED, range.getStartBound());
+    Assert.assertEquals(ByteString.copyFromUtf8("a"), range.getStart());
+    Assert.assertEquals(BoundType.OPEN, range.getEndBound());
+    Assert.assertEquals(ByteString.copyFromUtf8("b"), range.getEnd());
+  }
+
+  @Test
+  public void byteStringOfStringTest() {
+    ByteStringRange range = ByteStringRange.create("a", "b");
+
+    Assert.assertEquals(BoundType.CLOSED, range.getStartBound());
+    Assert.assertEquals(ByteString.copyFromUtf8("a"), range.getStart());
+    Assert.assertEquals(BoundType.OPEN, range.getEndBound());
+    Assert.assertEquals(ByteString.copyFromUtf8("b"), range.getEnd());
+  }
+
+  @Test
+  public void byteStringChangeStartTest() {
+    ByteStringRange range =
+        ByteStringRange.create(ByteString.copyFromUtf8("a"), ByteString.copyFromUtf8("z"))
+            .startOpen(ByteString.copyFromUtf8("b"));
+
+    Assert.assertEquals(BoundType.OPEN, range.getEndBound());
+    Assert.assertEquals(ByteString.copyFromUtf8("z"), range.getEnd());
+
+    Assert.assertEquals(BoundType.OPEN, range.getStartBound());
+    Assert.assertEquals(ByteString.copyFromUtf8("b"), range.getStart());
+
+    range = range.startClosed(ByteString.copyFromUtf8("c"));
+    Assert.assertEquals(BoundType.CLOSED, range.getStartBound());
+    Assert.assertEquals(ByteString.copyFromUtf8("c"), range.getStart());
+  }
+
+  @Test
+  public void byteStringChangeStartStringTest() {
+    ByteStringRange range = ByteStringRange.create("a", "z").startOpen("b");
+
+    Assert.assertEquals(BoundType.OPEN, range.getEndBound());
+    Assert.assertEquals(ByteString.copyFromUtf8("z"), range.getEnd());
+
+    Assert.assertEquals(BoundType.OPEN, range.getStartBound());
+    Assert.assertEquals(ByteString.copyFromUtf8("b"), range.getStart());
+
+    range = range.startClosed("c");
+    Assert.assertEquals(BoundType.CLOSED, range.getStartBound());
+    Assert.assertEquals(ByteString.copyFromUtf8("c"), range.getStart());
+  }
+
+  @Test
+  public void byteStringChangeEndTest() {
+    ByteStringRange range =
+        ByteStringRange.create(ByteString.copyFromUtf8("a"), ByteString.copyFromUtf8("z"))
+            .endClosed(ByteString.copyFromUtf8("y"));
+
+    Assert.assertEquals(BoundType.CLOSED, range.getStartBound());
+    Assert.assertEquals(ByteString.copyFromUtf8("a"), range.getStart());
+
+    Assert.assertEquals(BoundType.CLOSED, range.getEndBound());
+    Assert.assertEquals(ByteString.copyFromUtf8("y"), range.getEnd());
+
+    range = range.endOpen(ByteString.copyFromUtf8("x"));
+    Assert.assertEquals(BoundType.OPEN, range.getEndBound());
+    Assert.assertEquals(ByteString.copyFromUtf8("x"), range.getEnd());
+  }
+
+  @Test
+  public void byteStringChangeEndStringTest() {
+    ByteStringRange range = ByteStringRange.create("a", "z").endClosed("y");
+
+    Assert.assertEquals(BoundType.CLOSED, range.getStartBound());
+    Assert.assertEquals(ByteString.copyFromUtf8("a"), range.getStart());
+
+    Assert.assertEquals(BoundType.CLOSED, range.getEndBound());
+    Assert.assertEquals(ByteString.copyFromUtf8("y"), range.getEnd());
+
+    range = range.endOpen("x");
+    Assert.assertEquals(BoundType.OPEN, range.getEndBound());
+    Assert.assertEquals(ByteString.copyFromUtf8("x"), range.getEnd());
+  }
+}

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/TimestampFilterUtil.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/TimestampFilterUtil.java
@@ -48,6 +48,6 @@ public class TimestampFilterUtil {
    */
   public static Filter toTimestampRangeFilter(long bigtableStartTimestamp,
       long bigtableEndTimestamp) {
-    return FILTERS.timestamp().range(bigtableStartTimestamp, bigtableEndTimestamp);
+    return FILTERS.timestamp().range().of(bigtableStartTimestamp, bigtableEndTimestamp);
   }
 }

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/ScanAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/ScanAdapter.java
@@ -189,7 +189,7 @@ public class ScanAdapter implements ReadOperationAdapter<Scan> {
   }
 
   private Filters.Filter createFamilyFilter(byte[] familyName) {
-    return FILTERS.family().regex(ByteStringer.wrap(quoteRegex(familyName)));
+    return FILTERS.family().exactMatch(new String(familyName));
   }
 
   private Filters.Filter createColumnLimitFilter(int maxVersionsPerColumn) {


### PR DESCRIPTION
Sync with the filters that are in the upcoming veneer client. The changes are functionally split between commits to ease review. I think #7 is the only controversial one. 

1. reorder classes to make it easier to see the rest of the changes
2. cosmetic changes (doesn't api)
  - javadoc updates
  - decorate args with @Nonnull & @Nullable
  - enforce nonnull with preconditions
  - fix Preconditions import
  - minor style changes
3. Adds a common range base class to make all ranges consistent and updates `QualifierRangeFilter`, `TimestampRangeFilter` & `ValueRangeFilter` to inherit from it.
4. Make all Filters cloneable instead of just ChainFilter
5. remove range(start,end) from TimestampRangeFilter in favor of range().of()
6. overwrites all of the FilterTests with ones from the veneer client
7. removes FamilyFilter#regex(ByteString)

Justification for removing FamilyFilter#regex(ByteString):
I think this is semantically wrong, family ids are strings and should be compared to strings directly.
Furthermore, family ids are a maximum of 64 characters and the optimization lowers the copies from 3 to 2., so I think the benefit is negligible.