### PR TITLE
Updating TestCheckAndMutate, with a focus on Async

### DIFF
--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestCheckAndMutateHBase2.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestCheckAndMutateHBase2.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.RowMutations;
 import org.apache.hadoop.hbase.client.Table;
+import org.apache.hadoop.hbase.filter.CompareFilter.CompareOp;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.Assert;
 import org.junit.Rule;
@@ -354,7 +355,11 @@ public class TestCheckAndMutateHBase2 extends AbstractTest {
     success = table.checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qualToCheck,
       CompareOperator.NOT_EQUAL, Bytes.toBytes(4000l), someRandomPut);
     Assert.assertTrue("4000 != 2000 should succeed", success);
-  }
+
+    success = table.checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qualToCheck,
+      CompareOperator.NOT_EQUAL, null, someRandomPut);
+    Assert.assertTrue("4000 != null should succeed", success);
+}
 
   @Test
   public void testCompareOperatorsVersions() throws IOException {

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests-common/src/main/java/com/google/cloud/bigtable/hbase/TestCheckAndMutate.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests-common/src/main/java/com/google/cloud/bigtable/hbase/TestCheckAndMutate.java
@@ -351,7 +351,11 @@ public class TestCheckAndMutate extends AbstractTest {
     success = table.checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qualToCheck,
       CompareOp.NOT_EQUAL, Bytes.toBytes(4000l), someRandomPut);
     Assert.assertTrue("4000 != 2000 should succeed", success);
-  }
+
+    success = table.checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qualToCheck,
+      CompareOp.NOT_EQUAL, null, someRandomPut);
+    Assert.assertTrue("4000 != null should succeed", success);
+}
 
   @Test
   public void testCompareOpsVersions() throws IOException {
@@ -373,6 +377,5 @@ public class TestCheckAndMutate extends AbstractTest {
     success = table.checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qualToCheck,
       CompareOp.GREATER, Bytes.toBytes(3000l), someRandomPut);
     Assert.assertFalse("3000 > 4000 should fail", success);
-
   }
 }


### PR DESCRIPTION
- Adding a test for NOT_EQUALS null
- Allowing "NOT_EQUALS null" checks in BigtableAsyncTable
- Using synchronous calls for put and get in TestAsyncCheckAndMutate.  The tests were failing due to async puts not completing.
- Extracting ExecutionException.getCause() for exception checking in TestAsyncCheckAndMutate.