### PR TITLE
Default Scan()s should produce a "pass()" filter.

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/data/v2/wrappers/Filters.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/data/v2/wrappers/Filters.java
@@ -208,9 +208,12 @@ public final class Filters {
     @InternalApi
     @Override
     public RowFilter toProto() {
-      if (builder.getFiltersCount() == 1) {
+      switch (builder.getFiltersCount()) {
+      case 0:
+        return PASS.toProto();
+      case 1:
         return builder.getFilters(0);
-      } else {
+      default:
         return RowFilter.newBuilder().setChain(builder.build()).build();
       }
     }
@@ -246,9 +249,12 @@ public final class Filters {
     @InternalApi
     @Override
     public RowFilter toProto() {
-      if (builder.getFiltersCount() == 1) {
+      switch (builder.getFiltersCount()) {
+      case 0:
+        return PASS.toProto();
+      case 1:
         return builder.getFilters(0);
-      } else {
+      default:
         return RowFilter.newBuilder().setInterleave(builder.build()).build();
       }
     }


### PR DESCRIPTION
Currently, "new Scan()" would produce a RowFilter with an empty chain; that breaks on the server-side. Use "pass()" instead.