### PR TITLE
Fixing CheckAndMutate tests

### DIFF
--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestCheckAndMutateHBase2.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestCheckAndMutateHBase2.java
@@ -15,372 +15,62 @@
  */
 package com.google.cloud.bigtable.hbase;
 
-import com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule;
-import org.apache.hadoop.hbase.Cell;
-import org.apache.hadoop.hbase.CellUtil;
+import java.io.IOException;
+
 import org.apache.hadoop.hbase.CompareOperator;
-import org.apache.hadoop.hbase.DoNotRetryIOException;
 import org.apache.hadoop.hbase.client.Delete;
-import org.apache.hadoop.hbase.client.Get;
 import org.apache.hadoop.hbase.client.Put;
-import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.RowMutations;
-import org.apache.hadoop.hbase.client.Table;
 import org.apache.hadoop.hbase.filter.CompareFilter.CompareOp;
-import org.apache.hadoop.hbase.util.Bytes;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-import java.io.IOException;
-import java.util.List;
-
 @RunWith(JUnit4.class)
-public class TestCheckAndMutateHBase2 extends AbstractTest {
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
+public class TestCheckAndMutateHBase2 extends AbstractTestCheckAndMutate {
 
-  /**
-   * Requirement 7.1 - Atomically attempt a mutation, dependent on a successful value check within
-   * the same row.
-   *
-   * Requirement 7.3 - Pass a null value to check for the non-existence of a column.
-   */
-  @Test
-  public void testCheckAndPutSameQual() throws IOException {
-    // Initialize
-    try (Table table = getDefaultTable()) {
-      testCheckAndMutate(dataHelper, table);
+  @Override
+  protected boolean checkAndPut(byte[] row, byte[] family, byte[] qualifier, byte[] value, Put put)
+      throws IOException {
+    return getDefaultTable().checkAndPut(row, family, qualifier, value, put);
+  }
+
+  @Override
+  protected boolean checkAndPut(byte[] row, byte[] family, byte[] qualifier, CompareOp op,
+      byte[] value, Put put) throws IOException {
+    return getDefaultTable().checkAndPut(row, family, qualifier, translate(op), value, put);
+  }
+
+  @Override
+  protected boolean checkAndDelete(byte[] row, byte[] family, byte[] qualifier, byte[] value,
+      Delete delete) throws IOException {
+    return getDefaultTable().checkAndDelete(row, family, qualifier, value, delete);
+  }
+
+  @Override
+  protected boolean checkAndMutate(byte[] row, byte[] family, byte[] qualifier, CompareOp op,
+      byte[] value, RowMutations rm) throws IOException {
+    return getDefaultTable().checkAndMutate(row, family, qualifier, translate(op), value, rm);
+  }
+
+  public static CompareOperator translate(CompareOp op) {
+    switch(op){
+    case EQUAL:
+      return CompareOperator.EQUAL;
+    case GREATER:
+      return CompareOperator.GREATER;
+    case GREATER_OR_EQUAL:
+      return CompareOperator.GREATER_OR_EQUAL;
+    case LESS:
+      return CompareOperator.LESS;
+    case LESS_OR_EQUAL:
+      return CompareOperator.LESS_OR_EQUAL;
+    case NO_OP:
+      return CompareOperator.NO_OP;
+    case NOT_EQUAL:
+      return CompareOperator.NOT_EQUAL;
+    default:
+      throw new IllegalStateException("Could not translate operator: " + op);
     }
   }
 
-  public static void testCheckAndMutate(DataGenerationHelper dataHelper, Table table) throws IOException {
-    byte[] rowKey = dataHelper.randomData("rowKey-");
-    byte[] qual = dataHelper.randomData("qualifier-");
-    byte[] value1 = dataHelper.randomData("value-");
-    byte[] value2 = dataHelper.randomData("value-");
-
-    // Put with a bad check on a null value, then try with a good one
-    Put put = new Put(rowKey).addColumn(SharedTestEnvRule.COLUMN_FAMILY, qual, value1);
-    boolean success = table.checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qual, value2, put);
-    Assert.assertFalse("Column doesn't exist.  Should fail.", success);
-    success = table.checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qual, null, put);
-    Assert.assertTrue(success);
-
-    // Fail on null check, now there's a value there
-    put = new Put(rowKey).addColumn(SharedTestEnvRule.COLUMN_FAMILY, qual, value2);
-    success = table.checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qual, null, put);
-    Assert.assertFalse("Null check should fail", success);
-    success = table.checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qual, value2, put);
-    Assert.assertFalse("Wrong value should fail", success);
-    success = table.checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qual, value1, put);
-    Assert.assertTrue(success);
-
-    // Check results
-    Get get = new Get(rowKey);
-    get.readVersions(5);
-    Result result = table.get(get);
-    Assert.assertEquals("Should be two results", 2, result.size());
-    List<Cell> cells = result.getColumnCells(SharedTestEnvRule.COLUMN_FAMILY, qual);
-    Assert.assertArrayEquals(value2, CellUtil.cloneValue(cells.get(0)));
-    Assert.assertArrayEquals(value1, CellUtil.cloneValue(cells.get(1)));
-  }
-
-  /**
-   * Further tests for requirements 7.1 and 7.3.
-   */
-  @Test
-  public void testCheckAndDeleteSameQual() throws IOException {
-    // Initialize
-    Table table = getDefaultTable();
-    byte[] rowKey = dataHelper.randomData("rowKey-");
-    byte[] qual = dataHelper.randomData("qualifier-");
-    byte[] value1 = dataHelper.randomData("value-");
-    byte[] value2 = dataHelper.randomData("value-");
-
-    // Delete all previous versions if the value is found.
-    Delete delete = new Delete(rowKey).addColumns(SharedTestEnvRule.COLUMN_FAMILY, qual);
-    boolean success = table.checkAndDelete(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qual, value1, delete);
-    Assert.assertFalse("Column doesn't exist.  Should fail.", success);
-    success = table.checkAndDelete(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qual, null, delete);
-
-    // Add a value and check again
-    Put put = new Put(rowKey).addColumn(SharedTestEnvRule.COLUMN_FAMILY, qual, value1);
-    table.put(put);
-    success = table.checkAndDelete(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qual, value2, delete);
-    Assert.assertFalse("Wrong value.  Should fail.", success);
-    success = table.checkAndDelete(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qual, value1, delete);
-    Assert.assertTrue(success);
-    Assert.assertFalse("Row should be gone", table.exists(new Get(rowKey)));
-
-    table.close();
-  }
-
-  /**
-   * Further tests for requirements 7.1 and 7.3.
-   */
-  @Test
-  public void testCheckAndPutDiffQual() throws IOException {
-    // Initialize
-    Table table = getDefaultTable();
-    byte[] rowKey = dataHelper.randomData("rowKey-");
-    byte[] qual1 = dataHelper.randomData("qualifier-");
-    byte[] qual2 = dataHelper.randomData("qualifier-");
-    byte[] value1 = dataHelper.randomData("value-");
-    byte[] value2 = dataHelper.randomData("value-");
-
-    // Put then again
-    Put put = new Put(rowKey).addColumn(SharedTestEnvRule.COLUMN_FAMILY, qual1, value1);
-    boolean success = table.checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qual2, value2, put);
-    Assert.assertFalse("Column doesn't exist.  Should fail.", success);
-    success = table.checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qual2, null, put);
-    Assert.assertTrue(success);
-
-    // Fail on null check, now there's a value there
-    put = new Put(rowKey).addColumn(SharedTestEnvRule.COLUMN_FAMILY, qual2, value2);
-    success = table.checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qual1, null, put);
-    Assert.assertFalse("Null check should fail", success);
-    success = table.checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qual1, value2, put);
-    Assert.assertFalse("Wrong value should fail", success);
-    success = table.checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qual1, value1, put);
-    Assert.assertTrue(success);
-
-    // Check results
-    Get get = new Get(rowKey);
-    get.readVersions(5);
-    Result result = table.get(get);
-    Assert.assertEquals("Should be two results", 2, result.size());
-    Assert.assertArrayEquals(value1, CellUtil.cloneValue(result.getColumnLatestCell(SharedTestEnvRule.COLUMN_FAMILY, qual1)));
-    Assert.assertArrayEquals(value2, CellUtil.cloneValue(result.getColumnLatestCell(SharedTestEnvRule.COLUMN_FAMILY,
-      qual2)));
-
-    table.close();
-  }
-
-  /**
-   * Further tests for requirements 7.1 and 7.3.
-   */
-  @Test
-  public void testCheckAndDeleteDiffQual() throws IOException {
-    // Initialize
-    Table table = getDefaultTable();
-    byte[] rowKey = dataHelper.randomData("rowKey-");
-    byte[] qual1 = dataHelper.randomData("qualifier-");
-    byte[] qual2 = dataHelper.randomData("qualifier-");
-    byte[] value1 = dataHelper.randomData("value-");
-    byte[] value2 = dataHelper.randomData("value-");
-
-    // Delete all versions of a column if the latest version matches
-    Delete delete = new Delete(rowKey).addColumns(SharedTestEnvRule.COLUMN_FAMILY, qual1);
-    boolean success = table.checkAndDelete(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qual2, value2, delete);
-    Assert.assertFalse("Column doesn't exist.  Should fail.", success);
-    success = table.checkAndDelete(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qual2, null, delete);
-    Assert.assertTrue(success);
-
-    // Add a value now
-    Put put = new Put(rowKey)
-        .addColumn(SharedTestEnvRule.COLUMN_FAMILY, qual1, value1)
-        .addColumn(SharedTestEnvRule.COLUMN_FAMILY, qual2, value2);
-    table.put(put);
-
-    // Fail on null check, now there's a value there
-    success = table.checkAndDelete(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qual2, null, delete);
-    Assert.assertFalse("Null check should fail", success);
-    success = table.checkAndDelete(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qual2, value1, delete);
-    Assert.assertFalse("Wrong value should fail", success);
-    success = table.checkAndDelete(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qual2, value2, delete);
-    Assert.assertTrue(success);
-    delete = new Delete(rowKey).addColumns(SharedTestEnvRule.COLUMN_FAMILY, qual2);
-    success = table.checkAndDelete(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qual1, null, delete);
-    Assert.assertTrue(success);
-    Assert.assertFalse("Row should be gone", table.exists(new Get(rowKey)));
-
-    table.close();
-  }
-
-  /**
-   * Requirement 7.2 - Throws an IOException if the check is for a row other than the one in the
-   * mutation attempt.
-   */
-  @Test
-  public void testCheckAndPutDiffRow() throws IOException {
-    // Initialize
-    Table table = getDefaultTable();
-    byte[] rowKey1 = dataHelper.randomData("rowKey-");
-    byte[] rowKey2 = dataHelper.randomData("rowKey-");
-    byte[] qual = dataHelper.randomData("qualifier-");
-    byte[] value = dataHelper.randomData("value-");
-
-    // Put then again
-    Put put = new Put(rowKey1).addColumn(SharedTestEnvRule.COLUMN_FAMILY, qual, value);
-    //Fix behavior as a part of Async Impl
-    expectedException.expect(DoNotRetryIOException.class);
-//    expectedException.expect(IOException.class);
-    expectedException.expectMessage("Action's getRow must match");
-    table.checkAndPut(rowKey2, SharedTestEnvRule.COLUMN_FAMILY, qual, null, put);
-
-    table.close();
-  }
-
-  @Test
-  public void testCheckAndDeleteDiffRow() throws IOException {
-    // Initialize
-    Table table = getDefaultTable();
-    byte[] rowKey1 = dataHelper.randomData("rowKey-");
-    byte[] rowKey2 = dataHelper.randomData("rowKey-");
-    byte[] qual = dataHelper.randomData("qualifier-");
-
-    // Put then again
-    Delete delete = new Delete(rowKey1).addColumns(SharedTestEnvRule.COLUMN_FAMILY, qual);
-    expectedException.expect(DoNotRetryIOException.class);
-//    expectedException.expect(IOException.class);
-    expectedException.expectMessage("Action's getRow must match");
-    table.checkAndDelete(rowKey2, SharedTestEnvRule.COLUMN_FAMILY, qual, null, delete);
-
-    table.close();
-  }
-
-  @Test
-  public void testCheckAndMutate() throws IOException {
-    // Initialize
-    Table table = getDefaultTable();
-    byte[] rowKey = dataHelper.randomData("rowKey-");
-    byte[] qualCheck = dataHelper.randomData("qualifier-");
-    byte[] qualPut = dataHelper.randomData("qualifier-");
-    byte[] qualDelete = dataHelper.randomData("qualifier-");
-    byte[] valuePut = dataHelper.randomData("value-");
-    byte[] valueCheck = dataHelper.randomData("value-");
-
-    // Delete all versions of a column if the latest version matches
-    RowMutations rm = new RowMutations(rowKey);
-    rm.add(new Put(rowKey).addColumn(SharedTestEnvRule.COLUMN_FAMILY, qualPut, valuePut));
-    rm.add(new Delete(rowKey).addColumns(SharedTestEnvRule.COLUMN_FAMILY, qualDelete));
-
-    boolean success = table.checkAndMutate(
-        rowKey, SharedTestEnvRule.COLUMN_FAMILY, qualCheck, CompareOperator.EQUAL, valueCheck, rm);
-    Assert.assertFalse("Column doesn't exist.  Should fail.", success);
-    success = table.checkAndMutate(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qualCheck, CompareOperator.EQUAL, null, rm);
-    Assert.assertTrue(success);
-
-    // Add a value now
-    Put put = new Put(rowKey)
-        .addColumn(SharedTestEnvRule.COLUMN_FAMILY, qualCheck, valueCheck)
-        .addColumn(SharedTestEnvRule.COLUMN_FAMILY, qualDelete, Bytes.toBytes("todelete"));
-    table.put(put);
-    // Fail on null check, now there's a value there
-    success = table.checkAndMutate(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qualCheck, CompareOperator.EQUAL, null, rm);
-    Assert.assertFalse("Null check should fail", success);
-    // valuePut is in qualPut and not in qualCheck so this will fail:
-    success = table.checkAndMutate(
-        rowKey, SharedTestEnvRule.COLUMN_FAMILY, qualCheck, CompareOperator.EQUAL, valuePut, rm);
-    Assert.assertFalse("Wrong value should fail", success);
-    success = table.checkAndMutate(
-        rowKey, SharedTestEnvRule.COLUMN_FAMILY, qualCheck, CompareOperator.EQUAL, valueCheck, rm);
-    Assert.assertTrue(success);
-
-    Result row = table.get(new Get(rowKey).addFamily(SharedTestEnvRule.COLUMN_FAMILY));
-    // QualCheck and QualPut should exist
-    Assert.assertEquals(2, row.size());
-    Assert.assertFalse(
-        "QualDelete should be deleted",
-        row.containsColumn(SharedTestEnvRule.COLUMN_FAMILY, qualDelete));
-    Assert.assertTrue(
-        "QualPut should exist",
-        row.containsColumn(SharedTestEnvRule.COLUMN_FAMILY, qualPut));
-    table.close();
-  }
-
-  @Test
-  public void testCompareOperators() throws IOException {
-    byte[] rowKey = dataHelper.randomData("rowKey-");
-    byte[] qualToCheck = dataHelper.randomData("toCheck-");
-    byte[] otherQual = dataHelper.randomData("other-");
-    boolean success;
-
-    Table table = getDefaultTable();
-
-    table.put(new Put(rowKey).addColumn(SharedTestEnvRule.COLUMN_FAMILY, qualToCheck,
-      Bytes.toBytes(2000l)));
-
-    Put someRandomPut =
-        new Put(rowKey).addColumn(SharedTestEnvRule.COLUMN_FAMILY, otherQual, Bytes.toBytes(1l));
-
-    success = table.checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qualToCheck,
-      CompareOperator.LESS, Bytes.toBytes(1000l), someRandomPut);
-    Assert.assertTrue("1000 < 2000 should succeed", success);
-
-    success = table.checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qualToCheck,
-      CompareOperator.LESS, Bytes.toBytes(4000l), someRandomPut);
-    Assert.assertFalse("4000 < 2000 should fail", success);
-
-    success = table.checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qualToCheck,
-      CompareOperator.GREATER, Bytes.toBytes(1000l), someRandomPut);
-    Assert.assertFalse("1000 > 2000 should fail", success);
-
-    success = table.checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qualToCheck,
-      CompareOperator.GREATER, Bytes.toBytes(4000l), someRandomPut);
-    Assert.assertTrue("4000 > 2000 should succeed", success);
-
-    success = table.checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qualToCheck,
-      CompareOperator.LESS_OR_EQUAL, Bytes.toBytes(1000l), someRandomPut);
-    Assert.assertTrue("1000 <= 2000 should succeed", success);
-
-    success = table.checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qualToCheck,
-      CompareOperator.LESS_OR_EQUAL, Bytes.toBytes(4000l), someRandomPut);
-    Assert.assertFalse("4000 <= 2000 should fail", success);
-
-    success = table.checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qualToCheck,
-      CompareOperator.GREATER_OR_EQUAL, Bytes.toBytes(1000l), someRandomPut);
-    Assert.assertFalse("1000 >= 2000 should fail", success);
-
-    success = table.checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qualToCheck,
-      CompareOperator.GREATER_OR_EQUAL, Bytes.toBytes(4000l), someRandomPut);
-    Assert.assertTrue("4000 >= 2000 should succeed", success);
-
-    success = table.checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qualToCheck,
-      CompareOperator.EQUAL, Bytes.toBytes(1000l), someRandomPut);
-    Assert.assertFalse("1000 == 2000 should fail", success);
-
-    success = table.checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qualToCheck,
-      CompareOperator.EQUAL, Bytes.toBytes(2000l), someRandomPut);
-    Assert.assertTrue("2000 == 2000 should succeed", success);
-
-    success = table.checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qualToCheck,
-      CompareOperator.NOT_EQUAL, Bytes.toBytes(2000l), someRandomPut);
-    Assert.assertFalse("2000 != 2000 should fail", success);
-
-    success = table.checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qualToCheck,
-      CompareOperator.NOT_EQUAL, Bytes.toBytes(4000l), someRandomPut);
-    Assert.assertTrue("4000 != 2000 should succeed", success);
-
-    success = table.checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qualToCheck,
-      CompareOperator.NOT_EQUAL, null, someRandomPut);
-    Assert.assertTrue("4000 != null should succeed", success);
-}
-
-  @Test
-  public void testCompareOperatorsVersions() throws IOException {
-    byte[] rowKey = dataHelper.randomData("rowKey-");
-    byte[] qualToCheck = dataHelper.randomData("toCheck-");
-    byte[] otherQual = dataHelper.randomData("other-");
-    boolean success;
-
-    Table table = getDefaultTable();
-    Put someRandomPut =
-        new Put(rowKey).addColumn(SharedTestEnvRule.COLUMN_FAMILY, otherQual, Bytes.toBytes(1l));
-
-    table.put(new Put(rowKey, System.currentTimeMillis() - 10000)
-        .addColumn(SharedTestEnvRule.COLUMN_FAMILY, qualToCheck, Bytes.toBytes(2000l)));
-
-    table.put(new Put(rowKey, System.currentTimeMillis()).addColumn(SharedTestEnvRule.COLUMN_FAMILY,
-      qualToCheck, Bytes.toBytes(4000l)));
-
-    success = table.checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qualToCheck,
-      CompareOperator.GREATER, Bytes.toBytes(3000l), someRandomPut);
-    Assert.assertFalse("3000 > 4000 should fail", success);
-
-  }
 }

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/async/AbstractAsyncTest.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/async/AbstractAsyncTest.java
@@ -29,7 +29,7 @@ public abstract class AbstractAsyncTest extends AbstractTest {
 
   private static final String CONN_KEY = AbstractAsyncTest.class.getName() + "_asyncCon";
 
-  public static AsyncConnection getAsyncConnection()
+  public static synchronized AsyncConnection getAsyncConnection()
       throws InterruptedException, ExecutionException {
     SharedTestEnvRule sharedEnv = SharedTestEnvRule.getInstance();
     AsyncConnection conn = (AsyncConnection) sharedEnv.getClosable(CONN_KEY);

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/async/TestAsyncCheckAndMutate.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/async/TestAsyncCheckAndMutate.java
@@ -15,38 +15,30 @@
  */
 package com.google.cloud.bigtable.hbase.async;
 
-import com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
-
-import org.apache.hadoop.hbase.Cell;
-import org.apache.hadoop.hbase.CellUtil;
-import org.apache.hadoop.hbase.CompareOperator;
-import org.apache.hadoop.hbase.DoNotRetryIOException;
-import org.apache.hadoop.hbase.client.AsyncTable;
-import org.apache.hadoop.hbase.client.AsyncTableBase.CheckAndMutateBuilder;
-import org.apache.hadoop.hbase.client.Delete;
-import org.apache.hadoop.hbase.client.Get;
-import org.apache.hadoop.hbase.client.Put;
-import org.apache.hadoop.hbase.client.Result;
-import org.apache.hadoop.hbase.client.RowMutations;
-import org.apache.hadoop.hbase.util.Bytes;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
-
-import java.util.Arrays;
-import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import org.apache.hadoop.hbase.client.AsyncTable;
+import org.apache.hadoop.hbase.client.AsyncTableBase.CheckAndMutateBuilder;
+import org.apache.hadoop.hbase.client.Delete;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.RowMutations;
+import org.apache.hadoop.hbase.filter.CompareFilter.CompareOp;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import com.google.cloud.bigtable.hbase.AbstractTestCheckAndMutate;
+import com.google.cloud.bigtable.hbase.TestCheckAndMutateHBase2;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+
 @RunWith(JUnit4.class)
-public class TestAsyncCheckAndMutate extends AbstractAsyncTest {
+@SuppressWarnings("deprecation")
+public class TestAsyncCheckAndMutate extends AbstractTestCheckAndMutate {
   private static ExecutorService executor;
   @Rule
   public ExpectedException expectedException = ExpectedException.none();
@@ -62,486 +54,64 @@ public class TestAsyncCheckAndMutate extends AbstractAsyncTest {
     executor.shutdownNow();
   }
 
-  /**
-   * Requirement 7.1 - Atomically attempt a mutation, dependent on a successful value check within
-   * the same row.
-   *
-   * Requirement 7.3 - Pass a null value to check for the non-existence of a column.
-   */
-  @Test
-  public void testCheckAndPutSameQual() throws Exception {
-    // Initialize
-    AsyncTable table = getDefaultAsyncTable(executor);
-    byte[] rowKey = dataHelper.randomData("rowKey-");
-    byte[] qual = dataHelper.randomData("qualifier-");
-    byte[] value1 = dataHelper.randomData("value-");
-    byte[] value2 = dataHelper.randomData("value-");
-
-    // Put with a bad check on a null value, then try with a good one
-    Put put = new Put(rowKey).addColumn(SharedTestEnvRule.COLUMN_FAMILY, qual, value1);
-    boolean success = checkandMutate(table, rowKey, qual)
-        .ifEquals(value2)
-        .thenPut(put)
-        .get();
-    Assert.assertFalse("Column doesn't exist.  Should fail.", success);
-    success = checkandMutate(table, rowKey, qual)
-        .ifNotExists()
-        .thenPut(put)
-        .get();
-
-    Assert.assertTrue(success);
-
-    // Fail on null check, now there's a value there
-    put = new Put(rowKey).addColumn(SharedTestEnvRule.COLUMN_FAMILY, qual, value2);
-    success = checkandMutate(table, rowKey, qual)
-        .ifNotExists()
-        .thenPut(put)
-        .get();
-    Assert.assertFalse("Null check should fail", success);
-    success = checkandMutate(table, rowKey, qual)
-        .ifEquals(value2)
-        .thenPut(put)
-        .get();
-    Assert.assertFalse("Wrong value should fail", success);
-    success = checkandMutate(table, rowKey, qual)
-        .ifEquals(value1)
-        .thenPut(put)
-        .get();
-
-    Assert.assertTrue(success);
-
-    // Check results
-    Get get = new Get(rowKey);
-    get.readVersions(5);
-    Result result = getDefaultTable().get(get);
-    Assert.assertEquals("Should be two results", 2, result.size());
-    List<Cell> cells = result.getColumnCells(SharedTestEnvRule.COLUMN_FAMILY, qual);
-    Assert.assertArrayEquals(value2, CellUtil.cloneValue(cells.get(0)));
-    Assert.assertArrayEquals(value1, CellUtil.cloneValue(cells.get(1)));
-  }
-
-  private CheckAndMutateBuilder checkandMutate(AsyncTable table,
-      byte[] rowKey, byte[] qual) {
-    return table.checkAndMutate(rowKey, SharedTestEnvRule.COLUMN_FAMILY).qualifier(qual);
-  }
-
-  /**
-   * Further tests for requirements 7.1 and 7.3.
-   */
-  @Test
-  public void testCheckAndMutateSameQual() throws Exception {
-    // Initialize
-    AsyncTable table = getDefaultAsyncTable(executor);
-    byte[] rowKey = dataHelper.randomData("rowKey-");
-    byte[] qual = dataHelper.randomData("qualifier-");
-    byte[] value1 = dataHelper.randomData("value-");
-    byte[] value2 = dataHelper.randomData("value-");
-
-    // Delete all previous versions if the value is found.
-    Delete delete = new Delete(rowKey).addColumns(SharedTestEnvRule.COLUMN_FAMILY, qual);
-    boolean success = table.checkAndMutate(rowKey, SharedTestEnvRule.COLUMN_FAMILY)
-        .qualifier(qual)
-        .ifEquals(value1)
-        .thenDelete(delete)
-        .get();
-    Assert.assertFalse("Column doesn't exist.  Should fail.", success);
-    success = table.checkAndMutate(rowKey, SharedTestEnvRule.COLUMN_FAMILY)
-        .qualifier(qual)
-        .ifNotExists()
-        .thenDelete(delete)
-        .get();
-
-    // Add a value and check again
-    Put put = new Put(rowKey).addColumn(SharedTestEnvRule.COLUMN_FAMILY, qual, value1);
-    getDefaultTable().put(put);
-    success = table.checkAndMutate(rowKey, SharedTestEnvRule.COLUMN_FAMILY)
-        .qualifier(qual)
-        .ifEquals(value2)
-        .thenDelete(delete)
-        .get();
-    Assert.assertFalse("Wrong value.  Should fail.", success);
-    success = table.checkAndMutate(rowKey, SharedTestEnvRule.COLUMN_FAMILY)
-        .qualifier(qual)
-        .ifEquals(value1)
-        .thenDelete(delete)
-        .get();
-    Assert.assertTrue(success);
-    Assert.assertFalse("Row should be gone", getDefaultTable().exists(new Get(rowKey)));
-  }
-
-  /**
-   * Further tests for requirements 7.1 and 7.3.
-   */
-  @Test
-  public void testCheckAndPutDiffQual() throws Exception {
-    // Initialize
-    AsyncTable table = getDefaultAsyncTable(executor);
-    byte[] rowKey = dataHelper.randomData("rowKey-");
-    byte[] qual1 = dataHelper.randomData("qualifier-");
-    byte[] qual2 = dataHelper.randomData("qualifier-");
-    byte[] value1 = dataHelper.randomData("value-");
-    byte[] value2 = dataHelper.randomData("value-");
-
-    // Put then again
-    Put put = new Put(rowKey).addColumn(SharedTestEnvRule.COLUMN_FAMILY, qual1, value1);
-    boolean success = table.checkAndMutate(rowKey, SharedTestEnvRule.COLUMN_FAMILY)
-        .qualifier(qual2)
-        .ifEquals(value2)
-        .thenPut(put)
-        .get();
-    Assert.assertFalse("Column doesn't exist.  Should fail.", success);
-    success = table.checkAndMutate(rowKey, SharedTestEnvRule.COLUMN_FAMILY)
-        .qualifier(qual2)
-        .ifNotExists()
-        .thenPut(put)
-        .get();
-    Assert.assertTrue(success);
-
-    // Fail on null check, now there's a value there
-    put = new Put(rowKey).addColumn(SharedTestEnvRule.COLUMN_FAMILY, qual2, value2);
-    success = table.checkAndMutate(rowKey, SharedTestEnvRule.COLUMN_FAMILY)
-        .qualifier(qual1)
-        .ifNotExists()
-        .thenPut(put)
-        .get();
-    Assert.assertFalse("Null check should fail", success);
-    success = table.checkAndMutate(rowKey, SharedTestEnvRule.COLUMN_FAMILY)
-        .qualifier(qual1)
-        .ifEquals(value2)
-       .thenPut(put)
-       .get();
-    Assert.assertFalse("Wrong value should fail", success);
-    success = table.checkAndMutate(rowKey, SharedTestEnvRule.COLUMN_FAMILY)
-        .qualifier(qual1)
-          .ifEquals(value1)
-       .thenPut(put)
-       .get();
-    Assert.assertTrue(success);
-
-    // Check results
-    Get get = new Get(rowKey);
-    get.readVersions(5);
-    Result result = getDefaultTable().get(get);
-    Assert.assertEquals("Should be two results", 2, result.size());
-    Assert.assertArrayEquals(value1, CellUtil.cloneValue(result.getColumnLatestCell(SharedTestEnvRule.COLUMN_FAMILY, qual1)));
-    Assert.assertArrayEquals(value2, CellUtil.cloneValue(result.getColumnLatestCell(SharedTestEnvRule.COLUMN_FAMILY,
-      qual2)));
-
-
-  }
-
-  /**
-   * Further tests for requirements 7.1 and 7.3.
-   */
-  @Test
-  public void testCheckAndMutateDiffQual() throws Exception {
-    // Initialize
-    AsyncTable table = getDefaultAsyncTable(executor);
-    byte[] rowKey = dataHelper.randomData("rowKey-");
-    byte[] qual1 = dataHelper.randomData("qualifier-");
-    byte[] qual2 = dataHelper.randomData("qualifier-");
-    byte[] value1 = dataHelper.randomData("value-");
-    byte[] value2 = dataHelper.randomData("value-");
-
-    // Delete all versions of a column if the latest version matches
-    Delete delete = new Delete(rowKey).addColumns(SharedTestEnvRule.COLUMN_FAMILY, qual1);
-    boolean success = table.checkAndMutate(rowKey, SharedTestEnvRule.COLUMN_FAMILY)
-        .qualifier(qual2)
-        .ifEquals(value2)
-        .thenDelete(delete)
-        .get();
-    Assert.assertFalse("Column doesn't exist.  Should fail.", success);
-    success = table.checkAndMutate(rowKey, SharedTestEnvRule.COLUMN_FAMILY)
-       .qualifier(qual2)
-       .ifNotExists()
-       .thenDelete(delete)
-       .get();
-    Assert.assertTrue(success);
-
-    // Add a value now
-    Put put = new Put(rowKey)
-        .addColumn(SharedTestEnvRule.COLUMN_FAMILY, qual1, value1)
-        .addColumn(SharedTestEnvRule.COLUMN_FAMILY, qual2, value2);
-    getDefaultTable().put(put);
-
-    // Fail on null check, now there's a value there
-    success = table.checkAndMutate(rowKey, SharedTestEnvRule.COLUMN_FAMILY)
-        .qualifier(qual2)
-        .ifNotExists()
-        .thenDelete(delete)
-        .get();
-    Assert.assertFalse("Null check should fail", success);
-    success = table.checkAndMutate(rowKey, SharedTestEnvRule.COLUMN_FAMILY)
-        .qualifier(qual2)
-        .ifEquals(value1)
-        .thenDelete(delete)
-        .get();
-    Assert.assertFalse("Wrong value should fail", success);
-    success = table.checkAndMutate(rowKey, SharedTestEnvRule.COLUMN_FAMILY)
-        .qualifier(qual2)
-        .ifEquals(value2)
-        .thenDelete(delete)
-        .get();
-    Assert.assertTrue(success);
-    delete = new Delete(rowKey).addColumns(SharedTestEnvRule.COLUMN_FAMILY, qual2);
-    success = table.checkAndMutate(rowKey, SharedTestEnvRule.COLUMN_FAMILY)
-        .qualifier(qual1)
-        .ifNotExists()
-        .thenDelete(delete)
-        .get();
-    Assert.assertTrue(success);
-    Assert.assertFalse("Row should be gone", getDefaultTable().exists(new Get(rowKey)));
-  }
-
-  /**
-   * Requirement 7.2 - Throws an IOException if the check is for a row other than the one in the
-   * mutation attempt.
-   */
-  @Test
-  public void testCheckAndPutDiffRow() throws Throwable {
-    // Initialize
-    AsyncTable table = getDefaultAsyncTable(executor);
-    byte[] rowKey1 = dataHelper.randomData("rowKey-");
-    byte[] rowKey2 = dataHelper.randomData("rowKey-");
-    byte[] qual = dataHelper.randomData("qualifier-");
-    byte[] value = dataHelper.randomData("value-");
-
-    // Put then again
-    Put put = new Put(rowKey1).addColumn(SharedTestEnvRule.COLUMN_FAMILY, qual, value);
-    //Fix behavior as a part of Async Impl
-    expectedException.expect(DoNotRetryIOException.class);
-    expectedException.expectMessage("Action's getRow must match");
+  @Override
+  protected boolean checkAndPut(byte[] row, byte[] family, byte[] qualifier, byte[] value, Put put)
+      throws Exception {
     try {
-      table.checkAndMutate(rowKey2, SharedTestEnvRule.COLUMN_FAMILY)
-          .qualifier(qual)
-          .ifNotExists()
-          .thenPut(put)
-          .get();
+      return getBuilder(row, family, qualifier, CompareOp.EQUAL, value).thenPut(put).get();
     } catch (ExecutionException e) {
-      throw e.getCause();
+      throw (Exception) e.getCause();
     }
   }
 
-  @Test
-  public void testCheckAndMutateDiffRow() throws Throwable {
-    // Initialize
-    AsyncTable table = getDefaultAsyncTable(executor);
-    byte[] rowKey1 = dataHelper.randomData("rowKey-");
-    byte[] rowKey2 = dataHelper.randomData("rowKey-");
-    byte[] qual = dataHelper.randomData("qualifier-");
-
-    // Put then again
-    Delete delete = new Delete(rowKey1).addColumns(SharedTestEnvRule.COLUMN_FAMILY, qual);
-    expectedException.expect(DoNotRetryIOException.class);
-    expectedException.expectMessage("Action's getRow must match");
+  @Override
+  protected boolean checkAndPut(byte[] row, byte[] family, byte[] qualifier, CompareOp op,
+      byte[] value, Put put) throws Exception {
     try {
-      table.checkAndMutate(rowKey2, SharedTestEnvRule.COLUMN_FAMILY)
-          .ifEquals(qual)
-          .ifNotExists()
-          .thenDelete(delete)
-          .get();
+      return getBuilder(row, family, qualifier, op, value).thenPut(put).get();
     } catch (ExecutionException e) {
-      throw e.getCause();
+      throw (Exception) e.getCause();
     }
   }
 
-  @Test
-  public void testCheckAndMutate() throws Exception {
-    // Initialize
-    AsyncTable table = getDefaultAsyncTable(executor);
-    byte[] rowKey = dataHelper.randomData("rowKey-");
-    byte[] qualCheck = dataHelper.randomData("qualifier-");
-    byte[] qualPut = dataHelper.randomData("qualifier-");
-    byte[] qualDelete = dataHelper.randomData("qualifier-");
-    byte[] valuePut = dataHelper.randomData("value-");
-    byte[] valueCheck = dataHelper.randomData("value-");
-
-    // Delete all versions of a column if the latest version matches
-    RowMutations rm = new RowMutations(rowKey);
-    rm.add(new Put(rowKey).addColumn(SharedTestEnvRule.COLUMN_FAMILY, qualPut, valuePut));
-    rm.add(new Delete(rowKey).addColumns(SharedTestEnvRule.COLUMN_FAMILY, qualDelete));
-
-    boolean success = table.checkAndMutate(rowKey, SharedTestEnvRule.COLUMN_FAMILY)
-          .qualifier(qualCheck)
-          .ifEquals(valueCheck)
-          .thenMutate(rm)
-          .get();
-    Assert.assertFalse("Column doesn't exist.  Should fail.", success);
-    success = table.checkAndMutate(rowKey, SharedTestEnvRule.COLUMN_FAMILY)
-       .qualifier(qualCheck)
-       .ifNotExists()
-       .thenMutate(rm)
-       .get();
-    Assert.assertTrue(success);
-
-    // Add a value now
-    Put put = new Put(rowKey)
-        .addColumn(SharedTestEnvRule.COLUMN_FAMILY, qualCheck, valueCheck)
-        .addColumn(SharedTestEnvRule.COLUMN_FAMILY, qualDelete, Bytes.toBytes("todelete"));
-    getDefaultTable().put(put);
-    // Fail on null check, now there's a value there
-    success = table.checkAndMutate(rowKey, SharedTestEnvRule.COLUMN_FAMILY)
-       .qualifier(qualCheck)
-       .ifNotExists()
-       .thenMutate(rm)
-       .get();
-    Assert.assertFalse("Null check should fail", success);
-    // valuePut is in qualPut and not in qualCheck so this will fail:
-    success = table.checkAndMutate(rowKey, SharedTestEnvRule.COLUMN_FAMILY)
-        .qualifier(qualCheck)
-        .ifEquals(valuePut)
-        .thenMutate(rm)
-        .get();
-    Assert.assertFalse("Wrong value should fail", success);
-    success = table.checkAndMutate(rowKey, SharedTestEnvRule.COLUMN_FAMILY)
-        .qualifier(qualCheck)
-        .ifEquals(valueCheck)
-        .thenMutate(rm)
-        .get();
-    Assert.assertTrue(success);
-
-    Result row = getDefaultTable().get(new Get(rowKey).addFamily(SharedTestEnvRule.COLUMN_FAMILY));
-    // QualCheck and QualPut should exist
-    Assert.assertEquals(2, row.size());
-    Assert.assertFalse(
-        "QualDelete should be deleted",
-        row.containsColumn(SharedTestEnvRule.COLUMN_FAMILY, qualDelete));
-    Assert.assertTrue(
-        "QualPut should exist",
-        row.containsColumn(SharedTestEnvRule.COLUMN_FAMILY, qualPut));
+  @Override
+  protected boolean checkAndDelete(byte[] row, byte[] family, byte[] qualifier, byte[] value,
+      Delete delete) throws Exception {
+    try {
+      return getBuilder(row, family, qualifier, CompareOp.EQUAL, value).thenDelete(delete).get();
+    } catch (ExecutionException e) {
+      throw (Exception) e.getCause();
+    }
   }
 
-  @Test
-  public void testCompareOperators() throws Exception {
-    byte[] rowKey = dataHelper.randomData("rowKey-");
-    byte[] qualToCheck = dataHelper.randomData("toCheck-");
-    byte[] otherQual = dataHelper.randomData("other-");
-    boolean success;
-
-    AsyncTable table = getDefaultAsyncTable(executor);
-
-    getDefaultTable().put(new Put(rowKey)
-      .addColumn(SharedTestEnvRule.COLUMN_FAMILY, qualToCheck, Bytes.toBytes(2000l)));
-
-    Put someRandomPut =
-        new Put(rowKey).addColumn(SharedTestEnvRule.COLUMN_FAMILY, otherQual, Bytes.toBytes(1l));
-
-    success = table.checkAndMutate(rowKey, SharedTestEnvRule.COLUMN_FAMILY)
-        .qualifier(qualToCheck)
-        .ifMatches(CompareOperator.LESS, Bytes.toBytes(1000l))
-        .thenPut(someRandomPut)
-        .get();
-    Assert.assertTrue("1000 < 2000 should succeed", success);
-
-    success = table.checkAndMutate(rowKey, SharedTestEnvRule.COLUMN_FAMILY)
-        .qualifier(qualToCheck)
-        .ifMatches(CompareOperator.LESS, Bytes.toBytes(4000l))
-        .thenPut(someRandomPut)
-        .get();
-    Assert.assertFalse("4000 < 2000 should fail", success);
-
-    success = table.checkAndMutate(rowKey, SharedTestEnvRule.COLUMN_FAMILY)
-        .qualifier(qualToCheck)
-        .ifMatches(CompareOperator.GREATER, Bytes.toBytes(1000l))
-        .thenPut(someRandomPut)
-        .get();
-    Assert.assertFalse("1000 > 2000 should fail", success);
-
-    success = table.checkAndMutate(rowKey, SharedTestEnvRule.COLUMN_FAMILY)
-        .qualifier(qualToCheck)
-        .ifMatches(CompareOperator.GREATER, Bytes.toBytes(4000l))
-        .thenPut(someRandomPut)
-        .get();
-    Assert.assertTrue("4000 > 2000 should succeed", success);
-
-    success = table.checkAndMutate(rowKey, SharedTestEnvRule.COLUMN_FAMILY)
-        .qualifier(qualToCheck)
-        .ifMatches(CompareOperator.LESS_OR_EQUAL, Bytes.toBytes(1000l))
-        .thenPut(someRandomPut)
-        .get();
-    Assert.assertTrue("1000 <= 2000 should succeed", success);
-
-    success = table.checkAndMutate(rowKey, SharedTestEnvRule.COLUMN_FAMILY)
-        .qualifier(qualToCheck)
-        .ifMatches(CompareOperator.LESS_OR_EQUAL, Bytes.toBytes(4000l))
-        .thenPut(someRandomPut)
-        .get();
-    Assert.assertFalse("4000 <= 2000 should fail", success);
-
-    success = table.checkAndMutate(rowKey, SharedTestEnvRule.COLUMN_FAMILY)
-        .qualifier(qualToCheck)
-        .ifMatches(CompareOperator.GREATER_OR_EQUAL, Bytes.toBytes(1000l))
-        .thenPut(someRandomPut)
-        .get();
-    Assert.assertFalse("1000 >= 2000 should fail", success);
-
-    success = table.checkAndMutate(rowKey, SharedTestEnvRule.COLUMN_FAMILY)
-        .qualifier(qualToCheck)
-        .ifMatches(CompareOperator.GREATER_OR_EQUAL, Bytes.toBytes(4000l))
-        .thenPut(someRandomPut)
-        .get();
-    Assert.assertTrue("4000 >= 2000 should succeed", success);
-
-    success = table.checkAndMutate(rowKey, SharedTestEnvRule.COLUMN_FAMILY)
-        .qualifier(qualToCheck)
-        .ifMatches(CompareOperator.EQUAL, Bytes.toBytes(1000l))
-        .thenPut(someRandomPut)
-        .get();
-    Assert.assertFalse("1000 == 2000 should fail", success);
-
-    success = table.checkAndMutate(rowKey, SharedTestEnvRule.COLUMN_FAMILY)
-        .qualifier(qualToCheck)
-        .ifMatches(CompareOperator.EQUAL, Bytes.toBytes(2000l))
-        .thenPut(someRandomPut)
-        .get();
-    Assert.assertTrue("2000 == 2000 should succeed", success);
-
-    success = table.checkAndMutate(rowKey, SharedTestEnvRule.COLUMN_FAMILY)
-        .qualifier(qualToCheck)
-        .ifMatches(CompareOperator.NOT_EQUAL, Bytes.toBytes(2000l))
-        .thenPut(someRandomPut)
-        .get();
-    Assert.assertFalse("2000 != 2000 should fail", success);
-
-    success = table.checkAndMutate(rowKey, SharedTestEnvRule.COLUMN_FAMILY)
-        .qualifier(qualToCheck)
-        .ifMatches(CompareOperator.NOT_EQUAL, Bytes.toBytes(4000l))
-        .thenPut(someRandomPut)
-        .get();
-    Assert.assertTrue("4000 != 2000 should succeed", success);
-
-    success = table.checkAndMutate(rowKey, SharedTestEnvRule.COLUMN_FAMILY)
-        .qualifier(qualToCheck)
-        .ifMatches(CompareOperator.NOT_EQUAL, null)
-        .thenPut(someRandomPut)
-        .get();
-    Assert.assertTrue("4000 != null should succeed", success);
+  @Override
+  protected boolean checkAndMutate(byte[] row, byte[] family, byte[] qualifier, CompareOp op,
+      byte[] value, RowMutations rm) throws Exception {
+    try {
+      return getBuilder(row, family, qualifier, op, value).thenMutate(rm).get();
+    } catch (ExecutionException e) {
+      throw (Exception) e.getCause();
+    }
   }
 
-  @Test
-  public void testCompareOperatorsVersions() throws Exception {
-    byte[] rowKey = dataHelper.randomData("rowKey-");
-    byte[] qualToCheck = dataHelper.randomData("toCheck-");
-    byte[] otherQual = dataHelper.randomData("other-");
-    boolean success;
-
-    AsyncTable table = getDefaultAsyncTable(executor);
-    Put someRandomPut =
-        new Put(rowKey).addColumn(SharedTestEnvRule.COLUMN_FAMILY, otherQual, Bytes.toBytes(1l));
-
-    long now = System.currentTimeMillis();
-    Put put1 = new Put(rowKey, now - 10000).addColumn(SharedTestEnvRule.COLUMN_FAMILY, qualToCheck,
-      Bytes.toBytes(2000l));
-    Put put2 = new Put(rowKey, now).addColumn(SharedTestEnvRule.COLUMN_FAMILY, qualToCheck,
-      Bytes.toBytes(4000l));
-
-    getDefaultTable().put(Arrays.asList(put1, put2));
-
-    success = table.checkAndMutate(rowKey, SharedTestEnvRule.COLUMN_FAMILY)
-        .qualifier(qualToCheck)
-        .ifMatches(CompareOperator.GREATER, Bytes.toBytes(3000l))
-        .thenPut(someRandomPut)
-        .get();
-    Assert.assertFalse("3000 > 4000 should fail", success);
+  private CheckAndMutateBuilder getBuilder(byte[] row, byte[] family, byte[] qualifier,
+      CompareOp op, byte[] value) throws InterruptedException, ExecutionException {
+    CheckAndMutateBuilder builder = getDefaultAsyncTable().checkAndMutate(row,family)
+        .qualifier(qualifier);
+    if (op == CompareOp.EQUAL) {
+      if (value == null) {
+        return builder.ifNotExists();
+      } else {
+        return builder.ifEquals(value);
+      }
+    } else {
+      return builder.ifMatches(TestCheckAndMutateHBase2.translate(op), value);
+    }
   }
+
+  protected AsyncTable getDefaultAsyncTable() throws InterruptedException, ExecutionException {
+    return AbstractAsyncTest.getAsyncConnection().getTable(sharedTestEnv.getDefaultTableName(),
+      executor);
+  }
+
 }

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncTable.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncTable.java
@@ -165,6 +165,8 @@ public class BigtableAsyncTable implements AsyncTable {
       if (compareOp != CompareOperator.EQUAL && compareOp != CompareOperator.NOT_EQUAL) {
         this.value =
             Preconditions.checkNotNull(value, "value is null for compareOperator: " + compareOp);
+      } else {
+        this.value = value;
       }
       return this;
     }

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests-common/src/main/java/com/google/cloud/bigtable/hbase/AbstractTestCheckAndMutate.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests-common/src/main/java/com/google/cloud/bigtable/hbase/AbstractTestCheckAndMutate.java
@@ -1,0 +1,387 @@
+/*
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase;
+
+import com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule;
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.CellUtil;
+import org.apache.hadoop.hbase.client.Delete;
+import org.apache.hadoop.hbase.client.Get;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.RowMutations;
+import org.apache.hadoop.hbase.client.Table;
+import org.apache.hadoop.hbase.filter.CompareFilter.CompareOp;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.io.IOException;
+import java.util.List;
+
+public abstract class AbstractTestCheckAndMutate extends AbstractTest {
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+
+  /**
+   * Requirement 7.1 - Atomically attempt a mutation, dependent on a successful value check within
+   * the same row.
+   *
+   * Requirement 7.3 - Pass a null value to check for the non-existence of a column.
+   */
+  @Test
+  public void testCheckAndPutSameQual() throws Exception {
+    // Initialize
+    try (Table table = getDefaultTable()) {
+      byte[] rowKey = dataHelper.randomData("rowKey-");
+      byte[] qual = dataHelper.randomData("qualifier-");
+      byte[] value1 = dataHelper.randomData("value-");
+      byte[] value2 = dataHelper.randomData("value-");
+
+      // Put with a bad check on a null value, then try with a good one
+      Put put = new Put(rowKey).addColumn(SharedTestEnvRule.COLUMN_FAMILY, qual, value1);
+      boolean success = checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qual, value2, put);
+      Assert.assertFalse("Column doesn't exist.  Should fail.", success);
+      success = checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qual, null, put);
+      Assert.assertTrue(success);
+
+      // Fail on null check, now there's a value there
+      put = new Put(rowKey).addColumn(SharedTestEnvRule.COLUMN_FAMILY, qual, value2);
+      success = checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qual, null, put);
+      Assert.assertFalse("Null check should fail", success);
+      success = checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qual, value2, put);
+      Assert.assertFalse("Wrong value should fail", success);
+      success = checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qual, value1, put);
+      Assert.assertTrue(success);
+
+      // Check results
+      Get get = new Get(rowKey);
+      get.setMaxVersions(5);
+      Result result = table.get(get);
+      Assert.assertEquals("Should be two results", 2, result.size());
+      List<Cell> cells = result.getColumnCells(SharedTestEnvRule.COLUMN_FAMILY, qual);
+      Assert.assertArrayEquals(value2, CellUtil.cloneValue(cells.get(0)));
+      Assert.assertArrayEquals(value1, CellUtil.cloneValue(cells.get(1)));
+    }
+  }
+
+  protected abstract boolean checkAndPut(byte[] rowKey, byte[] columnFamily, byte[] qual,
+      byte[] value, Put put) throws Exception;
+
+  protected abstract boolean checkAndPut(byte[] rowKey, byte[] columnFamily, byte[] qualToCheck,
+      CompareOp op, byte[] bytes, Put someRandomPut) throws Exception;
+
+  protected abstract boolean checkAndDelete(byte[] rowKey, byte[] columnFamily, byte[] qual,
+      byte[] value, Delete delete) throws Exception;
+
+  protected abstract boolean checkAndMutate(byte[] rowKey, byte[] columnFamily, byte[] qual,
+      CompareOp op, byte[] value, RowMutations rm) throws Exception;
+
+  /**
+   * Further tests for requirements 7.1 and 7.3.
+   */
+  @Test
+  public void testCheckAndDeleteSameQual() throws Exception {
+    // Initialize
+    Table table = getDefaultTable();
+    byte[] rowKey = dataHelper.randomData("rowKey-");
+    byte[] qual = dataHelper.randomData("qualifier-");
+    byte[] value1 = dataHelper.randomData("value-");
+    byte[] value2 = dataHelper.randomData("value-");
+
+    // Delete all previous versions if the value is found.
+    Delete delete = new Delete(rowKey).addColumns(SharedTestEnvRule.COLUMN_FAMILY, qual);
+    boolean success = checkAndDelete(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qual, value1, delete);
+    Assert.assertFalse("Column doesn't exist.  Should fail.", success);
+    success = checkAndDelete(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qual, null, delete);
+
+    // Add a value and check again
+    Put put = new Put(rowKey).addColumn(SharedTestEnvRule.COLUMN_FAMILY, qual, value1);
+    table.put(put);
+    success = checkAndDelete(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qual, value2, delete);
+    Assert.assertFalse("Wrong value.  Should fail.", success);
+    success = checkAndDelete(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qual, value1, delete);
+    Assert.assertTrue(success);
+    Assert.assertFalse("Row should be gone", table.exists(new Get(rowKey)));
+
+    table.close();
+  }
+
+  /**
+   * Further tests for requirements 7.1 and 7.3.
+   */
+  @Test
+  public void testCheckAndPutDiffQual() throws Exception {
+    // Initialize
+    Table table = getDefaultTable();
+    byte[] rowKey = dataHelper.randomData("rowKey-");
+    byte[] qual1 = dataHelper.randomData("qualifier-");
+    byte[] qual2 = dataHelper.randomData("qualifier-");
+    byte[] value1 = dataHelper.randomData("value-");
+    byte[] value2 = dataHelper.randomData("value-");
+
+    // Put then again
+    Put put = new Put(rowKey).addColumn(SharedTestEnvRule.COLUMN_FAMILY, qual1, value1);
+    boolean success = checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qual2, value2, put);
+    Assert.assertFalse("Column doesn't exist.  Should fail.", success);
+    success = checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qual2, null, put);
+    Assert.assertTrue(success);
+
+    // Fail on null check, now there's a value there
+    put = new Put(rowKey).addColumn(SharedTestEnvRule.COLUMN_FAMILY, qual2, value2);
+    success = checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qual1, null, put);
+    Assert.assertFalse("Null check should fail", success);
+    success = checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qual1, value2, put);
+    Assert.assertFalse("Wrong value should fail", success);
+    success = checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qual1, value1, put);
+    Assert.assertTrue(success);
+
+    // Check results
+    Get get = new Get(rowKey);
+    get.setMaxVersions(5);
+    Result result = table.get(get);
+    Assert.assertEquals("Should be two results", 2, result.size());
+    Assert.assertArrayEquals(value1, CellUtil.cloneValue(result.getColumnLatestCell(SharedTestEnvRule.COLUMN_FAMILY, qual1)));
+    Assert.assertArrayEquals(value2, CellUtil.cloneValue(result.getColumnLatestCell(SharedTestEnvRule.COLUMN_FAMILY,
+      qual2)));
+
+    table.close();
+  }
+
+  /**
+   * Further tests for requirements 7.1 and 7.3.
+   */
+  @Test
+  public void testCheckAndDeleteDiffQual() throws Exception {
+    // Initialize
+    Table table = getDefaultTable();
+    byte[] rowKey = dataHelper.randomData("rowKey-");
+    byte[] qual1 = dataHelper.randomData("qualifier-");
+    byte[] qual2 = dataHelper.randomData("qualifier-");
+    byte[] value1 = dataHelper.randomData("value-");
+    byte[] value2 = dataHelper.randomData("value-");
+
+    // Delete all versions of a column if the latest version matches
+    Delete delete = new Delete(rowKey).addColumns(SharedTestEnvRule.COLUMN_FAMILY, qual1);
+    boolean success = checkAndDelete(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qual2, value2, delete);
+    Assert.assertFalse("Column doesn't exist.  Should fail.", success);
+    success = checkAndDelete(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qual2, null, delete);
+    Assert.assertTrue(success);
+
+    // Add a value now
+    Put put = new Put(rowKey)
+        .addColumn(SharedTestEnvRule.COLUMN_FAMILY, qual1, value1)
+        .addColumn(SharedTestEnvRule.COLUMN_FAMILY, qual2, value2);
+    table.put(put);
+
+    // Fail on null check, now there's a value there
+    success = checkAndDelete(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qual2, null, delete);
+    Assert.assertFalse("Null check should fail", success);
+    success = checkAndDelete(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qual2, value1, delete);
+    Assert.assertFalse("Wrong value should fail", success);
+    success = checkAndDelete(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qual2, value2, delete);
+    Assert.assertTrue(success);
+    delete = new Delete(rowKey).addColumns(SharedTestEnvRule.COLUMN_FAMILY, qual2);
+    success = checkAndDelete(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qual1, null, delete);
+    Assert.assertTrue(success);
+    Assert.assertFalse("Row should be gone", table.exists(new Get(rowKey)));
+
+    table.close();
+  }
+
+  /**
+   * Requirement 7.2 - Throws an IOException if the check is for a row other than the one in the
+   * mutation attempt.
+   */
+  @Test
+  public void testCheckAndPutDiffRow() throws Exception {
+    // Initialize
+    Table table = getDefaultTable();
+    byte[] rowKey1 = dataHelper.randomData("rowKey-");
+    byte[] rowKey2 = dataHelper.randomData("rowKey-");
+    byte[] qual = dataHelper.randomData("qualifier-");
+    byte[] value = dataHelper.randomData("value-");
+
+    // Put then again
+    Put put = new Put(rowKey1).addColumn(SharedTestEnvRule.COLUMN_FAMILY, qual, value);
+    expectedException.expect(IOException.class);
+    expectedException.expectMessage("Action's getRow must match the passed row");
+    checkAndPut(rowKey2, SharedTestEnvRule.COLUMN_FAMILY, qual, null, put);
+
+    table.close();
+  }
+
+  @Test
+  public void testCheckAndDeleteDiffRow() throws Exception {
+    // Initialize
+    try (Table table = getDefaultTable()) {
+      byte[] rowKey1 = dataHelper.randomData("rowKey-");
+      byte[] rowKey2 = dataHelper.randomData("rowKey-");
+      byte[] qual = dataHelper.randomData("qualifier-");
+
+      // Put then again
+      Delete delete = new Delete(rowKey1).addColumns(SharedTestEnvRule.COLUMN_FAMILY, qual);
+      checkAndDelete(rowKey2, SharedTestEnvRule.COLUMN_FAMILY, qual, null, delete);
+    } catch (IOException e) {
+      Assert.assertTrue(e.getMessage().contains("Action's getRow must match the passed row"));
+    }
+  }
+
+  @Test
+  public void testCheckAndMutate() throws Exception {
+    // Initialize
+    Table table = getDefaultTable();
+    byte[] rowKey = dataHelper.randomData("rowKey-");
+    byte[] qualCheck = dataHelper.randomData("qualifier-");
+    byte[] qualPut = dataHelper.randomData("qualifier-");
+    byte[] qualDelete = dataHelper.randomData("qualifier-");
+    byte[] valuePut = dataHelper.randomData("value-");
+    byte[] valueCheck = dataHelper.randomData("value-");
+
+    // Delete all versions of a column if the latest version matches
+    RowMutations rm = new RowMutations(rowKey);
+    rm.add(new Put(rowKey).addColumn(SharedTestEnvRule.COLUMN_FAMILY, qualPut, valuePut));
+    rm.add(new Delete(rowKey).addColumns(SharedTestEnvRule.COLUMN_FAMILY, qualDelete));
+
+    boolean success = checkAndMutate(
+        rowKey, SharedTestEnvRule.COLUMN_FAMILY, qualCheck, CompareOp.EQUAL, valueCheck, rm);
+    Assert.assertFalse("Column doesn't exist.  Should fail.", success);
+    success = checkAndMutate(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qualCheck, CompareOp.EQUAL, null, rm);
+    Assert.assertTrue(success);
+
+    // Add a value now
+    Put put = new Put(rowKey)
+        .addColumn(SharedTestEnvRule.COLUMN_FAMILY, qualCheck, valueCheck)
+        .addColumn(SharedTestEnvRule.COLUMN_FAMILY, qualDelete, Bytes.toBytes("todelete"));
+    table.put(put);
+    // Fail on null check, now there's a value there
+    success = checkAndMutate(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qualCheck, CompareOp.EQUAL, null, rm);
+    Assert.assertFalse("Null check should fail", success);
+    // valuePut is in qualPut and not in qualCheck so this will fail:
+    success = checkAndMutate(
+        rowKey, SharedTestEnvRule.COLUMN_FAMILY, qualCheck, CompareOp.EQUAL, valuePut, rm);
+    Assert.assertFalse("Wrong value should fail", success);
+    success = checkAndMutate(
+        rowKey, SharedTestEnvRule.COLUMN_FAMILY, qualCheck, CompareOp.EQUAL, valueCheck, rm);
+    Assert.assertTrue(success);
+
+    Result row = table.get(new Get(rowKey).addFamily(SharedTestEnvRule.COLUMN_FAMILY));
+    // QualCheck and QualPut should exist
+    Assert.assertEquals(2, row.size());
+    Assert.assertFalse(
+        "QualDelete should be deleted",
+        row.containsColumn(SharedTestEnvRule.COLUMN_FAMILY, qualDelete));
+    Assert.assertTrue(
+        "QualPut should exist",
+        row.containsColumn(SharedTestEnvRule.COLUMN_FAMILY, qualPut));
+    table.close();
+  }
+
+  @Test
+  public void testCompareOps() throws Exception {
+    byte[] rowKey = dataHelper.randomData("rowKey-");
+    byte[] qualToCheck = dataHelper.randomData("toCheck-");
+    byte[] otherQual = dataHelper.randomData("other-");
+    boolean success;
+
+    Table table = getDefaultTable();
+
+    table.put(new Put(rowKey).addColumn(SharedTestEnvRule.COLUMN_FAMILY, qualToCheck,
+      Bytes.toBytes(2000l)));
+
+    Put someRandomPut =
+        new Put(rowKey).addColumn(SharedTestEnvRule.COLUMN_FAMILY, otherQual, Bytes.toBytes(1l));
+
+    success = checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qualToCheck,
+      CompareOp.LESS, Bytes.toBytes(1000l), someRandomPut);
+    Assert.assertTrue("1000 < 2000 should succeed", success);
+
+    success = checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qualToCheck,
+      CompareOp.LESS, Bytes.toBytes(4000l), someRandomPut);
+    Assert.assertFalse("4000 < 2000 should fail", success);
+
+    success = checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qualToCheck,
+      CompareOp.GREATER, Bytes.toBytes(1000l), someRandomPut);
+    Assert.assertFalse("1000 > 2000 should fail", success);
+
+    success = checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qualToCheck,
+      CompareOp.GREATER, Bytes.toBytes(4000l), someRandomPut);
+    Assert.assertTrue("4000 > 2000 should succeed", success);
+
+    success = checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qualToCheck,
+      CompareOp.LESS_OR_EQUAL, Bytes.toBytes(1000l), someRandomPut);
+    Assert.assertTrue("1000 <= 2000 should succeed", success);
+
+    success = checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qualToCheck,
+      CompareOp.LESS_OR_EQUAL, Bytes.toBytes(4000l), someRandomPut);
+    Assert.assertFalse("4000 <= 2000 should fail", success);
+
+    success = checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qualToCheck,
+      CompareOp.GREATER_OR_EQUAL, Bytes.toBytes(1000l), someRandomPut);
+    Assert.assertFalse("1000 >= 2000 should fail", success);
+
+    success = checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qualToCheck,
+      CompareOp.GREATER_OR_EQUAL, Bytes.toBytes(4000l), someRandomPut);
+    Assert.assertTrue("4000 >= 2000 should succeed", success);
+
+    success = checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qualToCheck,
+      CompareOp.EQUAL, Bytes.toBytes(1000l), someRandomPut);
+    Assert.assertFalse("1000 == 2000 should fail", success);
+
+    success = checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qualToCheck,
+      CompareOp.EQUAL, Bytes.toBytes(2000l), someRandomPut);
+    Assert.assertTrue("2000 == 2000 should succeed", success);
+
+    success = checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qualToCheck,
+      CompareOp.NOT_EQUAL, Bytes.toBytes(2000l), someRandomPut);
+    Assert.assertFalse("2000 != 2000 should fail", success);
+
+    success = checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qualToCheck,
+      CompareOp.NOT_EQUAL, Bytes.toBytes(4000l), someRandomPut);
+    Assert.assertTrue("4000 != 2000 should succeed", success);
+
+    if (sharedTestEnv.isBigtable()) {
+      // This doesn't work in HBase, but we need this to work in CBT
+      success = checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qualToCheck,
+        CompareOp.NOT_EQUAL, null, someRandomPut);
+      Assert.assertTrue("4000 != null should succeed", success);
+    }
+  }
+
+  @Test
+  public void testCompareOpsVersions() throws Exception {
+    byte[] rowKey = dataHelper.randomData("rowKey-");
+    byte[] qualToCheck = dataHelper.randomData("toCheck-");
+    byte[] otherQual = dataHelper.randomData("other-");
+    boolean success;
+
+    Table table = getDefaultTable();
+    Put someRandomPut =
+        new Put(rowKey).addColumn(SharedTestEnvRule.COLUMN_FAMILY, otherQual, Bytes.toBytes(1l));
+
+    table.put(new Put(rowKey, System.currentTimeMillis() - 10000)
+        .addColumn(SharedTestEnvRule.COLUMN_FAMILY, qualToCheck, Bytes.toBytes(2000l)));
+
+    table.put(new Put(rowKey, System.currentTimeMillis()).addColumn(SharedTestEnvRule.COLUMN_FAMILY,
+      qualToCheck, Bytes.toBytes(4000l)));
+
+    success = checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qualToCheck,
+      CompareOp.GREATER, Bytes.toBytes(3000l), someRandomPut);
+    Assert.assertFalse("3000 > 4000 should fail", success);
+  }
+}

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests-common/src/main/java/com/google/cloud/bigtable/hbase/TestCheckAndMutate.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests-common/src/main/java/com/google/cloud/bigtable/hbase/TestCheckAndMutate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Google Inc. All Rights Reserved.
+ * Copyright 2018 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,367 +15,39 @@
  */
 package com.google.cloud.bigtable.hbase;
 
-import com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule;
-import org.apache.hadoop.hbase.Cell;
-import org.apache.hadoop.hbase.CellUtil;
-import org.apache.hadoop.hbase.DoNotRetryIOException;
+import java.io.IOException;
+
 import org.apache.hadoop.hbase.client.Delete;
-import org.apache.hadoop.hbase.client.Get;
 import org.apache.hadoop.hbase.client.Put;
-import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.RowMutations;
-import org.apache.hadoop.hbase.client.Table;
 import org.apache.hadoop.hbase.filter.CompareFilter.CompareOp;
-import org.apache.hadoop.hbase.util.Bytes;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-import java.io.IOException;
-import java.util.List;
-
 @RunWith(JUnit4.class)
-public class TestCheckAndMutate extends AbstractTest {
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
+public class TestCheckAndMutate extends AbstractTestCheckAndMutate {
 
-  /**
-   * Requirement 7.1 - Atomically attempt a mutation, dependent on a successful value check within
-   * the same row.
-   *
-   * Requirement 7.3 - Pass a null value to check for the non-existence of a column.
-   */
-  @Test
-  public void testCheckAndPutSameQual() throws IOException {
-    // Initialize
-    try (Table table = getDefaultTable()) {
-      testCheckAndMutate(dataHelper, table);
-    }
+  @Override
+  protected boolean checkAndPut(byte[] row, byte[] family, byte[] qualifier, byte[] value, Put put)
+      throws IOException {
+    return getDefaultTable().checkAndPut(row, family, qualifier, value, put);
   }
 
-  public static void testCheckAndMutate(DataGenerationHelper dataHelper, Table table) throws IOException {
-    byte[] rowKey = dataHelper.randomData("rowKey-");
-    byte[] qual = dataHelper.randomData("qualifier-");
-    byte[] value1 = dataHelper.randomData("value-");
-    byte[] value2 = dataHelper.randomData("value-");
-
-    // Put with a bad check on a null value, then try with a good one
-    Put put = new Put(rowKey).addColumn(SharedTestEnvRule.COLUMN_FAMILY, qual, value1);
-    boolean success = table.checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qual, value2, put);
-    Assert.assertFalse("Column doesn't exist.  Should fail.", success);
-    success = table.checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qual, null, put);
-    Assert.assertTrue(success);
-
-    // Fail on null check, now there's a value there
-    put = new Put(rowKey).addColumn(SharedTestEnvRule.COLUMN_FAMILY, qual, value2);
-    success = table.checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qual, null, put);
-    Assert.assertFalse("Null check should fail", success);
-    success = table.checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qual, value2, put);
-    Assert.assertFalse("Wrong value should fail", success);
-    success = table.checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qual, value1, put);
-    Assert.assertTrue(success);
-
-    // Check results
-    Get get = new Get(rowKey);
-    get.setMaxVersions(5);
-    Result result = table.get(get);
-    Assert.assertEquals("Should be two results", 2, result.size());
-    List<Cell> cells = result.getColumnCells(SharedTestEnvRule.COLUMN_FAMILY, qual);
-    Assert.assertArrayEquals(value2, CellUtil.cloneValue(cells.get(0)));
-    Assert.assertArrayEquals(value1, CellUtil.cloneValue(cells.get(1)));
+  @Override
+  protected boolean checkAndPut(byte[] row, byte[] family, byte[] qualifier, CompareOp op,
+      byte[] value, Put put) throws IOException {
+    return getDefaultTable().checkAndPut(row, family, qualifier, op, value, put);
   }
 
-  /**
-   * Further tests for requirements 7.1 and 7.3.
-   */
-  @Test
-  public void testCheckAndDeleteSameQual() throws IOException {
-    // Initialize
-    Table table = getDefaultTable();
-    byte[] rowKey = dataHelper.randomData("rowKey-");
-    byte[] qual = dataHelper.randomData("qualifier-");
-    byte[] value1 = dataHelper.randomData("value-");
-    byte[] value2 = dataHelper.randomData("value-");
-
-    // Delete all previous versions if the value is found.
-    Delete delete = new Delete(rowKey).addColumns(SharedTestEnvRule.COLUMN_FAMILY, qual);
-    boolean success = table.checkAndDelete(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qual, value1, delete);
-    Assert.assertFalse("Column doesn't exist.  Should fail.", success);
-    success = table.checkAndDelete(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qual, null, delete);
-
-    // Add a value and check again
-    Put put = new Put(rowKey).addColumn(SharedTestEnvRule.COLUMN_FAMILY, qual, value1);
-    table.put(put);
-    success = table.checkAndDelete(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qual, value2, delete);
-    Assert.assertFalse("Wrong value.  Should fail.", success);
-    success = table.checkAndDelete(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qual, value1, delete);
-    Assert.assertTrue(success);
-    Assert.assertFalse("Row should be gone", table.exists(new Get(rowKey)));
-
-    table.close();
+  @Override
+  protected boolean checkAndDelete(byte[] row, byte[] family, byte[] qualifier, byte[] value,
+      Delete delete) throws IOException {
+    return getDefaultTable().checkAndDelete(row, family, qualifier, value, delete);
   }
 
-  /**
-   * Further tests for requirements 7.1 and 7.3.
-   */
-  @Test
-  public void testCheckAndPutDiffQual() throws IOException {
-    // Initialize
-    Table table = getDefaultTable();
-    byte[] rowKey = dataHelper.randomData("rowKey-");
-    byte[] qual1 = dataHelper.randomData("qualifier-");
-    byte[] qual2 = dataHelper.randomData("qualifier-");
-    byte[] value1 = dataHelper.randomData("value-");
-    byte[] value2 = dataHelper.randomData("value-");
-
-    // Put then again
-    Put put = new Put(rowKey).addColumn(SharedTestEnvRule.COLUMN_FAMILY, qual1, value1);
-    boolean success = table.checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qual2, value2, put);
-    Assert.assertFalse("Column doesn't exist.  Should fail.", success);
-    success = table.checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qual2, null, put);
-    Assert.assertTrue(success);
-
-    // Fail on null check, now there's a value there
-    put = new Put(rowKey).addColumn(SharedTestEnvRule.COLUMN_FAMILY, qual2, value2);
-    success = table.checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qual1, null, put);
-    Assert.assertFalse("Null check should fail", success);
-    success = table.checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qual1, value2, put);
-    Assert.assertFalse("Wrong value should fail", success);
-    success = table.checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qual1, value1, put);
-    Assert.assertTrue(success);
-
-    // Check results
-    Get get = new Get(rowKey);
-    get.setMaxVersions(5);
-    Result result = table.get(get);
-    Assert.assertEquals("Should be two results", 2, result.size());
-    Assert.assertArrayEquals(value1, CellUtil.cloneValue(result.getColumnLatestCell(SharedTestEnvRule.COLUMN_FAMILY, qual1)));
-    Assert.assertArrayEquals(value2, CellUtil.cloneValue(result.getColumnLatestCell(SharedTestEnvRule.COLUMN_FAMILY,
-      qual2)));
-
-    table.close();
-  }
-
-  /**
-   * Further tests for requirements 7.1 and 7.3.
-   */
-  @Test
-  public void testCheckAndDeleteDiffQual() throws IOException {
-    // Initialize
-    Table table = getDefaultTable();
-    byte[] rowKey = dataHelper.randomData("rowKey-");
-    byte[] qual1 = dataHelper.randomData("qualifier-");
-    byte[] qual2 = dataHelper.randomData("qualifier-");
-    byte[] value1 = dataHelper.randomData("value-");
-    byte[] value2 = dataHelper.randomData("value-");
-
-    // Delete all versions of a column if the latest version matches
-    Delete delete = new Delete(rowKey).addColumns(SharedTestEnvRule.COLUMN_FAMILY, qual1);
-    boolean success = table.checkAndDelete(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qual2, value2, delete);
-    Assert.assertFalse("Column doesn't exist.  Should fail.", success);
-    success = table.checkAndDelete(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qual2, null, delete);
-    Assert.assertTrue(success);
-
-    // Add a value now
-    Put put = new Put(rowKey)
-        .addColumn(SharedTestEnvRule.COLUMN_FAMILY, qual1, value1)
-        .addColumn(SharedTestEnvRule.COLUMN_FAMILY, qual2, value2);
-    table.put(put);
-
-    // Fail on null check, now there's a value there
-    success = table.checkAndDelete(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qual2, null, delete);
-    Assert.assertFalse("Null check should fail", success);
-    success = table.checkAndDelete(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qual2, value1, delete);
-    Assert.assertFalse("Wrong value should fail", success);
-    success = table.checkAndDelete(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qual2, value2, delete);
-    Assert.assertTrue(success);
-    delete = new Delete(rowKey).addColumns(SharedTestEnvRule.COLUMN_FAMILY, qual2);
-    success = table.checkAndDelete(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qual1, null, delete);
-    Assert.assertTrue(success);
-    Assert.assertFalse("Row should be gone", table.exists(new Get(rowKey)));
-
-    table.close();
-  }
-
-  /**
-   * Requirement 7.2 - Throws an IOException if the check is for a row other than the one in the
-   * mutation attempt.
-   */
-  @Test
-  public void testCheckAndPutDiffRow() throws IOException {
-    // Initialize
-    Table table = getDefaultTable();
-    byte[] rowKey1 = dataHelper.randomData("rowKey-");
-    byte[] rowKey2 = dataHelper.randomData("rowKey-");
-    byte[] qual = dataHelper.randomData("qualifier-");
-    byte[] value = dataHelper.randomData("value-");
-
-    // Put then again
-    Put put = new Put(rowKey1).addColumn(SharedTestEnvRule.COLUMN_FAMILY, qual, value);
-    expectedException.expect(DoNotRetryIOException.class);
-    expectedException.expectMessage("Action's getRow must match the passed row");
-    table.checkAndPut(rowKey2, SharedTestEnvRule.COLUMN_FAMILY, qual, null, put);
-
-    table.close();
-  }
-
-  @Test
-  public void testCheckAndDeleteDiffRow() throws IOException {
-    // Initialize
-    Table table = getDefaultTable();
-    byte[] rowKey1 = dataHelper.randomData("rowKey-");
-    byte[] rowKey2 = dataHelper.randomData("rowKey-");
-    byte[] qual = dataHelper.randomData("qualifier-");
-
-    // Put then again
-    Delete delete = new Delete(rowKey1).addColumns(SharedTestEnvRule.COLUMN_FAMILY, qual);
-    expectedException.expect(DoNotRetryIOException.class);
-    expectedException.expectMessage("Action's getRow must match the passed row");
-    table.checkAndDelete(rowKey2, SharedTestEnvRule.COLUMN_FAMILY, qual, null, delete);
-
-    table.close();
-  }
-
-  @Test
-  public void testCheckAndMutate() throws IOException {
-    // Initialize
-    Table table = getDefaultTable();
-    byte[] rowKey = dataHelper.randomData("rowKey-");
-    byte[] qualCheck = dataHelper.randomData("qualifier-");
-    byte[] qualPut = dataHelper.randomData("qualifier-");
-    byte[] qualDelete = dataHelper.randomData("qualifier-");
-    byte[] valuePut = dataHelper.randomData("value-");
-    byte[] valueCheck = dataHelper.randomData("value-");
-
-    // Delete all versions of a column if the latest version matches
-    RowMutations rm = new RowMutations(rowKey);
-    rm.add(new Put(rowKey).addColumn(SharedTestEnvRule.COLUMN_FAMILY, qualPut, valuePut));
-    rm.add(new Delete(rowKey).addColumns(SharedTestEnvRule.COLUMN_FAMILY, qualDelete));
-
-    boolean success = table.checkAndMutate(
-        rowKey, SharedTestEnvRule.COLUMN_FAMILY, qualCheck, CompareOp.EQUAL, valueCheck, rm);
-    Assert.assertFalse("Column doesn't exist.  Should fail.", success);
-    success = table.checkAndMutate(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qualCheck, CompareOp.EQUAL, null, rm);
-    Assert.assertTrue(success);
-
-    // Add a value now
-    Put put = new Put(rowKey)
-        .addColumn(SharedTestEnvRule.COLUMN_FAMILY, qualCheck, valueCheck)
-        .addColumn(SharedTestEnvRule.COLUMN_FAMILY, qualDelete, Bytes.toBytes("todelete"));
-    table.put(put);
-    // Fail on null check, now there's a value there
-    success = table.checkAndMutate(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qualCheck, CompareOp.EQUAL, null, rm);
-    Assert.assertFalse("Null check should fail", success);
-    // valuePut is in qualPut and not in qualCheck so this will fail:
-    success = table.checkAndMutate(
-        rowKey, SharedTestEnvRule.COLUMN_FAMILY, qualCheck, CompareOp.EQUAL, valuePut, rm);
-    Assert.assertFalse("Wrong value should fail", success);
-    success = table.checkAndMutate(
-        rowKey, SharedTestEnvRule.COLUMN_FAMILY, qualCheck, CompareOp.EQUAL, valueCheck, rm);
-    Assert.assertTrue(success);
-
-    Result row = table.get(new Get(rowKey).addFamily(SharedTestEnvRule.COLUMN_FAMILY));
-    // QualCheck and QualPut should exist
-    Assert.assertEquals(2, row.size());
-    Assert.assertFalse(
-        "QualDelete should be deleted",
-        row.containsColumn(SharedTestEnvRule.COLUMN_FAMILY, qualDelete));
-    Assert.assertTrue(
-        "QualPut should exist",
-        row.containsColumn(SharedTestEnvRule.COLUMN_FAMILY, qualPut));
-    table.close();
-  }
-
-  @Test
-  public void testCompareOps() throws IOException {
-    byte[] rowKey = dataHelper.randomData("rowKey-");
-    byte[] qualToCheck = dataHelper.randomData("toCheck-");
-    byte[] otherQual = dataHelper.randomData("other-");
-    boolean success;
-
-    Table table = getDefaultTable();
-
-    table.put(new Put(rowKey).addColumn(SharedTestEnvRule.COLUMN_FAMILY, qualToCheck,
-      Bytes.toBytes(2000l)));
-
-    Put someRandomPut =
-        new Put(rowKey).addColumn(SharedTestEnvRule.COLUMN_FAMILY, otherQual, Bytes.toBytes(1l));
-
-    success = table.checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qualToCheck,
-      CompareOp.LESS, Bytes.toBytes(1000l), someRandomPut);
-    Assert.assertTrue("1000 < 2000 should succeed", success);
-
-    success = table.checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qualToCheck,
-      CompareOp.LESS, Bytes.toBytes(4000l), someRandomPut);
-    Assert.assertFalse("4000 < 2000 should fail", success);
-
-    success = table.checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qualToCheck,
-      CompareOp.GREATER, Bytes.toBytes(1000l), someRandomPut);
-    Assert.assertFalse("1000 > 2000 should fail", success);
-
-    success = table.checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qualToCheck,
-      CompareOp.GREATER, Bytes.toBytes(4000l), someRandomPut);
-    Assert.assertTrue("4000 > 2000 should succeed", success);
-
-    success = table.checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qualToCheck,
-      CompareOp.LESS_OR_EQUAL, Bytes.toBytes(1000l), someRandomPut);
-    Assert.assertTrue("1000 <= 2000 should succeed", success);
-
-    success = table.checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qualToCheck,
-      CompareOp.LESS_OR_EQUAL, Bytes.toBytes(4000l), someRandomPut);
-    Assert.assertFalse("4000 <= 2000 should fail", success);
-
-    success = table.checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qualToCheck,
-      CompareOp.GREATER_OR_EQUAL, Bytes.toBytes(1000l), someRandomPut);
-    Assert.assertFalse("1000 >= 2000 should fail", success);
-
-    success = table.checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qualToCheck,
-      CompareOp.GREATER_OR_EQUAL, Bytes.toBytes(4000l), someRandomPut);
-    Assert.assertTrue("4000 >= 2000 should succeed", success);
-
-    success = table.checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qualToCheck,
-      CompareOp.EQUAL, Bytes.toBytes(1000l), someRandomPut);
-    Assert.assertFalse("1000 == 2000 should fail", success);
-
-    success = table.checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qualToCheck,
-      CompareOp.EQUAL, Bytes.toBytes(2000l), someRandomPut);
-    Assert.assertTrue("2000 == 2000 should succeed", success);
-
-    success = table.checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qualToCheck,
-      CompareOp.NOT_EQUAL, Bytes.toBytes(2000l), someRandomPut);
-    Assert.assertFalse("2000 != 2000 should fail", success);
-
-    success = table.checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qualToCheck,
-      CompareOp.NOT_EQUAL, Bytes.toBytes(4000l), someRandomPut);
-    Assert.assertTrue("4000 != 2000 should succeed", success);
-
-    success = table.checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qualToCheck,
-      CompareOp.NOT_EQUAL, null, someRandomPut);
-    Assert.assertTrue("4000 != null should succeed", success);
-}
-
-  @Test
-  public void testCompareOpsVersions() throws IOException {
-    byte[] rowKey = dataHelper.randomData("rowKey-");
-    byte[] qualToCheck = dataHelper.randomData("toCheck-");
-    byte[] otherQual = dataHelper.randomData("other-");
-    boolean success;
-
-    Table table = getDefaultTable();
-    Put someRandomPut =
-        new Put(rowKey).addColumn(SharedTestEnvRule.COLUMN_FAMILY, otherQual, Bytes.toBytes(1l));
-
-    table.put(new Put(rowKey, System.currentTimeMillis() - 10000)
-        .addColumn(SharedTestEnvRule.COLUMN_FAMILY, qualToCheck, Bytes.toBytes(2000l)));
-
-    table.put(new Put(rowKey, System.currentTimeMillis()).addColumn(SharedTestEnvRule.COLUMN_FAMILY,
-      qualToCheck, Bytes.toBytes(4000l)));
-
-    success = table.checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qualToCheck,
-      CompareOp.GREATER, Bytes.toBytes(3000l), someRandomPut);
-    Assert.assertFalse("3000 > 4000 should fail", success);
+  @Override
+  protected boolean checkAndMutate(byte[] row, byte[] family, byte[] qualifier, CompareOp op,
+      byte[] value, RowMutations rm) throws IOException {
+    return getDefaultTable().checkAndMutate(row, family, qualifier, op, value, rm);
   }
 }

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests-common/src/main/java/com/google/cloud/bigtable/hbase/test_env/SharedTestEnvRule.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests-common/src/main/java/com/google/cloud/bigtable/hbase/test_env/SharedTestEnvRule.java
@@ -17,10 +17,10 @@ package com.google.cloud.bigtable.hbase.test_env;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -56,7 +56,7 @@ public abstract class SharedTestEnvRule extends ExternalResource {
   protected static final Log LOG = LogFactory.getLog(SharedTestEnvRule.class);
   private TableName defaultTableName;
   private SharedTestEnv sharedTestEnv;
-  private Map<String, Closeable> closeables = new HashMap<>();
+  private final Map<String, Closeable> closeables = new ConcurrentHashMap<>();
 
   @Override
   protected void before() throws Throwable {


### PR DESCRIPTION
There are 3 CheckAndMutate tests:
- TestCheckAndMutate
- TestCheckAndMutateHBase2
- TestAsyncCheckAndMutate

I moved the core logic into a new class AbstractTestCheckAndMutate.  Each of the core classes performs slightly different versions of check and mutate.  TestCheckAndMutate uses the hbase 1 methods.  TestCheckAndMutateHBase2 uses the new hbase 2 methods with CompareOperator.  TestAsyncCheckAndMutate uses AsyncTable. Each concrete class only implements the checkAnd* methods which are otherwise abstract in the parent class.

Fixed a bug in SharedTestEnvRule usage to only create a single AsyncConnection.