### PR TITLE
Upgrading grpc, hbase and other dependencies

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/pom.xml
+++ b/bigtable-client-core-parent/bigtable-client-core/pom.xml
@@ -35,7 +35,7 @@ limitations under the License.
         <dependency>
             <groupId>com.google.api.grpc</groupId>
             <artifactId>grpc-google-common-protos</artifactId>
-            <version>1.0.2</version>
+            <version>1.1.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>io.grpc</groupId>

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-hadoop/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-hadoop/pom.xml
@@ -29,7 +29,7 @@ limitations under the License.
   </description>
 
   <properties>
-     <hbase.version>${hbase.version.2.0}</hbase.version>
+     <hbase.version>${hbase.version.2}</hbase.version>
   </properties>
 
   <dependencies>

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/pom.xml
@@ -31,7 +31,7 @@ limitations under the License.
     </description>
 
     <properties>
-        <hbase.version>${hbase.version.2.0}</hbase.version>
+        <hbase.version>${hbase.version.2}</hbase.version>
         <google.bigtable.connection.impl>com.google.cloud.bigtable.hbase2_x.BigtableConnection</google.bigtable.connection.impl>
         <google.bigtable.async.connection.impl>org.apache.hadoop.hbase.client.BigtableAsyncConnection</google.bigtable.async.connection.impl>
         <google.bigtable.registry.impl>org.apache.hadoop.hbase.client.BigtableAsyncRegistry</google.bigtable.registry.impl>

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-shaded/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-shaded/pom.xml
@@ -31,7 +31,7 @@ limitations under the License.
   </description>
 
   <properties>
-     <hbase.version>${hbase.version.2.0}</hbase.version>
+     <hbase.version>${hbase.version.2}</hbase.version>
   </properties>
 
 <dependencies>

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/pom.xml
@@ -24,7 +24,7 @@ limitations under the License.
   </parent>
 
   <properties>
-     <hbase.version>${hbase.version.2.0}</hbase.version>
+     <hbase.version>${hbase.version.2}</hbase.version>
   </properties>
 
   <artifactId>bigtable-hbase-2.x</artifactId>

--- a/bigtable-hbase-parent/bigtable-hbase-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestBasicOps.java
+++ b/bigtable-hbase-parent/bigtable-hbase-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestBasicOps.java
@@ -158,7 +158,7 @@ public class TestBasicOps extends AbstractTest {
   @Test
   @Category(KnownEmulatorGap.class)
   public void testPutAlmostTooBigValue() throws IOException {
-    testPutGetDeleteExists(10 << 20, true, true); // 10 MB
+    testPutGetDeleteExists(10 << 20 - 4, true, true); // 10 MB
   }
 
   @Test
@@ -167,7 +167,7 @@ public class TestBasicOps extends AbstractTest {
   public void testPutAlmostTooBigValueTenTimes() throws IOException {
     for (int i = 0; i < 10; i++) {
       long start = System.currentTimeMillis();
-      testPutGetDeleteExists(10 << 20, true, true); // 10 MB
+      testPutGetDeleteExists(10 << 20 - 4, true, true); // 10 MB
       if (System.currentTimeMillis() - start > 5_000) {
         // If this is a slow connection, don't bother doing a performance test.
         break;

--- a/bigtable-hbase-parent/bigtable-hbase-1.x/src/main/java/com/google/cloud/bigtable/hbase1_x/BigtableAdmin.java
+++ b/bigtable-hbase-parent/bigtable-hbase-1.x/src/main/java/com/google/cloud/bigtable/hbase1_x/BigtableAdmin.java
@@ -28,6 +28,8 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 import org.apache.hadoop.hbase.ProcedureInfo;
+import org.apache.hadoop.hbase.ServerName;
+import org.apache.hadoop.hbase.TableExistsException;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.AbstractBigtableAdmin;
 import org.apache.hadoop.hbase.client.AbstractBigtableConnection;
@@ -40,6 +42,7 @@ import org.apache.hadoop.hbase.quotas.QuotaFilter;
 import org.apache.hadoop.hbase.quotas.QuotaRetriever;
 import org.apache.hadoop.hbase.quotas.QuotaSettings;
 import org.apache.hadoop.hbase.snapshot.HBaseSnapshotException;
+import org.apache.hadoop.hbase.snapshot.RestoreSnapshotException;
 import org.apache.hadoop.hbase.snapshot.SnapshotCreationException;
 import org.apache.hadoop.hbase.snapshot.UnknownSnapshotException;
 
@@ -117,6 +120,16 @@ public class BigtableAdmin extends AbstractBigtableAdmin {
   public boolean isSnapshotFinished(HBaseProtos.SnapshotDescription snapshot)
       throws IOException, HBaseSnapshotException, UnknownSnapshotException {
     throw new UnsupportedOperationException("isSnapshotFinished");  // TODO
+  }
+
+  @Override
+  public void restoreSnapshot(String s, boolean b, boolean b1) throws IOException, RestoreSnapshotException {
+
+  }
+
+  @Override
+  public void cloneSnapshot(String s, TableName tableName, boolean b) throws IOException, TableExistsException, RestoreSnapshotException {
+
   }
 
   /** {@inheritDoc} */
@@ -222,6 +235,26 @@ public class BigtableAdmin extends AbstractBigtableAdmin {
   }
 
   @Override
+  public boolean setCleanerChoreRunning(boolean b) throws IOException {
+      throw new UnsupportedOperationException("setCleanerChoreRunning"); // TODO
+  }
+
+  @Override
+  public boolean runCleanerChore() throws IOException {
+      throw new UnsupportedOperationException("runCleanerChore"); // TODO
+  }
+
+  @Override
+  public boolean isCleanerChoreEnabled() throws IOException {
+      throw new UnsupportedOperationException("isCleanerChoreEnabled"); // TODO
+  }
+
+  @Override
+  public boolean isMasterInMaintenanceMode() throws IOException {
+      throw new UnsupportedOperationException("isMasterInMaintenanceMode"); // TODO
+  }
+
+  @Override
   public boolean abortProcedure(long procId, boolean mayInterruptIfRunning) throws IOException {
     throw new UnsupportedOperationException("abortProcedure"); // TODO
   }
@@ -250,6 +283,16 @@ public class BigtableAdmin extends AbstractBigtableAdmin {
   @Override
   public boolean isSplitOrMergeEnabled(MasterSwitchType arg0) throws IOException {
     throw new UnsupportedOperationException("isSplitOrMergeEnabled"); // TODO
+  }
+
+  @Override
+  public List<ServerName> listDeadServers() throws IOException {
+      throw new UnsupportedOperationException("listDeadServers"); // TODO
+  }
+
+  @Override
+  public List<ServerName> clearDeadServers(List<ServerName> list) throws IOException {
+      throw new UnsupportedOperationException("clearDeadServers"); // TODO
   }
 
   @Override

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests-common/src/main/java/com/google/cloud/bigtable/hbase/test_env/MiniClusterEnv.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests-common/src/main/java/com/google/cloud/bigtable/hbase/test_env/MiniClusterEnv.java
@@ -20,9 +20,18 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.hadoop.hbase.HBaseTestingUtility;
+import org.apache.hadoop.hbase.ipc.HBaseRpcController;
 
 class MiniClusterEnv extends SharedTestEnv {
   private static final Log LOG = LogFactory.getLog(MiniClusterEnv.class);
+
+  static {
+    try {
+      HBaseRpcController.class.getName();
+    } catch(Throwable t) {
+      t.printStackTrace();
+    }
+  }
 
   private HBaseTestingUtility helper;
 

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/AbstractBigtableTable.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/AbstractBigtableTable.java
@@ -679,6 +679,26 @@ public abstract class AbstractBigtableTable implements Table {
   }
 
   @Override
+  public int getReadRpcTimeout() {
+    throw new UnsupportedOperationException("getReadRpcTimeout");
+  }
+
+  @Override
+  public void setReadRpcTimeout(int i) {
+    throw new UnsupportedOperationException("setReadRpcTimeout");
+  }
+
+  @Override
+  public int getWriteRpcTimeout() {
+    throw new UnsupportedOperationException("getWriteRpcTimeout");
+  }
+
+  @Override
+  public void setWriteRpcTimeout(int i) {
+    throw new UnsupportedOperationException("setWriteRpcTimeout");
+  }
+
+  @Override
   public int getRpcTimeout() {
     throw new UnsupportedOperationException("getRpcTimeout");
   }

--- a/pom.xml
+++ b/pom.xml
@@ -48,20 +48,18 @@ limitations under the License.
         <compileSource>1.7</compileSource>
         <compileSource.1.8>1.8</compileSource.1.8>
         <!-- dependency versions -->
-        <hbase.version.1.3>1.3.1</hbase.version.1.3>
-        <hbase.version.2.0>2.0.0-alpha4</hbase.version.2.0>
-        <hbase.version>${hbase.version.1.3}</hbase.version>
+        <hbase.version.1>1.4.1</hbase.version.1>
+        <hbase.version.2>2.0.0-alpha4</hbase.version.2>
+        <hbase.version>${hbase.version.1}</hbase.version>
         <hadoop.version>2.5.1</hadoop.version>
-        <compat.module>hbase-hadoop2-compat</compat.module>
         <junit.version>4.12</junit.version>
         <mockito.version>1.10.19</mockito.version>
-        <com.google.api.grpc.version>0.1.28</com.google.api.grpc.version>
-        <grpc.version>1.9.0</grpc.version>
-        <opencensus.version>0.10.1</opencensus.version>
+        <com.google.api.grpc.version>0.2.0</com.google.api.grpc.version>
+        <grpc.version>1.10.0</grpc.version>
+        <opencensus.version>0.12.2</opencensus.version>
         <netty.version>4.1.17.Final</netty.version>
         <netty-tcnative-boringssl-static.version>2.0.7.Final</netty-tcnative-boringssl-static.version>
         <protobuff-java.version>3.5.1</protobuff-java.version>
-        <protoc.version>3.4.0</protoc.version>
         <google.api.client.version>1.23.0</google.api.client.version>
         <google.http.client.version>1.23.0</google.http.client.version>
         <guava.version>19.0</guava.version>


### PR DESCRIPTION
- grpc is upgraded to 1.10.0
- grpc-google-common-protos is upgraded to 0.2.0
- hbase 1 version is updgraded to 1.4.1
- opencensus is ugpraded to 0.12.2
- The notion of "large row" change between hbase 1.3 and 1.4 by 4 bytes