### PR TITLE
Fixing HBase 2.* minicluster test

### DIFF
--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/IntegrationTests.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/IntegrationTests.java
@@ -56,6 +56,7 @@ import org.junit.runners.Suite;
     TestScan.class,
     TestSnapshots.class,
     TestIncrement.class,
+    TestListTables.class,
     TestListTablesHBase2.class,
     TestPut.class,
     TestTimestamp.class,

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestColumnFamilyAdmin.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestColumnFamilyAdmin.java
@@ -116,6 +116,11 @@ public class TestColumnFamilyAdmin extends AbstractTest {
   
   @Test
   public void testModifyColumnFamilyAsync() throws Exception {
+    if (!sharedTestEnv.isBigtable()) {
+      // this fails in hbase
+      return;
+    }
+
     HColumnDescriptor newColumn = new HColumnDescriptor("MODIFY_COLUMN");
     newColumn.setMaxVersions(2);
     admin.addColumnFamilyAsync(tableName, newColumn).get();
@@ -173,6 +178,10 @@ public class TestColumnFamilyAdmin extends AbstractTest {
   
   @Test
   public void testDeleteColumnFamilyAsync() throws Exception {
+    if (!sharedTestEnv.isBigtable()) {
+      // this fails in hbase
+      return;
+    }
     admin.deleteColumnFamilyAsync(tableName, DELETE_COLUMN_FAMILY).get();
     HTableDescriptor retrievedDescriptor = admin.getTableDescriptor(tableName);
 

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestListTablesHBase2.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestListTablesHBase2.java
@@ -61,7 +61,7 @@ public class TestListTablesHBase2 extends AbstractTestListTables {
   
   @Override
   protected void deleteTable(Admin admin, TableName tableName) throws Exception {
-    if (enableAsyncDelete) {
+    if (enableAsyncDelete && sharedTestEnv.isBigtable()) {
       admin.disableTableAsync(tableName).get();
       admin.deleteTableAsync(tableName).get();
     } else {

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestSnapshots.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestSnapshots.java
@@ -132,7 +132,7 @@ public class TestSnapshots extends AbstractTest {
       Assert.assertEquals(1, admin.listSnapshots(Pattern.compile(snapshotName + 1)).size());
       Assert.assertEquals(1, admin.listSnapshots(Pattern.compile(snapshotName + 2)).size());
       admin.deleteSnapshots(allSnapshots);
-      Assert.assertEquals(0, admin.listSnapshots(allSnapshots));
+      Assert.assertEquals(0, admin.listSnapshots(allSnapshots).size());
     }
   }
   

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/async/TestAsyncAdmin.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/async/TestAsyncAdmin.java
@@ -38,6 +38,7 @@ import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.hamcrest.core.IsInstanceOf;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -141,16 +142,21 @@ public class TestAsyncAdmin extends AbstractAsyncTest {
   }
 
   @Test
-  public void testgetTableDescriptor_nonExistingTable() throws Exception {
+  public void testGetTableDescriptor_nonExistingTable() throws Exception {
     AsyncAdmin asyncAdmin = getAsyncConnection().getAdmin();
-    TableName tableName = TableName.valueOf("TestTable" + UUID.randomUUID().toString());
+    TableName tableName = sharedTestEnv.newTestTableName();
     thrown.expect(ExecutionException.class);
     thrown.expectCause(IsInstanceOf.<Throwable>instanceOf(TableNotFoundException.class));
     asyncAdmin.getDescriptor(tableName).get();
   }  
 
   @Test
-  public void testgetTableDescriptor_nullTable() throws Exception {
+  public void testGetTableDescriptor_nullTable() throws Exception {
+    if (!sharedTestEnv.isBigtable()) {
+        // This condition gets the Minicluster into a really bad state as of HBase 2.0.0-beta1
+        // TODO: Attempt to add this test back one HBase versions increase.
+      return;
+    }
     AsyncAdmin asyncAdmin = getAsyncConnection().getAdmin();
     assertEquals(null, asyncAdmin.getDescriptor(null).get());
   }  
@@ -158,7 +164,7 @@ public class TestAsyncAdmin extends AbstractAsyncTest {
   @Test
   public void testCreateTableWithNumRegions_exception() throws Exception {
     AsyncAdmin asyncAdmin = getAsyncConnection().getAdmin();
-    TableName tableName = TableName.valueOf("TestTable" + UUID.randomUUID().toString());
+    TableName tableName = sharedTestEnv.newTestTableName();
     thrown.expect(ExecutionException.class);
     thrown.expectCause(IsInstanceOf.<Throwable>instanceOf(IllegalArgumentException.class));
     asyncAdmin.createTable(TableDescriptorBuilder.newBuilder(tableName).build(),
@@ -168,8 +174,8 @@ public class TestAsyncAdmin extends AbstractAsyncTest {
   @Test
   public void testCreateTableWithSplits() throws Exception {
     AsyncAdmin asyncAdmin = getAsyncConnection().getAdmin();
-    TableName tableName1 = TableName.valueOf("TestTable" + UUID.randomUUID().toString());
-    TableName tableName2 = TableName.valueOf("TestTable" + UUID.randomUUID().toString());
+    TableName tableName1 = sharedTestEnv.newTestTableName();
+    TableName tableName2 = sharedTestEnv.newTestTableName();
 
     try {
       asyncAdmin.createTable(
@@ -197,7 +203,7 @@ public class TestAsyncAdmin extends AbstractAsyncTest {
   @Test
   public void testEnableDisable() throws Exception {
     AsyncAdmin asyncAdmin = getAsyncConnection().getAdmin();
-    TableName tableName = TableName.valueOf("TestTable" + UUID.randomUUID().toString());
+    TableName tableName = sharedTestEnv.newTestTableName();
 
     // test non existing table
     checkThatNonExistingTableThrows(asyncAdmin, tableName);


### PR DESCRIPTION
There were a few problems
- `IntegrationTests` did not include `TestListTables.class`
- There was a race condition when multiple subclasses of `AbstractTestListTables` ran together relating to listing tables via a pattern.
- Multiple async admin methods throw `UnsupportedOperationException` in HBase's `Admin` and `AsyncAdmin` implementations.  Those tests should only run in Bigtable mode.
- HBase minicluster gets into a really bad state when this is run `asyncAdmin.getDescriptor(null).get()`.  The minicluster never shuts down.  This test should only run in Bigtable mode.

@pawan-qlogic, FYI.