### PR TITLE
Creating a CheckAndMutateBuilder

### DIFF
--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/async/TestAsyncCheckAndMutate.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/async/TestAsyncCheckAndMutate.java
@@ -98,12 +98,8 @@ public class TestAsyncCheckAndMutate extends AbstractTestCheckAndMutate {
       CompareOp op, byte[] value) throws InterruptedException, ExecutionException {
     CheckAndMutateBuilder builder = getDefaultAsyncTable().checkAndMutate(row,family)
         .qualifier(qualifier);
-    if (op == CompareOp.EQUAL) {
-      if (value == null) {
-        return builder.ifNotExists();
-      } else {
-        return builder.ifEquals(value);
-      }
+    if (value == null && op != CompareOp.NOT_EQUAL) {
+      return builder.ifNotExists();
     } else {
       return builder.ifMatches(TestCheckAndMutateHBase2.translate(op), value);
     }

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests-common/src/main/java/com/google/cloud/bigtable/hbase/AbstractTestCheckAndMutate.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests-common/src/main/java/com/google/cloud/bigtable/hbase/AbstractTestCheckAndMutate.java
@@ -361,13 +361,6 @@ public abstract class AbstractTestCheckAndMutate extends AbstractTest {
     success = checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qualToCheck,
         CompareOp.GREATER_OR_EQUAL, new byte[]{Byte.MIN_VALUE}, someRandomPut);
     Assert.assertTrue("4000 > MIN_BYTES should succeed", success);
-
-    if (sharedTestEnv.isBigtable()) {
-      // This doesn't work in HBase, but we need this to work in CBT
-      success = checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qualToCheck,
-        CompareOp.NOT_EQUAL, null, someRandomPut);
-      Assert.assertTrue("4000 != null should succeed", success);
-    }
   }
 
   @Test
@@ -409,13 +402,42 @@ public abstract class AbstractTestCheckAndMutate extends AbstractTest {
     success = checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, nullQual,
         CompareOp.GREATER_OR_EQUAL, new byte[]{Byte.MIN_VALUE}, someRandomPut);
     Assert.assertFalse("> MIN_BYTES should fail", success);
+  }
 
-    if (sharedTestEnv.isBigtable()) {
-      // This doesn't work in HBase, but we need this to work in CBT
-      success = checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, nullQual,
-          CompareOp.NOT_EQUAL, null, someRandomPut);
-      Assert.assertFalse("!= null should fail", success);
+  /**
+   * Bigtable supports a notion of `NOT_EQUALS null` checks equating with `check for existence`.  HBase
+   * does not support this notion, and always uses `{any comparator} null` to mean `check for non-existence`.
+   */
+  @Test
+  public void testNotEqualsNull_BigtableOnly() throws Exception {
+    if (!sharedTestEnv.isBigtable()) {
+      return;
     }
+
+    byte[] rowKey = dataHelper.randomData("rowKey-");
+    byte[] nullQual = dataHelper.randomData("null-");
+    byte[] popluatedQual = dataHelper.randomData("pupulated-");
+    byte[] otherQual = dataHelper.randomData("other-");
+
+    Table table = getDefaultTable();
+
+    table.put(new Put(rowKey).addColumn(SharedTestEnvRule.COLUMN_FAMILY, popluatedQual,
+        Bytes.toBytes(2000l)));
+
+    Put someRandomPut =
+        new Put(rowKey).addColumn(SharedTestEnvRule.COLUMN_FAMILY, otherQual, Bytes.toBytes(1l));
+
+    boolean success;
+
+    // This doesn't work in HBase, but we need this to work in CBT
+    success = checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, nullQual,
+        CompareOp.NOT_EQUAL, null, someRandomPut);
+    Assert.assertFalse("!= null should fail", success);
+
+    // This doesn't work in HBase, but we need this to work in CBT
+    success = checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, popluatedQual,
+        CompareOp.NOT_EQUAL, null, someRandomPut);
+    Assert.assertTrue("2000 != null should succeed", success);
   }
 
   @Test

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests-common/src/main/java/com/google/cloud/bigtable/hbase/AbstractTestCheckAndMutate.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests-common/src/main/java/com/google/cloud/bigtable/hbase/AbstractTestCheckAndMutate.java
@@ -358,11 +358,63 @@ public abstract class AbstractTestCheckAndMutate extends AbstractTest {
       CompareOp.NOT_EQUAL, Bytes.toBytes(4000l), someRandomPut);
     Assert.assertTrue("4000 != 2000 should succeed", success);
 
+    success = checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qualToCheck,
+        CompareOp.GREATER_OR_EQUAL, new byte[]{Byte.MIN_VALUE}, someRandomPut);
+    Assert.assertTrue("4000 > MIN_BYTES should succeed", success);
+
     if (sharedTestEnv.isBigtable()) {
       // This doesn't work in HBase, but we need this to work in CBT
       success = checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, qualToCheck,
         CompareOp.NOT_EQUAL, null, someRandomPut);
       Assert.assertTrue("4000 != null should succeed", success);
+    }
+  }
+
+  @Test
+  public void testCompareOpsNull() throws Exception {
+    byte[] rowKey = dataHelper.randomData("rowKey-");
+    byte[] nullQual = dataHelper.randomData("null-");
+    byte[] popluatedQual = dataHelper.randomData("pupulated-");
+    byte[] otherQual = dataHelper.randomData("other-");
+    boolean success;
+
+    Table table = getDefaultTable();
+
+    table.put(new Put(rowKey).addColumn(SharedTestEnvRule.COLUMN_FAMILY, popluatedQual,
+        Bytes.toBytes(2000l)));
+
+    Put someRandomPut =
+        new Put(rowKey).addColumn(SharedTestEnvRule.COLUMN_FAMILY, otherQual, Bytes.toBytes(1l));
+
+    success = checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, nullQual,
+        CompareOp.LESS, null, someRandomPut);
+    Assert.assertTrue("< null should succeed", success);
+
+    success = checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, nullQual,
+        CompareOp.GREATER, null, someRandomPut);
+    Assert.assertTrue("> null should succeed", success);
+
+    success = checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, nullQual,
+        CompareOp.LESS_OR_EQUAL, null, someRandomPut);
+    Assert.assertTrue("<= null should succeed", success);
+
+    success = checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, nullQual,
+        CompareOp.GREATER_OR_EQUAL, null, someRandomPut);
+    Assert.assertTrue(">= null should succeed", success);
+
+    success = checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, nullQual,
+        CompareOp.EQUAL, null, someRandomPut);
+    Assert.assertTrue("== null should succeed", success);
+
+    success = checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, nullQual,
+        CompareOp.GREATER_OR_EQUAL, new byte[]{Byte.MIN_VALUE}, someRandomPut);
+    Assert.assertFalse("> MIN_BYTES should fail", success);
+
+    if (sharedTestEnv.isBigtable()) {
+      // This doesn't work in HBase, but we need this to work in CBT
+      success = checkAndPut(rowKey, SharedTestEnvRule.COLUMN_FAMILY, nullQual,
+          CompareOp.NOT_EQUAL, null, someRandomPut);
+      Assert.assertFalse("!= null should fail", success);
     }
   }
 

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/AbstractBigtableTable.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/AbstractBigtableTable.java
@@ -383,7 +383,8 @@ public abstract class AbstractBigtableTable implements Table {
         new CheckAndMutateUtil.RequestBuilder(hbaseAdapter, row, family)
             .qualifier(qualifier)
             .ifMatches(compareOp, value)
-            .buildForPut(put);
+            .withPut(put)
+            .build();
 
     return checkAndMutate(row, request, "checkAndPut");
   }
@@ -425,7 +426,8 @@ public abstract class AbstractBigtableTable implements Table {
         new CheckAndMutateUtil.RequestBuilder(hbaseAdapter, row, family)
             .qualifier(qualifier)
             .ifMatches(compareOp, value)
-            .buildForDelete(delete);
+            .withDelete(delete)
+            .build();
 
     return checkAndMutate(row, request, "checkAndDelete");
   }
@@ -442,7 +444,8 @@ public abstract class AbstractBigtableTable implements Table {
         new CheckAndMutateUtil.RequestBuilder(hbaseAdapter, row, family)
             .qualifier(qualifier)
             .ifMatches(compareOp, value)
-            .buildForRowMutations(rm);
+            .withMutations(rm)
+            .build();
 
     return checkAndMutate(row, request, "checkAndMutate");
   }

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/AbstractBigtableTable.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/AbstractBigtableTable.java
@@ -389,8 +389,10 @@ public abstract class AbstractBigtableTable implements Table {
       CompareFilter.CompareOp compareOp, byte[] value, Put put) throws IOException {
     LOG.trace("checkAndPut(byte[], byte[], byte[], CompareOp, value, Put)");
     CheckAndMutateRowRequest request =
-        CheckAndMutateUtil.makeConditionalMutationRequest(hbaseAdapter, row, family, qualifier,
-          compareOp, value, put.getRow(), hbaseAdapter.adapt(put).getMutationsList());
+        new CheckAndMutateUtil.RequestBuilder(hbaseAdapter, row, family)
+            .qualifier(qualifier)
+            .ifMatches(compareOp, value)
+            .buildForPut(put);
 
     return checkAndMutate(row, request, "checkAndPut");
   }
@@ -429,8 +431,10 @@ public abstract class AbstractBigtableTable implements Table {
       CompareFilter.CompareOp compareOp, byte[] value, Delete delete) throws IOException {
     LOG.trace("checkAndDelete(byte[], byte[], byte[], CompareOp, byte[], Delete)");
     CheckAndMutateRowRequest request =
-        CheckAndMutateUtil.makeConditionalMutationRequest(hbaseAdapter, row, family, qualifier,
-          compareOp, value, delete.getRow(), hbaseAdapter.adapt(delete).getMutationsList());
+        new CheckAndMutateUtil.RequestBuilder(hbaseAdapter, row, family)
+            .qualifier(qualifier)
+            .ifMatches(compareOp, value)
+            .buildForDelete(delete);
 
     return checkAndMutate(row, request, "checkAndDelete");
   }
@@ -444,8 +448,10 @@ public abstract class AbstractBigtableTable implements Table {
     LOG.trace("checkAndMutate(byte[], byte[], byte[], CompareOp, byte[], RowMutations)");
 
     CheckAndMutateRowRequest request =
-        CheckAndMutateUtil.makeConditionalMutationRequest(hbaseAdapter, row, family, qualifier,
-          compareOp, value, rm.getRow(), hbaseAdapter.adapt(rm).getMutationsList());
+        new CheckAndMutateUtil.RequestBuilder(hbaseAdapter, row, family)
+            .qualifier(qualifier)
+            .ifMatches(compareOp, value)
+            .buildForRowMutations(rm);
 
     return checkAndMutate(row, request, "checkAndMutate");
   }

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/CheckAndMutateUtil.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/CheckAndMutateUtil.java
@@ -15,21 +15,20 @@
  */
 package com.google.cloud.bigtable.hbase.adapters;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
+import com.google.bigtable.v2.*;
+import com.google.common.base.Preconditions;
 import org.apache.hadoop.hbase.DoNotRetryIOException;
+import org.apache.hadoop.hbase.client.Delete;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.RowMutations;
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.filter.BinaryComparator;
-import org.apache.hadoop.hbase.filter.CompareFilter;
 import org.apache.hadoop.hbase.filter.ValueFilter;
 import org.apache.hadoop.hbase.filter.CompareFilter.CompareOp;
 
-import com.google.bigtable.v2.CheckAndMutateRowRequest;
-import com.google.bigtable.v2.CheckAndMutateRowResponse;
-import com.google.bigtable.v2.Mutation;
-import com.google.bigtable.v2.ReadRowsRequest;
 import com.google.cloud.bigtable.hbase.adapters.read.ReadHooks;
 import com.google.common.base.Function;
 import com.google.protobuf.ByteString;
@@ -71,66 +70,128 @@ public class CheckAndMutateUtil {
         || (request.getFalseMutationsCount() > 0
         && !response.getPredicateMatched());
   }
-  
-  /**
-   * <p>
-   * makeConditionalMutationRequest.
-   * </p>
-   * @param hbaseAdapter a {@link HBaseRequestAdapter} used to convert HBase
-   *          {@link org.apache.hadoop.hbase.client.Mutation} to Cloud Bigtable {@link Mutation}
-   * @param row an array of byte.
-   * @param family an array of byte.
-   * @param qualifier an array of byte.
-   * @param compareOp a {@link org.apache.hadoop.hbase.filter.CompareFilter.CompareOp} object.
-   * @param value an array of byte.
-   * @param actionRow an array of byte.
-   * @param mutations a {@link java.util.List} object.
-   * @return a {@link com.google.bigtable.v2.CheckAndMutateRowRequest.Builder} object.
-   * @throws java.io.IOException if any.
-   */
-  public static CheckAndMutateRowRequest makeConditionalMutationRequest(
-      HBaseRequestAdapter hbaseAdapter,
-      byte[] row,
-      byte[] family,
-      byte[] qualifier,
-      CompareFilter.CompareOp compareOp,
-      byte[] value,
-      byte[] actionRow,
-      List<com.google.bigtable.v2.Mutation> mutations) throws IOException {
-    if (!Arrays.equals(actionRow, row)) {
-      // The following odd exception message is for compatibility with HBase.
-      throw new DoNotRetryIOException("Action's getRow must match the passed row");
-    }
 
-    CheckAndMutateRowRequest.Builder requestBuilder =
+  /**
+   * This class can be used to convert HBase checkAnd* operations to Bigtable
+   * {@link CheckAndMutateRowRequest}s.
+   */
+  public static class RequestBuilder {
+    private final HBaseRequestAdapter hbaseAdapter;
+    private final CheckAndMutateRowRequest.Builder requestBuilder =
         CheckAndMutateRowRequest.newBuilder();
 
-    requestBuilder.setTableName(hbaseAdapter.getBigtableTableName().toString());
+    private final byte[] row;
+    private final byte[] family;
+    private byte[] qualifier;
+    private CompareOp compareOp;
+    private byte[] value;
+    private boolean checkNonExistence = false;
 
-    requestBuilder.setRowKey(ByteString.copyFrom(row));
-    Scan scan = new Scan().addColumn(family, qualifier);
-    scan.setMaxVersions(1);
-    if (value == null) {
-      // If we don't have a value and we are doing CompareOp.EQUAL, we want to mutate if there
-      // is no cell with the qualifier. If we are doing CompareOp.NOT_EQUAL, we want to mutate
-      // if there is any cell. We don't actually want an extra filter for either of these cases,
-      // but we do need to invert the compare op.
-      if (CompareFilter.CompareOp.EQUAL.equals(compareOp)) {
-        requestBuilder.addAllFalseMutations(mutations);
-      } else if (CompareFilter.CompareOp.NOT_EQUAL.equals(compareOp)) {
+    /**
+     * <p>
+     * RequestBuilder.
+     * </p>
+     * @param hbaseAdapter a {@link HBaseRequestAdapter} used to convert HBase
+     *          {@link org.apache.hadoop.hbase.client.Mutation} to Cloud Bigtable {@link Mutation}
+     * @param row the RowKey in which to to check value matching
+     * @param family the family in which to check value matching.
+     */
+    public RequestBuilder(HBaseRequestAdapter hbaseAdapter, byte[] row, byte[] family) {
+      requestBuilder.setRowKey(ByteString.copyFrom(row));
+      this.row = Preconditions.checkNotNull(row, "row is null");
+      this.family = Preconditions.checkNotNull(family, "family is null");
+
+      // TODO (issue #1709): The hbaseAdapter used here should not set client-side timestamps.
+      this.hbaseAdapter = hbaseAdapter;
+      requestBuilder.setTableName(hbaseAdapter.getBigtableTableName().toString());
+    }
+
+    public RequestBuilder qualifier(byte[] qualifier) {
+      this.qualifier = Preconditions.checkNotNull(qualifier, "qualifier is null. Consider using" +
+          " an empty byte array, or just do not call this method if you want a null qualifier");
+      return this;
+    }
+
+    public RequestBuilder ifNotExists() {
+      Preconditions.checkState(compareOp == null,
+          "ifNotExists and ifMatches are mutually exclusive");
+      this.checkNonExistence = true;
+      return this;
+    }
+
+    public RequestBuilder ifEquals(CompareOp compareOp, byte[] value) {
+      return ifMatches(CompareOp.EQUAL, value);
+    }
+
+    public RequestBuilder ifMatches(CompareOp compareOp, byte[] value) {
+      Preconditions.checkState(checkNonExistence == false,
+          "ifNotExists and ifMatches are mutually exclusive");
+
+      this.compareOp = Preconditions.checkNotNull(compareOp, "compareOp is null");
+
+      // TODO (issue #1704): only NOT_EQUALS should allow null.  Everything else should use ifNotExists();
+      this.value = value;
+      return this;
+    }
+
+    public CheckAndMutateRowRequest buildForPut(Put put) throws DoNotRetryIOException {
+      return buildForMutation(put.getRow(), hbaseAdapter.adapt(put).getMutationsList());
+    }
+
+    public CheckAndMutateRowRequest buildForDelete(Delete delete) throws DoNotRetryIOException {
+      return buildForMutation(delete.getRow(), hbaseAdapter.adapt(delete).getMutationsList());
+    }
+
+    public CheckAndMutateRowRequest buildForRowMutations(RowMutations rm) throws DoNotRetryIOException {
+      return buildForMutation(rm.getRow(), hbaseAdapter.adapt(rm).getMutationsList());
+    }
+
+    private CheckAndMutateRowRequest buildForMutation(byte[] actionRow, List<Mutation> mutations)
+        throws DoNotRetryIOException {
+      Preconditions.checkState(checkNonExistence || compareOp != null,
+          "condition is null. You need to specify the condition by" +
+          " calling ifNotExists/ifEquals/ifMatches before executing the request");
+
+      if (!Arrays.equals(actionRow, row)) {
+        // The following odd exception message is for compatibility with HBase.
+        throw new DoNotRetryIOException("Action's getRow must match the passed row");
+      }
+
+      Scan scan = new Scan().addColumn(family, qualifier);
+      scan.setMaxVersions(1);
+      if (value == null || checkNonExistence) {
+        // In HBase 1.* style check and mutate, value == null always means checkNonExistence regardless of compareOp.
+        // That's semantically confusing for CompareOperators other than EQUALS.  It's even more confusing
+        // if value == null and compareOp = NOT_EQUALS.
+        //
+        // HBase 2.* introduced a notion of checking for "Non-Existence" as an independent concept from compareOp
+        //
+        // Checking for existence in HBase can be
+        // expressed as follows:
+        //    compareOp = CompareOp.GREATER_OR_EQUAL, value = new byte[]{Byte.MIN_VALUE})
+        //
+        // Bigtable decided that value == null with a compareOp of NOT_EQUALS actually means check for existence, even
+        // though HBase will still treat it as non-existence.
+
+        if (CompareOp.NOT_EQUAL.equals(compareOp)) {
+          // check for existence
+          requestBuilder.addAllTrueMutations(mutations);
+        } else {
+          // check for non-existence
+          requestBuilder.addAllFalseMutations(mutations);
+        }
+      } else {
+        ValueFilter valueFilter =
+            new ValueFilter(reverseCompareOp(compareOp), new BinaryComparator(value));
+        scan.setFilter(valueFilter);
         requestBuilder.addAllTrueMutations(mutations);
       }
-    } else {
-      ValueFilter valueFilter =
-          new ValueFilter(reverseCompareOp(compareOp), new BinaryComparator(value));
-      scan.setFilter(valueFilter);
-      requestBuilder.addAllTrueMutations(mutations);
-    }
-    requestBuilder.setPredicateFilter(
-      Adapters.SCAN_ADAPTER.buildFilter(scan, UNSUPPORTED_READ_HOOKS));
-    return requestBuilder.build();
-  }
+      requestBuilder.setPredicateFilter(
+          Adapters.SCAN_ADAPTER.buildFilter(scan, UNSUPPORTED_READ_HOOKS));
 
+      return requestBuilder.build();
+    }
+  }
 
   /**
    * For some reason, the ordering of CheckAndMutate operations is the inverse order of normal


### PR DESCRIPTION
There was logic duplication in AbstractBigtableTable and BigtableAsyncTable.  The new CheckAndMutateUtil RequestBuilder combines the logic for both implementations.
Also, this should fix #1704. When value is null, and the CompareOp was not '==' or '!=' would do absolutely nothing, when it should have been an "non-existence" check.