### PR TITLE
Support Get.isCheckExistenceOnly().

### DIFF
--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/GetAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/GetAdapter.java
@@ -21,6 +21,8 @@ import com.google.protobuf.ByteString;
 
 import org.apache.hadoop.hbase.client.Get;
 import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.filter.FilterList;
+import org.apache.hadoop.hbase.filter.KeyOnlyFilter;
 
 /**
  * A Get adapter that transform the Get into a ReadRowsRequest using the proto-based
@@ -30,6 +32,16 @@ import org.apache.hadoop.hbase.client.Scan;
  * @version $Id: $Id
  */
 public class GetAdapter implements ReadOperationAdapter<Get> {
+
+  public static Get setCheckExistenceOnly(Get get) {
+    if (get.isCheckExistenceOnly()){
+      return get;
+    } else {
+      Get existsGet = new Get(get);
+      existsGet.setCheckExistenceOnly(true);
+      return existsGet;
+    }
+  }
 
   protected final ScanAdapter scanAdapter;
   /**
@@ -44,10 +56,25 @@ public class GetAdapter implements ReadOperationAdapter<Get> {
   /** {@inheritDoc} */
   @Override
   public ReadRowsRequest.Builder adapt(Get operation, ReadHooks readHooks) {
-    Scan operationAsScan = new Scan(operation);
+    Scan operationAsScan = new Scan(addKeyOnlyFilter(operation));
     scanAdapter.throwIfUnsupportedScan(operationAsScan);
     return ReadRowsRequest.newBuilder()
         .setFilter(scanAdapter.buildFilter(operationAsScan, readHooks))
         .setRows(RowSet.newBuilder().addRowKeys(ByteString.copyFrom(operation.getRow())));
   }
+
+  private Get addKeyOnlyFilter(Get get) {
+    if (get.isCheckExistenceOnly()) {
+      Get existsGet = new Get(get);
+      if (get.getFilter() == null) {
+        existsGet.setFilter(new KeyOnlyFilter());
+      } else {
+        existsGet.setFilter(new FilterList(get.getFilter(), new KeyOnlyFilter()));
+      }
+      return existsGet;
+    } else {
+      return get;
+    }
+  }
+
 }


### PR DESCRIPTION
HBase 1.0 had a setting for only checking existence, which is intended to have the same functionality as `Table.exists(Get)`.  `GetAdapter` should convert `Get`s with that flag to appropriate Bigtable Filter objects.  In addition, HBase 1 and 2 exist checks should just create new `Get` objects with `setCheckExistenceOnly(true)`.
This should fix issue #1707.