### PR TITLE
RetryingReadRowsOperation uses more final variables

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/RowMerger.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/RowMerger.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Objects;
 import com.google.bigtable.v2.ReadRowsRequest;
 import com.google.bigtable.v2.ReadRowsResponse;
@@ -445,13 +446,7 @@ public class RowMerger implements StreamObserver<ReadRowsResponse> {
     return lastCompletedRowKey;
   }
 
-  /** {@inheritDoc} */
-  @Override
-  public void onError(Throwable e) {
-    observer.onError(e);
-    complete = true;
-  }
-
+  @VisibleForTesting
   boolean isInNewState() {
     return state == RowMergerState.NewRow && rowInProgress == null;
   }
@@ -467,7 +462,14 @@ public class RowMerger implements StreamObserver<ReadRowsResponse> {
     state.handleOnComplete(observer);
   }
 
+  /** {@inheritDoc} */
+  @Override
+  public void onError(Throwable e) {
+    complete = true;
+    observer.onError(e);
+  }
 
+  @VisibleForTesting
   boolean isComplete() {
     return complete;
   }

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/RowMerger.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/RowMerger.java
@@ -364,8 +364,8 @@ public class RowMerger implements StreamObserver<ReadRowsResponse> {
 
   private RowMergerState state = RowMergerState.NewRow;
   private ByteString lastCompletedRowKey = null;
-  private RowInProgress rowInProgress;
-  private boolean complete;
+  private RowInProgress rowInProgress = null;
+  private boolean complete = false;
   private int rowCountInLastMessage = -1;
 
   /**
@@ -375,6 +375,13 @@ public class RowMerger implements StreamObserver<ReadRowsResponse> {
    */
   public RowMerger(StreamObserver<FlatRow> observer) {
     this.observer = observer;
+  }
+
+  public void reset() {
+    state = RowMergerState.NewRow;
+    lastCompletedRowKey = null;
+    rowInProgress = null;
+    rowCountInLastMessage = -1;
   }
 
   /** {@inheritDoc} */

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/scanner/RetryingReadRowsOperationTest.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/scanner/RetryingReadRowsOperationTest.java
@@ -233,7 +233,7 @@ public class RetryingReadRowsOperationTest {
     underTest.onMessage(buildResponse(key1));
     RowMerger rw1 = underTest.getRowMerger();
     underTest.onClose(Status.ABORTED, new Metadata());
-    Assert.assertNotSame(rw1, underTest.getRowMerger());
+    Assert.assertEquals(-1, underTest.getRowMerger().getRowCountInLastMessage());
     underTest.onMessage(buildResponse(key2));
     verify(mockFlatRowObserver, times(2)).onNext(any(FlatRow.class));
     checkRetryRequest(underTest, key2, 8);
@@ -255,7 +255,7 @@ public class RetryingReadRowsOperationTest {
     // a round of successful retries.
     RowMerger rw1 = underTest.getRowMerger();
     performSuccessfulScanTimeouts(underTest, time);
-    Assert.assertNotSame(rw1, underTest.getRowMerger());
+    Assert.assertEquals(-1, underTest.getRowMerger().getRowCountInLastMessage());
     underTest.onClose(Status.ABORTED, new Metadata());
     checkRetryRequest(underTest, key1, 9);
 


### PR DESCRIPTION
- RowMerger is final and now has a reset method
- `CallToStreamObserverAdapter` is now final, and use required no modification.