### PR TITLE
Moving windows dlls from META-INFO to META-INF

### DIFF
--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-shaded/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-shaded/pom.xml
@@ -211,7 +211,7 @@ limitations under the License.
                 </relocation>
                 <relocation>
                   <pattern>META-INF/native/netty</pattern>
-                  <shadedPattern>META-INFO/native/com_google_bigtable_repackaged_netty</shadedPattern>
+                  <shadedPattern>META-INF/native/com_google_bigtable_repackaged_netty</shadedPattern>
                 </relocation>
 
                 <relocation>

--- a/bigtable-hbase-parent/bigtable-hbase-1.x-shaded/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-1.x-shaded/pom.xml
@@ -196,7 +196,7 @@ limitations under the License.
                 </relocation>
                 <relocation>
                   <pattern>META-INF/native/netty</pattern>
-                  <shadedPattern>META-INFO/native/com_google_bigtable_repackaged_netty</shadedPattern>
+                  <shadedPattern>META-INF/native/com_google_bigtable_repackaged_netty</shadedPattern>
                 </relocation>
 
                 <relocation>


### PR DESCRIPTION
META-INFO was a typo.  See #1713 for more details.

@igorbernstein2, do I need a `libcom_google` prefix or is `com_google enough`?