### PR TITLE
AbstractRetryingOperation's call is now private.

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AbstractRetryingOperation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AbstractRetryingOperation.java
@@ -135,8 +135,8 @@ public abstract class AbstractRetryingOperation<RequestT, ResponseT, ResultT>
   protected int failedCount = 0;
 
   protected final GrpcFuture<ResultT> completionFuture;
-  protected Object callLock = new String("");
-  protected ClientCall<RequestT, ResponseT> call = NULL_CALL;
+  private Object callLock = new String("");
+  private ClientCall<RequestT, ResponseT> call = NULL_CALL;
   protected Timer.Context operationTimerContext;
   protected Timer.Context rpcTimerContext;
 
@@ -312,6 +312,10 @@ public abstract class AbstractRetryingOperation<RequestT, ResponseT, ResultT>
     } catch (Exception e) {
       setException(e);
     }
+  }
+
+  protected ClientCall<RequestT, ResponseT> getCall() {
+    return call;
   }
 
   protected CallOptions getCallOptions() {

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/RetryingStreamOperation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/RetryingStreamOperation.java
@@ -62,7 +62,7 @@ public class RetryingStreamOperation<RequestT, ResponseT>
   /** {@inheritDoc} */
   @Override
   public void onMessage(ResponseT message) {
-    call.request(1);
+    getCall().request(1);
     buffer.add(message);
   }
 

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/RetryingReadRowsOperation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/RetryingReadRowsOperation.java
@@ -57,22 +57,22 @@ public class RetryingReadRowsOperation extends
 
     @Override
     public void onNext(ReadRowsRequest value) {
-      call.sendMessage(value);
+      getCall().sendMessage(value);
     }
 
     @Override
     public void onError(Throwable t) {
-      call.cancel("Cancelled by client with StreamObserver.onError()", t);
+      getCall().cancel("Cancelled by client with StreamObserver.onError()", t);
     }
 
     @Override
     public void onCompleted() {
-      call.halfClose();
+      getCall().halfClose();
     }
 
     @Override
     public boolean isReady() {
-      return call.isReady();
+      return getCall().isReady();
     }
 
     @Override
@@ -86,17 +86,17 @@ public class RetryingReadRowsOperation extends
 
     @Override
     public void request(int count) {
-      call.request(count);
+      getCall().request(count);
     }
 
     @Override
     public void setMessageCompression(boolean enable) {
-      call.setMessageCompression(enable);
+      getCall().setMessageCompression(enable);
     }
 
     @Override
     public void cancel(@Nullable String s, @Nullable Throwable throwable) {
-      call.cancel(s, throwable);
+      getCall().cancel(s, throwable);
     }
   }
 
@@ -148,15 +148,13 @@ public class RetryingReadRowsOperation extends
   public void run() {
     try {
       // restart the clock.
-      synchronized (callLock) {
-        super.run();
-        // pre-fetch one more result, for performance reasons.
-        adapter.request(1);
-        if (rowObserver instanceof ClientResponseObserver) {
-          ((ClientResponseObserver<ReadRowsRequest, FlatRow>) rowObserver).beforeStart(adapter);
-        }
-        lastResponseMs = clock.currentTimeMillis();
+      super.run();
+      // pre-fetch one more result, for performance reasons.
+      adapter.request(1);
+      if (rowObserver instanceof ClientResponseObserver) {
+        ((ClientResponseObserver<ReadRowsRequest, FlatRow>) rowObserver).beforeStart(adapter);
       }
+      lastResponseMs = clock.currentTimeMillis();
     } catch (Exception e) {
       setException(e);
     }


### PR DESCRIPTION
`call` should be read only.