### PR TITLE
RefreshingOAuth2CredentialsInterceptor now honors CallOptions Deadlines

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/OAuthCredentialsCache.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/OAuthCredentialsCache.java
@@ -75,8 +75,6 @@ public class OAuthCredentialsCache {
     }
   }
 
-  // TODO: this should split into cache type operations and a token used by RefreshingOAuth2CredentialsInterceptor
-
   static class HeaderToken {
     private final Status status;
     private final String header;

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/OAuthCredentialsCache.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/OAuthCredentialsCache.java
@@ -181,9 +181,9 @@ public class OAuthCredentialsCache {
     return headerCache;
   }
 
-  HeaderToken getHeader(int timeoutSeconds) {
+  HeaderToken getHeader(long timeoutMs) {
     try {
-      return getHeaderUnsafe(timeoutSeconds).getToken();
+      return getHeaderUnsafe(timeoutMs).getToken();
     } catch (Exception e) {
       LOG.warn("Got an unexpected exception while trying to refresh google credentials.", e);
       Status status = Status.UNAUTHENTICATED
@@ -195,9 +195,9 @@ public class OAuthCredentialsCache {
 
   /**
    * Get the http credential header we need from a new oauth2 AccessToken.
-   * @param timeoutSeconds
+   * @param timeoutMs
    */
-  private HeaderCacheElement getHeaderUnsafe(int timeoutSeconds) {
+  private HeaderCacheElement getHeaderUnsafe(long timeoutMs) {
     // Optimize for the common case: do a volatile read to peek for a Good cache value
     HeaderCacheElement headerCacheUnsync = this.headerCache;
 
@@ -211,7 +211,7 @@ public class OAuthCredentialsCache {
       case Expired:
       case Exception:
         // defer the future resolution (asyncRefresh will spin up a thread that will try to acquire the lock)
-        return syncRefresh(timeoutSeconds);
+        return syncRefresh(timeoutMs);
       default:
         String message = "Could not process state: " + headerCacheUnsync.getCacheState();
         LOG.warn(message);
@@ -226,9 +226,9 @@ public class OAuthCredentialsCache {
    * been refreshed.
    * This method should not be called while holding the refresh lock
    */
-  private HeaderCacheElement syncRefresh(int timeoutSeconds) {
+  private HeaderCacheElement syncRefresh(long timeoutMs) {
     try (Closeable ss = Tracing.getTracer().spanBuilder("CredentialsRefresh").startScopedSpan()) {
-      return asyncRefresh().get(timeoutSeconds, TimeUnit.SECONDS);
+      return asyncRefresh().get(timeoutMs, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
       LOG.warn("Interrupted while trying to refresh google credentials.", e);
       Thread.currentThread().interrupt();

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptor.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptor.java
@@ -120,13 +120,13 @@ public class RefreshingOAuth2CredentialsInterceptor implements ClientInterceptor
 
       @Override
       public void start(Listener<RespT> responseListener, Metadata headers) {
-        int timeoutSeconds = TIMEOUT_SECONDS;
+        long timeoutMs = -1;
         if (callOptions.getDeadline() != null) {
-          long deadlineMs = callOptions.getDeadline().timeRemaining(TimeUnit.MILLISECONDS);
-          int deadlineSeconds = (int) Math.round(deadlineMs / 1000.0);
-          timeoutSeconds = Math.min(deadlineSeconds, timeoutSeconds);
+          timeoutMs = callOptions.getDeadline().timeRemaining(TimeUnit.MILLISECONDS);
+        } else {
+          timeoutMs = TimeUnit.SECONDS.toMillis(TIMEOUT_SECONDS);
         }
-        HeaderToken token = store.getHeader(timeoutSeconds);
+        HeaderToken token = store.getHeader(timeoutMs);
 
         if (!token.getStatus().isOk()) {
           unauthorized = true;

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptor.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptor.java
@@ -32,6 +32,7 @@ import io.grpc.MethodDescriptor;
 import io.grpc.Status;
 
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Client interceptor that authenticates all calls by binding header data provided by a credential.
@@ -107,7 +108,7 @@ public class RefreshingOAuth2CredentialsInterceptor implements ClientInterceptor
    */
   @Override
   public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(MethodDescriptor<ReqT, RespT> method,
-      CallOptions callOptions, Channel next) {
+      final CallOptions callOptions, Channel next) {
     return new SimpleForwardingClientCall<ReqT, RespT>(next.newCall(method, callOptions)) {
 
       /**
@@ -119,7 +120,13 @@ public class RefreshingOAuth2CredentialsInterceptor implements ClientInterceptor
 
       @Override
       public void start(Listener<RespT> responseListener, Metadata headers) {
-        HeaderToken token = store.getHeader(TIMEOUT_SECONDS);
+        int timeoutSeconds = TIMEOUT_SECONDS;
+        if (callOptions.getDeadline() != null) {
+          long deadlineMs = callOptions.getDeadline().timeRemaining(TimeUnit.MILLISECONDS);
+          int deadlineSeconds = (int) Math.round(deadlineMs / 1000.0);
+          timeoutSeconds = Math.min(deadlineSeconds, timeoutSeconds);
+        }
+        HeaderToken token = store.getHeader(timeoutSeconds);
 
         if (!token.getStatus().isOk()) {
           unauthorized = true;

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptorTest.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptorTest.java
@@ -95,21 +95,40 @@ public class RefreshingOAuth2CredentialsInterceptorTest {
         sendRequest(CallOptions.DEFAULT);
         receiveMessage();
         checkOKCompletedCorrectly();
-        assertEquals(RefreshingOAuth2CredentialsInterceptor.TIMEOUT_SECONDS, getDeadline());
     }
 
     @Test
     /**
-     * Basic test to make sure that the interceptor works properly
+     * Ensures that default deadline is honored
+     */
+    public void testDefaultDeadline() throws IOException {
+        initializeOk();
+        sendRequest(CallOptions.DEFAULT);
+        assertEquals(RefreshingOAuth2CredentialsInterceptor.TIMEOUT_SECONDS * 1000, getDeadlineMs());
+    }
+
+    @Test
+    /**
+     * Ensures that short deadlines in CallOptions are honored
      */
     public void testShortDeadline() throws IOException {
         initializeOk();
         sendRequest(CallOptions.DEFAULT.withDeadlineAfter(2, TimeUnit.SECONDS));
-        assertEquals(2, getDeadline());
+        assertTrue(getDeadlineMs() <= 2000);
     }
 
-    private int getDeadline() {
-        ArgumentCaptor<Integer> timeoutCaptor = ArgumentCaptor.forClass(Integer.class);
+    @Test
+    /**
+     * Ensures that long deadlines in CallOptions are honored
+     */
+    public void testLongDeadline() throws IOException {
+        initializeOk();
+        sendRequest(CallOptions.DEFAULT.withDeadlineAfter(60, TimeUnit.SECONDS));
+        assertTrue(getDeadlineMs() >= 59000);
+    }
+
+    private long getDeadlineMs() {
+        ArgumentCaptor<Long> timeoutCaptor = ArgumentCaptor.forClass(Long.class);
         verify(mockCache, times(1)).getHeader(timeoutCaptor.capture());
         return timeoutCaptor.getValue();
     }


### PR DESCRIPTION
This should fix #1718.