### PR TITLE
Fixing a problem with AbstractRetryingOperation

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AbstractRetryingOperation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AbstractRetryingOperation.java
@@ -378,11 +378,6 @@ public abstract class AbstractRetryingOperation<RequestT, ResponseT, ResultT>
    * @param message
    */
   protected void cancel(final String message) {
-    synchronized (callLock) {
-      if (call != null) {
-        call.cancel(message, null);
-        call = null;
-      }
-    }
+    call.cancel(message, null);
   }
 }


### PR DESCRIPTION
`call` should never be null, and yet it's set to null in cancel().  Don't set it to null, and let onClose() set it.