### PR TITLE
Fixing FuzzyRowFilterAdapter - add trailing \\C*

### DIFF
--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestFilters.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestFilters.java
@@ -17,14 +17,10 @@ package com.google.cloud.bigtable.hbase;
 
 import static com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule.COLUMN_FAMILY;
 import static com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule.COLUMN_FAMILY2;
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Set;
-import java.util.TreeSet;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang.RandomStringUtils;
@@ -2064,37 +2060,42 @@ public class TestFilters extends AbstractTest {
 
     return table;
   }
-  
+
+
   @Test
-  @Category(KnownGap.class)
-  public void run() throws Exception {
+  public void testFuzzyDifferentSizes() throws Exception {
     Table table = getDefaultTable();
-    List<byte[]> keys = ImmutableList.of(
-        createKey(1, 2, 3, 4, 5, 6), 
-        createKey(1, 9, 9, 4, 9, 9),
-        createKey(2, 3, 4, 5, 6, 7));
-    List<Put> puts = keys.stream()
-        .map(key -> new Put(key).addColumn(SharedTestEnvRule.COLUMN_FAMILY, Bytes.toBytes(0), Bytes.toBytes(0)))
-        .collect(Collectors.toList());
+    List<byte[]> keys = Collections.unmodifiableList(
+        Arrays.asList(
+            createKey(1, 2, 3, 4, 5, 6),
+            createKey(1, 9, 9, 4, 9, 9),
+            createKey(2, 3, 4, 5, 6, 7)));
+
+    List<Put> puts = new ArrayList<>();
+    for(byte[] key : keys) {
+      puts.add(new Put(key).addColumn(SharedTestEnvRule.COLUMN_FAMILY,
+          Bytes.toBytes(0), Bytes.toBytes(0)));
+    }
+
     table.put(puts);
 
     // match keys with 1 in the first position and 4 in the 4th position
-    Pair<byte[], byte[]> fuzzyData = Pair.newPair(createKey(1, 0, 0, 4), createKey(0, 1, 1, 0));
-    FuzzyRowFilter filter = new FuzzyRowFilter(ImmutableList.of(fuzzyData));
-    Scan scan = new Scan();
-    scan.setFilter(filter);
+    Pair<byte[], byte[]> fuzzyData = Pair
+        .newPair(
+            createKey(1, 0, 0, 4),
+            createKey(0, 1, 1, 0));
 
-    ResultScanner scanner = table.getScanner(scan);
-    
-    String expected1 = Arrays.toString(parseKey(createKey(1, 2, 3, 4, 5, 6)));
-    String expected2 = Arrays.toString(parseKey(createKey(1, 9, 9, 4, 9, 9)));
-    Result r1 = scanner.next();
-    assertEquals(expected1, Arrays.toString(parseKey(r1.getRow())));
-    Result r2 = scanner.next();
-    assertEquals(expected2, Arrays.toString(parseKey(r2.getRow())));
+    Scan scan = new Scan().setFilter(new FuzzyRowFilter(ImmutableList.of(fuzzyData)));
+
+    // only the first and second keys should be matched
+    try (ResultScanner scanner = table.getScanner(scan)) {
+      assertMatchingRow(scanner.next(), keys.get(0));
+      assertMatchingRow(scanner.next(), keys.get(1));
+      assertNull(scanner.next());
+    }
   }
-  
-  private byte[] createKey(int... values) {
+
+  private static byte[] createKey(int... values) {
     byte[] bytes = new byte[4 * values.length];
     for (int i = 0; i < values.length; i++) {
       System.arraycopy(Bytes.toBytes(values[i]), 0, bytes, 4 * i, 4);
@@ -2102,11 +2103,9 @@ public class TestFilters extends AbstractTest {
     return bytes;
   }
 
-  private int[] parseKey(byte[] key) {
-    int[] values = new int[key.length / 4];
-    for (int i = 0; i < values.length; i++) {
-      values[i] = Bytes.toInt(key, 4 * i);
-    }
-    return values;
+  private static void assertMatchingRow(Result result, byte[] key) {
+    assertNotNull(result);
+    assertTrue(CellUtil.matchingRows(result.rawCells()[0], key));
   }
+
 }

--- a/bigtable-hbase-parent/bigtable-hbase-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestFilters.java
+++ b/bigtable-hbase-parent/bigtable-hbase-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestFilters.java
@@ -17,7 +17,7 @@ package com.google.cloud.bigtable.hbase;
 
 import static com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule.COLUMN_FAMILY;
 import static com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule.COLUMN_FAMILY2;
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 import com.google.bigtable.repackaged.com.google.cloud.bigtable.data.v2.wrappers.Filters;
 import com.google.bigtable.repackaged.com.google.protobuf.ByteString;
@@ -113,7 +113,7 @@ public class TestFilters extends AbstractTest {
     Result result = table.get(get);
     Assert.assertEquals("Should have filtered to N columns", numColumnsToFilter, result.size());
     for (int i = 0 ; i < numColumnsToFilter; ++i) {
-      Assert.assertTrue("Should contain qual " + Bytes.toInt(quals[i]),
+      assertTrue("Should contain qual " + Bytes.toInt(quals[i]),
         result.containsColumn(COLUMN_FAMILY, quals[i]));
       List<Cell> cells = result.getColumnCells(COLUMN_FAMILY, quals[i]);
       Assert.assertEquals("Should have only the latest version", 1, cells.size());
@@ -159,7 +159,7 @@ public class TestFilters extends AbstractTest {
     Result result = table.get(get);
     Assert.assertEquals("Should have filtered to N columns", numColumnsToFilter, result.size());
     for (int i = offset ; i < (numColumnsToFilter + offset); ++i) {
-      Assert.assertTrue("Should contain qual " + Bytes.toInt(quals[i]),
+      assertTrue("Should contain qual " + Bytes.toInt(quals[i]),
         result.containsColumn(COLUMN_FAMILY, quals[i]));
       List<Cell> cells = result.getColumnCells(COLUMN_FAMILY, quals[i]);
       Assert.assertEquals("Should have only the latest version", 1, cells.size());
@@ -274,7 +274,7 @@ public class TestFilters extends AbstractTest {
     Assert.assertEquals("Should only return good columns", numGoodCols, result.size());
     Cell[] cells = result.rawCells();
     for (Cell cell : cells) {
-      Assert.assertTrue("Should have good column prefix",
+      assertTrue("Should have good column prefix",
         Bytes.toString(CellUtil.cloneQualifier(cell)).startsWith(goodColPrefix));
     }
 
@@ -1346,7 +1346,7 @@ public class TestFilters extends AbstractTest {
     Assert.assertEquals("Should only return good values", numGoodCols, result.size());
     Cell[] cells = result.rawCells();
     for (Cell cell : cells) {
-      Assert.assertTrue("Should have good value",
+      assertTrue("Should have good value",
           Bytes.toString(CellUtil.cloneValue(cell)).startsWith(goodValue));
     }
 
@@ -1429,11 +1429,11 @@ public class TestFilters extends AbstractTest {
     Cell[] cells = result.rawCells();
     Assert.assertEquals("Should have two cells, prefixes a- and b-.", 2, cells.length);
     byte[] qualifier0 = CellUtil.cloneQualifier(cells[0]);
-    Assert.assertTrue("qualifier0 should start with a-",
+    assertTrue("qualifier0 should start with a-",
         qualifier0[0] == 'a' && qualifier0[1] == '-');
 
     byte[] qualifier1 = CellUtil.cloneQualifier(cells[1]);
-    Assert.assertTrue("qualifier1 should start with b-",
+    assertTrue("qualifier1 should start with b-",
         qualifier1[0] == 'b' && qualifier1[1] == '-');
 
     table.close();
@@ -1602,7 +1602,7 @@ public class TestFilters extends AbstractTest {
     ResultScanner scanner = table.getScanner(scan);
     Result[] results = scanner.next(100);
 
-    Assert.assertTrue(
+    assertTrue(
         String.format("Using p=0.5, expected half of added rows, found %s", results.length),
         25 <= results.length && results.length <= 75);
   }
@@ -1673,7 +1673,7 @@ public class TestFilters extends AbstractTest {
     Assert.assertEquals(1, results.length);
     Result result = results[0];
     Assert.assertEquals(1, result.size());
-    Assert.assertTrue(result.containsColumn(COLUMN_FAMILY, qualifier2));
+    assertTrue(result.containsColumn(COLUMN_FAMILY, qualifier2));
     Assert.assertFalse(result.containsColumn(COLUMN_FAMILY, qualifier1));
     Assert.assertArrayEquals(
         value2_1,
@@ -1877,9 +1877,9 @@ public class TestFilters extends AbstractTest {
       Result result = table.get(get);
       Assert.assertEquals(1, result.size());
       Cell cell = result.rawCells()[0];
-      Assert.assertTrue(CellUtil.matchingFamily(cell, COLUMN_FAMILY));
-      Assert.assertTrue(CellUtil.matchingQualifier(cell, qualA));
-      Assert.assertTrue(CellUtil.matchingValue(cell, qualAValue));
+      assertTrue(CellUtil.matchingFamily(cell, COLUMN_FAMILY));
+      assertTrue(CellUtil.matchingQualifier(cell, qualA));
+      assertTrue(CellUtil.matchingValue(cell, qualAValue));
     }
 
     {
@@ -1888,9 +1888,9 @@ public class TestFilters extends AbstractTest {
       Result result = table.get(get);
       Assert.assertEquals(1, result.size());
       Cell cell = result.rawCells()[0];
-      Assert.assertTrue(CellUtil.matchingFamily(cell, COLUMN_FAMILY2));
-      Assert.assertTrue(CellUtil.matchingQualifier(cell, qualB));
-      Assert.assertTrue(CellUtil.matchingValue(cell, qualBValue));
+      assertTrue(CellUtil.matchingFamily(cell, COLUMN_FAMILY2));
+      assertTrue(CellUtil.matchingQualifier(cell, qualB));
+      assertTrue(CellUtil.matchingValue(cell, qualBValue));
     }
   }
 
@@ -2041,7 +2041,7 @@ public class TestFilters extends AbstractTest {
       Result result = table.get(new Get(rowKey).setFilter(bigtableFilter));
 
       Assert.assertEquals(1, result.size());
-      Assert.assertTrue(CellUtil.matchingValue(result.rawCells()[0], valA));
+      assertTrue(CellUtil.matchingValue(result.rawCells()[0], valA));
     }
   }
 
@@ -2066,41 +2066,41 @@ public class TestFilters extends AbstractTest {
 
     return table;
   }
-  
+
   @Test
-  @Category(KnownGap.class)
-  public void run() throws Exception {
+  public void testFuzzyDifferentSizes() throws Exception {
     Table table = getDefaultTable();
     List<byte[]> keys = Collections.unmodifiableList(
         Arrays.asList(
-        createKey(1, 2, 3, 4, 5, 6), 
+        createKey(1, 2, 3, 4, 5, 6),
         createKey(1, 9, 9, 4, 9, 9),
         createKey(2, 3, 4, 5, 6, 7)));
-    
+
     List<Put> puts = new ArrayList<>();
     for(byte[] key : keys) {
-      puts.add(new Put(key).addColumn(SharedTestEnvRule.COLUMN_FAMILY, Bytes.toBytes(0), Bytes.toBytes(0)));
+      puts.add(new Put(key).addColumn(SharedTestEnvRule.COLUMN_FAMILY,
+          Bytes.toBytes(0), Bytes.toBytes(0)));
     }
-    
+
     table.put(puts);
 
     // match keys with 1 in the first position and 4 in the 4th position
-    Pair<byte[], byte[]> fuzzyData = Pair.newPair(createKey(1, 0, 0, 4), createKey(0, 1, 1, 0));
-    FuzzyRowFilter filter = new FuzzyRowFilter(ImmutableList.of(fuzzyData));
-    Scan scan = new Scan();
-    scan.setFilter(filter);
+    Pair<byte[], byte[]> fuzzyData = Pair
+        .newPair(
+            createKey(1, 0, 0, 4),
+            createKey(0, 1, 1, 0));
 
-    ResultScanner scanner = table.getScanner(scan);
-    
-    String expected1 = Arrays.toString(parseKey(createKey(1, 2, 3, 4, 5, 6)));
-    String expected2 = Arrays.toString(parseKey(createKey(1, 9, 9, 4, 9, 9)));
-    Result r1 = scanner.next();
-    assertEquals(expected1, Arrays.toString(parseKey(r1.getRow())));
-    Result r2 = scanner.next();
-    assertEquals(expected2, Arrays.toString(parseKey(r2.getRow())));
+    Scan scan = new Scan().setFilter(new FuzzyRowFilter(ImmutableList.of(fuzzyData)));
+
+    // only the first and second keys should be matched
+    try (ResultScanner scanner = table.getScanner(scan)) {
+      assertMatchingRow(scanner.next(), keys.get(0));
+      assertMatchingRow(scanner.next(), keys.get(1));
+      assertNull(scanner.next());
+    }
   }
-  
-  private byte[] createKey(int... values) {
+
+  private static byte[] createKey(int... values) {
     byte[] bytes = new byte[4 * values.length];
     for (int i = 0; i < values.length; i++) {
       System.arraycopy(Bytes.toBytes(values[i]), 0, bytes, 4 * i, 4);
@@ -2108,11 +2108,9 @@ public class TestFilters extends AbstractTest {
     return bytes;
   }
 
-  private int[] parseKey(byte[] key) {
-    int[] values = new int[key.length / 4];
-    for (int i = 0; i < values.length; i++) {
-      values[i] = Bytes.toInt(key, 4 * i);
-    }
-    return values;
+  private static void assertMatchingRow(Result result, byte[] key) {
+    assertNotNull(result);
+    assertTrue(CellUtil.matchingRow(result.rawCells()[0], key));
   }
+
 }

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/FuzzyRowFilterAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/FuzzyRowFilterAdapter.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.List;
 
+import com.google.cloud.bigtable.config.Logger;
 import org.apache.hadoop.hbase.filter.FuzzyRowFilter;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.Pair;
@@ -71,6 +72,7 @@ public class FuzzyRowFilterAdapter extends TypedFilterAdapterBase<FuzzyRowFilter
           createSingleRowFilter(
               pair.getFirst(), pair.getSecond()));
     }
+    new Logger(FuzzyRowFilterAdapter.class).error("Adapted: " + interleave.toProto());
     return interleave.toProto();
   }
 
@@ -86,6 +88,8 @@ public class FuzzyRowFilterAdapter extends TypedFilterAdapterBase<FuzzyRowFilter
         baos.write(ReaderExpressionHelper.ANY_BYTE_BYTES);
       }
     }
+    // match any trailing bytes
+    baos.write(ReaderExpressionHelper.ALL_BYTE_BYTES);
     quotingStream.close();
     return FILTERS.key().regex(Bytes.toString(baos.toByteArray()));
   }

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/ReaderExpressionHelper.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/ReaderExpressionHelper.java
@@ -31,12 +31,16 @@ import java.io.OutputStream;
 public class ReaderExpressionHelper {
   /** Constant <code>ANY_BYTE="\\C"</code> */
   public static final String ANY_BYTE = "\\C";
+  /** Constant <code>ANY_BYTE="\\C"</code> */
+  public static final String ALL_BYTES = "\\C*";
   /** Constant <code>ANY_BYTE_BYTES=Bytes.toBytes(ANY_BYTE)</code> */
   public static final byte[] ANY_BYTE_BYTES = Bytes.toBytes(ANY_BYTE);
+  /** Constant <code>ANY_BYTE_BYTES=Bytes.toBytes(ANY_BYTE)</code> */
+  public static final byte[] ALL_BYTE_BYTES = Bytes.toBytes(ALL_BYTES);
   /** Constant <code>ALL_QUALIFIERS="\\C*"</code> */
-  public static final String ALL_QUALIFIERS = "\\C*";
+  public static final String ALL_QUALIFIERS = ALL_BYTES;
   /** Constant <code>ALL_QUALIFIERS_BYTES=Bytes.toBytes(ALL_QUALIFIERS)</code> */
-  public static final byte[] ALL_QUALIFIERS_BYTES = Bytes.toBytes(ALL_QUALIFIERS);
+  public static final byte[] ALL_QUALIFIERS_BYTES = ALL_BYTE_BYTES;
   /** Constant <code>ALL_FAMILIES=".*"</code> */
   public static final String ALL_FAMILIES = ".*";
   /** Constant <code>ALL_FAMILIES_BYTES=Bytes.toBytes(ALL_FAMILIES)</code> */

--- a/bigtable-hbase-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestFuzzyRowFilterAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestFuzzyRowFilterAdapter.java
@@ -4,9 +4,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,11 +15,13 @@
  */
 package com.google.cloud.bigtable.hbase.adapters.filters;
 
+import static com.google.cloud.bigtable.data.v2.wrappers.Filters.FILTERS;
+
 import com.google.bigtable.v2.RowFilter;
 import com.google.bigtable.v2.RowFilter.Interleave;
+import com.google.cloud.bigtable.data.v2.wrappers.Filters;
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.ByteString;
-
 
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.filter.FuzzyRowFilter;
@@ -33,40 +35,27 @@ import org.junit.runners.JUnit4;
 import java.io.IOException;
 import java.util.List;
 
-@RunWith(JUnit4.class)
-public class TestFuzzyRowFilterAdapter {
+@RunWith(JUnit4.class) public class TestFuzzyRowFilterAdapter {
   FuzzyRowFilterAdapter adapter = new FuzzyRowFilterAdapter();
   Scan emptyScan = new Scan();
   FilterAdapterContext context = new FilterAdapterContext(emptyScan, null);
 
-  @Test
-  public void fuzzyKeysAreTranslatedToRegularExpressions() throws IOException {
-    List<Pair<byte[], byte[]>> testPairs =
-        ImmutableList.<Pair<byte[], byte[]>>builder()
-            .add(new Pair<>(Bytes.toBytes("abcd"), new byte[] {-1, -1, -1, -1}))
-            .add(new Pair<>(Bytes.toBytes(".fgh"), new byte[] {0, 0, 1, 0}))
-            .add(new Pair<>(Bytes.toBytes("ijkl"), new byte[] {1, 1, 1, 1}))
-            .build();
+  @Test public void fuzzyKeysAreTranslatedToRegularExpressions() throws IOException {
+    List<Pair<byte[], byte[]>> testPairs = ImmutableList.<Pair<byte[], byte[]>>builder()
+        .add(new Pair<>(Bytes.toBytes("abcd"), new byte[] { -1, -1, -1, -1 }))
+        .add(new Pair<>(Bytes.toBytes(".fgh"), new byte[] { 0, 0, 1, 0 }))
+        .add(new Pair<>(Bytes.toBytes("ijkl"), new byte[] { 1, 1, 1, 1 }))
+        .build();
 
     FuzzyRowFilter filter = new FuzzyRowFilter(testPairs);
     RowFilter adaptedFilter = adapter.adapt(context, filter);
-    Assert.assertEquals(
-        RowFilter.newBuilder()
-            .setInterleave(
-                Interleave.newBuilder()
-                    .addFilters(
-                        RowFilter.newBuilder()
-                            .setRowKeyRegexFilter(
-                                ByteString.copyFromUtf8("abcd")))
-                    .addFilters(
-                        RowFilter.newBuilder()
-                            .setRowKeyRegexFilter(
-                                ByteString.copyFromUtf8("\\.f\\Ch")))
-                    .addFilters(
-                        RowFilter.newBuilder()
-                            .setRowKeyRegexFilter(
-                                ByteString.copyFromUtf8("\\C\\C\\C\\C"))))
-        .build(),
-        adaptedFilter);
+    RowFilter expected = FILTERS.interleave()
+        .filter(FILTERS.key().regex("abcd\\C*"))
+        .filter(FILTERS.key().regex("\\.f\\Ch\\C*"))
+        .filter(FILTERS.key().regex("\\C\\C\\C\\C\\C*"))
+        .toProto();
+
+
+    Assert.assertEquals(expected, adaptedFilter);
   }
 }


### PR DESCRIPTION
HBase fuzzy key matching is prefix oriented, so add the eqiuvalent of a trailing .*.