### PR TITLE
Fixing flaky OauthCredentialsCache test.

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/OAuthCredentialsCache.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/OAuthCredentialsCache.java
@@ -197,7 +197,8 @@ public class OAuthCredentialsCache {
   /**
    * Get the http credential header we need from a new oauth2 AccessToken.
    */
-  private HeaderCacheElement getHeaderUnsafe(Duration timeout) {
+  @VisibleForTesting
+  HeaderCacheElement getHeaderUnsafe(Duration timeout) {
     // Optimize for the common case: do a volatile read to peek for a Good cache value
     HeaderCacheElement headerCacheUnsync = this.headerCache;
 

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/io/OAuthCredentialsCacheTest.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/io/OAuthCredentialsCacheTest.java
@@ -184,9 +184,9 @@ public class OAuthCredentialsCacheTest {
     setTimeInMillieconds(10);
 
     // Second call - return stale token, but schedule refresh
-    OAuthCredentialsCache.HeaderToken secondResult = underTest.getHeader(TIMEOUT);
-    Assert.assertEquals(CacheState.Stale, underTest.getHeaderCache().getCacheState());
-    Assert.assertThat(secondResult.getHeader(), containsString("stale"));
+    HeaderCacheElement secondResult = underTest.getHeaderUnsafe(TIMEOUT);
+    Assert.assertEquals(CacheState.Stale, secondResult.getCacheState());
+    Assert.assertThat(secondResult.getToken().getHeader(), containsString("stale"));
 
     // forward to expired
     setTimeInMillieconds(expires);


### PR DESCRIPTION
There was a race condition in OAuthCredentialsCacheTest.testRefreshAfterStale().  The test is for a stale condition that should ensure that the token's cache state is `CacheState.Stale`.  The test would be consistent if only a single call is made to the core cache retrieval code; however, a second call to `getHeader()` was introduced and that second call may return the "Stale" token or the "Good" token depending on the execution of a different thread.
This change ensures that only a single call is made to refresh the header cache under stale conditions.