### PR TITLE
Upgrade grpc from 1.10.0 to 1.10.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@ limitations under the License.
         <junit.version>4.12</junit.version>
         <mockito.version>1.10.19</mockito.version>
         <com.google.api.grpc.version>0.2.0</com.google.api.grpc.version>
-        <grpc.version>1.10.0</grpc.version>
+        <grpc.version>1.10.1</grpc.version>
         <opencensus.version>0.12.2</opencensus.version>
         <netty.version>4.1.17.Final</netty.version>
         <netty-tcnative-boringssl-static.version>2.0.7.Final</netty-tcnative-boringssl-static.version>


### PR DESCRIPTION
upgraded grpc from 1.10.0 to 1.10.1, executed all the test cases successfully.