### PR TITLE
IntegrationTests no longer is required for running tests

### DIFF
--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/IntegrationTests.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/IntegrationTests.java
@@ -68,28 +68,6 @@ import org.junit.runners.Suite;
 })
 public class IntegrationTests {
 
-  static {
-    SharedTestEnvRule.setInstance(new SharedTestEnvRule() {
-      @Override
-      /*
-       * NOTE: This code is identical to the hbase 2.x code, but this produces binary incompatible
-       * results.  This code has to remain in the 1.x integration testing code-base.
-       */
-      public void createTable(TableName tableName) throws IOException {
-        try (Admin admin = getConnection().getAdmin()) {
-          LOG.info("Creating table " + tableName.getNameAsString());
-          HColumnDescriptor hcd = new HColumnDescriptor(COLUMN_FAMILY).setMaxVersions(MAX_VERSIONS);
-          HColumnDescriptor family2 = new HColumnDescriptor(COLUMN_FAMILY2).setMaxVersions(MAX_VERSIONS);
-          admin.createTable(
-              new HTableDescriptor(tableName)
-                  .addFamily(hcd)
-                  .addFamily(family2));
-          LOG.info("Created table " + tableName.getNameAsString());
-        }
-      }
-    });
-  }
-
   private static final int TIME_OUT_MINUTES =
       Integer.getInteger("integration.test.timeout.minutes", 3);
 

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/test_env/TableCreatorImpl.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/test_env/TableCreatorImpl.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018 Google LLC All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.test_env;
+
+import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Admin;
+
+import java.io.IOException;
+
+/**
+ * Creates a table for HBase 2.*.
+ */
+public class TableCreatorImpl implements TableCreator {
+  @Override
+  public void createTable(Admin admin, TableName tableName) throws IOException {
+    HColumnDescriptor hcd = new HColumnDescriptor(SharedTestEnvRule.COLUMN_FAMILY)
+        .setMaxVersions(SharedTestEnvRule.MAX_VERSIONS);
+    HColumnDescriptor family2 = new HColumnDescriptor(SharedTestEnvRule.COLUMN_FAMILY2)
+        .setMaxVersions(SharedTestEnvRule.MAX_VERSIONS);
+    admin.createTable(new HTableDescriptor(tableName).addFamily(hcd).addFamily(family2));
+  }
+}

--- a/bigtable-hbase-parent/bigtable-hbase-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/IntegrationTests.java
+++ b/bigtable-hbase-parent/bigtable-hbase-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/IntegrationTests.java
@@ -54,28 +54,6 @@ import org.junit.runners.Suite;
     TestTruncateTable.class
 })
 public class IntegrationTests {
-
-  static {
-    SharedTestEnvRule.setInstance(new SharedTestEnvRule() {
-      @Override
-      /*
-       * NOTE: This code is identical to the hbase 2.x code, but this produces binary incompatible
-       * results.  This code has to remain in the 1.x integration testing code-base.
-       */
-      public void createTable(TableName tableName) throws IOException {
-        try (Admin admin = getConnection().getAdmin()) {
-          LOG.info("Creating table " + tableName.getNameAsString());
-          HColumnDescriptor hcd = new HColumnDescriptor(COLUMN_FAMILY).setMaxVersions(MAX_VERSIONS);
-          HColumnDescriptor family2 = new HColumnDescriptor(COLUMN_FAMILY2).setMaxVersions(MAX_VERSIONS);
-          admin.createTable(
-              new HTableDescriptor(tableName)
-                  .addFamily(hcd)
-                  .addFamily(family2));
-        }
-      }
-    });
-  }
-
   private static final int TIME_OUT_MINUTES =
       Integer.getInteger("integration.test.timeout.minutes", 3);
 

--- a/bigtable-hbase-parent/bigtable-hbase-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/test_env/TableCreatorImpl.java
+++ b/bigtable-hbase-parent/bigtable-hbase-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/test_env/TableCreatorImpl.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018 Google LLC All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.test_env;
+
+import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Admin;
+
+import java.io.IOException;
+
+/**
+ * Creates a table for HBase 1.*.
+ */
+public class TableCreatorImpl implements TableCreator {
+  @Override
+  public void createTable(Admin admin, TableName tableName) throws IOException {
+    HColumnDescriptor hcd = new HColumnDescriptor(SharedTestEnvRule.COLUMN_FAMILY)
+        .setMaxVersions(SharedTestEnvRule.MAX_VERSIONS);
+    HColumnDescriptor family2 = new HColumnDescriptor(SharedTestEnvRule.COLUMN_FAMILY2)
+        .setMaxVersions(SharedTestEnvRule.MAX_VERSIONS);
+    admin.createTable(new HTableDescriptor(tableName).addFamily(hcd).addFamily(family2));
+  }
+}

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests-common/src/main/java/com/google/cloud/bigtable/hbase/test_env/SharedTestEnvRule.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests-common/src/main/java/com/google/cloud/bigtable/hbase/test_env/SharedTestEnvRule.java
@@ -53,17 +53,10 @@ public class SharedTestEnvRule extends ExternalResource {
       e.printStackTrace();
     }
   }
-  /**
-   * This class is generally a singleton, where implementation can change.  Some startup utility
-   * will set this instance.
-   */
-  public synchronized static void setInstance(SharedTestEnvRule instance) {
-    SharedTestEnvRule.instance = instance;
-  }
 
   public synchronized static SharedTestEnvRule getInstance() {
     if(instance == null) {
-      setInstance(new SharedTestEnvRule());
+      instance = new SharedTestEnvRule();
     }
     
     return instance;

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests-common/src/main/java/com/google/cloud/bigtable/hbase/test_env/TableCreator.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests-common/src/main/java/com/google/cloud/bigtable/hbase/test_env/TableCreator.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2018 Google LLC All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.test_env;
+
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Admin;
+
+import java.io.IOException;
+
+public interface TableCreator {
+  void createTable(Admin admin, TableName tableName) throws IOException;
+}


### PR DESCRIPTION
Added a new TableCreator interface that would alleviate some of the problems in running individual tests.  This should work towards a solution for #1755.