### PR TITLE
RefreshingOAuth2CredentialsInterceptor TIMEOUT is now final

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/pom.xml
+++ b/bigtable-client-core-parent/bigtable-client-core/pom.xml
@@ -107,11 +107,6 @@ limitations under the License.
             <artifactId>guava</artifactId>
             <version>${guava.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.threeten</groupId>
-            <artifactId>threetenbp</artifactId>
-            <version>${threetenbp.version}</version>
-        </dependency>
 
         <!-- Auth -->
         <dependency>

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-shaded/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-shaded/pom.xml
@@ -190,10 +190,6 @@ limitations under the License.
                   <shadedPattern>com.google.bigtable.repackaged.org.json</shadedPattern>
                 </relocation>
                 <relocation>
-                  <pattern>org.threeten</pattern>
-                  <shadedPattern>com.google.bigtable.repackaged.org.threeten</shadedPattern>
-                </relocation>
-                <relocation>
                   <pattern>com.lmax</pattern>
                   <shadedPattern>com.google.bigtable.repackaged.com.lmax</shadedPattern>
                 </relocation>

--- a/bigtable-hbase-parent/bigtable-hbase-1.x-shaded/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-1.x-shaded/pom.xml
@@ -173,10 +173,6 @@ limitations under the License.
                   <shadedPattern>com.google.bigtable.repackaged.org.json</shadedPattern>
                 </relocation>
                 <relocation>
-                  <pattern>org.threeten</pattern>
-                  <shadedPattern>com.google.bigtable.repackaged.org.threeten</shadedPattern>
-                </relocation>
-                <relocation>
                   <pattern>com.lmax</pattern>
                   <shadedPattern>com.google.bigtable.repackaged.com.lmax</shadedPattern>
                 </relocation>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,6 @@ limitations under the License.
         <guava.version>19.0</guava.version>
         <google.auth.library.version>0.9.0</google.auth.library.version>
         <dropwizard.metrics.version>3.1.2</dropwizard.metrics.version>
-        <threetenbp.version>1.3.3</threetenbp.version>
 
 
         <beam.version>2.3.0</beam.version>


### PR DESCRIPTION
The TIMEOUT existed as a way for users to override the default waiting behavior.  TIMEOUT was not final, which made it problematic as per issue #1775.  After changing TIMEOUT to 15 seconds (PR #1657), and using CallOptions deadline (#1727), users ought to have a much better experience with credentials refresh.
This PR removes threetenbp and replaces it with a long and an explicit TimeUnit.