### PR TITLE
Fixing some test

### DIFF
--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests-common/src/main/java/com/google/cloud/bigtable/hbase/AbstractTestCreateTable.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests-common/src/main/java/com/google/cloud/bigtable/hbase/AbstractTestCreateTable.java
@@ -77,7 +77,10 @@ public abstract class AbstractTestCreateTable extends AbstractTest {
     String[] badNames =
         { "-x", ".x", "a!", "a@", "a#", "a$", "a%", "a^", "a&", "a*", "a(", "a+", "a=", "a~", "a`",
             "a{", "a[", "a|", "a\\", "a/", "a<", "a,", "a?",
-            "a" + RandomStringUtils.random(10, false, false) };
+            // TODO(issue #1785): this always fails in Cloud Bigtable, but fails intermittently in
+            // HBase.  We need to find the difference, document it, and create a better test.
+            //            "a" + RandomStringUtils.random(10, false, false)
+        };
 
     for (String badName : badNames) {
       boolean failed = false;

--- a/bigtable-hbase-parent/bigtable-hbase-integration-tests-common/src/main/java/com/google/cloud/bigtable/hbase/AbstractTestFilters.java
+++ b/bigtable-hbase-parent/bigtable-hbase-integration-tests-common/src/main/java/com/google/cloud/bigtable/hbase/AbstractTestFilters.java
@@ -1978,6 +1978,7 @@ public abstract class AbstractTestFilters extends AbstractTest {
   }
 
   @Test
+  @Category(KnownGap.class)
   public void testFuzzyWithIntKeys() throws Exception {
     Table table = getDefaultTable();
     List<byte[]> keys = Collections.unmodifiableList(


### PR DESCRIPTION
TestCreateTable failed in HBse mode in many cases, so removing the test and adding issue #1785.
TestFilters failed in Bigtable in mode, since testFuzzyWithIntKeys() fails as per issue #1770.  Marking that test as a KnownGap so that the CI doesn't continuously fail.