### PR TITLE
Auth interceptor's TIMEOUT_MILLISECONDS should be final.

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptor.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptor.java
@@ -55,7 +55,7 @@ public class RefreshingOAuth2CredentialsInterceptor implements ClientInterceptor
   private static final Logger LOG = new Logger(RefreshingOAuth2CredentialsInterceptor.class);
 
   @VisibleForTesting
-  static long TIMEOUT_MILLISECONDS = TimeUnit.SECONDS.toMillis(15);
+  static final long TIMEOUT_MILLISECONDS = TimeUnit.SECONDS.toMillis(15);
 
   @VisibleForTesting
   static final Metadata.Key<String> AUTHORIZATION_HEADER_KEY = Metadata.Key.of(


### PR DESCRIPTION
This should fix #1775.