### PR TITLE
Add extension point for channel creation

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
@@ -373,6 +373,18 @@ public class BigtableSession implements Closeable {
         return createNettyChannel(hostString, options, clientInterceptors);
       }
     };
+    return createChannelPool(channelFactory, count);
+  }
+
+  /**
+   * Create a new {@link com.google.cloud.bigtable.grpc.io.ChannelPool}, with auth headers.
+   *
+   * @param channelFactory a {@link ChannelPool.ChannelFactory} object.
+   * @param count The number of channels in the pool.
+   * @return a {@link com.google.cloud.bigtable.grpc.io.ChannelPool} object.
+   * @throws java.io.IOException if any.
+   */
+  protected ChannelPool createChannelPool(final ChannelPool.ChannelFactory channelFactory, int count) throws IOException {
     return new ChannelPool(channelFactory, count);
   }
 


### PR DESCRIPTION
This simply adds a protected method to BigtableSession that allows hooking into the channel creation process.  

Previously `protected ChannelPool createChannelPool(final String hostString, int count)` existed but was insufficient, since the fields needed to actually create the channels correctly are private to `BigtableSession`.