### PR TITLE
Upgrading grpc, beam and others

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/pom.xml
+++ b/bigtable-client-core-parent/bigtable-client-core/pom.xml
@@ -35,7 +35,7 @@ limitations under the License.
         <dependency>
             <groupId>com.google.api.grpc</groupId>
             <artifactId>grpc-google-common-protos</artifactId>
-            <version>1.1.0</version>
+            <version>1.10.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>io.grpc</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -48,26 +48,26 @@ limitations under the License.
         <compileSource>1.7</compileSource>
         <compileSource.1.8>1.8</compileSource.1.8>
         <!-- dependency versions -->
-        <hbase.version.1>1.4.1</hbase.version.1>
+        <hbase.version.1>1.4.3</hbase.version.1>
         <hbase.version.2>2.0.0-beta-2</hbase.version.2>
         <hbase.version>${hbase.version.1}</hbase.version>
-        <hadoop.version>2.5.1</hadoop.version>
+        <hadoop.version>2.7.4</hadoop.version>
         <junit.version>4.12</junit.version>
         <mockito.version>1.10.19</mockito.version>
-        <com.google.api.grpc.version>0.2.0</com.google.api.grpc.version>
-        <grpc.version>1.10.1</grpc.version>
-        <opencensus.version>0.12.2</opencensus.version>
-        <netty.version>4.1.17.Final</netty.version>
+        <com.google.api.grpc.version>0.11.0</com.google.api.grpc.version>
+        <grpc.version>1.11.0</grpc.version>
+        <opencensus.version>0.13.0</opencensus.version>
+        <netty.version>4.1.22.Final</netty.version>
         <netty-tcnative-boringssl-static.version>2.0.7.Final</netty-tcnative-boringssl-static.version>
         <protobuff-java.version>3.5.1</protobuff-java.version>
         <google.api.client.version>1.23.0</google.api.client.version>
         <google.http.client.version>1.23.0</google.http.client.version>
-        <guava.version>19.0</guava.version>
-        <google.auth.library.version>0.9.0</google.auth.library.version>
+        <guava.version>20.0</guava.version>
+        <google.auth.library.version>0.9.1</google.auth.library.version>
         <dropwizard.metrics.version>3.1.2</dropwizard.metrics.version>
 
 
-        <beam.version>2.3.0</beam.version>
+        <beam.version>2.4.0</beam.version>
         <commons-lang.version>2.6</commons-lang.version>
         <google-auto-service.version>1.0-rc2</google-auto-service.version>
         <auto-value.version>1.1</auto-value.version>


### PR DESCRIPTION
grpc-google-common-protos: 1.1.0 to 1.10.0
hbase 1: 1.4.1 to 1.4.3
hadoop.version: 2.5.1 to 2.7.4
com.google.api.grpc.version: 0.2.0 to 0.11.0
grpc.version: 1.10.1 to 1.11.0
opencensus.version: 0.12.2 to 0.13.0
netty.version: 4.1.17.Final to 4.1.22.Final
guava.version: 19.0 to 20.0
google.auth.library.version: 0.9.0 to 0.9.1
beam.version: 2.3.0 to 2.4.0

@igorbernstein2, FYI