### PR TITLE
Refactorings

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableOptions.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableOptions.java
@@ -68,6 +68,10 @@ public class BigtableOptions implements Serializable, Cloneable {
     return (int) Math.min(250, Math.max(1, availableProcessors * 4));
   }
 
+  public static BigtableOptions getDefaultOptions() {
+    return new Builder().build();
+  }
+
   /**
    * A mutable builder for BigtableConnectionOptions.
    */
@@ -94,7 +98,6 @@ public class BigtableOptions implements Serializable, Cloneable {
       // the Google Compute Engine metadata service or gcloud configuration in other environments. A
       // user can also override the default behavior with P12 or JSON configuration.
       options.credentialOptions = CredentialOptions.defaultCredentials();
-
     }
 
     private Builder(BigtableOptions options) {

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
@@ -409,7 +409,7 @@ public class BigtableSession implements Closeable {
    * Create a {@link BigtableInstanceClient}.  {@link BigtableSession} objects assume that
    * {@link BigtableOptions} have a project and instance.  A {@link BigtableInstanceClient} does not
    * require project id or instance id, so {@link BigtableOptions#getDefaultOptions()} may be used
-   * if
+   * if there are no service account credentials settings.
    *
    * @return a fully formed {@link BigtableInstanceClient}
    * @throws IOException

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/OAuthCredentialsCache.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/OAuthCredentialsCache.java
@@ -279,7 +279,7 @@ public class OAuthCredentialsCache {
 
         Future<HeaderCacheElement> future = executor.submit(new Callable<HeaderCacheElement>() {
           @Override
-          public HeaderCacheElement call() throws Exception {
+          public HeaderCacheElement call() {
             return updateToken();
           }
         });

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/config/TestBigtableOptions.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/config/TestBigtableOptions.java
@@ -89,7 +89,7 @@ public class TestBigtableOptions {
 
   @Test
   public void testEmulator() {
-    Map<String, String> oldEnv = System.getenv();`
+    Map<String, String> oldEnv = System.getenv();
     Map<String, String> testEnv = new HashMap<>();
     testEnv.put(BigtableOptions.BIGTABLE_EMULATOR_HOST_ENV_VAR, "localhost:1234");
     setTestEnv(testEnv);

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/config/TestBigtableOptions.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/config/TestBigtableOptions.java
@@ -84,12 +84,12 @@ public class TestBigtableOptions {
 
   @Test
   public void testNullStringsDontThrowExceptions() {
-     new BigtableOptions.Builder().build();
+    BigtableOptions.getDefaultOptions();
   }
 
   @Test
   public void testEmulator() {
-    Map<String, String> oldEnv = System.getenv();
+    Map<String, String> oldEnv = System.getenv();`
     Map<String, String> testEnv = new HashMap<>();
     testEnv.put(BigtableOptions.BIGTABLE_EMULATOR_HOST_ENV_VAR, "localhost:1234");
     setTestEnv(testEnv);

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestBigtableSession.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestBigtableSession.java
@@ -19,6 +19,7 @@ package com.google.cloud.bigtable.grpc;
 import java.io.IOException;
 import java.lang.reflect.Field;
 
+import com.google.cloud.bigtable.config.CredentialOptions;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -84,7 +85,8 @@ public class TestBigtableSession {
   @Test
   public void testCreateInstanceClient() throws Throwable {
     try {
-      BigtableSession.createInstanceClient();
+      BigtableSession.createInstanceClient(new BigtableOptions.Builder().setCredentialOptions(
+          CredentialOptions.nullCredential()).build());
     } catch (IOException e) {
       if (e.getMessage().toLowerCase().contains("credentials")) {
         // ignore;  This is running on a system that doesn't have default credentails,

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestWaitForReplication.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestWaitForReplication.java
@@ -15,8 +15,13 @@
  */
 package com.google.cloud.bigtable.grpc;
 
-import java.util.concurrent.TimeoutException;
-
+import com.google.api.client.testing.util.MockBackOff;
+import com.google.bigtable.admin.v2.*;
+import com.google.cloud.bigtable.config.BigtableOptions;
+import io.grpc.Status;
+import io.grpc.StatusException;
+import io.grpc.stub.StreamObserver;
+import io.grpc.testing.GrpcServerRule;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -24,18 +29,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-import com.google.api.client.testing.util.MockBackOff;
-import com.google.bigtable.admin.v2.BigtableTableAdminGrpc;
-import com.google.bigtable.admin.v2.CheckConsistencyRequest;
-import com.google.bigtable.admin.v2.CheckConsistencyResponse;
-import com.google.bigtable.admin.v2.GenerateConsistencyTokenRequest;
-import com.google.bigtable.admin.v2.GenerateConsistencyTokenResponse;
-import com.google.cloud.bigtable.config.BigtableOptions;
-
-import io.grpc.Status;
-import io.grpc.testing.GrpcServerRule;
-import io.grpc.stub.StreamObserver;
-import io.grpc.StatusException;
+import java.util.concurrent.TimeoutException;
 
 @RunWith(JUnit4.class)
 @SuppressWarnings({"unchecked", "rawtypes"})
@@ -105,9 +99,7 @@ public class TestWaitForReplication {
     service = new ConsistencyServiceImpl();
     grpcServerRule.getServiceRegistry().addService(service);
 
-    BigtableOptions options = new BigtableOptions.Builder().build();
-
-    tableAdminClient = new BigtableTableAdminGrpcClient(grpcServerRule.getChannel(), null, options);
+    tableAdminClient = new BigtableTableAdminGrpcClient(grpcServerRule.getChannel(), null, BigtableOptions.getDefaultOptions());
     backoff = new MockBackOff();
   }
 

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-hadoop/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableConnection.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-hadoop/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableConnection.java
@@ -45,21 +45,13 @@ public class TestBigtableConnection {
 
   @Test
   public void testTable() throws IOException {
-    try {
-      Connection connection = new BigtableConnection(BigtableConfiguration.configure("projectId", "instanceId"));
-      Admin admin = connection.getAdmin();
-      Table table = connection.getTable(TableName.valueOf("someTable"));
-      BufferedMutator mutator = connection.getBufferedMutator(TableName.valueOf("someTable"));
-      connection.close();
-    } catch (IOException e) {
-      if (e.getMessage().toLowerCase().contains("credentials")) {
-        // ignore;  This is running on a system that doesn't have default credentails,
-        // and this test is to ensure that openssl works well.  Travis isn't sent up with
-        // credentials, so this test should pass in those conditions.
-      } else {
-        throw e;
-      }
-    }
+    Configuration conf = BigtableConfiguration.configure("projectId", "instanceId");
+    conf.set(BigtableOptionsFactory.BIGTABLE_NULL_CREDENTIAL_ENABLE_KEY, "true");
+    conf.set(BigtableOptionsFactory.BIGTABLE_USE_SERVICE_ACCOUNTS_KEY, "false");
+    BigtableConnection connection = new BigtableConnection(conf);
+    Admin admin = connection.getAdmin() ;
+    Table table = connection.getTable(TableName.valueOf("someTable"));
+    BufferedMutator mutator = connection.getBufferedMutator(TableName.valueOf("someTable"));
   }
 
   @Test

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-hadoop/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableConnection.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-hadoop/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableConnection.java
@@ -17,6 +17,7 @@ package com.google.cloud.bigtable.hbase;
 
 import java.io.IOException;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Admin;
 import org.apache.hadoop.hbase.client.BufferedMutator;

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableConnection.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableConnection.java
@@ -15,6 +15,11 @@
  */
 package com.google.cloud.bigtable.hbase;
 
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Admin;
+import org.apache.hadoop.hbase.client.BufferedMutator;
+import org.apache.hadoop.hbase.client.Table;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -22,8 +27,10 @@ import org.junit.runners.JUnit4;
 
 import com.google.cloud.bigtable.hbase2_x.BigtableConnection;
 
+import java.io.IOException;
+
 /**
- * This is a test to ensure that BigtableConnection can find {@link BigtableConnection}
+ * This is a test to ensure that {@link BigtableConfiguration} can find {@link BigtableConnection}
  *
  */
 @RunWith(JUnit4.class)
@@ -32,5 +39,16 @@ public class TestBigtableConnection {
   @Test
   public void testBigtableConnectionExists() {
     Assert.assertEquals(BigtableConnection.class, BigtableConfiguration.getConnectionClass());
+  }
+
+  @Test
+  public void testTable() throws IOException {
+    Configuration conf = BigtableConfiguration.configure("projectId", "instanceId");
+    conf.set(BigtableOptionsFactory.BIGTABLE_NULL_CREDENTIAL_ENABLE_KEY, "true");
+    conf.set(BigtableOptionsFactory.BIGTABLE_USE_SERVICE_ACCOUNTS_KEY, "false");
+    BigtableConnection connection = new BigtableConnection(conf);
+    Admin admin = connection.getAdmin() ;
+    Table table = connection.getTable(TableName.valueOf("someTable"));
+    BufferedMutator mutator = connection.getBufferedMutator(TableName.valueOf("someTable"));
   }
 }

--- a/bigtable-hbase-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/PutMicroBenchmark.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/PutMicroBenchmark.java
@@ -74,7 +74,7 @@ public class PutMicroBenchmark {
     run(hbaseAdapter, put, getChannelPool(useRealConnection), putCount);
   }
 
-  protected static ChannelPool getChannelPool(final boolean useRealConnection)
+  protected static ManagedChannel getChannelPool(final boolean useRealConnection)
       throws IOException, GeneralSecurityException {
     if (useRealConnection) {
       return BigtableSession.createChannelPool(options.getDataHost(), options);
@@ -118,7 +118,7 @@ public class PutMicroBenchmark {
     return put;
   }
 
-  protected static void run(final HBaseRequestAdapter hbaseAdapter, final Put put, ChannelPool cp,
+  protected static void run(final HBaseRequestAdapter hbaseAdapter, final Put put, ManagedChannel cp,
       final int putCount) throws InterruptedException {
     final BigtableDataClient client = new BigtableDataGrpcClient(cp,
         BigtableSessionSharedThreadPools.getInstance().getRetryExecutor(), options);

--- a/bigtable-hbase-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBatchExecutor.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBatchExecutor.java
@@ -84,8 +84,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 @SuppressWarnings({"unchecked", "rawtypes"})
 public class TestBatchExecutor {
 
-  BigtableOptions DEFAULT_OPTIONS = new BigtableOptions.Builder().build();
-
   private static Put randomPut() {
     return new Put(randomBytes(8))
         .addColumn(Bytes.toBytes("cf"), Bytes.toBytes("qual"), Bytes.toBytes("SomeValue"));
@@ -240,7 +238,7 @@ public class TestBatchExecutor {
     Object[] results = new Object[2];
 
     try {
-      createExecutor(DEFAULT_OPTIONS).batch(gets, results);
+      createExecutor(BigtableOptions.getDefaultOptions()).batch(gets, results);
     } catch(RetriesExhaustedWithDetailsException ignored) {
     }
     Assert.assertTrue("first result is a result", results[0] instanceof Result);
@@ -256,7 +254,7 @@ public class TestBatchExecutor {
     setFuture(ImmutableList.of(response));
     final Callback<Result> callback = Mockito.mock(Callback.class);
     List<Get> gets = Arrays.asList(new Get(key));
-    createExecutor(DEFAULT_OPTIONS).batchCallback(gets, new Object[1], callback);
+    createExecutor(BigtableOptions.getDefaultOptions()).batchCallback(gets, new Object[1], callback);
 
     verify(callback, times(1)).update(same(BatchExecutor.NO_REGION), same(key),
       argThat(matchesRow(Adapters.FLAT_ROW_ADAPTER.adaptResponse(response))));
@@ -294,7 +292,7 @@ public class TestBatchExecutor {
         .addCell("family", ByteString.EMPTY, System.nanoTime() / 1000, cellValue).build();
     when(mockFuture.get()).thenReturn(row);
 
-    BatchExecutor underTest = createExecutor(DEFAULT_OPTIONS);
+    BatchExecutor underTest = createExecutor(BigtableOptions.getDefaultOptions());
     Result[] results = underTest.batch(gets);
     verify(mockBulkRead, times(10)).add(any(ReadRowsRequest.class));
     verify(mockBulkRead, times(1)).flush();
@@ -327,6 +325,6 @@ public class TestBatchExecutor {
 
   private Result[] batch(final List<? extends org.apache.hadoop.hbase.client.Row> actions)
       throws Exception {
-    return createExecutor(DEFAULT_OPTIONS).batch(actions);
+    return createExecutor(BigtableOptions.getDefaultOptions()).batch(actions);
   }
 }


### PR DESCRIPTION
- Using ManagedChannel instead of ChannelPool in BigtableSession
- Adding a new BigtableOptions getDefaultOptions() method.