### PR TITLE
Convert parameters in CloudBigtableConfiguration to runtime parameters

### DIFF
--- a/bigtable-dataflow-parent/bigtable-hbase-beam/src/main/java/com/google/cloud/bigtable/beam/CloudBigtableConfiguration.java
+++ b/bigtable-dataflow-parent/bigtable-hbase-beam/src/main/java/com/google/cloud/bigtable/beam/CloudBigtableConfiguration.java
@@ -316,6 +316,8 @@ public class CloudBigtableConfiguration implements Serializable {
       return;
     }
 
+    // TODO(kevinsi): For each field, if it is not accessible, set of dummy value of
++   // "Unavailable during pipeline construction". This is for debugging purpose.
     builder.add(DisplayData.item("projectId", getProjectId())
       .withLabel("Project ID"));
     builder.add(DisplayData.item("instanceId", getInstanceId())

--- a/bigtable-dataflow-parent/bigtable-hbase-beam/src/main/java/com/google/cloud/bigtable/beam/CloudBigtableConfiguration.java
+++ b/bigtable-dataflow-parent/bigtable-hbase-beam/src/main/java/com/google/cloud/bigtable/beam/CloudBigtableConfiguration.java
@@ -23,6 +23,8 @@ import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.Map.Entry;
 
+import org.apache.beam.sdk.options.ValueProvider;
+import org.apache.beam.sdk.options.ValueProvider.StaticValueProvider;
 import org.apache.beam.sdk.repackaged.com.google.common.base.Preconditions;
 import org.apache.beam.sdk.repackaged.com.google.common.base.Strings;
 import org.apache.beam.sdk.repackaged.com.google.common.collect.ImmutableMap;
@@ -44,14 +46,14 @@ public class CloudBigtableConfiguration implements Serializable {
    * Builds a {@link CloudBigtableConfiguration}.
    */
   public static class Builder {
-    protected String projectId;
-    protected String instanceId;
-    protected Map<String, String> additionalConfiguration = new HashMap<>();
+    protected ValueProvider<String> projectId;
+    protected ValueProvider<String> instanceId;
+    protected Map<String, ValueProvider<String>> additionalConfiguration = new HashMap<>();
 
     public Builder() {
     }
 
-    protected void copyFrom(Map<String, String> configuration) {
+    protected void copyFrom(Map<String, ValueProvider<String>> configuration) {
       this.additionalConfiguration.putAll(configuration);
 
       this.projectId = this.additionalConfiguration.remove(BigtableOptionsFactory.PROJECT_ID_KEY);
@@ -63,8 +65,27 @@ public class CloudBigtableConfiguration implements Serializable {
      * @param projectId The project ID for the instance.
      * @return The {@link CloudBigtableConfiguration.Builder} for chaining convenience.
      */
-    public Builder withProjectId(String projectId) {
+    Builder withProjectId(ValueProvider<String> projectId) {
       this.projectId = projectId;
+      return this;
+    }
+
+    /**
+     * Specifies the project ID for the Cloud Bigtable instance.
+     * @param projectId The project ID for the instance.
+     * @return The {@link CloudBigtableConfiguration.Builder} for chaining convenience.
+     */
+    public Builder withProjectId(String projectId) {
+      return withProjectId(StaticValueProvider.of(projectId));
+    }
+
+    /**
+     * Specifies the Cloud Bigtable instanceId.
+     * @param instanceId The Cloud Bigtable instanceId.
+     * @return The {@link CloudBigtableConfiguration.Builder} for chaining convenience.
+     */
+    Builder withInstanceId(ValueProvider<String> instanceId) {
+      this.instanceId = instanceId;
       return this;
     }
 
@@ -74,10 +95,20 @@ public class CloudBigtableConfiguration implements Serializable {
      * @return The {@link CloudBigtableConfiguration.Builder} for chaining convenience.
      */
     public Builder withInstanceId(String instanceId) {
-      this.instanceId = instanceId;
-      return this;
+      return withInstanceId(StaticValueProvider.of(instanceId));
     }
 
+    /**
+     * Specifies the AppProfile to use.
+     *
+     * <p>This is a private alpha release of Cloud Bigtable replication. This feature
+     * is not currently available to most Cloud Bigtable customers. This feature
+     * might be changed in backward-incompatible ways and is not recommended for
+     * production use. It is not subject to any SLA or deprecation policy.
+     */
+    Builder withAppProfileId(ValueProvider<String> appProfileId) {
+      return withConfiguration(BigtableOptionsFactory.APP_PROFILE_ID_KEY, appProfileId);
+    }
 
     /**
      * Specifies the AppProfile to use.
@@ -88,7 +119,19 @@ public class CloudBigtableConfiguration implements Serializable {
      * production use. It is not subject to any SLA or deprecation policy.
      */
     public Builder withAppProfileId(String appProfileId) {
-      return withConfiguration(BigtableOptionsFactory.APP_PROFILE_ID_KEY, appProfileId);
+      return withAppProfileId(StaticValueProvider.of(appProfileId));
+    }
+
+    /**
+     * Adds additional connection configuration.
+     * {@link BigtableOptionsFactory#fromConfiguration(Configuration)} for more information about
+     * configuration options.
+     * @return The {@link CloudBigtableConfiguration.Builder} for chaining convenience.
+     */
+    Builder withConfiguration(String key, ValueProvider<String> value) {
+      Preconditions.checkArgument(value != null, "Value cannot be null");
+      this.additionalConfiguration.put(key, value);
+      return this;
     }
 
     /**
@@ -98,9 +141,7 @@ public class CloudBigtableConfiguration implements Serializable {
      * @return The {@link CloudBigtableConfiguration.Builder} for chaining convenience.
      */
     public Builder withConfiguration(String key, String value) {
-      Preconditions.checkArgument(value != null, "Value cannot be null");
-      this.additionalConfiguration.put(key, value);
-      return this;
+      return withConfiguration(key, StaticValueProvider.of(value));
     }
 
     /**
@@ -117,7 +158,7 @@ public class CloudBigtableConfiguration implements Serializable {
   }
 
   // Not final due to serialization of CloudBigtableScanConfiguration.
-  private Map<String, String> configuration;
+  private Map<String, ValueProvider<String>> configuration;
 
   // Used for serialization of CloudBigtableScanConfiguration.
   CloudBigtableConfiguration() {
@@ -129,17 +170,41 @@ public class CloudBigtableConfiguration implements Serializable {
    * @param projectId The project ID for the instance.
    * @param instanceId The instance ID.
    * @param additionalConfiguration A {@link Map} with additional connection configuration. See
-   *          {@link BigtableOptionsFactory#fromConfiguration(Configuration)} for more information
-   *          about configuration options.
+   *     {@link BigtableOptionsFactory#fromConfiguration(Configuration)} for more information about
+   *     configuration options. TODO(kevinsi4508): Remove this once CloudBigtableTableConfiguration
+   *     is templatized.
    */
-  protected CloudBigtableConfiguration(String projectId, String instanceId,
-      Map<String, String> additionalConfiguration) {
+  protected CloudBigtableConfiguration(
+      String projectId, String instanceId, Map<String, String> additionalConfiguration) {
+    this.configuration = new HashMap<>();
+    for (String key : additionalConfiguration.keySet()) {
+      configuration.put(key, StaticValueProvider.of(additionalConfiguration.get(key)));
+    }
+    setValue(
+        BigtableOptionsFactory.PROJECT_ID_KEY, StaticValueProvider.of(projectId), "Project ID");
+    setValue(
+        BigtableOptionsFactory.INSTANCE_ID_KEY, StaticValueProvider.of(instanceId), "Instance ID");
+  }
+
+  /**
+   * Creates a {@link CloudBigtableConfiguration} using the specified project ID and instance ID.
+   *
+   * @param projectId The project ID for the instance.
+   * @param instanceId The instance ID.
+   * @param additionalConfiguration A {@link Map} with additional connection configuration. See
+   *     {@link BigtableOptionsFactory#fromConfiguration(Configuration)} for more information about
+   *     configuration options.
+   */
+  protected CloudBigtableConfiguration(
+      ValueProvider<String> projectId,
+      ValueProvider<String> instanceId,
+      Map<String, ValueProvider<String>> additionalConfiguration) {
     this.configuration = new HashMap<>(additionalConfiguration);
     setValue(BigtableOptionsFactory.PROJECT_ID_KEY, projectId, "Project ID");
     setValue(BigtableOptionsFactory.INSTANCE_ID_KEY, instanceId, "Instance ID");
   }
 
-  private void setValue(String key, String value, String type) {
+  private void setValue(String key, ValueProvider<String> value, String type) {
     Preconditions.checkArgument(!configuration.containsKey(key), "%s was set twice", key);
     Preconditions.checkArgument(value != null, "%s must be set.", type);
     configuration.put(key, value);
@@ -150,7 +215,7 @@ public class CloudBigtableConfiguration implements Serializable {
    * @return The project ID for the instance.
    */
   public String getProjectId() {
-    return configuration.get(BigtableOptionsFactory.PROJECT_ID_KEY);
+    return configuration.get(BigtableOptionsFactory.PROJECT_ID_KEY).get();
   }
 
   /**
@@ -158,14 +223,14 @@ public class CloudBigtableConfiguration implements Serializable {
    * @return The Cloud Bigtable instance id.
    */
   public String getInstanceId() {
-    return configuration.get(BigtableOptionsFactory.INSTANCE_ID_KEY);
+    return configuration.get(BigtableOptionsFactory.INSTANCE_ID_KEY).get();
   }
 
   /**
    * Get the Cloud Bigtable App Profile id.
    */
   public String getAppProfileId() {
-    return configuration.get(BigtableOptionsFactory.APP_PROFILE_ID_KEY);
+    return configuration.get(BigtableOptionsFactory.APP_PROFILE_ID_KEY).get();
   }
 
   /**
@@ -201,8 +266,8 @@ public class CloudBigtableConfiguration implements Serializable {
     //    Builder.withConfiguration(BigtableOptionsFactory.BIGTABLE_ASYNC_MUTATOR_COUNT_KEY, 
     //                              BigtableOptions.BIGTABLE_ASYNC_MUTATOR_COUNT_DEFAULT);
     config.set(BigtableOptionsFactory.BIGTABLE_ASYNC_MUTATOR_COUNT_KEY, "0");
-    for (Entry<String, String> entry : configuration.entrySet()) {
-      config.set(entry.getKey(), entry.getValue());
+    for (Entry<String, ValueProvider<String>> entry : configuration.entrySet()) {
+      config.set(entry.getKey(), entry.getValue().get());
     }
     setUserAgent(config);
     return config;
@@ -229,12 +294,13 @@ public class CloudBigtableConfiguration implements Serializable {
   /**
    * Gets an immutable copy of the configuration map.
    */
-  protected ImmutableMap<String, String> getConfiguration() {
+  protected ImmutableMap<String, ValueProvider<String>> getConfiguration() {
     return ImmutableMap.copyOf(configuration);
   }
 
   /**
    * Compares this configuration with the specified object.
+   *
    * @param obj The object to compare this configuration against.
    * @return {@code true} if the given object has the same configuration, {@code false} otherwise.
    */
@@ -244,23 +310,45 @@ public class CloudBigtableConfiguration implements Serializable {
       return false;
     }
     CloudBigtableConfiguration other = (CloudBigtableConfiguration) obj;
-    return Objects.equals(configuration, other.configuration);
+    if (!Objects.equals(configuration.keySet(), other.configuration.keySet())) {
+      return false;
+    }
+    for (String key : configuration.keySet()) {
+      if (!Objects.equals(configuration.get(key).get(), other.configuration.get(key).get())) {
+        return false;
+      }
+    }
+    return true;
   }
 
   public void copyConfig(Builder builder) {
     builder.copyFrom(configuration);
   }
 
+  /**
+   * Checks if the parameters are accessible. Runtime parameters are not accessible at pipeline
+   * construction time.
+   */
+  protected boolean areParametersAccessible() {
+    return configuration.get(BigtableOptionsFactory.PROJECT_ID_KEY).isAccessible();
+  }
+
   public void populateDisplayData(DisplayData.Builder builder) {
+    if (!areParametersAccessible()) {
+      return;
+    }
+
     builder.add(DisplayData.item("projectId", getProjectId())
       .withLabel("Project ID"));
     builder.add(DisplayData.item("instanceId", getInstanceId())
       .withLabel("Instance ID"));
-    Map<String, String> hashMap = new HashMap<String, String>(configuration);
+    Map<String, ValueProvider<String>> hashMap =
+        new HashMap<String, ValueProvider<String>>(configuration);
     hashMap.remove(BigtableOptionsFactory.PROJECT_ID_KEY);
     hashMap.remove(BigtableOptionsFactory.INSTANCE_ID_KEY);
-    for (Entry<String, String> entry : configuration.entrySet()) {
-      builder.add(DisplayData.item(entry.getKey(), entry.getValue()).withLabel(entry.getKey()));
+    for (Entry<String, ValueProvider<String>> entry : configuration.entrySet()) {
+      builder.add(
+          DisplayData.item(entry.getKey(), entry.getValue().get()).withLabel(entry.getKey()));
     }
   }
 
@@ -271,7 +359,9 @@ public class CloudBigtableConfiguration implements Serializable {
   }
 
   public void validate() {
-    checkNotNullOrEmpty(getProjectId(), "projectId");
-    checkNotNullOrEmpty(getInstanceId(), "instanceId");
+    if (areParametersAccessible()) {
+      checkNotNullOrEmpty(getProjectId(), "projectId");
+      checkNotNullOrEmpty(getInstanceId(), "instanceId");
+    }
   }
 }

--- a/bigtable-dataflow-parent/bigtable-hbase-beam/src/main/java/com/google/cloud/bigtable/beam/CloudBigtableConfiguration.java
+++ b/bigtable-dataflow-parent/bigtable-hbase-beam/src/main/java/com/google/cloud/bigtable/beam/CloudBigtableConfiguration.java
@@ -170,8 +170,8 @@ public class CloudBigtableConfiguration implements Serializable {
    * @param projectId The project ID for the instance.
    * @param instanceId The instance ID.
    * @param additionalConfiguration A {@link Map} with additional connection configuration. See
-   *     {@link BigtableOptionsFactory#fromConfiguration(Configuration)} for more information about
-   *     configuration options.
+   *          {@link BigtableOptionsFactory#fromConfiguration(Configuration)} for more information
+   *          about configuration options.
    */
   protected CloudBigtableConfiguration(
       ValueProvider<String> projectId,

--- a/bigtable-dataflow-parent/bigtable-hbase-beam/src/main/java/com/google/cloud/bigtable/beam/CloudBigtableConfiguration.java
+++ b/bigtable-dataflow-parent/bigtable-hbase-beam/src/main/java/com/google/cloud/bigtable/beam/CloudBigtableConfiguration.java
@@ -65,9 +65,8 @@ public class CloudBigtableConfiguration implements Serializable {
      * @param projectId The project ID for the instance.
      * @return The {@link CloudBigtableConfiguration.Builder} for chaining convenience.
      */
-    Builder withProjectId(ValueProvider<String> projectId) {
-      this.projectId = projectId;
-      return this;
+    public Builder withProjectId(String projectId) {
+      return withProjectId(StaticValueProvider.of(projectId));
     }
 
     /**
@@ -75,17 +74,8 @@ public class CloudBigtableConfiguration implements Serializable {
      * @param projectId The project ID for the instance.
      * @return The {@link CloudBigtableConfiguration.Builder} for chaining convenience.
      */
-    public Builder withProjectId(String projectId) {
-      return withProjectId(StaticValueProvider.of(projectId));
-    }
-
-    /**
-     * Specifies the Cloud Bigtable instanceId.
-     * @param instanceId The Cloud Bigtable instanceId.
-     * @return The {@link CloudBigtableConfiguration.Builder} for chaining convenience.
-     */
-    Builder withInstanceId(ValueProvider<String> instanceId) {
-      this.instanceId = instanceId;
+    Builder withProjectId(ValueProvider<String> projectId) {
+      this.projectId = projectId;
       return this;
     }
 
@@ -99,15 +89,13 @@ public class CloudBigtableConfiguration implements Serializable {
     }
 
     /**
-     * Specifies the AppProfile to use.
-     *
-     * <p>This is a private alpha release of Cloud Bigtable replication. This feature
-     * is not currently available to most Cloud Bigtable customers. This feature
-     * might be changed in backward-incompatible ways and is not recommended for
-     * production use. It is not subject to any SLA or deprecation policy.
+     * Specifies the Cloud Bigtable instanceId.
+     * @param instanceId The Cloud Bigtable instanceId.
+     * @return The {@link CloudBigtableConfiguration.Builder} for chaining convenience.
      */
-    Builder withAppProfileId(ValueProvider<String> appProfileId) {
-      return withConfiguration(BigtableOptionsFactory.APP_PROFILE_ID_KEY, appProfileId);
+    Builder withInstanceId(ValueProvider<String> instanceId) {
+      this.instanceId = instanceId;
+      return this;
     }
 
     /**
@@ -123,15 +111,15 @@ public class CloudBigtableConfiguration implements Serializable {
     }
 
     /**
-     * Adds additional connection configuration.
-     * {@link BigtableOptionsFactory#fromConfiguration(Configuration)} for more information about
-     * configuration options.
-     * @return The {@link CloudBigtableConfiguration.Builder} for chaining convenience.
+     * Specifies the AppProfile to use.
+     *
+     * <p>This is a private alpha release of Cloud Bigtable replication. This feature
+     * is not currently available to most Cloud Bigtable customers. This feature
+     * might be changed in backward-incompatible ways and is not recommended for
+     * production use. It is not subject to any SLA or deprecation policy.
      */
-    Builder withConfiguration(String key, ValueProvider<String> value) {
-      Preconditions.checkArgument(value != null, "Value cannot be null");
-      this.additionalConfiguration.put(key, value);
-      return this;
+    Builder withAppProfileId(ValueProvider<String> appProfileId) {
+      return withConfiguration(BigtableOptionsFactory.APP_PROFILE_ID_KEY, appProfileId);
     }
 
     /**
@@ -142,6 +130,18 @@ public class CloudBigtableConfiguration implements Serializable {
      */
     public Builder withConfiguration(String key, String value) {
       return withConfiguration(key, StaticValueProvider.of(value));
+    }
+
+    /**
+     * Adds additional connection configuration.
+     * {@link BigtableOptionsFactory#fromConfiguration(Configuration)} for more information about
+     * configuration options.
+     * @return The {@link CloudBigtableConfiguration.Builder} for chaining convenience.
+     */
+    Builder withConfiguration(String key, ValueProvider<String> value) {
+      Preconditions.checkArgument(value != null, "Value cannot be null");
+      this.additionalConfiguration.put(key, value);
+      return this;
     }
 
     /**
@@ -162,28 +162,6 @@ public class CloudBigtableConfiguration implements Serializable {
 
   // Used for serialization of CloudBigtableScanConfiguration.
   CloudBigtableConfiguration() {
-  }
-
-  /**
-   * Creates a {@link CloudBigtableConfiguration} using the specified project ID and instance ID.
-   *
-   * @param projectId The project ID for the instance.
-   * @param instanceId The instance ID.
-   * @param additionalConfiguration A {@link Map} with additional connection configuration. See
-   *     {@link BigtableOptionsFactory#fromConfiguration(Configuration)} for more information about
-   *     configuration options. TODO(kevinsi4508): Remove this once CloudBigtableTableConfiguration
-   *     is templatized.
-   */
-  protected CloudBigtableConfiguration(
-      String projectId, String instanceId, Map<String, String> additionalConfiguration) {
-    this.configuration = new HashMap<>();
-    for (String key : additionalConfiguration.keySet()) {
-      configuration.put(key, StaticValueProvider.of(additionalConfiguration.get(key)));
-    }
-    setValue(
-        BigtableOptionsFactory.PROJECT_ID_KEY, StaticValueProvider.of(projectId), "Project ID");
-    setValue(
-        BigtableOptionsFactory.INSTANCE_ID_KEY, StaticValueProvider.of(instanceId), "Instance ID");
   }
 
   /**

--- a/bigtable-dataflow-parent/bigtable-hbase-beam/src/main/java/com/google/cloud/bigtable/beam/CloudBigtableScanConfiguration.java
+++ b/bigtable-dataflow-parent/bigtable-hbase-beam/src/main/java/com/google/cloud/bigtable/beam/CloudBigtableScanConfiguration.java
@@ -46,15 +46,15 @@ public class CloudBigtableScanConfiguration extends CloudBigtableTableConfigurat
   private static final long serialVersionUID = 2435897354284600685L;
 
   /**
-   * Converts a {@link CloudBigtableTableConfiguration} object to a {@link
-   * CloudBigtableScanConfiguration} that will perform the specified {@link Scan} on the table.
-   *
+   * Converts a {@link CloudBigtableTableConfiguration} object to a
+   * {@link CloudBigtableScanConfiguration} that will perform the specified {@link Scan} on the
+   * table.
    * @param config The {@link CloudBigtableTableConfiguration} object.
    * @param scan The {@link Scan} to add to the configuration.
    * @return The new {@link CloudBigtableScanConfiguration}.
    */
-  public static CloudBigtableScanConfiguration fromConfig(
-      CloudBigtableTableConfiguration config, Scan scan) {
+  public static CloudBigtableScanConfiguration fromConfig(CloudBigtableTableConfiguration config,
+      Scan scan) {
     CloudBigtableScanConfiguration.Builder builder = new CloudBigtableScanConfiguration.Builder();
     config.copyConfig(builder);
     return builder.withScan(scan).build();
@@ -67,7 +67,8 @@ public class CloudBigtableScanConfiguration extends CloudBigtableTableConfigurat
     private Scan scan;
     private ReadRowsRequest request;
 
-    public Builder() {}
+    public Builder() {
+    }
 
     /**
      * Specifies the {@link Scan} that will be used to filter the table.
@@ -123,9 +124,6 @@ public class CloudBigtableScanConfiguration extends CloudBigtableTableConfigurat
 
     /**
      * {@inheritDoc}
-     *
-     * <p>Overrides {@link CloudBigtableTableConfiguration.Builder#withInstanceId(String)} so that
-     * it returns {@link CloudBigtableScanConfiguration.Builder}.
      */
     @Override
     public Builder withInstanceId(String instanceId) {
@@ -135,9 +133,6 @@ public class CloudBigtableScanConfiguration extends CloudBigtableTableConfigurat
 
     /**
      * {@inheritDoc}
-     *
-     * <p>Overrides {@link CloudBigtableTableConfiguration.Builder#withConfiguration(String,
-     * String)} so that it returns {@link CloudBigtableScanConfiguration.Builder}.
      */
     @Override
     public Builder withConfiguration(String key, String value) {
@@ -146,10 +141,8 @@ public class CloudBigtableScanConfiguration extends CloudBigtableTableConfigurat
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * <p>Overrides {@link CloudBigtableTableConfiguration.Builder#withTableId(String)} so that it
-     * returns {@link CloudBigtableScanConfiguration.Builder}.
+     * {@inheritDoc} Overrides {@link CloudBigtableScanConfiguration.Builder#withTableId(String)} so
+     * that it returns {@link CloudBigtableScanConfiguration.Builder}.
      */
     @Override
     public Builder withTableId(String tableId) {
@@ -183,7 +176,6 @@ public class CloudBigtableScanConfiguration extends CloudBigtableTableConfigurat
   /**
    * Creates a {@link CloudBigtableScanConfiguration} using the specified project ID, instance ID,
    * table ID, {@link Scan} and additional connection configuration.
-   *
    * @param projectId The project ID for the instance.
    * @param instanceId The instance ID.
    * @param tableId The table to connect to in the instance.
@@ -217,9 +209,8 @@ public class CloudBigtableScanConfiguration extends CloudBigtableTableConfigurat
   }
 
   /**
-   * Gets the {@link ReadRowsRequest}. Sets the table name if it is not yet set.
-   *
-   * @return The {@link ReadRowsRequest}.
+   * Gets the {@link Scan} used to filter the table.
+   * @return The {@link Scan}.
    */
   public ReadRowsRequest getRequest() {
     return request.get();
@@ -281,7 +272,7 @@ public class CloudBigtableScanConfiguration extends CloudBigtableTableConfigurat
 
   public void copyConfig(Builder builder) {
     super.copyConfig(builder);
-    builder.withRequest(request.get());
+    builder.withRequest(getRequest());
   }
 
   /**

--- a/bigtable-dataflow-parent/bigtable-hbase-beam/src/main/java/com/google/cloud/bigtable/beam/CloudBigtableScanConfiguration.java
+++ b/bigtable-dataflow-parent/bigtable-hbase-beam/src/main/java/com/google/cloud/bigtable/beam/CloudBigtableScanConfiguration.java
@@ -289,6 +289,8 @@ public class CloudBigtableScanConfiguration extends CloudBigtableTableConfigurat
   @Override
   public void populateDisplayData(DisplayData.Builder builder) {
     super.populateDisplayData(builder);
+    // TODO(kevinsi): For each field, if it is not accessible, set of dummy value of
+    // "Unavailable during pipeline construction". This is debugging purpose.
     if (areParametersAccessible()) {
       builder.add(
           DisplayData.item("readRowsRequest", request.toString()).withLabel("ReadRowsRequest"));

--- a/bigtable-dataflow-parent/bigtable-hbase-beam/src/main/java/com/google/cloud/bigtable/beam/CloudBigtableScanConfiguration.java
+++ b/bigtable-dataflow-parent/bigtable-hbase-beam/src/main/java/com/google/cloud/bigtable/beam/CloudBigtableScanConfiguration.java
@@ -290,7 +290,7 @@ public class CloudBigtableScanConfiguration extends CloudBigtableTableConfigurat
   public void populateDisplayData(DisplayData.Builder builder) {
     super.populateDisplayData(builder);
     // TODO(kevinsi): For each field, if it is not accessible, set of dummy value of
-    // "Unavailable during pipeline construction". This is debugging purpose.
+    // "Unavailable during pipeline construction". This is for debugging purpose.
     if (areParametersAccessible()) {
       builder.add(
           DisplayData.item("readRowsRequest", request.toString()).withLabel("ReadRowsRequest"));

--- a/bigtable-dataflow-parent/bigtable-hbase-beam/src/main/java/com/google/cloud/bigtable/beam/CloudBigtableScanConfiguration.java
+++ b/bigtable-dataflow-parent/bigtable-hbase-beam/src/main/java/com/google/cloud/bigtable/beam/CloudBigtableScanConfiguration.java
@@ -192,6 +192,8 @@ public class CloudBigtableScanConfiguration extends CloudBigtableTableConfigurat
     this.request =
         NestedValueProvider.of(
             // Eventually the input request will be ValueProvider<ReadRowsRequest>.
+            // TODO(kevinsi): Make sure that the resulting request object is accessible only when
+            // all dependent runtime parameters are accessible.
             StaticValueProvider.of(request),
             new SerializableFunction<ReadRowsRequest, ReadRowsRequest>() {
               @Override

--- a/bigtable-dataflow-parent/bigtable-hbase-beam/src/main/java/com/google/cloud/bigtable/beam/CloudBigtableTableConfiguration.java
+++ b/bigtable-dataflow-parent/bigtable-hbase-beam/src/main/java/com/google/cloud/bigtable/beam/CloudBigtableTableConfiguration.java
@@ -17,7 +17,7 @@ package com.google.cloud.bigtable.beam;
 
 import java.util.Map;
 import java.util.Objects;
-
+import org.apache.beam.sdk.options.ValueProvider;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 
 /**
@@ -109,10 +109,10 @@ public class CloudBigtableTableConfiguration extends CloudBigtableConfiguration 
    * @param additionalConfiguration A {@link Map} with additional connection configuration.
    */
   protected CloudBigtableTableConfiguration(
-      String projectId,
-      String instanceId,
+      ValueProvider<String> projectId,
+      ValueProvider<String> instanceId,
       String tableId,
-      Map<String, String> additionalConfiguration) {
+      Map<String, ValueProvider<String>> additionalConfiguration) {
     super(projectId, instanceId, additionalConfiguration);
     this.tableId = tableId;
   }

--- a/bigtable-dataflow-parent/bigtable-hbase-beam/src/test/java/com/google/cloud/bigtable/beam/CloudBigtableConfigurationTest.java
+++ b/bigtable-dataflow-parent/bigtable-hbase-beam/src/test/java/com/google/cloud/bigtable/beam/CloudBigtableConfigurationTest.java
@@ -23,7 +23,7 @@ import org.junit.Assert;
 import com.google.cloud.bigtable.beam.CloudBigtableConfiguration;
 import com.google.cloud.bigtable.beam.CloudBigtableConfiguration.Builder;
 import com.google.cloud.bigtable.hbase.BigtableOptionsFactory;
-
+import org.apache.beam.sdk.options.ValueProvider.StaticValueProvider;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -36,7 +36,25 @@ import org.junit.runners.JUnit4;
 public class CloudBigtableConfigurationTest {
 
   private static final String PROJECT = "my_project";
+
   private static final String INSTANCE = "instance";
+
+  private Builder createBaseBuilder() {
+    return createBaseBuilder(PROJECT, INSTANCE);
+  }
+
+  private Builder createBaseBuilder(String project, String instance) {
+    return new CloudBigtableConfiguration.Builder().withProjectId(project).withInstanceId(instance);
+  }
+
+  @Test
+  public void testToBuilder() {
+    CloudBigtableConfiguration underTest =
+        createBaseBuilder().withConfiguration("somekey", "somevalue").build();
+    CloudBigtableConfiguration copy = underTest.toBuilder().build();
+    Assert.assertNotSame(underTest, copy);
+    Assert.assertEquals(underTest, copy);
+  }
 
   @Test
   public void testHBaseConfig() {
@@ -69,23 +87,24 @@ public class CloudBigtableConfigurationTest {
 
     // Test CloudBigtableConfiguration with the same extended parameters are equal.
     Assert.assertEquals(underTest3, underTest5);
-}
-
-  private Builder createBaseBuilder() {
-    return createBaseBuilder(PROJECT, INSTANCE);
   }
 
-  private Builder createBaseBuilder(String project, String instance) {
-    return new CloudBigtableConfiguration.Builder().withProjectId(project).withInstanceId(instance);
-  }
-
+  /**
+   * This ensures that the config built from regular parameters are the same as the config built
+   * from runtime parameters, so that we don't have to use runtime parameters to repeat the same
+   * tests.
+   */
   @Test
-  public void testToBuilder() {
-    CloudBigtableConfiguration underTest =
+  public void testRegularAndRuntimeParametersAreEqual() {
+    CloudBigtableConfiguration withRegularParameters =
         createBaseBuilder().withConfiguration("somekey", "somevalue").build();
-    CloudBigtableConfiguration copy = underTest.toBuilder().build();
-    Assert.assertNotSame(underTest, copy);
-    Assert.assertEquals(underTest, copy);
+    CloudBigtableConfiguration withRuntimeParameters =
+        new CloudBigtableConfiguration.Builder()
+            .withProjectId(StaticValueProvider.of(PROJECT))
+            .withInstanceId(StaticValueProvider.of(INSTANCE))
+            .withConfiguration("somekey", StaticValueProvider.of("somevalue"))
+            .build();
+    Assert.assertNotSame(withRegularParameters, withRuntimeParameters);
+    Assert.assertEquals(withRegularParameters, withRuntimeParameters);
   }
 }
-


### PR DESCRIPTION
Though I tried to have minimum change, 'request' object in CloudBigtableScanConfiguration needs to be converted to runtime parameter as well because it depends on project ID and instance ID.