### PR TITLE
Workaround Java 9 overridden methods with covariant return types

### DIFF
--- a/bigtable-dataflow-parent/bigtable-beam-import/src/main/java/com/google/cloud/bigtable/beam/sequencefiles/SequenceFileSink.java
+++ b/bigtable-dataflow-parent/bigtable-beam-import/src/main/java/com/google/cloud/bigtable/beam/sequencefiles/SequenceFileSink.java
@@ -214,7 +214,7 @@ class SequenceFileSink<K,V> extends FileBasedSink<KV<K,V>, Void, KV<K, V>> {
       while (written < len) {
         // Workaround Java 9 overridden methods with covariant return types
         ((Buffer)byteBuffer).position(written + off);
-        written += this.inner.write((ByteBuffer) byteBuffer);
+        written += this.inner.write(byteBuffer);
       }
     }
 

--- a/bigtable-dataflow-parent/bigtable-beam-import/src/main/java/com/google/cloud/bigtable/beam/sequencefiles/SequenceFileSink.java
+++ b/bigtable-dataflow-parent/bigtable-beam-import/src/main/java/com/google/cloud/bigtable/beam/sequencefiles/SequenceFileSink.java
@@ -18,6 +18,7 @@ package com.google.cloud.bigtable.beam.sequencefiles;
 import com.google.common.collect.Sets;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.WritableByteChannel;
 import java.util.Set;
@@ -211,8 +212,9 @@ class SequenceFileSink<K,V> extends FileBasedSink<KV<K,V>, Void, KV<K, V>> {
       ByteBuffer byteBuffer = ByteBuffer.wrap(b, off, len);
 
       while (written < len) {
-        byteBuffer.position(written + off);
-        written += this.inner.write(byteBuffer);
+        // Workaround Java 9 overridden methods with covariant return types
+        ((Buffer)byteBuffer).position(written + off);
+        written += this.inner.write((ByteBuffer) byteBuffer);
       }
     }
 
@@ -221,13 +223,15 @@ class SequenceFileSink<K,V> extends FileBasedSink<KV<K,V>, Void, KV<K, V>> {
      */
     @Override
     public void write(int b) throws IOException {
-      singleByteBuffer.clear();
+      // Workaround Java 9 overridden methods with covariant return types
+      ((Buffer)singleByteBuffer).clear();
       singleByteBuffer.put((byte)b);
 
       int written = 0;
 
       while (written == 0) {
-        singleByteBuffer.position(0);
+        // Workaround Java 9 overridden methods with covariant return types
+        ((Buffer)singleByteBuffer).position(0);
         written = this.inner.write(singleByteBuffer);
       }
     }

--- a/bigtable-dataflow-parent/bigtable-beam-import/src/main/java/com/google/cloud/bigtable/beam/sequencefiles/SequenceFileSource.java
+++ b/bigtable-dataflow-parent/bigtable-beam-import/src/main/java/com/google/cloud/bigtable/beam/sequencefiles/SequenceFileSource.java
@@ -22,6 +22,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.primitives.UnsignedBytes;
 import java.io.EOFException;
 import java.io.IOException;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.SeekableByteChannel;
@@ -367,7 +368,8 @@ class SequenceFileSource<K, V> extends FileBasedSource<KV<K, V>> {
     public int read() throws IOException {
       int numRead = 0;
 
-      singleByteBuffer.clear();
+      // Workaround Java 9 overridden methods with covariant return types
+      ((Buffer)singleByteBuffer).clear();
       while (numRead == 0) {
         numRead = inner.read(singleByteBuffer);
       }


### PR DESCRIPTION
A better approach would've been to use -release compiler flag, but it gets messy because we have different modules targeting different jdks and sprinkling auto activated jdk9 profile gets messy