### PR TITLE
 Fixing HBase 2 column famin admin

### DIFF
--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/IntegrationTests.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/IntegrationTests.java
@@ -18,13 +18,8 @@ package com.google.cloud.bigtable.hbase;
 import com.google.cloud.bigtable.hbase.async.*;
 import com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule;
 
-import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.hadoop.hbase.HColumnDescriptor;
-import org.apache.hadoop.hbase.HTableDescriptor;
-import org.apache.hadoop.hbase.TableName;
-import org.apache.hadoop.hbase.client.Admin;
 import org.junit.ClassRule;
 import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
@@ -40,6 +35,8 @@ import org.junit.runners.Suite;
     TestCheckAndMutateHBase2.class,
     TestCheckAndMutateHBase2Builder.class,
     TestColumnFamilyAdmin.class,
+    TestColumnFamilyAdminHBase2.class,
+    TestColumnFamilyAdminAsync.class,
     TestCreateTable.class,
     TestCreateTableHBase2.class,
     TestDisableTable.class,

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestColumnFamilyAdmin.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestColumnFamilyAdmin.java
@@ -15,20 +15,9 @@
  */
 package com.google.cloud.bigtable.hbase;
 
-import static com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule.COLUMN_FAMILY;
-import static org.junit.Assert.assertEquals;
-
 import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.TableName;
-import org.apache.hadoop.hbase.client.Admin;
-import org.apache.hadoop.hbase.client.ColumnFamilyDescriptor;
-import org.apache.hadoop.hbase.client.TableDescriptor;
-import org.apache.hadoop.hbase.util.Bytes;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
 
 import java.io.IOException;
 
@@ -36,129 +25,24 @@ import java.io.IOException;
  * Tests creation and deletion of column families.
  */
 public class TestColumnFamilyAdmin extends AbstractTestColumnFamilyAdmin {
-  
-  @Before
-  public void setup() throws IOException {
-    admin = getConnection().getAdmin();
-    tableName = sharedTestEnv.newTestTableName();
 
-    descriptor = new HTableDescriptor(tableName);
-    descriptor.addFamily(new HColumnDescriptor(COLUMN_FAMILY));
-    descriptor.addFamily(new HColumnDescriptor(DELETE_COLUMN_FAMILY));
-    admin.createTable(descriptor);
-  }
-
-  @After
-  public void tearDown() throws IOException {
-    admin.disableTable(tableName);
-    admin.deleteTable(tableName);
-  }
-  
-  @Test
-  public void testAddAndCompareColumn() throws IOException {
-    HColumnDescriptor newColumn = new HColumnDescriptor("NEW_COLUMN");
-    admin.addColumn(tableName, newColumn);
-
-    HTableDescriptor expectedDescriptor = new HTableDescriptor(descriptor);
-    expectedDescriptor.addFamily(newColumn);
-
-    HTableDescriptor retrievedDescriptor = admin.getTableDescriptor(tableName);
-    Assert.assertEquals(expectedDescriptor, retrievedDescriptor);
-  }
-
-  @Test
-  public void testModifyColumnFamilyAsync() throws Exception {
-    HColumnDescriptor newColumn = new HColumnDescriptor("MODIFY_COLUMN");
-    newColumn.setMaxVersions(2);
-    admin.addColumnFamilyAsync(tableName, newColumn).get();
-
-    HTableDescriptor expectedDescriptor = new HTableDescriptor(descriptor);
-    expectedDescriptor.addFamily(newColumn);
-
-    HTableDescriptor retrievedDescriptor = admin.getTableDescriptor(tableName);
-    Assert.assertEquals(expectedDescriptor, retrievedDescriptor);
-
-    newColumn.setMaxVersions(100);
-    admin.modifyColumnFamilyAsync(tableName, newColumn).get();
-
-    expectedDescriptor = new HTableDescriptor(descriptor);
-    expectedDescriptor.addFamily(newColumn);
-
-    retrievedDescriptor = admin.getTableDescriptor(tableName);
-    Assert.assertEquals(expectedDescriptor, retrievedDescriptor);
-
-  }
-
-  @Test
-  public void testAddAndCompareColumnFamily() throws IOException {
-    HColumnDescriptor newColumn = new HColumnDescriptor("NEW_COLUMN");
-    admin.addColumnFamily(tableName, newColumn);
-
-    HTableDescriptor expectedDescriptor = new HTableDescriptor(descriptor);
-    expectedDescriptor.addFamily(newColumn);
-
-    HTableDescriptor retrievedDescriptor = admin.getTableDescriptor(tableName);
-    Assert.assertEquals(expectedDescriptor, retrievedDescriptor);
-  }
-  
-  @Test
-  public void testDeleteColumnFamily() throws IOException {
-    //Count column before delete.
-    TableDescriptor tblDesc = admin.getDescriptor(tableName);
-    ColumnFamilyDescriptor colDescArr[] = tblDesc.getColumnFamilies();
-    assertEquals(2, colDescArr.length);
-    assertEquals(Bytes.toString(COLUMN_FAMILY), colDescArr[0].getNameAsString());
-    assertEquals(Bytes.toString(DELETE_COLUMN_FAMILY), colDescArr[1].getNameAsString());
-    
-    admin.deleteColumnFamily(tableName, DELETE_COLUMN_FAMILY);
-    
-    //count column after delete.
-    tblDesc = admin.getDescriptor(tableName);
-    ColumnFamilyDescriptor colDescArrDel[] = tblDesc.getColumnFamilies();
-    assertEquals(1, colDescArrDel.length);
-    assertEquals(Bytes.toString(COLUMN_FAMILY), colDescArrDel[0].getNameAsString());
-  }
-  
-  @Test
-  public void testDeleteColumnFamilyAsync() throws Exception {
-  //Count column before delete.
-    TableDescriptor tblDesc = admin.getDescriptor(tableName);
-    ColumnFamilyDescriptor colDescArr[] = tblDesc.getColumnFamilies();
-    assertEquals(2, colDescArr.length);
-    assertEquals(Bytes.toString(COLUMN_FAMILY), colDescArr[0].getNameAsString());
-    assertEquals(Bytes.toString(DELETE_COLUMN_FAMILY), colDescArr[1].getNameAsString());
-    
-    admin.deleteColumnFamilyAsync(tableName, DELETE_COLUMN_FAMILY).get();
-    
-  //count column after delete.
-    tblDesc = admin.getDescriptor(tableName);
-    ColumnFamilyDescriptor colDescArrDel[] = tblDesc.getColumnFamilies();
-    assertEquals(1, colDescArrDel.length);
-    assertEquals(Bytes.toString(COLUMN_FAMILY), colDescArrDel[0].getNameAsString());
-  }
-  
   @Override
-  protected void addColumn(String colmnName) throws Exception {
-    HColumnDescriptor newColumn = new HColumnDescriptor(colmnName);
-    admin.addColumn(tableName, newColumn);
-  }
-  
-  @Override
-  protected void addColumn(String colmnName, int version) throws Exception {
-    HColumnDescriptor newColumn = new HColumnDescriptor(colmnName);
-    newColumn.setMaxVersions(version);
-    admin.addColumn(tableName, newColumn);
-  }
-  
-  @Override
-  protected void modifyColumn(String columnName, int version) throws Exception {
-    HColumnDescriptor newColumn = new HColumnDescriptor(columnName);
-    newColumn.setMaxVersions(version);
-    admin.modifyColumn(tableName, newColumn);
+  protected HTableDescriptor getTableDescriptor(TableName tableName) throws IOException {
+    return admin.getTableDescriptor(tableName);
   }
 
   @Override
-  protected void deleteColumn() throws Exception {
-    admin.deleteColumnFamily(tableName, DELETE_COLUMN_FAMILY);
+  protected void addColumn(byte[] columnName, int versions) throws Exception {
+    admin.addColumn(tableName, new HColumnDescriptor(columnName).setMaxVersions(versions));
+  }
+
+  @Override
+  protected void modifyColumn(byte[] columnName, int versions) throws Exception {
+    admin.modifyColumn(tableName, new HColumnDescriptor(columnName).setMaxVersions(versions));
+  }
+
+  @Override
+  protected void deleteColumn(byte[] columnName) throws Exception {
+    admin.deleteColumn(tableName, columnName);
   }
 }

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestColumnFamilyAdminAsync.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestColumnFamilyAdminAsync.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2018 Google LLC All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase;
+
+import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.ColumnFamilyDescriptor;
+import org.apache.hadoop.hbase.client.ColumnFamilyDescriptorBuilder;
+import org.apache.hadoop.hbase.client.TableDescriptor;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule.COLUMN_FAMILY;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests creation and deletion of column families.
+ */
+public class TestColumnFamilyAdminAsync extends AbstractTestColumnFamilyAdmin {
+  @Override
+  protected HTableDescriptor getTableDescriptor(TableName tableName) throws Exception {
+    return admin.getTableDescriptor(tableName);
+  }
+
+  @Override
+  protected void addColumn(byte[] columnName, int version) throws Exception {
+    ColumnFamilyDescriptor descriptor =
+        ColumnFamilyDescriptorBuilder.newBuilder(columnName).setMaxVersions(version)
+            .build();
+    admin.addColumnFamilyAsync(tableName, descriptor).get();
+  }
+
+  @Override
+  protected void modifyColumn(byte[] columnName, int version) throws Exception {
+    ColumnFamilyDescriptor descriptor =
+        ColumnFamilyDescriptorBuilder.newBuilder(columnName).setMaxVersions(version)
+            .build();
+    admin.modifyColumnFamilyAsync(tableName, descriptor).get();
+  }
+
+  @Override
+  protected void deleteColumn(byte[] columnName) throws Exception {
+    admin.deleteColumnFamilyAsync(tableName, DELETE_COLUMN_FAMILY).get();
+  }
+}

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestColumnFamilyAdminHBase2.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestColumnFamilyAdminHBase2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Google LLC. All Rights Reserved.
+ * Copyright 2018 Google LLC All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,70 +13,54 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.cloud.bigtable.hbase.async;
+package com.google.cloud.bigtable.hbase;
 
 import static com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule.COLUMN_FAMILY;
 import static org.junit.Assert.assertEquals;
 
-import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-
 import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.TableName;
-import org.apache.hadoop.hbase.client.AsyncAdmin;
+import org.apache.hadoop.hbase.client.Admin;
 import org.apache.hadoop.hbase.client.ColumnFamilyDescriptor;
 import org.apache.hadoop.hbase.client.ColumnFamilyDescriptorBuilder;
 import org.apache.hadoop.hbase.client.TableDescriptor;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.google.cloud.bigtable.hbase.AbstractTestColumnFamilyAdmin;
-import com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule;
+import java.io.IOException;
 
-public class TestAsyncColumnFamily extends AbstractTestColumnFamilyAdmin {
-  private AsyncAdmin asyncAdmin = null;
-
-  public TestAsyncColumnFamily () {
-    try {
-      asyncAdmin =  AbstractAsyncTest.getAsyncConnection().getAdmin();
-    } catch (InterruptedException e) {
-      e.printStackTrace();
-    } catch (ExecutionException e) {
-      e.printStackTrace();
-    }
-  }
+/**
+ * Tests creation and deletion of column families.
+ */
+public class TestColumnFamilyAdminHBase2 extends AbstractTestColumnFamilyAdmin {
 
   @Override
   protected HTableDescriptor getTableDescriptor(TableName tableName) throws Exception {
-    try {
-      return (HTableDescriptor) asyncAdmin.getDescriptor(tableName).get();
-    } catch(ExecutionException e) {
-      throw (Exception) e.getCause();
-    }
+    return admin.getTableDescriptor(tableName);
   }
 
   @Override
   protected void addColumn(byte[] columnName, int version) throws Exception {
-    ColumnFamilyDescriptorBuilder colFamilyDescBuilder =
-        ColumnFamilyDescriptorBuilder.newBuilder(columnName);
-    colFamilyDescBuilder.setMaxVersions(version);
-    asyncAdmin.addColumnFamily(tableName, colFamilyDescBuilder.build()).get();
+    ColumnFamilyDescriptor descriptor =
+        ColumnFamilyDescriptorBuilder.newBuilder(columnName).setMaxVersions(version)
+            .build();
+    admin.addColumnFamily(tableName, descriptor);
   }
-  
+
   @Override
   protected void modifyColumn(byte[] columnName, int version) throws Exception {
-    ColumnFamilyDescriptorBuilder colFamilyDescBuilder =
-        ColumnFamilyDescriptorBuilder.newBuilder(columnName);
-    colFamilyDescBuilder.setMaxVersions(version);
-    asyncAdmin.modifyColumnFamily(tableName, colFamilyDescBuilder.build()).get();
+    ColumnFamilyDescriptor descriptor =
+        ColumnFamilyDescriptorBuilder.newBuilder(columnName).setMaxVersions(version)
+            .build();
+    admin.modifyColumnFamily(tableName, descriptor);
   }
 
   @Override
   protected void deleteColumn(byte[] columnName) throws Exception {
-    asyncAdmin.deleteColumnFamily(tableName, columnName).get();
+    admin.deleteColumnFamily(tableName, columnName);
   }
-  
 }

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/admin/TableAdapter.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/admin/TableAdapter.java
@@ -18,9 +18,9 @@ package com.google.cloud.bigtable.hbase.adapters.admin;
 import com.google.bigtable.admin.v2.ColumnFamily;
 import com.google.bigtable.admin.v2.CreateTableRequest;
 import com.google.bigtable.admin.v2.Table;
-import com.google.cloud.bigtable.config.BigtableOptions;
 import com.google.cloud.bigtable.grpc.BigtableInstanceName;
 
+import com.google.common.base.Preconditions;
 import com.google.protobuf.ByteString;
 import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HTableDescriptor;
@@ -48,7 +48,8 @@ public class TableAdapter {
    */
   public TableAdapter(BigtableInstanceName bigtableInstanceName,
       ColumnDescriptorAdapter columnDescriptorAdapter) {
-    this.bigtableInstanceName = bigtableInstanceName;
+    this.bigtableInstanceName = Preconditions
+        .checkNotNull(bigtableInstanceName, "bigtableInstanceName cannot be null.");
     this.columnDescriptorAdapter = columnDescriptorAdapter;
   }
 

--- a/bigtable-hbase-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableAdmin.java
+++ b/bigtable-hbase-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableAdmin.java
@@ -46,13 +46,7 @@ import com.google.protobuf.ByteString;
 import com.google.protobuf.Duration;
 import io.grpc.Status;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.TimeoutException;
 import java.util.regex.Pattern;
 import org.apache.hadoop.conf.Configuration;
@@ -576,8 +570,11 @@ public abstract class AbstractBigtableAdmin implements Admin {
   @Override
   public void addColumn(TableName tableName, HColumnDescriptor column) throws IOException {
     String columnName = column.getNameAsString();
-    Modification.Builder modification = Modification.newBuilder().setId(columnName)
-        .setCreate(columnDescriptorAdapter.adapt(column).build());
+    Modification modification = Modification
+        .newBuilder()
+        .setId(columnName)
+        .setCreate(columnDescriptorAdapter.adapt(column).build())
+        .build();
     modifyColumn(tableName, columnName, "add", modification);
   }
 
@@ -586,8 +583,11 @@ public abstract class AbstractBigtableAdmin implements Admin {
   @Override
   public void modifyColumn(TableName tableName, HColumnDescriptor column) throws IOException {
     String columnName = column.getNameAsString();
-    Modification.Builder modification = Modification.newBuilder().setId(columnName)
-        .setUpdate(columnDescriptorAdapter.adapt(column).build());
+    Modification modification = Modification
+        .newBuilder()
+        .setId(columnName)
+        .setUpdate(columnDescriptorAdapter.adapt(column).build())
+        .build();
     modifyColumn(tableName, columnName, "update", modification);
   }
 
@@ -595,8 +595,11 @@ public abstract class AbstractBigtableAdmin implements Admin {
   @Override
   public void deleteColumn(TableName tableName, byte[] columnName) throws IOException {
     final String columnNameStr = Bytes.toString(columnName);
-    Modification.Builder modification = Modification.newBuilder().setId(columnNameStr)
-        .setDrop(true);
+    Modification modification = Modification
+        .newBuilder()
+        .setId(columnNameStr)
+        .setDrop(true)
+        .build();
     modifyColumn(tableName, columnNameStr, "delete", modification);
   }
 
@@ -606,16 +609,19 @@ public abstract class AbstractBigtableAdmin implements Admin {
    * @param tableName a {@link org.apache.hadoop.hbase.TableName} object.
    * @param columnName a {@link java.lang.String} object.
    * @param modificationType a {@link java.lang.String} object.
-   * @param modification a {@link com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest.Modification.Builder} object.
+   * @param modifications an array of {@link com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest.Modification} object.
    * @throws java.io.IOException if any.
    */
   protected void modifyColumn(TableName tableName, String columnName,
-      String modificationType, Modification.Builder modification) throws IOException {
-    ModifyColumnFamiliesRequest.Builder modifyColumnBuilder = ModifyColumnFamiliesRequest
-        .newBuilder().addModifications(modification).setName(toBigtableName(tableName));
+      String modificationType, Modification... modifications) throws IOException {
+    ModifyColumnFamiliesRequest modifyColumn = ModifyColumnFamiliesRequest
+        .newBuilder()
+        .addAllModifications(Arrays.asList(modifications))
+        .setName(toBigtableName(tableName))
+        .build();
 
     try {
-      bigtableTableAdminClient.modifyColumnFamily(modifyColumnBuilder.build());
+      bigtableTableAdminClient.modifyColumnFamily(modifyColumn);
     } catch (Throwable throwable) {
       throw new IOException(
           String.format(


### PR DESCRIPTION
- fixing structure of integration tests.  Now, there's one top class that does the core tests, and a bunch of subclasses that perform
- fixing HBase 2's assumption that all `ColumnFamilyDescriptor`s are `HColumnFamilyDscriptor`s
- other cleanup.