### PR TITLE
Fixing an exception handling case in BigtabeAsyncAdmin

### DIFF
--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncAdmin.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncAdmin.java
@@ -287,10 +287,12 @@ public class BigtableAsyncAdmin implements AsyncAdmin {
       if (ex != null) {
         if (Status.fromThrowable(ex).getCode() == Status.Code.NOT_FOUND) {
           throw new CompletionException(new TableNotFoundException(tableName));
+        } else {
+          throw new CompletionException(ex);
         }
+      } else {
+        return tableAdapter2x.adapt(resp);
       }
-
-      return tableAdapter2x.adapt(resp);
     });
   }
 


### PR DESCRIPTION
getDescriptor needs to throw exceptions even if the exception is not `TableNotFound`