### PR TITLE
Use grpc-netty-shaded instead of grpc-netty.

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/pom.xml
+++ b/bigtable-client-core-parent/bigtable-client-core/pom.xml
@@ -161,11 +161,6 @@ limitations under the License.
         </dependency>
 
         <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-tcnative-boringssl-static</artifactId>
-            <version>${netty-tcnative-boringssl-static.version}</version>
-        </dependency>
-        <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-protobuf</artifactId>
             <version>${grpc.version}</version>
@@ -182,7 +177,7 @@ limitations under the License.
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>
-            <artifactId>grpc-netty</artifactId>
+            <artifactId>grpc-netty-shaded</artifactId>
             <version>${grpc.version}</version>
         </dependency>
         <dependency>

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestBigtableSession.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestBigtableSession.java
@@ -17,18 +17,14 @@
 package com.google.cloud.bigtable.grpc;
 
 import java.io.IOException;
-import java.lang.reflect.Field;
 
 import com.google.cloud.bigtable.config.CredentialOptions;
-import org.junit.Assert;
+import io.grpc.netty.shaded.io.netty.handler.ssl.OpenSsl;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import com.google.cloud.bigtable.config.BigtableOptions;
-
-import io.netty.handler.ssl.OpenSsl;
-import io.netty.util.Recycler;
 
 @SuppressWarnings({"resource","unused"})
 public class TestBigtableSession {

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestBulkMutationAwaitCompletion.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestBulkMutationAwaitCompletion.java
@@ -26,12 +26,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -57,7 +52,6 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import com.google.rpc.Status;
 
-import io.netty.util.concurrent.ScheduledFuture;
 
 /**
  * Tests for {@link BulkMutation} that ensure that RPC failures and highly asynchronous calls work

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-hadoop/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableConnection.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-hadoop/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableConnection.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-import com.google.bigtable.repackaged.io.netty.handler.ssl.OpenSsl;
+import com.google.bigtable.repackaged.io.grpc.netty.shaded.io.netty.handler.ssl.OpenSsl;
 import com.google.cloud.bigtable.hbase2_x.BigtableConnection;
 
 

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-shaded/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-shaded/pom.xml
@@ -200,16 +200,12 @@ limitations under the License.
                     https://github.com/grpc/grpc-java/pull/2485
                 -->
                 <relocation>
-                  <pattern>io.netty</pattern>
-                  <shadedPattern>com.google.bigtable.repackaged.io.netty</shadedPattern>
+                  <pattern>META-INF/native/libio_grpc_netty_shaded_netty</pattern>
+                  <shadedPattern>META-INF/native/libcom_google_bigtable_repackaged_io_grpc_netty_shaded_netty</shadedPattern>
                 </relocation>
                 <relocation>
-                  <pattern>META-INF/native/libnetty</pattern>
-                  <shadedPattern>META-INF/native/libcom_google_bigtable_repackaged_netty</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>META-INF/native/netty</pattern>
-                  <shadedPattern>META-INF/native/com_google_bigtable_repackaged_netty</shadedPattern>
+                  <pattern>META-INF/native/io_grpc_netty_shaded_netty</pattern>
+                  <shadedPattern>META-INF/native/com_google_bigtable_repackaged_io_grpc_netty_shaded_netty</shadedPattern>
                 </relocation>
 
                 <relocation>

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-shaded/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-shaded/pom.xml
@@ -175,6 +175,15 @@ limitations under the License.
                   <pattern>com.twitter</pattern>
                   <shadedPattern>com.google.bigtable.repackaged.com.twitter</shadedPattern>
                 </relocation>
+
+                <!-- Take special care of grpc-netty-shaded, it uses the package
+                     io.grpc.netty.shaded.io.grpc.netty, which will cause the
+                     ServicesResourceTransformer to replace both occurrences of io.grpc
+                 -->
+                <relocation>
+                  <pattern>io.grpc.netty.shaded.io.grpc.netty</pattern>
+                  <shadedPattern>com.google.bigtable.repackaged.io.grpc.netty</shadedPattern>
+                </relocation>
                 <relocation>
                   <pattern>io.grpc</pattern>
                   <shadedPattern>com.google.bigtable.repackaged.io.grpc</shadedPattern>

--- a/bigtable-hbase-parent/bigtable-hbase-1.x-hadoop/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableConnection.java
+++ b/bigtable-hbase-parent/bigtable-hbase-1.x-hadoop/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableConnection.java
@@ -20,7 +20,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-import com.google.bigtable.repackaged.io.netty.handler.ssl.OpenSsl;
+import com.google.bigtable.repackaged.io.grpc.netty.shaded.io.netty.handler.ssl.OpenSsl;
 import com.google.cloud.bigtable.hbase1_x.BigtableConnection;
 
 

--- a/bigtable-hbase-parent/bigtable-hbase-1.x-shaded/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-1.x-shaded/pom.xml
@@ -158,6 +158,14 @@ limitations under the License.
                   <pattern>com.twitter</pattern>
                   <shadedPattern>com.google.bigtable.repackaged.com.twitter</shadedPattern>
                 </relocation>
+                <!-- Take special care of grpc-netty-shaded, it uses the package
+                     io.grpc.netty.shaded.io.grpc.netty, which will cause the
+                     ServicesResourceTransformer to replace both occurrences of io.grpc
+                 -->
+                <relocation>
+                  <pattern>io.grpc.netty.shaded.io.grpc.netty</pattern>
+                  <shadedPattern>com.google.bigtable.repackaged.io.grpc.netty</shadedPattern>
+                </relocation>
                 <relocation>
                   <pattern>io.grpc</pattern>
                   <shadedPattern>com.google.bigtable.repackaged.io.grpc</shadedPattern>

--- a/bigtable-hbase-parent/bigtable-hbase-1.x-shaded/pom.xml
+++ b/bigtable-hbase-parent/bigtable-hbase-1.x-shaded/pom.xml
@@ -183,16 +183,12 @@ limitations under the License.
                     https://github.com/grpc/grpc-java/pull/2485
                 -->
                 <relocation>
-                  <pattern>io.netty</pattern>
-                  <shadedPattern>com.google.bigtable.repackaged.io.netty</shadedPattern>
+                  <pattern>META-INF/native/libio_grpc_netty_shaded_netty</pattern>
+                  <shadedPattern>META-INF/native/libcom_google_bigtable_repackaged_io_grpc_netty_shaded_netty</shadedPattern>
                 </relocation>
                 <relocation>
-                  <pattern>META-INF/native/libnetty</pattern>
-                  <shadedPattern>META-INF/native/libcom_google_bigtable_repackaged_netty</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>META-INF/native/netty</pattern>
-                  <shadedPattern>META-INF/native/com_google_bigtable_repackaged_netty</shadedPattern>
+                  <pattern>META-INF/native/io_grpc_netty_shaded_netty</pattern>
+                  <shadedPattern>META-INF/native/com_google_bigtable_repackaged_io_grpc_netty_shaded_netty</shadedPattern>
                 </relocation>
 
                 <relocation>

--- a/pom.xml
+++ b/pom.xml
@@ -57,8 +57,6 @@ limitations under the License.
         <com.google.api.grpc.version>0.11.0</com.google.api.grpc.version>
         <grpc.version>1.11.0</grpc.version>
         <opencensus.version>0.13.0</opencensus.version>
-        <netty.version>4.1.22.Final</netty.version>
-        <netty-tcnative-boringssl-static.version>2.0.7.Final</netty-tcnative-boringssl-static.version>
         <protobuff-java.version>3.5.1</protobuff-java.version>
         <google.api.client.version>1.23.0</google.api.client.version>
         <google.http.client.version>1.23.0</google.http.client.version>


### PR DESCRIPTION
@igorbernstein2, the `google-cloud-java` BOM uses `grpc-netty-shaded`, so this would be a prereq for using the BOM.  I'm running into trouble with the `Provider` which is expecting this:

* com.google.bigtable.repackaged.io.grpc.netty.shaded.com.google.bigtable.repackaged.io.grpc.netty.NettyChannelProvider

Do you have any thoughts on how to fix the service file?