### PR TITLE
Use the google-cloud-bom.

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/pom.xml
+++ b/bigtable-client-core-parent/bigtable-client-core/pom.xml
@@ -30,12 +30,23 @@ limitations under the License.
        This project contains artifacts bigtable client needs to interact with grpc.
     </description>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.google.cloud</groupId>
+                <artifactId>google-cloud-bom</artifactId>
+                <version>${google-cloud-bom.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <!-- Protos -->
         <dependency>
             <groupId>com.google.api.grpc</groupId>
             <artifactId>grpc-google-common-protos</artifactId>
-            <version>1.10.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>io.grpc</groupId>
@@ -50,7 +61,6 @@ limitations under the License.
         <dependency>
             <groupId>com.google.api.grpc</groupId>
             <artifactId>proto-google-cloud-bigtable-v2</artifactId>
-            <version>${com.google.api.grpc.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>io.grpc</groupId>
@@ -61,7 +71,6 @@ limitations under the License.
         <dependency>
             <groupId>com.google.api.grpc</groupId>
             <artifactId>proto-google-cloud-bigtable-admin-v2</artifactId>
-            <version>${com.google.api.grpc.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>io.grpc</groupId>
@@ -72,7 +81,6 @@ limitations under the License.
         <dependency>
             <groupId>com.google.api.grpc</groupId>
             <artifactId>grpc-google-cloud-bigtable-v2</artifactId>
-            <version>${com.google.api.grpc.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>io.grpc</groupId>
@@ -83,7 +91,6 @@ limitations under the License.
         <dependency>
             <groupId>com.google.api.grpc</groupId>
             <artifactId>grpc-google-cloud-bigtable-admin-v2</artifactId>
-            <version>${com.google.api.grpc.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>io.grpc</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@ limitations under the License.
         <hadoop.version>2.7.4</hadoop.version>
         <junit.version>4.12</junit.version>
         <mockito.version>1.10.19</mockito.version>
-        <com.google.api.grpc.version>0.11.0</com.google.api.grpc.version>
+        <google-cloud-bom.version>0.50.0-alpha</google-cloud-bom.version>
         <grpc.version>1.11.0</grpc.version>
         <opencensus.version>0.13.0</opencensus.version>
         <netty.version>4.1.22.Final</netty.version>


### PR DESCRIPTION
In a future PR, use google-cloud-core-grpc to get the standard grpc dependencies