### PR TITLE
Using google-cloud-core-http for auth

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/pom.xml
+++ b/bigtable-client-core-parent/bigtable-client-core/pom.xml
@@ -35,7 +35,7 @@ limitations under the License.
         <dependency>
             <groupId>com.google.api.grpc</groupId>
             <artifactId>grpc-google-common-protos</artifactId>
-            <version>1.10.0</version>
+            <version>1.11.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>io.grpc</groupId>
@@ -110,45 +110,18 @@ limitations under the License.
 
         <!-- Auth -->
         <dependency>
-            <groupId>com.google.auth</groupId>
-            <artifactId>google-auth-library-oauth2-http</artifactId>
-            <version>${google.auth.library.version}</version>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-core-http</artifactId>
+            <!-- TODO(sduskis) remove explicit versioning when the BOM is used. -->
+            <version>1.32.0</version>
             <exclusions>
                 <exclusion>
-                    <groupId>com.google.guava</groupId>
-                    <artifactId>guava-jdk5</artifactId>
+                    <groupId>org.threeten</groupId>
+                    <artifactId>*</artifactId>
                 </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>com.google.auth</groupId>
-            <artifactId>google-auth-library-credentials</artifactId>
-            <version>${google.auth.library.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.google.auth</groupId>
-            <artifactId>google-auth-library-appengine</artifactId>
-            <version>${google.auth.library.version}</version>
-            <exclusions>
                 <exclusion>
-                    <groupId>com.google.guava</groupId>
-                    <artifactId>guava-jdk5</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>com.google.http-client</groupId>
-            <artifactId>google-http-client</artifactId>
-            <version>${google.http.client.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.google.api-client</groupId>
-            <artifactId>google-api-client</artifactId>
-            <version>${google.api.client.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.google.guava</groupId>
-                    <artifactId>guava-jdk5</artifactId>
+                    <groupId>org.codehaus.jackson</groupId>
+                    <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/bigtable-client-core-parent/bigtable-client-core/pom.xml
+++ b/bigtable-client-core-parent/bigtable-client-core/pom.xml
@@ -117,6 +117,27 @@ limitations under the License.
 
         <!-- Auth -->
         <dependency>
+            <groupId>com.google.auth</groupId>
+            <artifactId>google-auth-library-oauth2-http</artifactId>
+            <version>${google.auth.library.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava-jdk5</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.google.auth</groupId>
+            <artifactId>google-auth-library-credentials</artifactId>
+            <version>${google.auth.library.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.http-client</groupId>
+            <artifactId>google-http-client</artifactId>
+            <version>${google.http.client.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-core-http</artifactId>
             <exclusions>
@@ -146,11 +167,6 @@ limitations under the License.
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-protobuf</artifactId>
-            <version>${grpc.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.grpc</groupId>
-            <artifactId>grpc-auth</artifactId>
             <version>${grpc.version}</version>
         </dependency>
         <dependency>

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/CredentialFactory.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/CredentialFactory.java
@@ -33,6 +33,7 @@ import com.google.auth.oauth2.ServiceAccountCredentials;
 import com.google.cloud.bigtable.config.CredentialOptions.JsonCredentialsOptions;
 import com.google.cloud.bigtable.config.CredentialOptions.P12CredentialOptions;
 import com.google.cloud.bigtable.config.CredentialOptions.UserSuppliedCredentialOptions;
+import com.google.cloud.http.HttpTransportOptions;
 import com.google.common.collect.ImmutableList;
 
 /**
@@ -91,16 +92,7 @@ public class CredentialFactory {
 
   public static HttpTransportFactory getHttpTransportFactory() {
     if (httpTransportFactory == null) {
-      httpTransportFactory = new HttpTransportFactory() {
-        @Override
-        public HttpTransport create() {
-          try {
-            return GoogleNetHttpTransport.newTrustedTransport();
-          } catch (Exception e) {
-            throw new RuntimeException("Could not create a GoogleNetHttpTransport: " + e.getMessage(), e);
-          }
-        }
-      };
+      httpTransportFactory = new HttpTransportOptions.DefaultHttpTransportFactory();
     }
     return httpTransportFactory;
   }

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@ limitations under the License.
         <hadoop.version>2.7.4</hadoop.version>
         <junit.version>4.12</junit.version>
         <mockito.version>1.10.19</mockito.version>
-        <com.google.api.grpc.version>0.11.0</com.google.api.grpc.version>
+        <com.google.api.grpc.version>0.15.0</com.google.api.grpc.version>
         <grpc.version>1.11.0</grpc.version>
         <opencensus.version>0.13.0</opencensus.version>
         <netty.version>4.1.22.Final</netty.version>


### PR DESCRIPTION
This allows us to use a centralized configuration for all auth related dependencies.