### PR TITLE
ScanAdapter now supports inclusive/exclusive

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/ScanAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/ScanAdapter.java
@@ -54,18 +54,19 @@ import java.util.NavigableSet;
 public class ScanAdapter implements ReadOperationAdapter<Scan> {
 
   private static final int UNSET_MAX_RESULTS_PER_COLUMN_FAMILY = -1;
-  private static boolean OPEN_CLOSED_AVAILABLE;
+  private static final boolean OPEN_CLOSED_AVAILABLE = isOpenClosedAvailable();
 
-  static {
+  /**
+   * HBase supports include(Stop|Start)Row only at 1.4.0+, so check to make sure that the HBase
+   * runtime dependency supports this feature.  Specifically, Beam uses HBase 1.2.0.
+   */
+  private static boolean isOpenClosedAvailable() {
     try {
-      // Not all versions of HBase support include(Stop|Start)Row, so check at startup.
-      // Specifically,
       new Scan().includeStopRow();
-      OPEN_CLOSED_AVAILABLE = true;
+      return true;
     } catch(NoSuchMethodError e) {
-      OPEN_CLOSED_AVAILABLE = false;
+      return false;
     }
-
   }
 
   private final FilterAdapter filterAdapter;

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/read/TestScanAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/read/TestScanAdapter.java
@@ -90,18 +90,92 @@ public class TestScanAdapter {
   public void testNewScan() {
     Scan scan = new Scan();
     ReadRowsRequest.Builder request = scanAdapter.adapt(scan, throwingReadHooks);
-    Assert.assertEquals(RowSet.newBuilder()
-        .addRowRanges(RowRange.getDefaultInstance()).build(),
+    Assert.assertEquals(toRowSet(RowRange.getDefaultInstance()),
       request.getRows());
+  }
+
+  @Test
+  public void testStartDefault() {
+    byte[] startKey = Bytes.toBytes("startKey");
+    Scan scan = new Scan().withStartRow(startKey);
+    ReadRowsRequest.Builder request = scanAdapter.adapt(scan, throwingReadHooks);
+    RowSet expected = toRowSet(
+        RowRange.newBuilder().setStartKeyClosed(ByteString.copyFrom(startKey)).build());
+    Assert.assertEquals(expected, request.getRows());
+  }
+
+  @Test
+  public void testStartInclusive() {
+    byte[] startKey = Bytes.toBytes("startKey");
+    Scan scan = new Scan().withStartRow(startKey, true);
+    ReadRowsRequest.Builder request = scanAdapter.adapt(scan, throwingReadHooks);
+    RowSet expected = toRowSet(
+        RowRange.newBuilder().setStartKeyClosed(ByteString.copyFrom(startKey)).build());
+    Assert.assertEquals(expected, request.getRows());
+  }
+
+  @Test
+  public void testStartExclusive() {
+    byte[] startKey = Bytes.toBytes("startKey");
+    Scan scan = new Scan().withStartRow(startKey, false);
+    ReadRowsRequest.Builder request = scanAdapter.adapt(scan, throwingReadHooks);
+    RowSet expected = toRowSet(
+        RowRange.newBuilder().setStartKeyOpen(ByteString.copyFrom(startKey)).build());
+    Assert.assertEquals(expected, request.getRows());
+  }
+
+  @Test
+  public void testStopDefault() {
+    byte[] stopKey = Bytes.toBytes("stopKey");
+    Scan scan = new Scan().withStopRow(stopKey);
+    ReadRowsRequest.Builder request = scanAdapter.adapt(scan, throwingReadHooks);
+    RowSet expected = toRowSet(
+        RowRange.newBuilder().setEndKeyOpen(ByteString.copyFrom(stopKey)).build());
+    Assert.assertEquals(expected, request.getRows());
+  }
+
+  @Test
+  public void testStopInclusive() {
+    byte[] stopKey = Bytes.toBytes("stopKey");
+    Scan scan = new Scan().withStopRow(stopKey, true);
+    ReadRowsRequest.Builder request = scanAdapter.adapt(scan, throwingReadHooks);
+    RowSet expected = toRowSet(
+        RowRange.newBuilder().setEndKeyClosed(ByteString.copyFrom(stopKey)).build());
+    Assert.assertEquals(expected, request.getRows());
+  }
+
+  @Test
+  public void testStopExclusive() {
+    byte[] stopKey = Bytes.toBytes("stopKey");
+    Scan scan = new Scan().withStopRow(stopKey, false);
+    ReadRowsRequest.Builder request = scanAdapter.adapt(scan, throwingReadHooks);
+    RowSet expected = toRowSet(
+        RowRange.newBuilder().setEndKeyOpen(ByteString.copyFrom(stopKey)).build());
+    Assert.assertEquals(expected, request.getRows());
   }
 
   @Test
   public void testStartAndEndKeysAreSet() {
     byte[] startKey = Bytes.toBytes("startKey");
     byte[] stopKey = Bytes.toBytes("stopKey");
-    Scan scan = new Scan(startKey, stopKey);
+    Scan scan = new Scan()
+        .withStartRow(startKey)
+        .withStopRow(stopKey);
     ReadRowsRequest.Builder request = scanAdapter.adapt(scan, throwingReadHooks);
     Assert.assertEquals(toRowSet(toRange(startKey, stopKey)), request.getRows());
+  }
+
+  @Test
+  public void testStartAndEndKeysNonDefault() {
+    byte[] startKey = Bytes.toBytes("startKey");
+    byte[] stopKey = Bytes.toBytes("stopKey");
+    Scan scan = new Scan()
+        .withStartRow(startKey, false)
+        .withStopRow(stopKey, true);
+    ReadRowsRequest.Builder request = scanAdapter.adapt(scan, throwingReadHooks);
+    Assert.assertEquals(toRowSet(
+        RowRange.newBuilder().setStartKeyOpen(ByteStringer.wrap(startKey))
+            .setEndKeyClosed(ByteStringer.wrap(stopKey)).build()), request.getRows());
   }
 
   @Test


### PR DESCRIPTION
HBase 1.4+ have the ability to set inclusive/exclusive on Scans.  The `ScanAdapter` should support explicit settings of inclusive/exclusive.  It should also be backwards compatible with versions less than 1.4.

This fixes #1850 