### PR TITLE
Implement Bigtable write throttle for import

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableOptionsFactory.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableOptionsFactory.java
@@ -396,7 +396,7 @@ public class BigtableOptionsFactory {
 
     if (configuration.getBoolean(BIGTABLE_BUFFERED_MUTATOR_ENABLE_THROTTLING,
       BulkOptions.BIGTABLE_BULK_ENABLE_THROTTLE_REBALANCE_DEFAULT)) {
-      LOG.info("Setting up Bigtable throttling with latency threshold %d",
+      LOG.info("Bigtable mutation latency throttling enabled with threshold %d",
           configuration.getInt(BIGTABLE_BUFFERED_MUTATOR_THROTTLING_THRESHOLD_MILLIS,
           BulkOptions.BIGTABLE_BULK_THROTTLE_TARGET_MS_DEFAULT));
       bulkOptionsBuilder.enableBulkMutationThrottling();

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableOptionsFactory.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableOptionsFactory.java
@@ -396,6 +396,9 @@ public class BigtableOptionsFactory {
 
     if (configuration.getBoolean(BIGTABLE_BUFFERED_MUTATOR_ENABLE_THROTTLING,
       BulkOptions.BIGTABLE_BULK_ENABLE_THROTTLE_REBALANCE_DEFAULT)) {
+      LOG.info("Setting up big table throttling with latency threshold %d",
+          configuration.getInt(BIGTABLE_BUFFERED_MUTATOR_THROTTLING_THRESHOLD_MILLIS,
+          BulkOptions.BIGTABLE_BULK_THROTTLE_TARGET_MS_DEFAULT));
       bulkOptionsBuilder.enableBulkMutationThrottling();
       bulkOptionsBuilder.setBulkMutationRpcTargetMs(
         configuration.getInt(BIGTABLE_BUFFERED_MUTATOR_THROTTLING_THRESHOLD_MILLIS,

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableOptionsFactory.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableOptionsFactory.java
@@ -396,7 +396,7 @@ public class BigtableOptionsFactory {
 
     if (configuration.getBoolean(BIGTABLE_BUFFERED_MUTATOR_ENABLE_THROTTLING,
       BulkOptions.BIGTABLE_BULK_ENABLE_THROTTLE_REBALANCE_DEFAULT)) {
-      LOG.info("Setting up big table throttling with latency threshold %d",
+      LOG.info("Setting up Bigtable throttling with latency threshold %d",
           configuration.getInt(BIGTABLE_BUFFERED_MUTATOR_THROTTLING_THRESHOLD_MILLIS,
           BulkOptions.BIGTABLE_BULK_THROTTLE_TARGET_MS_DEFAULT));
       bulkOptionsBuilder.enableBulkMutationThrottling();

--- a/bigtable-dataflow-parent/bigtable-beam-import/src/main/java/com/google/cloud/bigtable/beam/TemplateUtils.java
+++ b/bigtable-dataflow-parent/bigtable-beam-import/src/main/java/com/google/cloud/bigtable/beam/TemplateUtils.java
@@ -26,6 +26,7 @@ import java.nio.charset.CharacterCodingException;
 import org.apache.beam.sdk.options.ValueProvider;
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.filter.ParseFilter;
+//import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory;
 
 /**
  * !!! DO NOT TOUCH THIS CLASS !!!
@@ -44,6 +45,14 @@ public class TemplateUtils {
             .withTableId(opts.getBigtableTableId());
     if (opts.getBigtableAppProfileId() != null) {
       builder.withAppProfileId(opts.getBigtableAppProfileId());
+    }
+
+    if (opts.getBigtableWriteThrottleMs() != null) {
+      builder.withConfiguration("google.bigtable.buffered.mutator.throttling.enable" , // BigtableOptionsFactory.BIGTABLE_BUFFERED_MUTATOR_ENABLE_THROTTLING,
+          "true");
+      builder.withConfiguration(
+          "google.bigtable.buffered.mutator.throttling.threshold.ms", // BigTableOptionsFactory.BIGTABLE_BUFFERED_MUTATOR_THROTTLING_THRESHOLD_MILLIS,
+          opts.getBigtableWriteThrottleMs());
     }
     return builder.build();
   }

--- a/bigtable-dataflow-parent/bigtable-beam-import/src/main/java/com/google/cloud/bigtable/beam/TemplateUtils.java
+++ b/bigtable-dataflow-parent/bigtable-beam-import/src/main/java/com/google/cloud/bigtable/beam/TemplateUtils.java
@@ -24,7 +24,6 @@ import com.google.cloud.bigtable.hbase.adapters.read.ReadHooks;
 import java.io.Serializable;
 import java.nio.charset.CharacterCodingException;
 import org.apache.beam.sdk.options.ValueProvider;
-import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.filter.ParseFilter;
 import com.google.cloud.bigtable.hbase.BigtableOptionsFactory;
@@ -49,11 +48,11 @@ public class TemplateUtils {
     }
 
     ValueProvider enableThrottling = ValueProvider.NestedValueProvider.of(
-        opts.getBigtableWriteThrottleMs(), (Integer throttleMs) -> String.valueOf(throttleMs > 0));
+        opts.getMutationThrottleLatencyMs(), (Integer throttleMs) -> String.valueOf(throttleMs > 0));
 
     builder.withConfiguration(BigtableOptionsFactory.BIGTABLE_BUFFERED_MUTATOR_ENABLE_THROTTLING, enableThrottling);
     builder.withConfiguration(BigtableOptionsFactory.BIGTABLE_BUFFERED_MUTATOR_THROTTLING_THRESHOLD_MILLIS,
-        String.valueOf(opts.getBigtableWriteThrottleMs()));
+        ValueProvider.NestedValueProvider.of(opts.getMutationThrottleLatencyMs(), String::valueOf));
 
     return builder.build();
   }

--- a/bigtable-dataflow-parent/bigtable-beam-import/src/main/java/com/google/cloud/bigtable/beam/sequencefiles/ImportJob.java
+++ b/bigtable-dataflow-parent/bigtable-beam-import/src/main/java/com/google/cloud/bigtable/beam/sequencefiles/ImportJob.java
@@ -109,11 +109,11 @@ public class ImportJob {
     @SuppressWarnings("unused")
     void setSourcePattern(ValueProvider<String> sourcePath);
 
-    @Description("Optional Enable BigTable write throttling. Value in milliseconds.")
+    @Description("Optional Set mutation latency throttling (enables the feature). Value in milliseconds.")
     @Default.Integer(0)
-    ValueProvider<Integer> getBigtableWriteThrottleMs();
+    ValueProvider<Integer> getMutationThrottleLatencyMs();
     @SuppressWarnings("unused")
-    void setBigtableWriteThrottleMs(ValueProvider<Integer> throttleMs);
+    void setMutationThrottleLatencyMs(ValueProvider<Integer> throttleMs);
 
     // When creating a template, this flag must be set to false.
     @Description("Wait for pipeline to finish.")

--- a/bigtable-dataflow-parent/bigtable-beam-import/src/main/java/com/google/cloud/bigtable/beam/sequencefiles/ImportJob.java
+++ b/bigtable-dataflow-parent/bigtable-beam-import/src/main/java/com/google/cloud/bigtable/beam/sequencefiles/ImportJob.java
@@ -109,6 +109,11 @@ public class ImportJob {
     @SuppressWarnings("unused")
     void setSourcePattern(ValueProvider<String> sourcePath);
 
+    @Description("Optional BigTable write throttling in milliseconds")
+    ValueProvider<String> getBigtableWriteThrottleMs();
+    @SuppressWarnings("unused")
+    void setBigtableWriteThrottleMs(ValueProvider<String> throttleMs);
+
     // When creating a template, this flag must be set to false.
     @Description("Wait for pipeline to finish.")
     @Default.Boolean(true)

--- a/bigtable-dataflow-parent/bigtable-beam-import/src/main/java/com/google/cloud/bigtable/beam/sequencefiles/ImportJob.java
+++ b/bigtable-dataflow-parent/bigtable-beam-import/src/main/java/com/google/cloud/bigtable/beam/sequencefiles/ImportJob.java
@@ -109,10 +109,11 @@ public class ImportJob {
     @SuppressWarnings("unused")
     void setSourcePattern(ValueProvider<String> sourcePath);
 
-    @Description("Optional BigTable write throttling in milliseconds")
-    ValueProvider<String> getBigtableWriteThrottleMs();
+    @Description("Optional Enable BigTable write throttling. Value in milliseconds.")
+    @Default.Integer(0)
+    ValueProvider<Integer> getBigtableWriteThrottleMs();
     @SuppressWarnings("unused")
-    void setBigtableWriteThrottleMs(ValueProvider<String> throttleMs);
+    void setBigtableWriteThrottleMs(ValueProvider<Integer> throttleMs);
 
     // When creating a template, this flag must be set to false.
     @Description("Wait for pipeline to finish.")


### PR DESCRIPTION
Otherwise import is practically useless as it can't safely import without overloading BigTable