### PR TITLE
Revert "Enable throttling in BufferedMutator by default"

### DIFF
--- a/bigtable-dataflow-parent/bigtable-beam-import/README.md
+++ b/bigtable-dataflow-parent/bigtable-beam-import/README.md
@@ -42,5 +42,3 @@ java -jar bigtable-beam-import-1.1.0-shaded.jar import \
     --maxNumWorkers=[3x number of nodes] \
     --zone=[zone of your cluster]
 ```
-
-NOTE: Throttling in BufferedMutator is enabled by default. The throttling will kick in only when the mutation latency has reached the target latency of 100 milliseconds.

--- a/bigtable-dataflow-parent/bigtable-beam-import/src/main/java/com/google/cloud/bigtable/beam/TemplateUtils.java
+++ b/bigtable-dataflow-parent/bigtable-beam-import/src/main/java/com/google/cloud/bigtable/beam/TemplateUtils.java
@@ -18,7 +18,6 @@ package com.google.cloud.bigtable.beam;
 import com.google.bigtable.repackaged.com.google.bigtable.v2.ReadRowsRequest;
 import com.google.cloud.bigtable.beam.sequencefiles.ExportJob.ExportOptions;
 import com.google.cloud.bigtable.beam.sequencefiles.ImportJob.ImportOptions;
-import com.google.cloud.bigtable.hbase.BigtableOptionsFactory;
 import com.google.cloud.bigtable.hbase.adapters.Adapters;
 import com.google.cloud.bigtable.hbase.adapters.read.DefaultReadHooks;
 import com.google.cloud.bigtable.hbase.adapters.read.ReadHooks;
@@ -46,16 +45,6 @@ public class TemplateUtils {
     if (opts.getBigtableAppProfileId() != null) {
       builder.withAppProfileId(opts.getBigtableAppProfileId());
     }
-
-    // Enable throttling in BufferedMutator by default.
-    // We don't want to expose this as a parameter because we want to make the default Dataflow
-    // pipeline or template easier to use. User can (but not recommended) alter this behavior by
-    // implementing their own custom pipeline. With this flag turned on, a default target latency of
-    // 100 milliseconds (see {@link BulkOptions.BIGTABLE_BULK_THROTTLE_TARGET_MS_DEFAULT}) is used.
-    // The throttling will kick in only when the mutation latency has reached the target latency.
-    builder.withConfiguration(
-        BigtableOptionsFactory.BIGTABLE_BUFFERED_MUTATOR_ENABLE_THROTTLING, Boolean.toString(true));
-
     return builder.build();
   }
 


### PR DESCRIPTION
Reverts GoogleCloudPlatform/cloud-bigtable-client#1854

Throttling based on latency doesn't work well. Revert and let users figure out what is going and set the max number of workers themselves.