### PR TITLE
Adding "Not Start" state to Watchdog

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/io/WatchdogTest.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/io/WatchdogTest.java
@@ -81,7 +81,29 @@ public class WatchdogTest {
   }
 
   @Test
-  public void testIdleTimeout() throws InterruptedException {
+  public void testNotStarted() {
+    clock.setTime(idleTimeMs - 1);
+    watchdog.run();
+    Assert.assertNull(call.cancelMessage);
+
+    clock.setTime(idleTimeMs);
+    watchdog.run();
+    Assert.assertNotNull(call.cancelMessage);
+
+    call.listener
+        .onClose(
+            Status.CANCELLED.withDescription("Some upstream exception representing cancellation"),
+            new Metadata());
+
+    Assert.assertEquals(listener.closeStatus.getDescription(),
+        "Some upstream exception representing cancellation");
+  }
+
+  @Test
+  public void testIdleTimeout() {
+    call.request(1);
+    call.listener.onMessage("");
+
     clock.setTime(idleTimeMs - 1);
     watchdog.run();
     Assert.assertNull(call.cancelMessage);


### PR DESCRIPTION
The master branch is broken.  It appears that there's a discrepancy between "idle" and "not started" states that were breaking the tests.  This PR adds the notion of "not started" and also has some other minor touch ups.