### PR TITLE
Updating the latest version of google-cloud-clients

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,8 +59,8 @@ limitations under the License.
         <hamcrest.version>1.3</hamcrest.version>
 
         <!-- google-cloud-java related dependency versions -->
-        <google-cloud.version>0.53.0-alpha</google-cloud.version>
-        <opencensus.version>0.11.1</opencensus.version>
+        <google-cloud.version>0.54.0-alpha</google-cloud.version>
+        <opencensus.version>0.12.3</opencensus.version>
         <guava.version>20.0</guava.version>
 
         <!-- hbase dependency versions -->


### PR DESCRIPTION
google-cloud.version is updated to 0.54.0-alpha
grpc is updated to 1.13.1 (via 0.54.0-alpha)
opencensus to 0.12.3.