### PR TITLE
Making a distinction between RPC and Operation deadlines

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AbstractRetryingOperation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AbstractRetryingOperation.java
@@ -369,7 +369,7 @@ public abstract class AbstractRetryingOperation<RequestT, ResponseT, ResultT>
   //      RetryingReadRowsOperation like it should.
   protected boolean isStreamingRead() {
     return request instanceof ReadRowsRequest &&
-            CallOptionsFactory.ConfiguredCallOptionsFactory.isGet((ReadRowsRequest) request);
+            !CallOptionsFactory.ConfiguredCallOptionsFactory.isGet((ReadRowsRequest) request);
   }
 
   protected RequestT getRetryRequest() {

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AbstractRetryingOperation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AbstractRetryingOperation.java
@@ -340,6 +340,17 @@ public abstract class AbstractRetryingOperation<RequestT, ResponseT, ResultT>
   /**
    * Create an {@link CallOption} that has a fail safe RPC deadline to make sure that unary operations don't hang. This
    * will have to be overridden for streaming RPCs like read rows.
+   * <p>
+   * The logic is as follows:
+   * <ol>
+   *   <li> If the user provides a deadline, use the deadline</li>
+   *   <li> Else If this is a streaming read, don't set an explicit deadline.  The
+   *   {@link com.google.cloud.bigtable.grpc.io.Watchdog} will handle hangling</li>
+   *   <li> Else Set a deadline of {@link #UNARY_DEADLINE_MINUTES} minutes deadline.</li>
+   * </ol>
+   *
+   * @ee the
+   * {@link com.google.cloud.bigtable.grpc.io.Watchdog} handles hanging for streaming reads
    *
    * @return a {@link CallOptions}
    */

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/RetryingUnaryOperation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/RetryingUnaryOperation.java
@@ -70,13 +70,4 @@ public class RetryingUnaryOperation<RequestT, ResponseT>
     }
     return true;
   }
-
-  @Override
-  protected CallOptions getCallOptions() {
-    CallOptions originalCallOptions = super.getCallOptions();
-    if (originalCallOptions.getDeadline() != null) {
-      return originalCallOptions;
-    }
-    return originalCallOptions.withDeadlineAfter(UNARY_DEADLINE_MINUTES, TimeUnit.MINUTES);
-  }
 }

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/RetryingReadRowsOperation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/RetryingReadRowsOperation.java
@@ -205,25 +205,6 @@ public class RetryingReadRowsOperation extends
   }
 
   @Override
-  /**
-   * Override the default behavior of {@link AbstractRetryingOperation#getRpcCallOptions()} to ensure that deadlines
-   * are not set for streaming reads.
-   */
-  protected CallOptions getRpcCallOptions() {
-    if (CallOptionsFactory.ConfiguredCallOptionsFactory.isGet(nextRequest)) {
-      // This is a single get.  Treat this Operation line any unary operation.
-      return super.getRpcCallOptions();
-
-    } else {
-      // This is a streaming read.  There should not be a difference between an "Rpc" and an "Operation"
-      // as far as Deadlines are concerned.  Absolute Deadlines don't really work for stream RPCs, since there's
-      // no way to determine how many responses the service will return.  However, there's a "Watchdog" interceptor
-      // that has a more complex method of tracking activity and helps ensure that there won't be hanging.
-      return super.getOperationCallOptions();
-    }
-  }
-
-  @Override
   protected void finalizeStats(Status status) {
     super.finalizeStats(status);
     // Add an annotation for the total number of rows that were returned across all responses.

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/RetryingReadRowsOperation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/RetryingReadRowsOperation.java
@@ -16,7 +16,6 @@
 package com.google.cloud.bigtable.grpc.scanner;
 
 import com.google.api.client.util.Preconditions;
-import com.google.cloud.bigtable.grpc.CallOptionsFactory;
 import com.google.cloud.bigtable.grpc.io.Watchdog.State;
 import com.google.cloud.bigtable.grpc.io.Watchdog.StreamWaitTimeoutException;
 import java.util.concurrent.ScheduledExecutorService;


### PR DESCRIPTION
Users set deadlines on logical operations.  Logical operations may consist of multiple RPCs, depending on the number of times temporary failures occur.  Each RPC has an additional concept of a deadline as a "safety net" if a user doesn't explicitly set a Deadline; this prevents hanging behavior. This PR distinguishes between the two in `AbstractRetryingOperation`.  This is a step towards fixing issue #1858. 