### PR TITLE
Cleaning up ReadRows operation.

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AbstractRetryingOperation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AbstractRetryingOperation.java
@@ -200,7 +200,7 @@ public abstract class AbstractRetryingOperation<RequestT, ResponseT, ResultT>
     Code code = status.getCode();
     // CANCELLED
     if (code == Status.Code.CANCELLED) {
-      completionFuture.setException(status.asRuntimeException());
+      setException(status.asRuntimeException());
       // An explicit user cancellation is not considered a failure.
       finalizeStats(status);
       return;
@@ -373,10 +373,6 @@ public abstract class AbstractRetryingOperation<RequestT, ResponseT, ResultT>
   }
 
   protected RequestT getRetryRequest() {
-    return request;
-  }
-
-  public final RequestT getOriginalRequest() {
     return request;
   }
 

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/RetryingReadRowsOperation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/RetryingReadRowsOperation.java
@@ -24,7 +24,6 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 
 import com.google.api.client.util.BackOff;
-import com.google.api.client.util.Clock;
 import com.google.bigtable.v2.ReadRowsRequest;
 import com.google.bigtable.v2.ReadRowsResponse;
 import com.google.cloud.bigtable.config.RetryOptions;
@@ -101,8 +100,6 @@ public class RetryingReadRowsOperation extends
     }
   }
 
-  @VisibleForTesting
-  Clock clock = Clock.SYSTEM;
   private final ReadRowsRequestManager requestManager;
   private final StreamObserver<FlatRow> rowObserver;
   private final RowMerger rowMerger;

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/OperationClock.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/OperationClock.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2018 Google LLC. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.grpc.async;
+
+import com.google.api.client.util.ExponentialBackOff;
+import com.google.api.client.util.NanoClock;
+import com.google.cloud.bigtable.config.RetryOptions;
+import org.junit.Assert;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
+
+/**
+ * An implementation of {@link NanoClock} that is geared towards {@link AbstractRetryingOperation}.
+ * It can configure a mock {@link ScheduledExecutorService} to set internal time, and it can
+ * validate that the amount of sleep time matches expectations.
+ */
+public class OperationClock implements NanoClock {
+
+  private long timeNs;
+  private long totalSleepTime = 0;
+
+  public OperationClock() {
+    this.timeNs = System.nanoTime();
+  }
+
+  @Override
+  public synchronized long nanoTime() {
+    return timeNs + totalSleepTime;
+  }
+
+  /**
+   * Sets up a mock {@link ScheduledExecutorService} to use update the clock based on the amount
+   * of time the scheduler was set to.
+   */
+  public void initializeMockSchedule(ScheduledExecutorService mockExecutor,
+     final ScheduledFuture future) {
+
+    Answer<ScheduledFuture> runAutomatically = new Answer<ScheduledFuture>() {
+      @Override public ScheduledFuture answer(InvocationOnMock invocation)  {
+        long duration = invocation.getArgumentAt(1, Long.class);
+        TimeUnit timeUnit = invocation.getArgumentAt(2, TimeUnit.class);
+        synchronized (OperationClock.this) {
+          totalSleepTime += timeUnit.toNanos(duration);
+        }
+        invocation.getArgumentAt(0, Runnable.class).run();
+        return future;
+      }
+    };
+
+    when(mockExecutor.schedule(any(Runnable.class), any(Long.class), any(TimeUnit.class)))
+        .then(runAutomatically);
+  }
+
+  /**
+   * Creates a {@link ExponentialBackOff} with this as its {@link NanoClock}.
+   */
+  public ExponentialBackOff createBackoff(RetryOptions retryOptions) {
+    return new ExponentialBackOff.Builder()
+        .setNanoClock(this)
+        .setInitialIntervalMillis(retryOptions.getInitialBackoffMillis())
+        .setMaxElapsedTimeMillis(retryOptions.getMaxElapsedBackoffMillis())
+        .setMultiplier(retryOptions.getBackoffMultiplier()).build();
+  }
+
+  /**
+   * Checks to make sure that the expected sleep time matches the actual time slept.
+   */
+  public synchronized void assertTimeWithinExpectations(long expectedSleepNs) {
+    long sleptSeconds = TimeUnit.NANOSECONDS.toSeconds(totalSleepTime);
+    Assert.assertTrue(String.format("Slept only %d seconds", sleptSeconds),
+        totalSleepTime >= expectedSleepNs);
+    Assert.assertTrue(String.format("Slept more than expected (%d seconds)", sleptSeconds),
+        totalSleepTime < expectedSleepNs * 2);
+  }
+}

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestRetryingMutateRowsOperation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestRetryingMutateRowsOperation.java
@@ -17,42 +17,49 @@ package com.google.cloud.bigtable.grpc.async;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.TimeoutException;
 
+import com.google.api.client.util.ExponentialBackOff;
+import com.google.cloud.bigtable.config.RetryOptions;
+import io.grpc.ClientCall;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import com.google.api.client.util.NanoClock;
 import com.google.bigtable.v2.BigtableGrpc;
 import com.google.bigtable.v2.MutateRowsRequest;
 import com.google.bigtable.v2.MutateRowsRequest.Entry;
 import com.google.bigtable.v2.MutateRowsResponse;
 import com.google.bigtable.v2.Mutation;
 import com.google.bigtable.v2.Mutation.SetCell;
-import com.google.cloud.bigtable.config.RetryOptions;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.rpc.Status;
 
 import io.grpc.CallOptions;
 import io.grpc.Metadata;
 import io.grpc.Status.Code;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
 /**
  * Tests for {@link RetryingMutateRowsOperation}.
  *
  */
 public class TestRetryingMutateRowsOperation {
+
+  private static final RetryOptions RETRY_OPTIONS = new RetryOptions.Builder().build();
 
   private static Status OK = statusOf(io.grpc.Status.Code.OK);
   private static Status DEADLINE_EXCEEDED = statusOf(io.grpc.Status.Code.DEADLINE_EXCEEDED);
@@ -110,25 +117,19 @@ public class TestRetryingMutateRowsOperation {
   @Mock
   private BigtableAsyncRpc<MutateRowsRequest, MutateRowsResponse> mutateRows;
 
-  private AtomicLong time = new AtomicLong();
-  private NanoClock nanoClock = new NanoClock() {
-    @Override
-    public long nanoTime() {
-      return time.get();
-    }
-  };
-
   @Mock
   private ScheduledExecutorService executorService;
 
-  private RetryOptions retryOptions;
+  private OperationClock clock;
 
   @Before
   public void setup() {
     MockitoAnnotations.initMocks(this);
     when(mutateRows.getRpcMetrics()).thenReturn(metrics);
+    when(mutateRows.isRetryable(any(MutateRowsRequest.class))).thenReturn(true);
     when(mutateRows.getMethodDescriptor()).thenReturn(BigtableGrpc.getMutateRowsMethod());
-    retryOptions = new RetryOptions.Builder().build();
+    clock = new OperationClock();
+    clock.initializeMockSchedule(executorService, null);
   }
 
   @Test
@@ -162,6 +163,34 @@ public class TestRetryingMutateRowsOperation {
   }
 
   @Test
+  public void testCompleteFailure() throws InterruptedException, TimeoutException {
+    doAnswer(new Answer<Void>() {
+      @Override public Void answer(InvocationOnMock invocation) {
+        invocation.getArgumentAt(1, ClientCall.Listener.class)
+            .onClose(io.grpc.Status.DEADLINE_EXCEEDED, new Metadata());
+        return null;
+      }
+    }).when(mutateRows).start(any(MutateRowsRequest.class), any(ClientCall.Listener.class),
+        any(Metadata.class), any(ClientCall.class));
+    MutateRowsRequest request = createRequest(2);
+    final RetryingMutateRowsOperation underTest = createOperation(request);
+
+    ListenableFuture<List<MutateRowsResponse>> future = underTest.getAsyncResult();
+    underTest.onClose(io.grpc.Status.DEADLINE_EXCEEDED, new Metadata());
+    try {
+      future.get(1, TimeUnit.MINUTES);
+      Assert.fail("Expecting a DEADLINE_EXCEEDED exception");
+    } catch (ExecutionException e) {
+      Assert.assertEquals(io.grpc.Status.DEADLINE_EXCEEDED.getCode(),
+          io.grpc.Status.fromThrowable(e).getCode());
+    }
+
+    // Check that the amount of sleep required is correct
+    clock.assertTimeWithinExpectations(
+        TimeUnit.MILLISECONDS.toNanos(RETRY_OPTIONS.getMaxElapsedBackoffMillis()));
+  }
+
+  @Test
   public void testResponseOutOfOrder() throws Exception {
     MutateRowsRequest request = createRequest(2);
     RetryingMutateRowsOperation underTest = createOperation(request);
@@ -174,7 +203,7 @@ public class TestRetryingMutateRowsOperation {
   }
 
   @Test
-  public void testPartialResponse() throws Exception {
+  public void testPartialResponse() {
     RetryingMutateRowsOperation underTest = createOperation(createRequest(2));
     ListenableFuture<?> future = underTest.getAsyncResult();
     send(underTest, OK);
@@ -182,7 +211,6 @@ public class TestRetryingMutateRowsOperation {
       future.get(3, TimeUnit.MILLISECONDS);
       Assert.fail("Expected exception");
     } catch (ExecutionException e) {
-      System.out.println(e.getClass().getName());
       Assert.assertEquals(io.grpc.Status.Code.INTERNAL, io.grpc.Status.fromThrowable(e).getCode());
     } catch (Exception e) {
       Assert.fail("Expected ExecutionException.");
@@ -190,8 +218,13 @@ public class TestRetryingMutateRowsOperation {
   }
 
   private RetryingMutateRowsOperation createOperation(MutateRowsRequest request) {
-    return new RetryingMutateRowsOperation(retryOptions, request,
-        mutateRows, CallOptions.DEFAULT, executorService, new Metadata());
+    return new RetryingMutateRowsOperation(RETRY_OPTIONS, request, mutateRows, CallOptions.DEFAULT,
+        executorService, new Metadata()) {
+      @Override
+      protected ExponentialBackOff createBackoff() {
+        return clock.createBackoff(retryOptions);
+      }
+    };
   }
 
   private void checkExecutor(int count) {

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/scanner/RetryingReadRowsOperationTest.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/scanner/RetryingReadRowsOperationTest.java
@@ -18,18 +18,22 @@ package com.google.cloud.bigtable.grpc.scanner;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.api.client.util.ExponentialBackOff;
+import com.google.cloud.bigtable.config.RetryOptions;
+import com.google.cloud.bigtable.grpc.async.OperationClock;
 import com.google.cloud.bigtable.grpc.io.Watchdog;
 import com.google.cloud.bigtable.grpc.io.Watchdog.StreamWaitTimeoutException;
 import java.io.UnsupportedEncodingException;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -42,7 +46,6 @@ import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
-import com.google.api.client.util.Clock;
 import com.google.bigtable.v2.BigtableGrpc;
 import com.google.bigtable.v2.ReadRowsRequest;
 import com.google.bigtable.v2.ReadRowsResponse;
@@ -50,7 +53,6 @@ import com.google.bigtable.v2.ReadRowsResponse.Builder;
 import com.google.bigtable.v2.ReadRowsResponse.CellChunk;
 import com.google.bigtable.v2.RowRange;
 import com.google.bigtable.v2.RowSet;
-import com.google.cloud.bigtable.config.RetryOptions;
 import com.google.cloud.bigtable.grpc.async.BigtableAsyncRpc;
 import com.google.cloud.bigtable.grpc.async.BigtableAsyncRpc.RpcMetrics;
 import com.google.cloud.bigtable.metrics.Timer;
@@ -69,7 +71,8 @@ import io.grpc.stub.StreamObserver;
  */
 @RunWith(JUnit4.class)
 public class RetryingReadRowsOperationTest {
-  static final RetryOptions RETRY_OPTIONS = new RetryOptions.Builder().build();
+
+  private static final RetryOptions RETRY_OPTIONS = new RetryOptions.Builder().build();
 
   private static ReadRowsRequest READ_ENTIRE_TABLE_REQUEST =
       ReadRowsRequest.newBuilder()
@@ -98,6 +101,8 @@ public class RetryingReadRowsOperationTest {
   @Mock
   private ScheduledExecutorService mockRetryExecutorService;
 
+  private OperationClock clock;
+
   @Mock
   private BigtableAsyncRpc<ReadRowsRequest, ReadRowsResponse> mockRetryableRpc;
 
@@ -125,25 +130,27 @@ public class RetryingReadRowsOperationTest {
     when(mockRetryableRpc.newCall(any(CallOptions.class))).thenReturn(mockClientCall);
     when(mockRetryableRpc.getRpcMetrics()).thenReturn(mockRpcMetrics);
     when(mockRetryableRpc.getMethodDescriptor()).thenReturn(BigtableGrpc.getReadRowsMethod());
+    when(mockRetryableRpc.isRetryable(any(ReadRowsRequest.class))).thenReturn(true);
     when(mockRpcMetrics.timeOperation()).thenReturn(mockOperationTimerContext);
     when(mockRpcMetrics.timeRpc()).thenReturn(mockRpcTimerContext);
 
-    Answer<ScheduledFuture> runAutomatically = new Answer<ScheduledFuture>() {
-      @Override
-      public ScheduledFuture answer(InvocationOnMock invocation) throws Throwable {
-        invocation.getArgumentAt(0, Runnable.class).run();
-        return scheduledFuture;
-      }
-    };
-    when(
-      mockRetryExecutorService.schedule(any(Runnable.class), any(Long.class), any(TimeUnit.class)))
-          .then(runAutomatically);
-    doAnswer(runAutomatically).when(mockRetryExecutorService).execute(any(Runnable.class));
+    clock = new OperationClock();
+
+    clock.initializeMockSchedule(mockRetryExecutorService, scheduledFuture);
   }
 
   protected RetryingReadRowsOperation createOperation(StreamObserver<FlatRow> observer) {
+    return createOperation(CallOptions.DEFAULT, observer);
+  }
+
+  protected RetryingReadRowsOperation createOperation(CallOptions options,
+      StreamObserver<FlatRow> observer) {
     return new RetryingReadRowsOperation(observer, RETRY_OPTIONS, READ_ENTIRE_TABLE_REQUEST,
-        mockRetryableRpc, CallOptions.DEFAULT, mockRetryExecutorService, metaData);
+        mockRetryableRpc, options, mockRetryExecutorService, metaData) {
+      @Override protected ExponentialBackOff createBackoff() {
+        return clock.createBackoff(retryOptions);
+      }
+    };
   }
 
   @Test
@@ -172,7 +179,6 @@ public class RetryingReadRowsOperationTest {
 
     finishOK(underTest, 0);
   }
-
 
   @Test
   public void testDoubleResponse() throws UnsupportedEncodingException {
@@ -221,6 +227,34 @@ public class RetryingReadRowsOperationTest {
   }
 
   @Test
+  public void testFailure() throws Exception {
+    doAnswer(new Answer<Void>() {
+      @Override public Void answer(InvocationOnMock invocation) {
+        invocation.getArgumentAt(1, ClientCall.Listener.class)
+            .onClose(Status.DEADLINE_EXCEEDED, new Metadata());
+        return null;
+      }
+    }).when(mockRetryableRpc)
+        .start(any(ReadRowsRequest.class), any(ClientCall.Listener.class), any(Metadata.class),
+            any(ClientCall.class));
+
+    RetryingReadRowsOperation underTest =
+        createOperation(CallOptions.DEFAULT, mockFlatRowObserver);
+    try {
+      underTest.getAsyncResult().get(100, TimeUnit.MILLISECONDS);
+    } catch (ExecutionException e) {
+      Assert.assertEquals(BigtableRetriesExhaustedException.class, e.getCause().getClass());
+      Assert.assertEquals(Status.DEADLINE_EXCEEDED.getCode(), Status.fromThrowable(e).getCode());
+    }
+
+    Assert.assertEquals(
+        ((ExponentialBackOff) underTest.getCurrentBackoff()).getMaxElapsedTimeMillis(),
+        RETRY_OPTIONS.getMaxElapsedBackoffMillis(), 10);
+    clock.assertTimeWithinExpectations(
+        TimeUnit.MILLISECONDS.toNanos(RETRY_OPTIONS.getMaxElapsedBackoffMillis()));
+  }
+
+  @Test
   public void testMultipleResponsesWithException() throws UnsupportedEncodingException {
     RetryingReadRowsOperation underTest = createOperation(mockFlatRowObserver);
     start(underTest);
@@ -233,17 +267,16 @@ public class RetryingReadRowsOperationTest {
     underTest.onMessage(buildResponse(key2));
     verify(mockFlatRowObserver, times(2)).onNext(any(FlatRow.class));
     checkRetryRequest(underTest, key2, 8);
-    verify(mockClientCall, times(4)).request(eq(1));
+    verify(mockClientCall, atLeast(2)).request(eq(1));
 
     finishOK(underTest, 1);
   }
 
   @Test
-  public void testScanTimeoutSucceed() throws UnsupportedEncodingException, BigtableRetriesExhaustedException {
+  public void testScanTimeoutSucceed() throws UnsupportedEncodingException {
     RetryingReadRowsOperation underTest = createOperation(mockFlatRowObserver);
     start(underTest);
 
-    final AtomicLong time = setupClock(underTest);
     ByteString key0 = ByteString.copyFrom("SomeKey0", "UTF-8");
     ByteString key1 = ByteString.copyFrom("SomeKey1", "UTF-8");
     ByteString key2 = ByteString.copyFrom("SomeKey2", "UTF-8");
@@ -255,7 +288,7 @@ public class RetryingReadRowsOperationTest {
     Assert.assertFalse(underTest.getRowMerger().isInNewState());
 
     // a round of successful retries.
-    performSuccessfulScanTimeouts(underTest, time);
+    performSuccessfulScanTimeouts(underTest);
     Assert.assertTrue(underTest.getRowMerger().isInNewState());
 
     underTest.onClose(Status.ABORTED, new Metadata());
@@ -268,53 +301,47 @@ public class RetryingReadRowsOperationTest {
     checkRetryRequest(underTest, key2, 8);
 
     // more successful retries
-    performSuccessfulScanTimeouts(underTest, time);
+    performSuccessfulScanTimeouts(underTest);
 
     checkRetryRequest(underTest, key2, 8);
-    verify(mockClientCall, times(RETRY_OPTIONS.getMaxScanTimeoutRetries() * 2 + 5))
-        .request(eq(1));
+    verify(mockClientCall, atLeast(RETRY_OPTIONS.getMaxScanTimeoutRetries() * 2)).request(eq(1));
 
-    // a succsesful finish.  There were 2 x RETRY_OPTIONS.getMaxScanTimeoutRetries() timeouts,
+    // a successful finish.  There were 2 x RETRY_OPTIONS.getMaxScanTimeoutRetries() timeouts,
     // and 1 ABORTED status.
     finishOK(underTest, RETRY_OPTIONS.getMaxScanTimeoutRetries() * 2 + 1);
   }
 
-  private ReadRowsResponse setCommitToFalse(ReadRowsResponse message1) {
-    int lastIndex = message1.getChunksCount() - 1;
-    CellChunk lastChunk = message1.getChunks(lastIndex);
-    message1 = message1.toBuilder()
+  private ReadRowsResponse setCommitToFalse(ReadRowsResponse message) {
+    int lastIndex = message.getChunksCount() - 1;
+    CellChunk lastChunk = message.getChunks(lastIndex);
+    return message.toBuilder()
         .setChunks(lastIndex, lastChunk.toBuilder().setCommitRow(false).build())
         .build();
-    return message1;
   }
 
   @Test
-  public void testScanTimeoutFail() throws UnsupportedEncodingException, BigtableRetriesExhaustedException {
+  public void testScanTimeoutFail() throws UnsupportedEncodingException {
     RetryingReadRowsOperation underTest = createOperation(mockFlatRowObserver);
     start(underTest);
-
-    final AtomicLong time = setupClock(underTest);
 
     ByteString key = ByteString.copyFrom("SomeKey1", "UTF-8");
     underTest.onMessage(buildResponse(key));
 
     // N successful scan timeout retries
-    performSuccessfulScanTimeouts(underTest, time);
+    performSuccessfulScanTimeouts(underTest);
 
     checkRetryRequest(underTest, key, 9);
 
     // one last scan timeout that fails.
-    performTimeout(underTest, time);
+    performTimeout(underTest);
     verify(mockFlatRowObserver).onError(any(BigtableRetriesExhaustedException.class));
   }
 
   @Test
-  public void testMixScanTimeoutAndStatusExceptions()
-      throws UnsupportedEncodingException {
+  public void testMixScanTimeoutAndStatusExceptions() throws UnsupportedEncodingException {
     RetryingReadRowsOperation underTest = createOperation(mockFlatRowObserver);
     start(underTest);
 
-    final AtomicLong time = setupClock(underTest);
     int expectedRetryCount = 0;
 
     ByteString key1 = ByteString.copyFrom("SomeKey1", "UTF-8");
@@ -327,7 +354,7 @@ public class RetryingReadRowsOperationTest {
 
     // N successful scan timeout retries
     for (int i = 0; i < 2; i++) {
-      performTimeout(underTest, time);
+      performTimeout(underTest);
       expectedRetryCount++;
     }
     checkRetryRequest(underTest, key1, 9);
@@ -338,7 +365,7 @@ public class RetryingReadRowsOperationTest {
       underTest.onClose(Status.ABORTED, new Metadata());
       expectedRetryCount++;
 
-      performTimeout(underTest, time);
+      performTimeout(underTest);
       Assert.assertNull(underTest.getCurrentBackoff());
       expectedRetryCount++;
     }
@@ -346,7 +373,7 @@ public class RetryingReadRowsOperationTest {
     verify(mockRpcMetrics, times(expectedRetryCount)).markRetry();
     verify(mockRpcTimerContext, times(expectedRetryCount)).close();
 
-    performTimeout(underTest, time);
+    performTimeout(underTest);
     verify(mockFlatRowObserver).onError(any(BigtableRetriesExhaustedException.class));
   }
 
@@ -369,8 +396,7 @@ public class RetryingReadRowsOperationTest {
     start(underTest);
   }
 
-  protected void performTimeout(RetryingReadRowsOperation underTest, AtomicLong time) {
-    time.addAndGet(RETRY_OPTIONS.getReadPartialRowTimeoutMillis() + 1);
+  protected void performTimeout(RetryingReadRowsOperation underTest) {
     underTest.onClose(
         Status.CANCELLED.withCause(new
             StreamWaitTimeoutException(
@@ -379,21 +405,10 @@ public class RetryingReadRowsOperationTest {
     );
   }
 
-  private AtomicLong setupClock(RetryingReadRowsOperation underTest) {
-    final AtomicLong time = new AtomicLong(0);
-    underTest.clock = new Clock() {
-      @Override
-      public long currentTimeMillis() {
-        return time.get();
-      }
-    };
-    return time;
-  }
-
-  private void performSuccessfulScanTimeouts(RetryingReadRowsOperation underTest, AtomicLong time) {
+  private void performSuccessfulScanTimeouts(RetryingReadRowsOperation underTest) {
     for (int i = 0; i < RETRY_OPTIONS.getMaxScanTimeoutRetries(); i++) {
       Assert.assertEquals(i, underTest.getTimeoutRetryCount());
-      performTimeout(underTest, time);
+      performTimeout(underTest);
     }
   }
 


### PR DESCRIPTION
Adding some tests to the operation test suite, and doing some refactoring for common elements.  Primarily, adding tests that ensure that retries of all times have expected max elapsed timeouts.