### PR TITLE
Retrying operations stop after deadline exceeded

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/RetryingReadRowsOperation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/RetryingReadRowsOperation.java
@@ -307,12 +307,12 @@ public class RetryingReadRowsOperation extends
   }
 
   @VisibleForTesting
-  BackOff getCurrentBackoff() {
-    return currentBackoff;
+  RowMerger getRowMerger() {
+    return rowMerger;
   }
 
   @VisibleForTesting
-  RowMerger getRowMerger() {
-    return rowMerger;
+  BackOff getCurrentBackoff() {
+    return super.currentBackoff;
   }
 }

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestCallOptionsFactory.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestCallOptionsFactory.java
@@ -18,6 +18,7 @@ package com.google.cloud.bigtable.grpc;
 import com.google.bigtable.v2.MutateRowRequest;
 import com.google.bigtable.v2.MutateRowsRequest;
 import com.google.cloud.bigtable.config.CallOptionsConfig;
+import com.google.cloud.bigtable.grpc.async.OperationClock;
 import io.grpc.CallOptions;
 import io.grpc.Context;
 import io.grpc.Deadline;
@@ -39,7 +40,7 @@ import java.util.concurrent.TimeUnit;
 @RunWith(JUnit4.class)
 public class TestCallOptionsFactory {
 
-  private static final long NOW = System.nanoTime();
+  private static final OperationClock CLOCK = new OperationClock();
 
   @Mock
   ScheduledExecutorService mockExecutor;
@@ -57,7 +58,7 @@ public class TestCallOptionsFactory {
 
   @Test
   public void testDefaultWithContext() {
-    final Deadline deadline = DeadlineUtil.deadlineWithFixedTime(1, TimeUnit.SECONDS, NOW);
+    final Deadline deadline = DeadlineUtil.deadlineWithFixedTime(1, TimeUnit.SECONDS, CLOCK);
     Context.CancellableContext context = Context.current().withDeadline(deadline, mockExecutor);
     context.run(new Runnable() {
       @Override
@@ -94,7 +95,7 @@ public class TestCallOptionsFactory {
 
   @Test
   public void testConfiguredWithContext() {
-    Deadline deadline = DeadlineUtil.deadlineWithFixedTime(1, TimeUnit.SECONDS, NOW);
+    Deadline deadline = DeadlineUtil.deadlineWithFixedTime(1, TimeUnit.SECONDS, CLOCK);
     Context.CancellableContext context = Context.current().withDeadline(deadline, mockExecutor);
     context.run(new Runnable() {
       @Override

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestRetryingMutateRowsOperation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestRetryingMutateRowsOperation.java
@@ -162,9 +162,20 @@ public class TestRetryingMutateRowsOperation {
   }
 
   @Test
-  public void testCompleteFailure() throws InterruptedException, TimeoutException {
+  public void testCompleteFailure_default() throws InterruptedException, TimeoutException {
+    testFailure(RETRY_OPTIONS.getMaxElapsedBackoffMillis(), CallOptions.DEFAULT);
+  }
+
+  @Test
+  public void testCompleteFailure_withDeadline() throws InterruptedException, TimeoutException {
+    testFailure((int) TimeUnit.SECONDS.toMillis(5),
+        clock.createCallOptionsWithDeadline(5, TimeUnit.SECONDS));
+  }
+
+  private void testFailure(int expectedMaxElapsedTimeMs, CallOptions callOptions)
+      throws InterruptedException, TimeoutException {
     MutateRowsRequest request = createRequest(2);
-    final RetryingMutateRowsOperation underTest = createOperation(request);
+    final RetryingMutateRowsOperation underTest = createOperation(request, callOptions);
 
     doAnswer(new Answer<Void>() {
       @Override public Void answer(InvocationOnMock invocation) {
@@ -172,8 +183,8 @@ public class TestRetryingMutateRowsOperation {
             .onClose(io.grpc.Status.DEADLINE_EXCEEDED, new Metadata());
         return null;
       }
-    }).when(mutateRows).start(any(MutateRowsRequest.class), any(ClientCall.Listener.class),
-        any(Metadata.class), any(ClientCall.class));
+    }).when(mutateRows).start(any(MutateRowsRequest.class), any(ClientCall.Listener.class), any(Metadata.class),
+        any(ClientCall.class));
 
     try {
       underTest.getAsyncResult().get(1, TimeUnit.MINUTES);
@@ -183,9 +194,11 @@ public class TestRetryingMutateRowsOperation {
           io.grpc.Status.fromThrowable(e).getCode());
     }
 
-    // Check that the amount of sleep required is correct
-    clock.assertTimeWithinExpectations(
-        TimeUnit.MILLISECONDS.toNanos(RETRY_OPTIONS.getMaxElapsedBackoffMillis()));
+    int actualElapsedTimeMs =
+        ((ExponentialBackOff) underTest.getCurrentBackoff()).getMaxElapsedTimeMillis();
+
+    Assert.assertEquals(expectedMaxElapsedTimeMs, actualElapsedTimeMs);
+    clock.assertTimeWithinExpectations(TimeUnit.MILLISECONDS.toNanos(actualElapsedTimeMs));
   }
 
   @Test
@@ -216,11 +229,16 @@ public class TestRetryingMutateRowsOperation {
   }
 
   private RetryingMutateRowsOperation createOperation(MutateRowsRequest request) {
-    return new RetryingMutateRowsOperation(RETRY_OPTIONS, request, mutateRows, CallOptions.DEFAULT,
+    return createOperation(request, CallOptions.DEFAULT);
+  }
+
+  private RetryingMutateRowsOperation createOperation(final MutateRowsRequest request,
+      final CallOptions options) {
+    return new RetryingMutateRowsOperation(RETRY_OPTIONS, request, mutateRows, options,
         executorService, new Metadata()) {
       @Override
-      protected ExponentialBackOff createBackoff() {
-        return clock.createBackoff(retryOptions);
+      protected ExponentialBackOff createBackoff(int maxTimeoutMs) {
+        return clock.createBackoff(retryOptions, maxTimeoutMs);
       }
     };
   }

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestRetryingMutateRowsOperation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestRetryingMutateRowsOperation.java
@@ -237,8 +237,9 @@ public class TestRetryingMutateRowsOperation {
     return new RetryingMutateRowsOperation(RETRY_OPTIONS, request, mutateRows, options,
         executorService, new Metadata()) {
       @Override
-      protected ExponentialBackOff createBackoff(int maxTimeoutMs) {
-        return clock.createBackoff(retryOptions, maxTimeoutMs);
+      protected ExponentialBackOff.Builder configureBackoffBuilder(
+          ExponentialBackOff.Builder builder) {
+        return builder.setNanoClock(clock);
       }
     };
   }

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestRetryingUnaryOperation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestRetryingUnaryOperation.java
@@ -185,8 +185,9 @@ public class TestRetryingUnaryOperation {
     return new RetryingUnaryOperation<ReadRowsRequest, ReadRowsResponse>(RETRY_OPTIONS,
         ReadRowsRequest.getDefaultInstance(), readAsync, options, executorService, new Metadata()) {
       @Override
-      protected ExponentialBackOff createBackoff(int maxTimeoutMs) {
-        return clock.createBackoff(retryOptions, maxTimeoutMs);
+      protected ExponentialBackOff.Builder configureBackoffBuilder(
+          ExponentialBackOff.Builder builder) {
+        return builder.setNanoClock(clock);
       }
     };
   }

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestRetryingUnaryOperation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestRetryingUnaryOperation.java
@@ -137,8 +137,19 @@ public class TestRetryingUnaryOperation {
   }
 
   @Test
-  public void testCompleteFailure() throws Exception {
-    final Status errorStatus = Status.UNAVAILABLE;
+  public void testCompleteFailure_default() throws Exception {
+    testFailure(RETRY_OPTIONS.getMaxElapsedBackoffMillis(), CallOptions.DEFAULT);
+  }
+
+  @Test
+  public void testCompleteFailure_withDeadline() throws Exception {
+    testFailure((int) TimeUnit.SECONDS.toMillis(5),
+        clock.createCallOptionsWithDeadline(5, TimeUnit.SECONDS));
+  }
+
+  private void testFailure(int expectedMaxElapsedTimeMs, CallOptions options)
+      throws InterruptedException, java.util.concurrent.TimeoutException {
+    final Status errorStatus = Status.DEADLINE_EXCEEDED;
     Answer<Void> answer = new Answer<Void>() {
       @Override
       public Void answer(InvocationOnMock invocation) {
@@ -153,24 +164,29 @@ public class TestRetryingUnaryOperation {
             any(Listener.class),
             any(Metadata.class),
             any(ClientCall.class));
+    RetryingUnaryOperation underTest = createOperation(options);
     try {
-      createOperation(CallOptions.DEFAULT).getAsyncResult().get(1, TimeUnit.SECONDS);
+      underTest.getAsyncResult().get(1, TimeUnit.SECONDS);
       Assert.fail();
     } catch (ExecutionException e) {
       Assert.assertEquals(BigtableRetriesExhaustedException.class, e.getCause().getClass());
       Assert.assertEquals(errorStatus.getCode(), Status.fromThrowable(e).getCode());
     }
 
+    int actualElapsedTimeMs =
+        ((ExponentialBackOff) underTest.getCurrentBackoff()).getMaxElapsedTimeMillis();
+
+    Assert.assertEquals(expectedMaxElapsedTimeMs, actualElapsedTimeMs);
     clock.assertTimeWithinExpectations(
-        TimeUnit.MILLISECONDS.toNanos(RETRY_OPTIONS.getMaxElapsedBackoffMillis()));
+        TimeUnit.MILLISECONDS.toNanos(expectedMaxElapsedTimeMs));
   }
 
   private RetryingUnaryOperation createOperation(CallOptions options) {
     return new RetryingUnaryOperation<ReadRowsRequest, ReadRowsResponse>(RETRY_OPTIONS,
         ReadRowsRequest.getDefaultInstance(), readAsync, options, executorService, new Metadata()) {
       @Override
-      protected ExponentialBackOff createBackoff() {
-        return clock.createBackoff(retryOptions);
+      protected ExponentialBackOff createBackoff(int maxTimeoutMs) {
+        return clock.createBackoff(retryOptions, maxTimeoutMs);
       }
     };
   }

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/scanner/RetryingReadRowsOperationTest.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/scanner/RetryingReadRowsOperationTest.java
@@ -147,8 +147,10 @@ public class RetryingReadRowsOperationTest {
       StreamObserver<FlatRow> observer) {
     return new RetryingReadRowsOperation(observer, RETRY_OPTIONS, READ_ENTIRE_TABLE_REQUEST,
         mockRetryableRpc, options, mockRetryExecutorService, metaData) {
-      protected ExponentialBackOff createBackoff(int maxTimeoutMs) {
-        return clock.createBackoff(retryOptions, maxTimeoutMs);
+      @Override
+      protected ExponentialBackOff.Builder configureBackoffBuilder(
+          ExponentialBackOff.Builder builder) {
+        return builder.setNanoClock(clock);
       }
     };
   }

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/scanner/RetryingReadRowsOperationTest.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/scanner/RetryingReadRowsOperationTest.java
@@ -147,8 +147,8 @@ public class RetryingReadRowsOperationTest {
       StreamObserver<FlatRow> observer) {
     return new RetryingReadRowsOperation(observer, RETRY_OPTIONS, READ_ENTIRE_TABLE_REQUEST,
         mockRetryableRpc, options, mockRetryExecutorService, metaData) {
-      @Override protected ExponentialBackOff createBackoff() {
-        return clock.createBackoff(retryOptions);
+      protected ExponentialBackOff createBackoff(int maxTimeoutMs) {
+        return clock.createBackoff(retryOptions, maxTimeoutMs);
       }
     };
   }
@@ -227,7 +227,18 @@ public class RetryingReadRowsOperationTest {
   }
 
   @Test
-  public void testFailure() throws Exception {
+  public void testFailure_default() throws Exception {
+    testFailure(CallOptions.DEFAULT, RETRY_OPTIONS.getMaxElapsedBackoffMillis());
+  }
+
+  @Test
+  public void testFailure_withDeadline() throws Exception {
+    testFailure(clock.createCallOptionsWithDeadline(5, TimeUnit.SECONDS),
+        (int) TimeUnit.SECONDS.toMillis(5));
+  }
+
+  private void testFailure(CallOptions options, int expectedMaxElapsedTimeMs)
+      throws InterruptedException, java.util.concurrent.TimeoutException {
     doAnswer(new Answer<Void>() {
       @Override public Void answer(InvocationOnMock invocation) {
         invocation.getArgumentAt(1, ClientCall.Listener.class)
@@ -239,7 +250,7 @@ public class RetryingReadRowsOperationTest {
             any(ClientCall.class));
 
     RetryingReadRowsOperation underTest =
-        createOperation(CallOptions.DEFAULT, mockFlatRowObserver);
+        createOperation(options, mockFlatRowObserver);
     try {
       underTest.getAsyncResult().get(100, TimeUnit.MILLISECONDS);
     } catch (ExecutionException e) {
@@ -247,9 +258,8 @@ public class RetryingReadRowsOperationTest {
       Assert.assertEquals(Status.DEADLINE_EXCEEDED.getCode(), Status.fromThrowable(e).getCode());
     }
 
-    int expectedMaxElapsedTimeMs =
+    int actualElapsedTimeMs =
         ((ExponentialBackOff) underTest.getCurrentBackoff()).getMaxElapsedTimeMillis();
-    int actualElapsedTimeMs = RETRY_OPTIONS.getMaxElapsedBackoffMillis();
 
     Assert.assertEquals(expectedMaxElapsedTimeMs, actualElapsedTimeMs);
     clock.assertTimeWithinExpectations(TimeUnit.MILLISECONDS.toNanos(actualElapsedTimeMs));

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/io/grpc/DeadlineUtil.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/io/grpc/DeadlineUtil.java
@@ -15,6 +15,8 @@
  */
 package io.grpc;
 
+import com.google.api.client.util.NanoClock;
+
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -22,11 +24,11 @@ import java.util.concurrent.TimeUnit;
  */
 public class DeadlineUtil {
 
-  public static Deadline deadlineWithFixedTime(int duration, TimeUnit unit, final long timeNs) {
+  public static Deadline deadlineWithFixedTime(int duration, TimeUnit unit, final NanoClock clock) {
     return Deadline.after(duration, unit, new Deadline.Ticker() {
       @Override
       public long read() {
-        return timeNs;
+        return clock.nanoTime();
       }
     });
   }


### PR DESCRIPTION
Users can set Deadlines in a variety of ways.  If they set it, then the max retry timeout should be no more than that deadline.

This PR fixes issue #1858.