### PR TITLE
Manually upgrading the version of auth.

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/pom.xml
+++ b/bigtable-client-core-parent/bigtable-client-core/pom.xml
@@ -92,6 +92,7 @@ limitations under the License.
         <dependency>
             <groupId>com.google.auth</groupId>
             <artifactId>google-auth-library-oauth2-http</artifactId>
+            <version>${google-auth.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.google.guava</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,11 @@ limitations under the License.
         <opencensus.version>0.12.3</opencensus.version>
         <guava.version>20.0</guava.version>
 
+        <!--
+           TODO: This can be removed once google-cloud-clients's versions are updated.
+        -->
+        <google-auth.version>0.10.0</google-auth.version>
+
         <!-- hbase dependency versions -->
         <hbase.version.1>1.4.5</hbase.version.1>
         <hbase.version.2>2.0.1</hbase.version.2>


### PR DESCRIPTION
There's a bug fix in the latest version of auth that customers need.  We can remove the explicit use of versions once google-cloud-java is updated.