### PR TITLE
HBase2 tests now run

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestListTables.java
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestListTables.java
@@ -52,7 +52,9 @@ public abstract class AbstractTestListTables extends AbstractTest {
     try (Admin admin = getConnection().getAdmin()) {
       for (TableName tableName : tablesToDelete) {
         if (admin.tableExists(tableName)) {
-          admin.disableTable(tableName);
+          if (admin.isTableEnabled(tableName)) {
+            admin.disableTable(tableName);
+          }
           admin.deleteTable(tableName);
         }
       }

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestColumnFamilyAdminAsync.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestColumnFamilyAdminAsync.java
@@ -28,6 +28,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 
 import static com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule.COLUMN_FAMILY;
 import static org.junit.Assert.assertEquals;
@@ -38,27 +39,30 @@ import static org.junit.Assert.assertEquals;
 public class TestColumnFamilyAdminAsync extends AbstractTestColumnFamilyAdmin {
   @Override
   protected HTableDescriptor getTableDescriptor(TableName tableName) throws Exception {
-    return admin.getTableDescriptor(tableName);
+    return new HTableDescriptor(admin.getDescriptor(tableName));
   }
 
   @Override
   protected void addColumn(byte[] columnName, int version) throws Exception {
-    ColumnFamilyDescriptor descriptor =
-        ColumnFamilyDescriptorBuilder.newBuilder(columnName).setMaxVersions(version)
-            .build();
-    admin.addColumnFamilyAsync(tableName, descriptor).get();
+    admin.addColumnFamilyAsync(tableName, createFamilyDescriptor(columnName, version))
+        .get(1, TimeUnit.SECONDS);
   }
 
   @Override
   protected void modifyColumn(byte[] columnName, int version) throws Exception {
-    ColumnFamilyDescriptor descriptor =
-        ColumnFamilyDescriptorBuilder.newBuilder(columnName).setMaxVersions(version)
-            .build();
-    admin.modifyColumnFamilyAsync(tableName, descriptor).get();
+    admin.modifyColumnFamilyAsync(tableName, createFamilyDescriptor(columnName, version))
+        .get(1, TimeUnit.SECONDS);
   }
 
   @Override
   protected void deleteColumn(byte[] columnName) throws Exception {
-    admin.deleteColumnFamilyAsync(tableName, DELETE_COLUMN_FAMILY).get();
+    admin.deleteColumnFamilyAsync(tableName, DELETE_COLUMN_FAMILY)
+        .get(1, TimeUnit.SECONDS);
   }
+
+  private ColumnFamilyDescriptor createFamilyDescriptor(byte[] columnName, int version) {
+    return ColumnFamilyDescriptorBuilder.newBuilder(columnName).setMaxVersions(version)
+        .build();
+  }
+
 }

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestListTablesHBase2.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestListTablesHBase2.java
@@ -20,6 +20,7 @@ import static com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule.COLUMN_
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
 import org.apache.hadoop.hbase.HColumnDescriptor;
@@ -60,8 +61,8 @@ public class TestListTablesHBase2 extends AbstractTestListTables {
   @Override
   protected void deleteTable(Admin admin, TableName tableName) throws Exception {
     if (enableAsyncDelete) {
-      admin.disableTableAsync(tableName).get();
-      admin.deleteTableAsync(tableName).get();
+      admin.disableTableAsync(tableName).get(10, TimeUnit.SECONDS);
+      admin.deleteTableAsync(tableName).get(10, TimeUnit.SECONDS);
     } else {
       super.deleteTable(admin, tableName);
     }

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/async/TestAsyncAdmin.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/async/TestAsyncAdmin.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.util.List;
-import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.regex.Pattern;
 
@@ -38,12 +37,13 @@ import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.hamcrest.core.IsInstanceOf;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+
+import com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule;
 
 /**
  * Integration tests for BigtableAsyncAdmin
@@ -152,8 +152,11 @@ public class TestAsyncAdmin extends AbstractAsyncTest {
 
   @Test
   public void testGetTableDescriptor_nullTable() throws Exception {
-    AsyncAdmin asyncAdmin = getAsyncConnection().getAdmin();
-    assertEquals(null, asyncAdmin.getDescriptor(null).get());
+    // This breaks the minicluster, for some reason.
+    if (SharedTestEnvRule.getInstance().isBigtable()) {
+      AsyncAdmin asyncAdmin = getAsyncConnection().getAdmin();
+      assertEquals(null, asyncAdmin.getDescriptor(null).get());
+    }
   }  
 
   @Test

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/async/TestAsyncAdmin.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/async/TestAsyncAdmin.java
@@ -37,6 +37,7 @@ import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.hamcrest.core.IsInstanceOf;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -152,12 +153,11 @@ public class TestAsyncAdmin extends AbstractAsyncTest {
 
   @Test
   public void testGetTableDescriptor_nullTable() throws Exception {
-    // This breaks the minicluster, for some reason.
-    if (SharedTestEnvRule.getInstance().isBigtable()) {
-      AsyncAdmin asyncAdmin = getAsyncConnection().getAdmin();
-      assertEquals(null, asyncAdmin.getDescriptor(null).get());
-    }
-  }  
+    // This breaks the minicluster, for some reason, so only run it for Cloud Bigtable.
+    Assume.assumeTrue(SharedTestEnvRule.getInstance().isBigtable());
+    AsyncAdmin asyncAdmin = getAsyncConnection().getAdmin();
+    assertEquals(null, asyncAdmin.getDescriptor(null).get());
+  }
 
   @Test
   public void testCreateTableWithNumRegions_exception() throws Exception {

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/async/TestAsyncAdmin.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/async/TestAsyncAdmin.java
@@ -154,7 +154,8 @@ public class TestAsyncAdmin extends AbstractAsyncTest {
   @Test
   public void testGetTableDescriptor_nullTable() throws Exception {
     // This breaks the minicluster, for some reason, so only run it for Cloud Bigtable.
-    Assume.assumeTrue(SharedTestEnvRule.getInstance().isBigtable());
+    Assume.assumeTrue("HBase asyncAdmin.getDescriptor(null) seems to break the mini-cluster",
+        SharedTestEnvRule.getInstance().isBigtable());
     AsyncAdmin asyncAdmin = getAsyncConnection().getAdmin();
     assertEquals(null, asyncAdmin.getDescriptor(null).get());
   }

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/async/TestAsyncColumnFamily.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/async/TestAsyncColumnFamily.java
@@ -52,7 +52,7 @@ public class TestAsyncColumnFamily extends AbstractTestColumnFamilyAdmin {
   @Override
   protected HTableDescriptor getTableDescriptor(TableName tableName) throws Exception {
     try {
-      return (HTableDescriptor) asyncAdmin.getDescriptor(tableName).get();
+      return new HTableDescriptor(asyncAdmin.getDescriptor(tableName).get());
     } catch(ExecutionException e) {
       throw (Exception) e.getCause();
     }


### PR DESCRIPTION
Fixing a variety of HBase 2 related failures:
- `get()` isn't supported on Futures, but `get(int, TimeUnit)` is
- HBase 2 returns a different implementation of `TableDescriptor`, so that had to be converted in the test
- `asyncAdmin.getDescriptor(null)` seems to hang the mini-cluster, so only have that test in Bigtable mode for now.

This fixes #1843 