### PR TITLE
Added static Builder method.

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/CallOptionsConfig.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/CallOptionsConfig.java
@@ -48,11 +48,16 @@ public class CallOptionsConfig implements Serializable {
    */
   public static final int LONG_TIMEOUT_MS_DEFAULT = 600_000;
 
+  public static Builder builder() {
+    return new Builder();
+  }
+  
   public static class Builder {
     private boolean useTimeout = USE_TIMEOUT_DEFAULT;
     private int shortRpcTimeoutMs = SHORT_TIMEOUT_MS_DEFAULT;
     private int longRpcTimeoutMs = LONG_TIMEOUT_MS_DEFAULT;
 
+    @Deprecated
     public Builder() {
     }
 
@@ -120,6 +125,7 @@ public class CallOptionsConfig implements Serializable {
    * @param unaryRpcTimeoutMs an int.
    * @param longRpcTimeoutMs an int.
    */
+  @Deprecated
   public CallOptionsConfig(boolean useTimeout, int unaryRpcTimeoutMs, int longRpcTimeoutMs) {
     this.useTimeout = useTimeout;
     this.shortRpcTimeoutMs = unaryRpcTimeoutMs;

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/CallOptionsConfig.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/CallOptionsConfig.java
@@ -204,4 +204,5 @@ public class CallOptionsConfig implements Serializable {
   public Builder toBuilder() {
     return new Builder(this);
   }
+  
 }


### PR DESCRIPTION
Added static builder method & Builder() as deprecated, which will be helpful after implementation of Autovalue.