### PR TITLE
Turning off testFuzzyWithIntKeys

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestFilters.java
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestFilters.java
@@ -2023,6 +2023,7 @@ public abstract class AbstractTestFilters extends AbstractTest {
   }
 
   @Test
+  @Category(KnownGap.class)
   public void testFuzzyWithIntKeys() throws Exception {
     Table table = getDefaultTable();
     List<byte[]> keys = Collections.unmodifiableList(


### PR DESCRIPTION
It works in HBase, but not in Cloud Bigtable mode.

FYI @ajaaym.