### PR TITLE
Fixing Cloud Bigtable's interpretation of FuzzyRowFilter.

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestFilters.java
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestFilters.java
@@ -2023,7 +2023,6 @@ public abstract class AbstractTestFilters extends AbstractTest {
   }
 
   @Test
-  @Category(KnownGap.class)
   public void testFuzzyWithIntKeys() throws Exception {
     Table table = getDefaultTable();
     List<byte[]> keys = Collections.unmodifiableList(

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/FuzzyRowFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/FuzzyRowFilterAdapter.java
@@ -17,14 +17,12 @@ package com.google.cloud.bigtable.hbase.adapters.filters;
 
 import static com.google.cloud.bigtable.data.v2.wrappers.Filters.FILTERS;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.List;
 
-import com.google.cloud.bigtable.config.Logger;
+import com.google.protobuf.ByteString;
 import org.apache.hadoop.hbase.filter.FuzzyRowFilter;
-import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.Pair;
 
 import com.google.cloud.bigtable.data.v2.wrappers.Filters.Filter;
@@ -72,26 +70,24 @@ public class FuzzyRowFilterAdapter extends TypedFilterAdapterBase<FuzzyRowFilter
           createSingleRowFilter(
               pair.getFirst(), pair.getSecond()));
     }
-    new Logger(FuzzyRowFilterAdapter.class).error("Adapted: " + interleave.toProto());
     return interleave.toProto();
   }
 
   private static Filter createSingleRowFilter(byte[] key, byte[] mask) throws IOException {
-    ByteArrayOutputStream baos =
-        new ByteArrayOutputStream(key.length * 2);
-    QuoteMetaOutputStream quotingStream = new QuoteMetaOutputStream(baos);
+    ByteString.Output output = ByteString.newOutput(key.length * 2);
+    QuoteMetaOutputStream quotingStream = new QuoteMetaOutputStream(output);
     for (int i = 0; i < mask.length; i++) {
       if (mask[i] == -1) {
         quotingStream.write(key[i]);
       } else {
         // Write unquoted to match any byte at this position:
-        baos.write(ReaderExpressionHelper.ANY_BYTE_BYTES);
+        output.write(ReaderExpressionHelper.ANY_BYTE_BYTES);
       }
     }
     // match any trailing bytes
-    baos.write(ReaderExpressionHelper.ALL_BYTE_BYTES);
+    output.write(ReaderExpressionHelper.ALL_BYTE_BYTES);
     quotingStream.close();
-    return FILTERS.key().regex(Bytes.toString(baos.toByteArray()));
+    return FILTERS.key().regex(output.toByteString());
   }
 
   @SuppressWarnings("unchecked")


### PR DESCRIPTION
Removed a `.toString` that was encoding bytes incorrectly.

This PR fixes #1770.