### PR TITLE
Adding interface for CommonCon for HBase 1.x & 2.x

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableConnection.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableConnection.java
@@ -53,7 +53,7 @@ import java.util.concurrent.atomic.AtomicLong;
  * @author sduskis
  * @version $Id: $Id
  */
-public abstract class AbstractBigtableConnection implements Connection, Closeable {
+public abstract class AbstractBigtableConnection implements Connection, Closeable, CommonConnection {
   private static final AtomicLong SEQUENCE_GENERATOR = new AtomicLong();
   private static final Map<Long, BigtableBufferedMutator> ACTIVE_BUFFERED_MUTATORS =
       Collections.synchronizedMap(new HashMap<Long, BigtableBufferedMutator>());
@@ -349,7 +349,8 @@ public abstract class AbstractBigtableConnection implements Connection, Closeabl
    *
    * @return a {@link com.google.cloud.bigtable.config.BigtableOptions} object.
    */
-  protected BigtableOptions getOptions() {
+  @Override
+  public BigtableOptions getOptions() {
     return options;
   }
 
@@ -358,7 +359,8 @@ public abstract class AbstractBigtableConnection implements Connection, Closeabl
    *
    * @return a {@link java.util.Set} object.
    */
-  protected Set<TableName> getDisabledTables() {
+  @Override
+  public Set<TableName> getDisabledTables() {
     return disabledTables;
   }
 
@@ -367,6 +369,7 @@ public abstract class AbstractBigtableConnection implements Connection, Closeabl
    *
    * @return a {@link com.google.cloud.bigtable.grpc.BigtableSession} object.
    */
+  @Override
   public BigtableSession getSession() {
     return session;
   }

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/CommonConnection.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/CommonConnection.java
@@ -1,0 +1,41 @@
+package org.apache.hadoop.hbase.client;
+
+import java.io.IOException;
+import java.util.Set;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.TableName;
+
+import com.google.cloud.bigtable.config.BigtableOptions;
+import com.google.cloud.bigtable.grpc.BigtableSession;
+
+public interface CommonConnection {
+
+  /**
+   * returns an instance of BigtableSession
+   *
+   * @return {@link BigtableSession}
+   */
+  BigtableSession getSession() throws IOException;
+
+  /**
+   * return current connection's configuration
+   *
+   * @return {@link Configuration}
+   */
+  Configuration getConfiguration() throws IOException;
+
+  /**
+   * returns an instance of Options object
+   *
+   * @return {@link BigtableOptions}
+   */
+  BigtableOptions getOptions() throws IOException;
+
+  /**
+   * returns a collection of disabled TableName
+   * @return Set<TableName>
+   */
+  Set<TableName> getDisabledTables() throws IOException;
+
+}

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/CommonConnection.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/CommonConnection.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.hadoop.hbase.client;
 
 import java.io.IOException;
@@ -12,29 +27,30 @@ import com.google.cloud.bigtable.grpc.BigtableSession;
 public interface CommonConnection {
 
   /**
-   * returns an instance of BigtableSession
+   * <p>Getter for the field <code>session</code>.</p>
    *
-   * @return {@link BigtableSession}
+   * @return a {@link com.google.cloud.bigtable.grpc.BigtableSession} object.
    */
   BigtableSession getSession() throws IOException;
 
   /**
-   * return current connection's configuration
+   * Returns the {@link org.apache.hadoop.conf.Configuration} object used by this instance.
    *
-   * @return {@link Configuration}
+   * The reference returned is not a copy, so any change made to it will affect this instance.
    */
   Configuration getConfiguration() throws IOException;
 
   /**
-   * returns an instance of Options object
+   * <p>Getter for the field <code>options</code>.</p>
    *
-   * @return {@link BigtableOptions}
+   * @return a {@link com.google.cloud.bigtable.config.BigtableOptions} object.
    */
   BigtableOptions getOptions() throws IOException;
 
   /**
-   * returns a collection of disabled TableName
-   * @return Set<TableName>
+   * <p>Getter for the field <code>disabledTables</code>.</p>
+   *
+   * @return a {@link java.util.Set} object.
    */
   Set<TableName> getDisabledTables() throws IOException;
 

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/org/apache/hadoop/hbase/client/BigtableAsyncConnection.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/org/apache/hadoop/hbase/client/BigtableAsyncConnection.java
@@ -45,7 +45,7 @@ import com.google.cloud.bigtable.hbase2_x.BigtableAsyncTableRegionLocator;
  *
  * @author spollapally
  */
-public class BigtableAsyncConnection implements AsyncConnection, Closeable {
+public class BigtableAsyncConnection implements AsyncConnection, Closeable, CommonConnection {
   private final Logger LOG = new Logger(getClass());
 
   private final Configuration conf;
@@ -95,14 +95,17 @@ public class BigtableAsyncConnection implements AsyncConnection, Closeable {
     return new HBaseRequestAdapter(options, tableName, mutationAdapters);
   }
 
+  @Override
   public BigtableSession getSession() {
     return this.session;
   }
 
+  @Override
   public BigtableOptions getOptions() {
     return this.options;
   }
 
+  @Override
   public Set<TableName> getDisabledTables() {
     return disabledTables;
   }
@@ -214,51 +217,51 @@ public class BigtableAsyncConnection implements AsyncConnection, Closeable {
       ExecutorService es) {
     return getBufferedMutatorBuilder(tableName);
   }
-  
+
   @Override
   public AsyncTableBuilder<AdvancedScanResultConsumer> getTableBuilder(TableName tableName) {
     return new AsyncTableBuilder<AdvancedScanResultConsumer>() {
-      
+
       @Override
       public AsyncTableBuilder<AdvancedScanResultConsumer> setWriteRpcTimeout(long arg0, TimeUnit arg1) {
         return this;
       }
-      
+
       @Override
       public AsyncTableBuilder<AdvancedScanResultConsumer> setStartLogErrorsCnt(int arg0) {
         return this;
       }
-      
+
       @Override
       public AsyncTableBuilder<AdvancedScanResultConsumer> setScanTimeout(long arg0, TimeUnit arg1) {
         return this;
       }
-      
+
       @Override
       public AsyncTableBuilder<AdvancedScanResultConsumer> setRpcTimeout(long arg0, TimeUnit arg1) {
         return this;
       }
-      
+
       @Override
       public AsyncTableBuilder<AdvancedScanResultConsumer> setRetryPause(long arg0, TimeUnit arg1) {
         return this;
       }
-      
+
       @Override
       public AsyncTableBuilder<AdvancedScanResultConsumer> setReadRpcTimeout(long arg0, TimeUnit arg1) {
         return this;
       }
-      
+
       @Override
       public AsyncTableBuilder<AdvancedScanResultConsumer> setOperationTimeout(long arg0, TimeUnit arg1) {
         return this;
       }
-      
+
       @Override
       public AsyncTableBuilder<AdvancedScanResultConsumer> setMaxAttempts(int arg0) {
         return this;
       }
-      
+
       @Override
       public AsyncTable build() {
         return new BigtableAsyncTable(BigtableAsyncConnection.this, createAdapter(tableName));


### PR DESCRIPTION
Adding `CommonConnection` interface to be implemented in `AbstractBigtableConnection`& `BigtableAsyncConnection.`  
Also `connection.getRegionLocator()` which is using connection would convert into `getConnection().getRegionLocator()`. 
I have added initial implementation for this interface [here](https://github.com/rahulKQL/cloud-bigtable-client/commit/491295e11e7955e6276ef8d42bd8910dd66da92f)
@sduskis  Could you please have a look and let me know your thoughts on this.
