### PR TITLE
test-deduplication in ColumnFamily & ListSnapshot

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestColumnFamilyAdmin.java
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestColumnFamilyAdmin.java
@@ -4,9 +4,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -72,7 +72,7 @@ public abstract class AbstractTestColumnFamilyAdmin extends AbstractTest {
     assertEquals(SharedTestEnvRule.MAX_VERSIONS, retrievedDescriptor.getFamily(COLUMN_FAMILY).getMaxVersions());
     assertEquals(SharedTestEnvRule.MAX_VERSIONS, retrievedDescriptor.getFamily(COLUMN_FAMILY2).getMaxVersions());
   }
-  
+
   @Test
   public void testAddColumn() throws Exception {
     byte[] new_column = Bytes.toBytes("NEW_COLUMN");
@@ -80,7 +80,7 @@ public abstract class AbstractTestColumnFamilyAdmin extends AbstractTest {
     HTableDescriptor tblDesc = getTableDescriptor(tableName);
     assertNotNull(tblDesc.getFamily(new_column));
   }
-  
+
   @Test
   public void testModifyColumnFamily() throws Exception {
     byte[] modifyColumn = Bytes.toBytes("MODIFY_COLUMN");
@@ -90,7 +90,7 @@ public abstract class AbstractTestColumnFamilyAdmin extends AbstractTest {
     modifyColumn(modifyColumn, 100);
     assertEquals(100, getTableDescriptor(tableName).getFamily(modifyColumn).getMaxVersions());
   }
-  
+
   @Test
   public void testRemoveColumn() throws Exception {
     addColumn(DELETE_COLUMN_FAMILY, 2);
@@ -107,8 +107,20 @@ public abstract class AbstractTestColumnFamilyAdmin extends AbstractTest {
     getTableDescriptor(TableName.valueOf("does-not-exist"));
   }
 
-  protected abstract HTableDescriptor getTableDescriptor(TableName tableName) throws Exception;
-  protected abstract void addColumn(byte[] columnName, int version) throws Exception;
-  protected abstract void modifyColumn(byte[] columnName, int version) throws Exception;
-  protected abstract void deleteColumn(byte[] columnName) throws Exception;
+  protected HTableDescriptor getTableDescriptor(TableName tableName) throws Exception {
+    return admin.getTableDescriptor(tableName);
+  }
+
+  protected void addColumn(byte[] columnName, int versions) throws Exception {
+    admin.addColumn(tableName, new HColumnDescriptor(columnName).setMaxVersions(versions));
+  }
+
+  protected void modifyColumn(byte[] columnName, int versions) throws Exception {
+    admin.modifyColumn(tableName, new HColumnDescriptor(columnName).setMaxVersions(versions));
+  }
+
+  protected void deleteColumn(byte[] columnName) throws Exception {
+    admin.deleteColumn(tableName, columnName);
+  }
+
 }

--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestSnapshot.java
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestSnapshot.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.regex.Pattern;
 
+import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.TableExistsException;
 import org.apache.hadoop.hbase.TableName;
@@ -124,7 +125,7 @@ public abstract class AbstractTestSnapshot extends AbstractTest {
     }
     final Pattern allSnapshots = Pattern.compile(snapshotName + ".*");
     createTable(tableName);
-    Map<String, Long> values = createAndPopulateTable(tableName);
+    createAndPopulateTable(tableName);
     Assert.assertEquals(0, listSnapshotsSize(allSnapshots));
     snapshot(snapshotName, tableName);
     Assert.assertEquals(1, listSnapshotsSize(snapshotName));
@@ -233,20 +234,82 @@ public abstract class AbstractTestSnapshot extends AbstractTest {
     Assert.assertTrue("There were missing keys.", values.isEmpty());
   }
 
+  protected void snapshot(String snapshotName, TableName tableName)
+      throws IOException {
+    try(Admin admin = getConnection().getAdmin()) {
+      admin.snapshot(snapshotName, tableName);
+    }
+
+  }
+
+  protected int listSnapshotsSize(String regEx) throws IOException {
+    try(Admin admin = getConnection().getAdmin()) {
+      return admin.listSnapshots(regEx).size();
+    }
+  }
+
+  protected void deleteSnapshot(String snapshotName) throws IOException {
+    try(Admin admin = getConnection().getAdmin()) {
+      admin.deleteSnapshot(snapshotName);
+    }
+  }
+
+  protected boolean tableExists(TableName tableName) throws IOException {
+    try(Admin admin = getConnection().getAdmin()) {
+      return admin.tableExists(tableName);
+    }
+  }
+
+  protected void disableTable(TableName tableName) throws IOException {
+    try(Admin admin = getConnection().getAdmin()) {
+      admin.disableTable(tableName);
+    }
+  }
+
+  protected void cloneSnapshot(String snapshotName, TableName tableName)
+      throws IOException, TableExistsException, RestoreSnapshotException {
+    try(Admin admin = getConnection().getAdmin()) {
+      admin.cloneSnapshot(snapshotName,tableName);
+    }
+  }
+
+  protected void deleteSnapshots(Pattern pattern) throws IOException {
+    try(Admin admin = getConnection().getAdmin()) {
+      admin.deleteSnapshots(pattern);
+    }
+  }
+
+  protected int listTableSnapshotsSize(String tableNameRegex,
+      String snapshotNameRegex) throws IOException {
+    try(Admin admin = getConnection().getAdmin()) {
+      return admin.listTableSnapshots(tableNameRegex,snapshotNameRegex).size();
+    }
+  }
+
+  protected int listSnapshotsSize(Pattern pattern) throws IOException {
+    try(Admin admin = getConnection().getAdmin()) {
+      return admin.listSnapshots(pattern).size();
+    }
+  }
+
+  protected int listTableSnapshotsSize(Pattern tableNamePattern,
+      Pattern snapshotNamePattern) throws IOException {
+    try(Admin admin = getConnection().getAdmin()) {
+      return admin.listTableSnapshots(tableNamePattern, snapshotNamePattern).size();
+    }
+  }
+
+  protected void deleteTable(TableName tableName) throws IOException {
+    try(Admin admin = getConnection().getAdmin()) {
+      admin.deleteTable(tableName);
+    }
+  }
+
+  protected int listTableSnapshotsSize(Pattern tableNamePattern) throws Exception {
+    try(Admin admin = getConnection().getAdmin()){
+      return admin.listTableSnapshots(tableNamePattern, Pattern.compile(".*")).size();
+    }
+  }
+
   protected abstract void createTable(TableName tableName) throws IOException;
-  protected abstract void snapshot(String snapshotName, TableName tableName) throws IOException;
-  protected abstract int listSnapshotsSize(String regEx) throws IOException;
-  protected abstract int listSnapshotsSize(Pattern pattern) throws IOException;
-  protected abstract void deleteSnapshot(String snapshotName) throws IOException;
-  protected abstract boolean tableExists(final TableName tableName) throws IOException;
-  protected abstract void disableTable(final TableName tableName) throws IOException;
-  protected abstract void cloneSnapshot(final String snapshotName, final TableName tableName)
-      throws IOException, TableExistsException, RestoreSnapshotException;
-  protected abstract int listTableSnapshotsSize(String tableNameRegex,
-      String snapshotNameRegex) throws IOException;
-  protected abstract int listTableSnapshotsSize(Pattern tableNamePattern,
-      Pattern snapshotNamePattern) throws IOException;
-  protected abstract void deleteSnapshots(final Pattern pattern) throws IOException;
-  protected abstract void deleteTable(final TableName tableName) throws IOException;
-  protected abstract int listTableSnapshotsSize(Pattern tableNamePattern) throws Exception;
 }

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestColumnFamilyAdmin.java
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestColumnFamilyAdmin.java
@@ -4,9 +4,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,34 +15,9 @@
  */
 package com.google.cloud.bigtable.hbase;
 
-import org.apache.hadoop.hbase.HColumnDescriptor;
-import org.apache.hadoop.hbase.HTableDescriptor;
-import org.apache.hadoop.hbase.TableName;
-
-import java.io.IOException;
-
 /**
  * Tests creation and deletion of column families.
  */
 public class TestColumnFamilyAdmin extends AbstractTestColumnFamilyAdmin {
 
-  @Override
-  protected HTableDescriptor getTableDescriptor(TableName tableName) throws IOException {
-    return admin.getTableDescriptor(tableName);
-  }
-
-  @Override
-  protected void addColumn(byte[] columnName, int versions) throws Exception {
-    admin.addColumn(tableName, new HColumnDescriptor(columnName).setMaxVersions(versions));
-  }
-
-  @Override
-  protected void modifyColumn(byte[] columnName, int versions) throws Exception {
-    admin.modifyColumn(tableName, new HColumnDescriptor(columnName).setMaxVersions(versions));
-  }
-
-  @Override
-  protected void deleteColumn(byte[] columnName) throws Exception {
-    admin.deleteColumn(tableName, columnName);
-  }
 }

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestSnapshots.java
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestSnapshots.java
@@ -18,14 +18,11 @@ package com.google.cloud.bigtable.hbase;
 import static com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule.COLUMN_FAMILY;
 
 import java.io.IOException;
-import java.util.regex.Pattern;
 
 import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HTableDescriptor;
-import org.apache.hadoop.hbase.TableExistsException;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Admin;
-import org.apache.hadoop.hbase.snapshot.RestoreSnapshotException;
 
 public class TestSnapshots extends AbstractTestSnapshot {
 
@@ -35,96 +32,6 @@ public class TestSnapshots extends AbstractTestSnapshot {
       HTableDescriptor descriptor = new HTableDescriptor(tableName);
       descriptor.addFamily(new HColumnDescriptor(COLUMN_FAMILY));
       admin.createTable(descriptor);
-    }
-    
-  }
-
-  @Override
-  protected void snapshot(String snapshotName, TableName tableName)
-      throws IOException {
-    try(Admin admin = getConnection().getAdmin()) {
-      admin.snapshot(snapshotName, tableName);
-    }
-  }
-
-  @Override
-  protected int listSnapshotsSize(String regEx) throws IOException {
-    try(Admin admin = getConnection().getAdmin()) {
-      return admin.listSnapshots(regEx).size();
-    }
-  }
-
-  @Override
-  protected void deleteSnapshot(String snapshotName) throws IOException {
-    try(Admin admin = getConnection().getAdmin()) {
-      admin.deleteSnapshot(snapshotName);
-    }
-    
-  }
-
-  @Override
-  protected boolean tableExists(TableName tableName) throws IOException {
-    try(Admin admin = getConnection().getAdmin()) {
-      return admin.tableExists(tableName);
-    }
-  }
-
-  @Override
-  protected void disableTable(TableName tableName) throws IOException {
-    try(Admin admin = getConnection().getAdmin()) {
-      admin.disableTable(tableName);
-    }
-  }
-
-  @Override
-  protected void cloneSnapshot(String snapshotName, TableName tableName)
-      throws IOException, TableExistsException, RestoreSnapshotException {
-    try(Admin admin = getConnection().getAdmin()) {
-      admin.cloneSnapshot(snapshotName, tableName);
-    }
-  }
-
-  @Override
-  protected void deleteSnapshots(Pattern pattern) throws IOException {
-    try(Admin admin = getConnection().getAdmin()) {
-      admin.deleteSnapshots(pattern);
-    }
-  }
-
-  @Override
-  protected int listTableSnapshotsSize(String tableNameRegex,
-      String snapshotNameRegex) throws IOException {
-    try(Admin admin = getConnection().getAdmin()) {
-      return admin.listTableSnapshots(tableNameRegex, snapshotNameRegex).size();
-    }
-  }
-
-  @Override
-  protected int listSnapshotsSize(Pattern pattern) throws IOException {
-    try(Admin admin = getConnection().getAdmin()) {
-      return admin.listSnapshots(pattern).size();
-    }
-  }
-
-  @Override
-  protected int listTableSnapshotsSize(Pattern tableNamePattern,
-      Pattern snapshotNamePattern) throws IOException {
-    try(Admin admin = getConnection().getAdmin()) {
-      return admin.listTableSnapshots(tableNamePattern, snapshotNamePattern).size();
-    }
-  }
-
-  @Override
-  protected void deleteTable(TableName tableName) throws IOException {
-    try(Admin admin = getConnection().getAdmin()) {
-      admin.deleteTable(tableName);
-    }
-  }
-
-  @Override
-  protected int listTableSnapshotsSize(Pattern tableNamePattern) throws Exception {
-    try(Admin admin = getConnection().getAdmin()){
-      return admin.listTableSnapshots(tableNamePattern, Pattern.compile(".*")).size();
     }
   }
 }

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestColumnFamilyAdmin.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestColumnFamilyAdmin.java
@@ -4,9 +4,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,20 +16,11 @@
 package com.google.cloud.bigtable.hbase;
 
 import org.apache.hadoop.hbase.HColumnDescriptor;
-import org.apache.hadoop.hbase.HTableDescriptor;
-import org.apache.hadoop.hbase.TableName;
-
-import java.io.IOException;
 
 /**
  * Tests creation and deletion of column families.
  */
 public class TestColumnFamilyAdmin extends AbstractTestColumnFamilyAdmin {
-
-  @Override
-  protected HTableDescriptor getTableDescriptor(TableName tableName) throws IOException {
-    return admin.getTableDescriptor(tableName);
-  }
 
   @Override
   protected void addColumn(byte[] columnName, int versions) throws Exception {
@@ -39,10 +30,5 @@ public class TestColumnFamilyAdmin extends AbstractTestColumnFamilyAdmin {
   @Override
   protected void modifyColumn(byte[] columnName, int versions) throws Exception {
     admin.modifyColumn(tableName, new HColumnDescriptor(columnName).setMaxVersions(versions));
-  }
-
-  @Override
-  protected void deleteColumn(byte[] columnName) throws Exception {
-    admin.deleteColumn(tableName, columnName);
   }
 }

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestColumnFamilyAdminHBase2.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestColumnFamilyAdminHBase2.java
@@ -4,9 +4,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,33 +15,13 @@
  */
 package com.google.cloud.bigtable.hbase;
 
-import static com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule.COLUMN_FAMILY;
-import static org.junit.Assert.assertEquals;
-
-import org.apache.hadoop.hbase.HColumnDescriptor;
-import org.apache.hadoop.hbase.HTableDescriptor;
-import org.apache.hadoop.hbase.TableName;
-import org.apache.hadoop.hbase.client.Admin;
 import org.apache.hadoop.hbase.client.ColumnFamilyDescriptor;
 import org.apache.hadoop.hbase.client.ColumnFamilyDescriptorBuilder;
-import org.apache.hadoop.hbase.client.TableDescriptor;
-import org.apache.hadoop.hbase.util.Bytes;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-
-import java.io.IOException;
 
 /**
  * Tests creation and deletion of column families.
  */
 public class TestColumnFamilyAdminHBase2 extends AbstractTestColumnFamilyAdmin {
-
-  @Override
-  protected HTableDescriptor getTableDescriptor(TableName tableName) throws Exception {
-    return admin.getTableDescriptor(tableName);
-  }
 
   @Override
   protected void addColumn(byte[] columnName, int version) throws Exception {

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestSnapshots.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestSnapshots.java
@@ -14,18 +14,14 @@
  * limitations under the License.
  */package com.google.cloud.bigtable.hbase;
 
-
 import static com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule.COLUMN_FAMILY;
 
 import java.io.IOException;
-import java.util.regex.Pattern;
 
 import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HTableDescriptor;
-import org.apache.hadoop.hbase.TableExistsException;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Admin;
-import org.apache.hadoop.hbase.snapshot.RestoreSnapshotException;
 
 public class TestSnapshots extends AbstractTestSnapshot {
 
@@ -35,95 +31,6 @@ public class TestSnapshots extends AbstractTestSnapshot {
       HTableDescriptor descriptor = new HTableDescriptor(tableName);
       descriptor.addFamily(new HColumnDescriptor(COLUMN_FAMILY));
       admin.createTable(descriptor);
-    }
-  }
-
-  @Override
-  protected void snapshot(String snapshotName, TableName tableName)
-      throws IOException {
-    try(Admin admin = getConnection().getAdmin()) {
-      admin.snapshot(snapshotName, tableName);
-    }
-    
-  }
-
-  @Override
-  protected int listSnapshotsSize(String regEx) throws IOException {
-    try(Admin admin = getConnection().getAdmin()) {
-      return admin.listSnapshots(regEx).size();
-    }
-  }
-
-  @Override
-  protected void deleteSnapshot(String snapshotName) throws IOException {
-    try(Admin admin = getConnection().getAdmin()) {
-      admin.deleteSnapshot(snapshotName);
-    }
-  }
-
-  @Override
-  protected boolean tableExists(TableName tableName) throws IOException {
-    try(Admin admin = getConnection().getAdmin()) {
-      return admin.tableExists(tableName);
-    }
-  }
-
-  @Override
-  protected void disableTable(TableName tableName) throws IOException {
-    try(Admin admin = getConnection().getAdmin()) {
-      admin.disableTable(tableName);
-    }
-  }
-
-  @Override
-  protected void cloneSnapshot(String snapshotName, TableName tableName)
-      throws IOException, TableExistsException, RestoreSnapshotException {
-    try(Admin admin = getConnection().getAdmin()) {
-      admin.cloneSnapshot(snapshotName,tableName);
-    }
-  }
-
-  @Override
-  protected void deleteSnapshots(Pattern pattern) throws IOException {
-    try(Admin admin = getConnection().getAdmin()) {
-      admin.deleteSnapshots(pattern);
-    }
-  }
-
-  @Override
-  protected int listTableSnapshotsSize(String tableNameRegex,
-      String snapshotNameRegex) throws IOException {
-    try(Admin admin = getConnection().getAdmin()) {
-      return admin.listTableSnapshots(tableNameRegex,snapshotNameRegex).size();
-    }
-  }
-
-  @Override
-  protected int listSnapshotsSize(Pattern pattern) throws IOException {
-    try(Admin admin = getConnection().getAdmin()) {
-      return admin.listSnapshots(pattern).size();
-    }
-  }
-
-  @Override
-  protected int listTableSnapshotsSize(Pattern tableNamePattern,
-      Pattern snapshotNamePattern) throws IOException {
-    try(Admin admin = getConnection().getAdmin()) {
-      return admin.listTableSnapshots(tableNamePattern, snapshotNamePattern).size();
-    }
-  }
-
-  @Override
-  protected void deleteTable(TableName tableName) throws IOException {
-    try(Admin admin = getConnection().getAdmin()) {
-      admin.deleteTable(tableName);
-    }
-  }
-
-  @Override
-  protected int listTableSnapshotsSize(Pattern tableNamePattern) throws Exception {
-    try(Admin admin = getConnection().getAdmin()){
-      return admin.listTableSnapshots(tableNamePattern, Pattern.compile(".*")).size();
     }
   }
 }


### PR DESCRIPTION
### Description
To remove duplicate code from Integration-Test-1.x & 2.x

Refactoring of below test classes to remove duplication: 
 - AbstractTestColumnFamilyAdmin (commons-tests)
 - TestColumnFamilyAdmin (integration-test 1.x & 2.x)
 - AbstractTestSnapshot (commons-tests)
 - TestSnapshots (integration-test 1.x & 2.x)