### PR TITLE
BigtableOptions batch settings fix

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableOptions.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableOptions.java
@@ -260,12 +260,21 @@ public class BigtableOptions implements Serializable, Cloneable {
         options.instanceName = null;
       }
 
-      if(options.useBatch) {
+      if (options.useBatch) {
         options.useCachedDataPool = true;
-        options.dataHost = BIGTABLE_BATCH_DATA_HOST_DEFAULT;
+        if (options.dataHost.equals(BIGTABLE_DATA_HOST_DEFAULT)) {
+          options.dataHost = BIGTABLE_BATCH_DATA_HOST_DEFAULT;
+        }
         RetryOptions.Builder retryOptionsBuilder = options.retryOptions.toBuilder();
-        retryOptionsBuilder.setInitialBackoffMillis((int) TimeUnit.SECONDS.toMillis(5));
-        retryOptionsBuilder.setMaxElapsedBackoffMillis((int) TimeUnit.SECONDS.toMillis(5));
+        if (options.retryOptions.getInitialBackoffMillis()
+            == RetryOptions.DEFAULT_INITIAL_BACKOFF_MILLIS) {
+          retryOptionsBuilder.setInitialBackoffMillis((int) TimeUnit.SECONDS.toMillis(5));
+        }
+
+        if (options.retryOptions.getMaxElapsedBackoffMillis()
+            == RetryOptions.DEFAULT_MAX_ELAPSED_BACKOFF_MILLIS) {
+          retryOptionsBuilder.setMaxElapsedBackoffMillis((int) TimeUnit.MINUTES.toMillis(5));
+        }
         options.retryOptions = retryOptionsBuilder.build();
       }
       LOG.debug("Connection Configuration: projectId: %s, instanceId: %s, data host %s, "

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/config/TestBigtableOptions.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/config/TestBigtableOptions.java
@@ -115,12 +115,23 @@ public class TestBigtableOptions {
   }
 
   @Test
-  public void testUseBatch() {
+  public void testUseBatch_default() {
     BigtableOptions options = BigtableOptions.builder().setUseBatch(true).build();
     Assert.assertTrue(options.useCachedChannel());
     Assert.assertEquals(BigtableOptions.BIGTABLE_BATCH_DATA_HOST_DEFAULT, options.getDataHost());
     Assert.assertEquals(5000, options.getRetryOptions().getInitialBackoffMillis());
-    Assert.assertEquals(5000, options.getRetryOptions().getMaxElapsedBackoffMillis());
+    Assert.assertEquals(300_000, options.getRetryOptions().getMaxElapsedBackoffMillis());
+  }
+
+  @Test
+  public void testUseBatch_withOverrides() {
+    String host = "myHost";
+    BigtableOptions options =
+        BigtableOptions.builder().setDataHost(host).setUseBatch(true).build();
+    Assert.assertTrue(options.useCachedChannel());
+    Assert.assertEquals(host, options.getDataHost());
+    Assert.assertEquals(5000, options.getRetryOptions().getInitialBackoffMillis());
+    Assert.assertEquals(300_000, options.getRetryOptions().getMaxElapsedBackoffMillis());
   }
 
   /**


### PR DESCRIPTION
Only set batch options if a user did not explicitly set those settings.