### PR TITLE
AppendAdapter, IncrementAdapter and HBaseRequestAdapter changes

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/AppendAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/AppendAdapter.java
@@ -15,8 +15,7 @@
  */
 package com.google.cloud.bigtable.hbase.adapters;
 
-import com.google.bigtable.v2.ReadModifyWriteRowRequest;
-import com.google.bigtable.v2.ReadModifyWriteRule;
+import com.google.cloud.bigtable.data.v2.models.ReadModifyWriteRow;
 import com.google.protobuf.ByteString;
 
 import org.apache.hadoop.hbase.Cell;
@@ -32,33 +31,29 @@ import java.util.Map;
  * @author sduskis
  * @version $Id: $Id
  */
-public class AppendAdapter implements OperationAdapter<Append, ReadModifyWriteRowRequest.Builder> {
+public class AppendAdapter implements OperationAdapter<Append, ReadModifyWriteRow> {
 
   /** {@inheritDoc} */
   @Override
-  public void adapt(Append operation, ReadModifyWriteRowRequest.Builder result) {
-    result.setRowKey(ByteString.copyFrom(operation.getRow()));
-
-    for (Map.Entry<byte[], List<Cell>> entry : operation.getFamilyCellMap().entrySet()){
+  public void adapt(Append operation, ReadModifyWriteRow readModifyWriteRow) {
+    for (Map.Entry<byte[], List<Cell>> entry : operation.getFamilyCellMap().entrySet()) {
       String familyName = Bytes.toString(entry.getKey());
       // Bigtable applies all appends present in a single RPC. HBase applies only the last
       // mutation present, if any. We remove all but the last mutation for each qualifier here:
       List<Cell> cells = CellDeduplicationHelper.deduplicateFamily(operation, entry.getKey());
 
       for (Cell cell : cells) {
-        ReadModifyWriteRule.Builder rule = ReadModifyWriteRule.newBuilder();
-        rule.setFamilyName(familyName);
-        rule.setColumnQualifier(
+        readModifyWriteRow.append(
+            familyName,
             ByteString.copyFrom(
                 cell.getQualifierArray(),
                 cell.getQualifierOffset(),
-                cell.getQualifierLength()));
-        rule.setAppendValue(
+                cell.getQualifierLength()),
             ByteString.copyFrom(
                 cell.getValueArray(),
                 cell.getValueOffset(),
-                cell.getValueLength()));
-        result.addRules(rule.build());
+                cell.getValueLength())
+        );
       }
     }
   }

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/HBaseRequestAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/HBaseRequestAdapter.java
@@ -20,6 +20,7 @@ import com.google.cloud.bigtable.data.v2.internal.RequestContext;
 import com.google.cloud.bigtable.data.v2.models.InstanceName;
 import com.google.cloud.bigtable.data.v2.models.Mutation;
 import com.google.cloud.bigtable.data.v2.models.MutationApi;
+import com.google.cloud.bigtable.data.v2.models.ReadModifyWriteRow;
 import com.google.cloud.bigtable.data.v2.models.RowMutation;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.ByteString;
@@ -199,11 +200,9 @@ public class HBaseRequestAdapter {
    * @return a {@link com.google.bigtable.v2.ReadModifyWriteRowRequest} object.
    */
   public ReadModifyWriteRowRequest adapt(Append append) {
-    ReadModifyWriteRowRequest.Builder builder = ReadModifyWriteRowRequest.newBuilder();
-    //TODO: change APPEND_ADAPTER to adapt to {@link com.google.cloud.bigtable.data.v2.models.ReadModifyWriteRow} model
-    Adapters.APPEND_ADAPTER.adapt(append, builder);
-    builder.setTableName(getTableNameString());
-    return builder.build();
+    ReadModifyWriteRow readModifyWriteRow = ReadModifyWriteRow.create(bigtableTableName.getTableId(), ByteString.copyFrom(append.getRow()));
+    Adapters.APPEND_ADAPTER.adapt(append, readModifyWriteRow);
+    return readModifyWriteRow.toProto(requestContext);
   }
 
   /**
@@ -213,11 +212,9 @@ public class HBaseRequestAdapter {
    * @return a {@link com.google.bigtable.v2.ReadModifyWriteRowRequest} object.
    */
   public ReadModifyWriteRowRequest adapt(Increment increment) {
-    ReadModifyWriteRowRequest.Builder builder = ReadModifyWriteRowRequest.newBuilder();
-    //TODO: change INCREMENT_ADAPTER to adapt to {@link com.google.cloud.bigtable.data.v2.models.ReadModifyWriteRow} model
-    Adapters.INCREMENT_ADAPTER.adapt(increment, builder);
-    builder.setTableName(getTableNameString());
-    return builder.build();
+    ReadModifyWriteRow readModifyWriteRow = ReadModifyWriteRow.create(bigtableTableName.getTableId(), ByteString.copyFrom(increment.getRow()));
+    Adapters.INCREMENT_ADAPTER.adapt(increment, readModifyWriteRow);
+    return readModifyWriteRow.toProto(requestContext);
   }
 
   /**

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/IncrementAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/IncrementAdapter.java
@@ -15,9 +15,7 @@
  */
 package com.google.cloud.bigtable.hbase.adapters;
 
-
-import com.google.bigtable.v2.ReadModifyWriteRowRequest;
-import com.google.bigtable.v2.ReadModifyWriteRule;
+import com.google.cloud.bigtable.data.v2.models.ReadModifyWriteRow;
 import com.google.protobuf.ByteString;
 
 import org.apache.hadoop.hbase.Cell;
@@ -36,17 +34,15 @@ import java.util.NavigableMap;
  * @version $Id: $Id
  */
 public class IncrementAdapter
-    implements OperationAdapter<Increment, ReadModifyWriteRowRequest.Builder>{
+    implements OperationAdapter<Increment, ReadModifyWriteRow>{
 
   /** {@inheritDoc} */
   @Override
-  public void adapt(Increment operation, ReadModifyWriteRowRequest.Builder result) {
+  public void adapt(Increment operation, ReadModifyWriteRow readModifyWriteRow) {
     if (!operation.getTimeRange().isAllTime()) {
       throw new UnsupportedOperationException(
           "Setting the time range in an Increment is not implemented");
     }
-
-    result.setRowKey(ByteString.copyFrom(operation.getRow()));
 
     for (Map.Entry<byte[], NavigableMap<byte[], Long>> familyEntry :
         operation.getFamilyMapOfLongs().entrySet()) {
@@ -56,17 +52,15 @@ public class IncrementAdapter
       List<Cell> mutationCells =
           CellDeduplicationHelper.deduplicateFamily(operation, familyEntry.getKey());
 
-      for (Cell cell : mutationCells){
-        ReadModifyWriteRule.Builder rule = ReadModifyWriteRule.newBuilder();
-        rule.setIncrementAmount(
-            Bytes.toLong(cell.getValueArray(), cell.getValueOffset(), cell.getValueLength()));
-        rule.setFamilyName(familyName);
-        rule.setColumnQualifier(
+      for (Cell cell : mutationCells) {
+        readModifyWriteRow.increment(
+            familyName,
             ByteString.copyFrom(
                 cell.getQualifierArray(),
                 cell.getQualifierOffset(),
-                cell.getQualifierLength()));
-        result.addRules(rule.build());
+                cell.getQualifierLength()),
+            Bytes.toLong(cell.getValueArray(), cell.getValueOffset(), cell.getValueLength())
+        );
       }
     }
   }


### PR DESCRIPTION
adapt methods in `AppendAdapter `and `IncrementAdapter `changed to accept `ReadModifyWriteRow `as parameter instead of `ReadModifyWriteRowRequest.Builder`.
`HBaseRequestAdapter `revised to match the above changes.
`TestAppendAdapter `and `TestIncrementAdapter `test files updated.