### PR TITLE
AppendAdapter, IncrementAdapter and HBaseRequestAdapter changes

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/AppendAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/AppendAdapter.java
@@ -15,8 +15,7 @@
  */
 package com.google.cloud.bigtable.hbase.adapters;
 
-import com.google.bigtable.v2.ReadModifyWriteRowRequest;
-import com.google.bigtable.v2.ReadModifyWriteRule;
+import com.google.cloud.bigtable.data.v2.models.ReadModifyWriteRow;
 import com.google.protobuf.ByteString;
 
 import org.apache.hadoop.hbase.Cell;
@@ -32,33 +31,29 @@ import java.util.Map;
  * @author sduskis
  * @version $Id: $Id
  */
-public class AppendAdapter implements OperationAdapter<Append, ReadModifyWriteRowRequest.Builder> {
+public class AppendAdapter implements OperationAdapter<Append, ReadModifyWriteRow> {
 
   /** {@inheritDoc} */
   @Override
-  public void adapt(Append operation, ReadModifyWriteRowRequest.Builder result) {
-    result.setRowKey(ByteString.copyFrom(operation.getRow()));
-
-    for (Map.Entry<byte[], List<Cell>> entry : operation.getFamilyCellMap().entrySet()){
+  public void adapt(Append operation, ReadModifyWriteRow readModifyWriteRow) {
+    for (Map.Entry<byte[], List<Cell>> entry : operation.getFamilyCellMap().entrySet()) {
       String familyName = Bytes.toString(entry.getKey());
       // Bigtable applies all appends present in a single RPC. HBase applies only the last
       // mutation present, if any. We remove all but the last mutation for each qualifier here:
       List<Cell> cells = CellDeduplicationHelper.deduplicateFamily(operation, entry.getKey());
 
       for (Cell cell : cells) {
-        ReadModifyWriteRule.Builder rule = ReadModifyWriteRule.newBuilder();
-        rule.setFamilyName(familyName);
-        rule.setColumnQualifier(
+        readModifyWriteRow.append(
+            familyName,
             ByteString.copyFrom(
                 cell.getQualifierArray(),
                 cell.getQualifierOffset(),
-                cell.getQualifierLength()));
-        rule.setAppendValue(
+                cell.getQualifierLength()),
             ByteString.copyFrom(
                 cell.getValueArray(),
                 cell.getValueOffset(),
-                cell.getValueLength()));
-        result.addRules(rule.build());
+                cell.getValueLength())
+        );
       }
     }
   }

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/HBaseRequestAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/HBaseRequestAdapter.java
@@ -20,6 +20,7 @@ import com.google.cloud.bigtable.data.v2.internal.RequestContext;
 import com.google.cloud.bigtable.data.v2.models.InstanceName;
 import com.google.cloud.bigtable.data.v2.models.Mutation;
 import com.google.cloud.bigtable.data.v2.models.MutationApi;
+import com.google.cloud.bigtable.data.v2.models.ReadModifyWriteRow;
 import com.google.cloud.bigtable.data.v2.models.RowMutation;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.ByteString;
@@ -198,11 +199,10 @@ public class HBaseRequestAdapter {
    * @return a {@link com.google.bigtable.v2.ReadModifyWriteRowRequest} object.
    */
   public ReadModifyWriteRowRequest adapt(Append append) {
-    ReadModifyWriteRowRequest.Builder builder = ReadModifyWriteRowRequest.newBuilder();
-    //TODO: change APPEND_ADAPTER to adapt to {@link com.google.cloud.bigtable.data.v2.models.ReadModifyWriteRow} model
-    Adapters.APPEND_ADAPTER.adapt(append, builder);
-    builder.setTableName(getTableNameString());
-    return builder.build();
+    ReadModifyWriteRow readModifyWriteRow = ReadModifyWriteRow
+        .create(bigtableTableName.getTableId(), ByteString.copyFrom(append.getRow()));
+    Adapters.APPEND_ADAPTER.adapt(append, readModifyWriteRow);
+    return readModifyWriteRow.toProto(requestContext);
   }
 
   /**
@@ -212,11 +212,10 @@ public class HBaseRequestAdapter {
    * @return a {@link com.google.bigtable.v2.ReadModifyWriteRowRequest} object.
    */
   public ReadModifyWriteRowRequest adapt(Increment increment) {
-    ReadModifyWriteRowRequest.Builder builder = ReadModifyWriteRowRequest.newBuilder();
-    //TODO: change INCREMENT_ADAPTER to adapt to {@link com.google.cloud.bigtable.data.v2.models.ReadModifyWriteRow} model
-    Adapters.INCREMENT_ADAPTER.adapt(increment, builder);
-    builder.setTableName(getTableNameString());
-    return builder.build();
+    ReadModifyWriteRow readModifyWriteRow = ReadModifyWriteRow
+        .create(bigtableTableName.getTableId(), ByteString.copyFrom(increment.getRow()));
+    Adapters.INCREMENT_ADAPTER.adapt(increment, readModifyWriteRow);
+    return readModifyWriteRow.toProto(requestContext);
   }
 
   /**

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/IncrementAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/IncrementAdapter.java
@@ -15,9 +15,7 @@
  */
 package com.google.cloud.bigtable.hbase.adapters;
 
-
-import com.google.bigtable.v2.ReadModifyWriteRowRequest;
-import com.google.bigtable.v2.ReadModifyWriteRule;
+import com.google.cloud.bigtable.data.v2.models.ReadModifyWriteRow;
 import com.google.protobuf.ByteString;
 
 import org.apache.hadoop.hbase.Cell;
@@ -36,17 +34,15 @@ import java.util.NavigableMap;
  * @version $Id: $Id
  */
 public class IncrementAdapter
-    implements OperationAdapter<Increment, ReadModifyWriteRowRequest.Builder>{
+    implements OperationAdapter<Increment, ReadModifyWriteRow>{
 
   /** {@inheritDoc} */
   @Override
-  public void adapt(Increment operation, ReadModifyWriteRowRequest.Builder result) {
+  public void adapt(Increment operation, ReadModifyWriteRow readModifyWriteRow) {
     if (!operation.getTimeRange().isAllTime()) {
       throw new UnsupportedOperationException(
           "Setting the time range in an Increment is not implemented");
     }
-
-    result.setRowKey(ByteString.copyFrom(operation.getRow()));
 
     for (Map.Entry<byte[], NavigableMap<byte[], Long>> familyEntry :
         operation.getFamilyMapOfLongs().entrySet()) {
@@ -56,17 +52,15 @@ public class IncrementAdapter
       List<Cell> mutationCells =
           CellDeduplicationHelper.deduplicateFamily(operation, familyEntry.getKey());
 
-      for (Cell cell : mutationCells){
-        ReadModifyWriteRule.Builder rule = ReadModifyWriteRule.newBuilder();
-        rule.setIncrementAmount(
-            Bytes.toLong(cell.getValueArray(), cell.getValueOffset(), cell.getValueLength()));
-        rule.setFamilyName(familyName);
-        rule.setColumnQualifier(
+      for (Cell cell : mutationCells) {
+        readModifyWriteRow.increment(
+            familyName,
             ByteString.copyFrom(
                 cell.getQualifierArray(),
                 cell.getQualifierOffset(),
-                cell.getQualifierLength()));
-        result.addRules(rule.build());
+                cell.getQualifierLength()),
+            Bytes.toLong(cell.getValueArray(), cell.getValueOffset(), cell.getValueLength())
+        );
       }
     }
   }

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/TestAppendAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/TestAppendAdapter.java
@@ -17,6 +17,9 @@ package com.google.cloud.bigtable.hbase.adapters;
 
 import com.google.bigtable.v2.ReadModifyWriteRowRequest;
 import com.google.bigtable.v2.ReadModifyWriteRule;
+import com.google.cloud.bigtable.data.v2.internal.RequestContext;
+import com.google.cloud.bigtable.data.v2.models.InstanceName;
+import com.google.cloud.bigtable.data.v2.models.ReadModifyWriteRow;
 import com.google.cloud.bigtable.hbase.DataGenerationHelper;
 import com.google.protobuf.ByteString;
 
@@ -31,6 +34,11 @@ import java.util.List;
 
 @RunWith(JUnit4.class)
 public class TestAppendAdapter {
+  private static final String PROJECT_ID = "test-project-id";
+  private static final String INSTANCE_ID = "test-instance-id";
+  private static final String TABLE_ID = "test-table-id";
+  private static final String APP_PROFILE_ID = "test-app-profile-id";
+  private RequestContext requestContext = RequestContext.create(InstanceName.of(PROJECT_ID, INSTANCE_ID), APP_PROFILE_ID);
   protected AppendAdapter appendAdapter = new AppendAdapter();
   protected DataGenerationHelper dataHelper = new DataGenerationHelper();
 
@@ -38,9 +46,10 @@ public class TestAppendAdapter {
   public void testBasicRowKeyAppend() {
     byte[] rowKey = dataHelper.randomData("rk1-");
     Append append = new Append(rowKey);
-    ReadModifyWriteRowRequest.Builder requestBuilder = ReadModifyWriteRowRequest.newBuilder();
-    appendAdapter.adapt(append, requestBuilder);
-    ReadModifyWriteRowRequest request = requestBuilder.build();
+    ReadModifyWriteRow readModifyWriteRow = ReadModifyWriteRow
+        .create(TABLE_ID, ByteString.copyFrom(rowKey));
+    appendAdapter.adapt(append, readModifyWriteRow);
+    ReadModifyWriteRowRequest request = readModifyWriteRow.toProto(requestContext);
     ByteString adaptedRowKey = request.getRowKey();
     Assert.assertArrayEquals(rowKey, adaptedRowKey.toByteArray());
   }
@@ -61,9 +70,10 @@ public class TestAppendAdapter {
     append.add(family1, qualifier1, value1);
     append.add(family2, qualifier2, value2);
 
-    ReadModifyWriteRowRequest.Builder requestBuilder = ReadModifyWriteRowRequest.newBuilder();
-    appendAdapter.adapt(append, requestBuilder);
-    ReadModifyWriteRowRequest request = requestBuilder.build();
+    ReadModifyWriteRow readModifyWriteRow = ReadModifyWriteRow
+        .create(TABLE_ID, ByteString.copyFrom(rowKey));
+    appendAdapter.adapt(append, readModifyWriteRow);
+    ReadModifyWriteRowRequest request = readModifyWriteRow.toProto(requestContext);
     List<ReadModifyWriteRule> rules = request.getRulesList();
     Assert.assertEquals(2, rules.size());
 
@@ -95,9 +105,10 @@ public class TestAppendAdapter {
     append.add(family2, qualifier2, value2);
     append.add(family2, qualifier2, value3);
 
-    ReadModifyWriteRowRequest.Builder requestBuilder = ReadModifyWriteRowRequest.newBuilder();
-    appendAdapter.adapt(append, requestBuilder);
-    ReadModifyWriteRowRequest request = requestBuilder.build();
+    ReadModifyWriteRow readModifyWriteRow = ReadModifyWriteRow
+        .create(TABLE_ID, ByteString.copyFrom(rowKey));
+    appendAdapter.adapt(append, readModifyWriteRow);
+    ReadModifyWriteRowRequest request = readModifyWriteRow.toProto(requestContext);
     List<ReadModifyWriteRule> rules = request.getRulesList();
     Assert.assertEquals(2, rules.size());
 
@@ -126,9 +137,10 @@ public class TestAppendAdapter {
     append.add(family1, qualifier1, value1);
     append.add(family2, qualifier1, value2);
 
-    ReadModifyWriteRowRequest.Builder requestBuilder = ReadModifyWriteRowRequest.newBuilder();
-    appendAdapter.adapt(append, requestBuilder);
-    ReadModifyWriteRowRequest request = requestBuilder.build();
+    ReadModifyWriteRow readModifyWriteRow = ReadModifyWriteRow
+        .create(TABLE_ID, ByteString.copyFrom(rowKey));
+    appendAdapter.adapt(append, readModifyWriteRow);
+    ReadModifyWriteRowRequest request = readModifyWriteRow.toProto(requestContext);
     List<ReadModifyWriteRule> rules = request.getRulesList();
     Assert.assertEquals(2, rules.size());
 

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/TestIncrementAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/TestIncrementAdapter.java
@@ -17,6 +17,9 @@ package com.google.cloud.bigtable.hbase.adapters;
 
 import com.google.bigtable.v2.ReadModifyWriteRowRequest;
 import com.google.bigtable.v2.ReadModifyWriteRule;
+import com.google.cloud.bigtable.data.v2.internal.RequestContext;
+import com.google.cloud.bigtable.data.v2.models.InstanceName;
+import com.google.cloud.bigtable.data.v2.models.ReadModifyWriteRow;
 import com.google.cloud.bigtable.hbase.DataGenerationHelper;
 import com.google.protobuf.ByteString;
 
@@ -36,6 +39,11 @@ public class TestIncrementAdapter {
   @Rule
   public ExpectedException expectedException = ExpectedException.none();
 
+  private static final String PROJECT_ID = "test-project-id";
+  private static final String INSTANCE_ID = "test-instance-id";
+  private static final String TABLE_ID = "test-table-id";
+  private static final String APP_PROFILE_ID = "test-app-profile-id";
+  private RequestContext requestContext = RequestContext.create(InstanceName.of(PROJECT_ID, INSTANCE_ID), APP_PROFILE_ID);
   protected IncrementAdapter incrementAdapter = new IncrementAdapter();
   protected DataGenerationHelper dataHelper = new DataGenerationHelper();
 
@@ -43,8 +51,10 @@ public class TestIncrementAdapter {
   public void testBasicRowKeyIncrement() {
     byte[] rowKey = dataHelper.randomData("rk1-");
     Increment incr = new Increment(rowKey);
-    ReadModifyWriteRowRequest.Builder requestBuilder = ReadModifyWriteRowRequest.newBuilder();
-    incrementAdapter.adapt(incr, requestBuilder);
+    ReadModifyWriteRow readModifyWriteRow = ReadModifyWriteRow
+        .create(TABLE_ID, ByteString.copyFrom(rowKey));
+    incrementAdapter.adapt(incr, readModifyWriteRow);
+    ReadModifyWriteRowRequest requestBuilder = readModifyWriteRow.toProto(requestContext);
     ByteString adaptedRowKey = requestBuilder.getRowKey();
     Assert.assertArrayEquals(rowKey, adaptedRowKey.toByteArray());
   }
@@ -59,8 +69,10 @@ public class TestIncrementAdapter {
     Increment incr = new Increment(rowKey);
     incr.addColumn(family, qualifier, amount);
 
-    ReadModifyWriteRowRequest.Builder requestBuilder = ReadModifyWriteRowRequest.newBuilder();
-    incrementAdapter.adapt(incr, requestBuilder);
+    ReadModifyWriteRow readModifyWriteRow = ReadModifyWriteRow
+        .create(TABLE_ID, ByteString.copyFrom(rowKey));
+    incrementAdapter.adapt(incr, readModifyWriteRow);
+    ReadModifyWriteRowRequest requestBuilder = readModifyWriteRow.toProto(requestContext);
 
     Assert.assertEquals(1, requestBuilder.getRulesCount());
     ReadModifyWriteRule rule = requestBuilder.getRules(0);
@@ -86,8 +98,10 @@ public class TestIncrementAdapter {
     incr.addColumn(family1, qualifier1, amount1);
     incr.addColumn(family2, qualifier2, amount2);
 
-    ReadModifyWriteRowRequest.Builder requestBuilder = ReadModifyWriteRowRequest.newBuilder();
-    incrementAdapter.adapt(incr, requestBuilder);
+    ReadModifyWriteRow readModifyWriteRow = ReadModifyWriteRow
+        .create(TABLE_ID, ByteString.copyFrom(rowKey));
+    incrementAdapter.adapt(incr, readModifyWriteRow);
+    ReadModifyWriteRowRequest requestBuilder = readModifyWriteRow.toProto(requestContext);
     Assert.assertEquals(2, requestBuilder.getRulesCount());
 
     ReadModifyWriteRule rule = requestBuilder.getRules(0);
@@ -121,8 +135,10 @@ public class TestIncrementAdapter {
     incr.addColumn(family2, qualifier2, amount2);
     incr.addColumn(family2, qualifier2, amount3);
 
-    ReadModifyWriteRowRequest.Builder requestBuilder = ReadModifyWriteRowRequest.newBuilder();
-    incrementAdapter.adapt(incr, requestBuilder);
+    ReadModifyWriteRow readModifyWriteRow = ReadModifyWriteRow
+        .create(TABLE_ID, ByteString.copyFrom(rowKey));
+    incrementAdapter.adapt(incr, readModifyWriteRow);
+    ReadModifyWriteRowRequest requestBuilder = readModifyWriteRow.toProto(requestContext);
     Assert.assertEquals(2, requestBuilder.getRulesCount());
 
     ReadModifyWriteRule rule = requestBuilder.getRules(0);
@@ -146,6 +162,8 @@ public class TestIncrementAdapter {
     expectedException.expect(UnsupportedOperationException.class);
     expectedException.expectMessage("Setting the time range in an Increment is not implemented");
 
-    incrementAdapter.adapt(incr, ReadModifyWriteRowRequest.newBuilder());
+    ReadModifyWriteRow readModifyWriteRow = ReadModifyWriteRow
+        .create(TABLE_ID, ByteString.copyFrom(rowKey));
+    incrementAdapter.adapt(incr, readModifyWriteRow);
   }
 }


### PR DESCRIPTION
adapt methods in `AppendAdapter `and `IncrementAdapter `changed to accept `ReadModifyWriteRow `as parameter instead of `ReadModifyWriteRowRequest.Builder`.
`HBaseRequestAdapter `revised to match the above changes.
`TestAppendAdapter `and `TestIncrementAdapter `test files updated.