### PR TITLE
Admin method changes 

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ infrequent product and client library announcements.
    Use the following command to run the Cloud Bigtable integration tests for HBase 1:
 
    ```sh
-   mvn clean integration-test \
+   mvn clean verify \
        -PbigtableIntegrationTest \
        -Dgoogle.bigtable.project.id=[your cloud project id] \
        -Dgoogle.bigtable.instance.id=[your cloud bigtable instance id]
@@ -89,7 +89,7 @@ infrequent product and client library announcements.
    Use the following command to run the Cloud Bigtable integration tests for HBase 2:
 
    ```sh
-   mvn clean integration-test \
+   mvn clean verify \
        -PbigtableIntegrationTestH2 \
        -Dgoogle.bigtable.project.id=[your cloud project id] \
        -Dgoogle.bigtable.instance.id=[your cloud bigtable instance id]
@@ -97,10 +97,10 @@ infrequent product and client library announcements.
    
    There are also tests that perform compatibility tests against an HBase Minicluster, which can be invoked with the following commands for HBase 1 and HBase 2 respectively: 
    ```sh
-   mvn clean integration-test -PhbaseLocalMiniClusterTest
+   mvn clean verify -PhbaseLocalMiniClusterTest
    ```
    ```sh
-   mvn clean integration-test -PhbaseLocalMiniClusterTestH2
+   mvn clean verify -PhbaseLocalMiniClusterTestH2
    ```
 
 

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableInstanceName.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableInstanceName.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.bigtable.grpc;
 
+import com.google.cloud.bigtable.data.v2.models.InstanceName;
 import java.io.Serializable;
 
 import com.google.api.client.util.Strings;
@@ -119,6 +120,10 @@ public class BigtableInstanceName implements Serializable {
    */
   public String getInstanceName() {
     return instanceName;
+  }
+
+  public InstanceName toGcbInstanceName() {
+    return InstanceName.of(projectId, instanceId);
   }
 
   public BigtableClusterName toClusterName(String clusterId) {

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableInstanceName.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableInstanceName.java
@@ -126,6 +126,11 @@ public class BigtableInstanceName implements Serializable {
     return InstanceName.of(projectId, instanceId);
   }
 
+  //TODO(rahulkql): Refactor once google-cloud-java/issues/4091 is resolved.
+  public com.google.bigtable.admin.v2.InstanceName toAdminInstanceName() {
+    return com.google.bigtable.admin.v2.InstanceName.of(projectId, instanceId);
+  }
+
   public BigtableClusterName toClusterName(String clusterId) {
     return new BigtableClusterName(instanceName + "/clusters/" + clusterId);
   }

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableTableName.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableTableName.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.bigtable.grpc;
 
+import com.google.cloud.bigtable.data.v2.models.InstanceName;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -68,6 +69,10 @@ public class BigtableTableName {
    */
   public String getTableId() {
     return tableId;
+  }
+
+  public InstanceName toGcbInstanceName() {
+    return InstanceName.of(projectId, instanceId);
   }
 
   /** {@inheritDoc} */

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/RetryingMutateRowsOperation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/RetryingMutateRowsOperation.java
@@ -84,8 +84,8 @@ public class RetryingMutateRowsOperation extends
     }
 
     // Perform a partial retry, if the backoff policy allows it.
-    long nextBackOff = getNextBackoff();
-    if (nextBackOff == BackOff.STOP) {
+    Long nextBackOff = getNextBackoff();
+    if (nextBackOff == null) {
       // Return the response as is, and don't retry;
       rpc.getRpcMetrics().markRetriesExhasted();
       completionFuture.set(Arrays.asList(requestManager.buildResponse()));

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/Watchdog.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/Watchdog.java
@@ -119,8 +119,12 @@ public class Watchdog implements Runnable {
   }
 
   public void stop() {
-    scheduledFuture.cancel(true);
+    ScheduledFuture<?> tmp = scheduledFuture;
     scheduledFuture = null;
+    
+    if (tmp != null) {
+        tmp.cancel(true);
+    }
   }
 
   private class WatchedCall<ReqT, RespT> extends SimpleForwardingClientCall<ReqT, RespT> {

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestBigtableInstanceName.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestBigtableInstanceName.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.bigtable.grpc;
 
+import com.google.cloud.bigtable.data.v2.models.InstanceName;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -96,5 +97,16 @@ public class TestBigtableInstanceName {
   public void testNoInstanceName() {
     expectedException.expect(IllegalArgumentException.class);
     new BigtableInstanceName("project", "");
+  }
+
+  @Test
+  public void testGcbInstanceName(){
+    Assert.assertTrue(bigtableInstanceName.toGcbInstanceName() instanceof InstanceName);
+  }
+
+  @Test
+  public void testAdminInstanceName(){
+    Assert.assertTrue(bigtableInstanceName.toAdminInstanceName() instanceof
+            com.google.bigtable.admin.v2.InstanceName);
   }
 }

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/OperationClock.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/OperationClock.java
@@ -15,10 +15,9 @@
  */
 package com.google.cloud.bigtable.grpc.async;
 
-import com.google.api.client.util.ExponentialBackOff;
 import com.google.api.client.util.NanoClock;
 import com.google.api.core.ApiClock;
-import com.google.cloud.bigtable.config.RetryOptions;
+import com.google.common.annotations.VisibleForTesting;
 import org.junit.Assert;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -42,6 +41,11 @@ public class OperationClock implements ApiClock {
 
   public OperationClock() {
     this.timeNs = System.nanoTime();
+  }
+
+  @VisibleForTesting
+  void setTime(long time, TimeUnit timeUnit) {
+    this.timeNs = timeUnit.toNanos(time);
   }
 
   @Override

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/io/WatchdogTest.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/io/WatchdogTest.java
@@ -121,6 +121,12 @@ public class WatchdogTest {
         "Some upstream exception representing cancellation");
   }
 
+  @Test
+  public void testStopTwice() throws Exception {
+    watchdog.stop();
+    watchdog.stop(); // make sure don't get NPE
+  }
+
   static class FakeClientCall extends ClientCall<String, String> {
 
     Listener<String> listener;

--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestFilters.java
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestFilters.java
@@ -1383,7 +1383,9 @@ public abstract class AbstractTestFilters extends AbstractTest {
     byte[] rowKey = dataHelper.randomData("testRow-");
     Put put = new Put(rowKey);
     for (int i = 0; i < numCols; ++i) {
-      put.addColumn(COLUMN_FAMILY, dataHelper.randomData(""), Bytes.toBytes(goodValue));
+      byte[] qual = dataHelper.randomData("");
+      put.addColumn(COLUMN_FAMILY, qual, 100L, Bytes.toBytes(goodValue));
+      put.addColumn(COLUMN_FAMILY, qual, 5000L, Bytes.toBytes(goodValue));
     }
     table.put(put);
 
@@ -1393,6 +1395,7 @@ public abstract class AbstractTestFilters extends AbstractTest {
     Get get = new Get(rowKey).setFilter(filter);
     Result result = table.get(get);
     Cell[] cells = result.rawCells();
+    Assert.assertEquals("Should return " + numCols + " cells", numCols, cells.length);
     for (Cell cell : cells) {
       Assert.assertEquals(
           "Should NOT have a length.",

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/AbstractBigtableTable.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/AbstractBigtableTable.java
@@ -352,7 +352,7 @@ public abstract class AbstractBigtableTable implements Table {
   @Override
   public void put(Put put) throws IOException {
     LOG.trace("put(Put)");
-    MutateRowRequest request = hbaseAdapter.adapt(put);
+    MutateRowRequest request = hbaseAdapter.adapt(put).toProto(requestContext);
     mutateRow(put, request, "put");
   }
 
@@ -399,7 +399,7 @@ public abstract class AbstractBigtableTable implements Table {
   @Override
   public void delete(Delete delete) throws IOException {
     LOG.trace("delete(Delete)");
-    MutateRowRequest request = hbaseAdapter.adapt(delete);
+    MutateRowRequest request = hbaseAdapter.adapt(delete).toProto(requestContext);
     mutateRow(delete, request, "delete");
   }
 
@@ -486,7 +486,7 @@ public abstract class AbstractBigtableTable implements Table {
     LOG.trace("mutateRow(RowMutation)");
     Span span = TRACER.spanBuilder("BigtableTable.mutateRow").startSpan();
     try (Scope scope = TRACER.withSpan(span)) {
-      MutateRowRequest request = hbaseAdapter.adapt(rm);
+      MutateRowRequest request = hbaseAdapter.adapt(rm).toProto(requestContext);
       client.mutateRow(request);
     } catch (Throwable t) {
       span.setStatus(Status.UNKNOWN);

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/AppendAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/AppendAdapter.java
@@ -15,8 +15,7 @@
  */
 package com.google.cloud.bigtable.hbase.adapters;
 
-import com.google.bigtable.v2.ReadModifyWriteRowRequest;
-import com.google.bigtable.v2.ReadModifyWriteRule;
+import com.google.cloud.bigtable.data.v2.models.ReadModifyWriteRow;
 import com.google.protobuf.ByteString;
 
 import org.apache.hadoop.hbase.Cell;
@@ -32,33 +31,29 @@ import java.util.Map;
  * @author sduskis
  * @version $Id: $Id
  */
-public class AppendAdapter implements OperationAdapter<Append, ReadModifyWriteRowRequest.Builder> {
+public class AppendAdapter implements OperationAdapter<Append, ReadModifyWriteRow> {
 
   /** {@inheritDoc} */
   @Override
-  public void adapt(Append operation, ReadModifyWriteRowRequest.Builder result) {
-    result.setRowKey(ByteString.copyFrom(operation.getRow()));
-
-    for (Map.Entry<byte[], List<Cell>> entry : operation.getFamilyCellMap().entrySet()){
+  public void adapt(Append operation, ReadModifyWriteRow readModifyWriteRow) {
+    for (Map.Entry<byte[], List<Cell>> entry : operation.getFamilyCellMap().entrySet()) {
       String familyName = Bytes.toString(entry.getKey());
       // Bigtable applies all appends present in a single RPC. HBase applies only the last
       // mutation present, if any. We remove all but the last mutation for each qualifier here:
       List<Cell> cells = CellDeduplicationHelper.deduplicateFamily(operation, entry.getKey());
 
       for (Cell cell : cells) {
-        ReadModifyWriteRule.Builder rule = ReadModifyWriteRule.newBuilder();
-        rule.setFamilyName(familyName);
-        rule.setColumnQualifier(
+        readModifyWriteRow.append(
+            familyName,
             ByteString.copyFrom(
                 cell.getQualifierArray(),
                 cell.getQualifierOffset(),
-                cell.getQualifierLength()));
-        rule.setAppendValue(
+                cell.getQualifierLength()),
             ByteString.copyFrom(
                 cell.getValueArray(),
                 cell.getValueOffset(),
-                cell.getValueLength()));
-        result.addRules(rule.build());
+                cell.getValueLength())
+        );
       }
     }
   }

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/CheckAndMutateUtil.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/CheckAndMutateUtil.java
@@ -15,11 +15,12 @@
  */
 package com.google.cloud.bigtable.hbase.adapters;
 
+import static com.google.cloud.bigtable.data.v2.models.Filters.FILTERS;
 import com.google.bigtable.v2.CheckAndMutateRowRequest;
 import com.google.bigtable.v2.CheckAndMutateRowResponse;
-import com.google.bigtable.v2.Mutation;
 import com.google.bigtable.v2.ReadRowsRequest;
 import com.google.bigtable.v2.RowFilter;
+import com.google.cloud.bigtable.data.v2.models.ConditionalRowMutation;
 import com.google.cloud.bigtable.hbase.adapters.read.ReadHooks;
 import com.google.cloud.bigtable.hbase.filter.TimestampRangeFilter;
 import com.google.common.base.Function;
@@ -37,9 +38,7 @@ import org.apache.hadoop.hbase.filter.FilterList;
 import org.apache.hadoop.hbase.filter.ValueFilter;
 
 import javax.annotation.Nullable;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 
 public class CheckAndMutateUtil {
 
@@ -80,13 +79,13 @@ public class CheckAndMutateUtil {
 
   /**
    * This class can be used to convert HBase checkAnd* operations to Bigtable
-   * {@link CheckAndMutateRowRequest}s.
+   * {@link ConditionalRowMutation}s.
    */
   public static class RequestBuilder {
     private final HBaseRequestAdapter hbaseAdapter;
-    private final CheckAndMutateRowRequest.Builder requestBuilder;
 
-    private final List<Mutation> mutations = new ArrayList<>();
+    private final com.google.cloud.bigtable.data.v2.models.Mutation mutations =
+        com.google.cloud.bigtable.data.v2.models.Mutation.createUnsafe();
 
     private final byte[] row;
     private final byte[] family;
@@ -101,17 +100,14 @@ public class CheckAndMutateUtil {
      * RequestBuilder.
      * </p>
      * @param hbaseAdapter a {@link HBaseRequestAdapter} used to convert HBase
-     *          {@link org.apache.hadoop.hbase.client.Mutation} to Cloud Bigtable {@link Mutation}
+     *          {@link org.apache.hadoop.hbase.client.Mutation} to Cloud Bigtable
+     *          {@link com.google.cloud.bigtable.data.v2.models.Mutation}
      * @param row the RowKey in which to to check value matching
      * @param family the family in which to check value matching.
      */
     public RequestBuilder(HBaseRequestAdapter hbaseAdapter, byte[] row, byte[] family) {
       this.row = Preconditions.checkNotNull(row, "row is null");
       this.family = Preconditions.checkNotNull(family, "family is null");
-
-      requestBuilder = CheckAndMutateRowRequest.newBuilder()
-          .setRowKey(ByteString.copyFrom(row))
-          .setTableName(hbaseAdapter.getBigtableTableName().toString());
 
       // The hbaseAdapter used here should not set client-side timestamps, since that may cause strange contention
       // issues.  See issue #1709.
@@ -177,31 +173,36 @@ public class CheckAndMutateUtil {
     }
 
     public RequestBuilder withPut(Put put) throws DoNotRetryIOException {
-      return addMutations(put.getRow(), hbaseAdapter.adapt(put).getMutationsList());
+      validateRow(put.getRow());
+      hbaseAdapter.adapt(put, mutations);
+      return this;
     }
 
     public RequestBuilder withDelete(Delete delete) throws DoNotRetryIOException {
-      return addMutations(delete.getRow(), hbaseAdapter.adapt(delete).getMutationsList());
+      validateRow(delete.getRow());
+      hbaseAdapter.adapt(delete, mutations);
+      return this;
     }
 
     public RequestBuilder withMutations(RowMutations rm) throws DoNotRetryIOException {
-      return addMutations(rm.getRow(), hbaseAdapter.adapt(rm).getMutationsList());
+      validateRow(rm.getRow());
+      hbaseAdapter.adapt(rm, mutations);
+      return this;
     }
 
-    private RequestBuilder addMutations(byte[] actionRow, List<Mutation> mutations) throws DoNotRetryIOException {
+    private void validateRow(byte[] actionRow) throws DoNotRetryIOException {
       if (!Arrays.equals(actionRow, row)) {
         // The following odd exception message is for compatibility with HBase.
         throw new DoNotRetryIOException("Action's getRow must match the passed row");
       }
-      this.mutations.addAll(mutations);
-      return this;
     }
 
-    public CheckAndMutateRowRequest build() {
+    public ConditionalRowMutation build() {
       Preconditions.checkState(checkNonExistence || compareOp != null,
           "condition is null. You need to specify the condition by" +
           " calling ifNotExists/ifEquals/ifMatches before executing the request");
-
+      ConditionalRowMutation conditionalRowMutation = ConditionalRowMutation
+          .create(hbaseAdapter.getBigtableTableName().getTableId(), ByteString.copyFrom(row));
       Scan scan = new Scan();
       scan.setMaxVersions(1);
       scan.addColumn(family, qualifier);
@@ -210,10 +211,10 @@ public class CheckAndMutateUtil {
         // See ifMatches javadoc for more information on this
         if (CompareOp.NOT_EQUAL.equals(compareOp)) {
           // check for existence
-          requestBuilder.addAllTrueMutations(mutations);
+          conditionalRowMutation.then(mutations);
         } else {
           // check for non-existence
-          requestBuilder.addAllFalseMutations(mutations);
+          conditionalRowMutation.otherwise(mutations);
         }
         if (timeFilter != null) {
           scan.setFilter(timeFilter);
@@ -226,12 +227,13 @@ public class CheckAndMutateUtil {
         } else {
           scan.setFilter(valueFilter);
         }
-        requestBuilder.addAllTrueMutations(mutations);
+        conditionalRowMutation.then(mutations);
       }
-      requestBuilder.setPredicateFilter(
-          Adapters.SCAN_ADAPTER.buildFilter(scan, UNSUPPORTED_READ_HOOKS));
+      conditionalRowMutation.condition(
+          FILTERS.fromProto(Adapters.SCAN_ADAPTER.buildFilter(scan, UNSUPPORTED_READ_HOOKS))
+      );
 
-      return requestBuilder.build();
+      return conditionalRowMutation;
     }
   }
 

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/CheckAndMutateUtil.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/CheckAndMutateUtil.java
@@ -15,7 +15,6 @@
  */
 package com.google.cloud.bigtable.hbase.adapters;
 
-import static com.google.cloud.bigtable.data.v2.models.Filters.FILTERS;
 import com.google.bigtable.v2.CheckAndMutateRowRequest;
 import com.google.bigtable.v2.CheckAndMutateRowResponse;
 import com.google.bigtable.v2.ReadRowsRequest;
@@ -230,7 +229,7 @@ public class CheckAndMutateUtil {
         conditionalRowMutation.then(mutations);
       }
       conditionalRowMutation.condition(
-          FILTERS.fromProto(Adapters.SCAN_ADAPTER.buildFilter(scan, UNSUPPORTED_READ_HOOKS))
+         Adapters.SCAN_ADAPTER.buildFilter(scan, UNSUPPORTED_READ_HOOKS)
       );
 
       return conditionalRowMutation;

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/CheckAndMutateUtil.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/CheckAndMutateUtil.java
@@ -21,6 +21,7 @@ import com.google.bigtable.v2.CheckAndMutateRowResponse;
 import com.google.bigtable.v2.ReadRowsRequest;
 import com.google.bigtable.v2.RowFilter;
 import com.google.cloud.bigtable.data.v2.models.ConditionalRowMutation;
+import com.google.cloud.bigtable.data.v2.models.Mutation;
 import com.google.cloud.bigtable.hbase.adapters.read.ReadHooks;
 import com.google.cloud.bigtable.hbase.filter.TimestampRangeFilter;
 import com.google.common.base.Function;
@@ -84,8 +85,7 @@ public class CheckAndMutateUtil {
   public static class RequestBuilder {
     private final HBaseRequestAdapter hbaseAdapter;
 
-    private final com.google.cloud.bigtable.data.v2.models.Mutation mutations =
-        com.google.cloud.bigtable.data.v2.models.Mutation.createUnsafe();
+    private final Mutation mutations = Mutation.createUnsafe();
 
     private final byte[] row;
     private final byte[] family;

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/HBaseRequestAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/HBaseRequestAdapter.java
@@ -20,6 +20,7 @@ import com.google.cloud.bigtable.data.v2.internal.RequestContext;
 import com.google.cloud.bigtable.data.v2.models.InstanceName;
 import com.google.cloud.bigtable.data.v2.models.Mutation;
 import com.google.cloud.bigtable.data.v2.models.MutationApi;
+import com.google.cloud.bigtable.data.v2.models.ReadModifyWriteRow;
 import com.google.cloud.bigtable.data.v2.models.RowMutation;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.ByteString;
@@ -198,11 +199,10 @@ public class HBaseRequestAdapter {
    * @return a {@link com.google.bigtable.v2.ReadModifyWriteRowRequest} object.
    */
   public ReadModifyWriteRowRequest adapt(Append append) {
-    ReadModifyWriteRowRequest.Builder builder = ReadModifyWriteRowRequest.newBuilder();
-    //TODO: change APPEND_ADAPTER to adapt to {@link com.google.cloud.bigtable.data.v2.models.ReadModifyWriteRow} model
-    Adapters.APPEND_ADAPTER.adapt(append, builder);
-    builder.setTableName(getTableNameString());
-    return builder.build();
+    ReadModifyWriteRow readModifyWriteRow = ReadModifyWriteRow
+        .create(bigtableTableName.getTableId(), ByteString.copyFrom(append.getRow()));
+    Adapters.APPEND_ADAPTER.adapt(append, readModifyWriteRow);
+    return readModifyWriteRow.toProto(requestContext);
   }
 
   /**
@@ -212,11 +212,10 @@ public class HBaseRequestAdapter {
    * @return a {@link com.google.bigtable.v2.ReadModifyWriteRowRequest} object.
    */
   public ReadModifyWriteRowRequest adapt(Increment increment) {
-    ReadModifyWriteRowRequest.Builder builder = ReadModifyWriteRowRequest.newBuilder();
-    //TODO: change INCREMENT_ADAPTER to adapt to {@link com.google.cloud.bigtable.data.v2.models.ReadModifyWriteRow} model
-    Adapters.INCREMENT_ADAPTER.adapt(increment, builder);
-    builder.setTableName(getTableNameString());
-    return builder.build();
+    ReadModifyWriteRow readModifyWriteRow = ReadModifyWriteRow
+        .create(bigtableTableName.getTableId(), ByteString.copyFrom(increment.getRow()));
+    Adapters.INCREMENT_ADAPTER.adapt(increment, readModifyWriteRow);
+    return readModifyWriteRow.toProto(requestContext);
   }
 
   /**

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/HBaseRequestAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/HBaseRequestAdapter.java
@@ -135,12 +135,12 @@ public class HBaseRequestAdapter {
    * <p>adapt.</p>
    *
    * @param delete a {@link org.apache.hadoop.hbase.client.Delete} object.
-   * @return a {@link com.google.bigtable.v2.MutateRowRequest} object.
+   * @return a {@link RowMutation} object.
    */
-  public MutateRowRequest adapt(Delete delete) {
+  public RowMutation adapt(Delete delete) {
     RowMutation rowMutation = newRowMutationModel(delete.getRow());
     adapt(delete, rowMutation);
-    return rowMutation.toProto(requestContext);
+    return rowMutation;
   }
 
   /**
@@ -222,12 +222,12 @@ public class HBaseRequestAdapter {
    * <p>adapt.</p>
    *
    * @param put a {@link org.apache.hadoop.hbase.client.Put} object.
-   * @return a {@link com.google.bigtable.v2.MutateRowRequest} object.
+   * @return a {@link RowMutation} object.
    */
-  public MutateRowRequest adapt(Put put) {
+  public RowMutation adapt(Put put) {
     RowMutation rowMutation = newRowMutationModel(put.getRow());
     adapt(put, rowMutation);
-    return rowMutation.toProto(requestContext);
+    return rowMutation;
   }
 
   /**
@@ -256,12 +256,12 @@ public class HBaseRequestAdapter {
    * <p>adapt.</p>
    *
    * @param mutations a {@link org.apache.hadoop.hbase.client.RowMutations} object.
-   * @return a {@link com.google.bigtable.v2.MutateRowRequest} object.
+   * @return a {@link RowMutation} object.
    */
-  public MutateRowRequest adapt(RowMutations mutations) {
+  public RowMutation adapt(RowMutations mutations) {
     RowMutation rowMutation = newRowMutationModel(mutations.getRow());
     adapt(mutations, rowMutation);
-    return rowMutation.toProto(requestContext);
+    return rowMutation;
   }
 
   /**

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/IncrementAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/IncrementAdapter.java
@@ -15,9 +15,7 @@
  */
 package com.google.cloud.bigtable.hbase.adapters;
 
-
-import com.google.bigtable.v2.ReadModifyWriteRowRequest;
-import com.google.bigtable.v2.ReadModifyWriteRule;
+import com.google.cloud.bigtable.data.v2.models.ReadModifyWriteRow;
 import com.google.protobuf.ByteString;
 
 import org.apache.hadoop.hbase.Cell;
@@ -36,17 +34,15 @@ import java.util.NavigableMap;
  * @version $Id: $Id
  */
 public class IncrementAdapter
-    implements OperationAdapter<Increment, ReadModifyWriteRowRequest.Builder>{
+    implements OperationAdapter<Increment, ReadModifyWriteRow>{
 
   /** {@inheritDoc} */
   @Override
-  public void adapt(Increment operation, ReadModifyWriteRowRequest.Builder result) {
+  public void adapt(Increment operation, ReadModifyWriteRow readModifyWriteRow) {
     if (!operation.getTimeRange().isAllTime()) {
       throw new UnsupportedOperationException(
           "Setting the time range in an Increment is not implemented");
     }
-
-    result.setRowKey(ByteString.copyFrom(operation.getRow()));
 
     for (Map.Entry<byte[], NavigableMap<byte[], Long>> familyEntry :
         operation.getFamilyMapOfLongs().entrySet()) {
@@ -56,17 +52,15 @@ public class IncrementAdapter
       List<Cell> mutationCells =
           CellDeduplicationHelper.deduplicateFamily(operation, familyEntry.getKey());
 
-      for (Cell cell : mutationCells){
-        ReadModifyWriteRule.Builder rule = ReadModifyWriteRule.newBuilder();
-        rule.setIncrementAmount(
-            Bytes.toLong(cell.getValueArray(), cell.getValueOffset(), cell.getValueLength()));
-        rule.setFamilyName(familyName);
-        rule.setColumnQualifier(
+      for (Cell cell : mutationCells) {
+        readModifyWriteRow.increment(
+            familyName,
             ByteString.copyFrom(
                 cell.getQualifierArray(),
                 cell.getQualifierOffset(),
-                cell.getQualifierLength()));
-        result.addRules(rule.build());
+                cell.getQualifierLength()),
+            Bytes.toLong(cell.getValueArray(), cell.getValueOffset(), cell.getValueLength())
+        );
       }
     }
   }

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/admin/ColumnDescriptorAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/admin/ColumnDescriptorAdapter.java
@@ -15,22 +15,26 @@
  */
 package com.google.cloud.bigtable.hbase.adapters.admin;
 
-import static com.google.cloud.bigtable.admin.v2.models.GCRules.GCRULES;
-
 import com.google.bigtable.admin.v2.ColumnFamily;
 import com.google.bigtable.admin.v2.GcRule;
+import com.google.bigtable.admin.v2.GcRule.Intersection;
 import com.google.bigtable.admin.v2.GcRule.RuleCase;
+import com.google.bigtable.admin.v2.GcRule.Union;
 import com.google.cloud.bigtable.admin.v2.models.GCRules.GCRule;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import org.threeten.bp.Duration;
+import com.google.protobuf.Duration;
 
 import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HConstants;
 
+import static com.google.cloud.bigtable.admin.v2.models.GCRules.GCRULES;
+
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -163,10 +167,11 @@ public class ColumnDescriptorAdapter {
   }
 
   /**
-   * Construct an Bigtable {@link GCRule} from the given column descriptor.
+   * Construct an Bigtable {@link com.google.cloud.bigtable.admin.v2.models.GCRules.GCRule} from the
+   * given column descriptor.
    *
    * @param columnDescriptor a {@link org.apache.hadoop.hbase.HColumnDescriptor} object.
-   * @return a {@link GCRule} object.
+   * @return a {@link com.google.cloud.bigtable.admin.v2.models.GCRules.GCRule} object.
    */
   public static GCRule buildGarbageCollectionRule(HColumnDescriptor columnDescriptor) {
     int maxVersions = columnDescriptor.getMaxVersions();
@@ -185,7 +190,7 @@ public class ColumnDescriptorAdapter {
     }
 
     // minVersions only comes into play with a TTL:
-    GCRule ageRule = GCRULES.maxAge(Duration.ofSeconds(ttlSeconds));
+    GCRule ageRule = GCRULES.maxAge(org.threeten.bp.Duration.ofSeconds(ttlSeconds));
     if (minVersions != HColumnDescriptor.DEFAULT_MIN_VERSIONS) {
       // The logic here is: only delete a cell if:
       //  1) the age is older than :ttlSeconds AND
@@ -202,6 +207,34 @@ public class ColumnDescriptorAdapter {
     } else {
       return GCRULES.union().rule(ageRule).rule(GCRULES.maxVersions(maxVersions));
     }
+  }
+
+  @VisibleForTesting
+  static GcRule intersection(GcRule... rules) {
+    return GcRule.newBuilder()
+        .setIntersection(Intersection.newBuilder().addAllRules(Arrays.asList(rules)).build())
+        .build();
+  }
+
+  @VisibleForTesting
+  static GcRule union(GcRule... rules) {
+    return GcRule.newBuilder()
+        .setUnion(Union.newBuilder().addAllRules(Arrays.asList(rules)).build())
+        .build();
+  }
+
+  private static Duration duration(int ttlSeconds) {
+    return Duration.newBuilder().setSeconds(ttlSeconds).build();
+  }
+
+  @VisibleForTesting
+  static GcRule maxAge(int ttlSeconds) {
+    return GcRule.newBuilder().setMaxAge(duration(ttlSeconds)).build();
+  }
+
+  @VisibleForTesting
+  static GcRule maxVersions(int maxVersions) {
+    return GcRule.newBuilder().setMaxNumVersions(maxVersions).build();
   }
 
   /**
@@ -309,9 +342,9 @@ public class ColumnDescriptorAdapter {
     throwIfRequestingUnsupportedFeatures(columnDescriptor);
 
     ColumnFamily.Builder resultBuilder = ColumnFamily.newBuilder();
-    GCRule gcRule = buildGarbageCollectionRule(columnDescriptor);
-    if (gcRule != null) {
-      resultBuilder.setGcRule(gcRule.toProto());
+    GCRule gcRuleModel = buildGarbageCollectionRule(columnDescriptor);
+    if (gcRuleModel != null) {
+      resultBuilder.setGcRule(gcRuleModel.toProto());
     }
     return resultBuilder.build();
   }

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/BigtableFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/BigtableFilterAdapter.java
@@ -18,6 +18,7 @@ package com.google.cloud.bigtable.hbase.adapters.filters;
 import java.io.IOException;
 
 import com.google.bigtable.v2.RowFilter;
+import com.google.cloud.bigtable.data.v2.models.Filters.Filter;
 import com.google.cloud.bigtable.hbase.filter.BigtableFilter;
 
 /**
@@ -26,8 +27,8 @@ import com.google.cloud.bigtable.hbase.filter.BigtableFilter;
 public class BigtableFilterAdapter extends TypedFilterAdapterBase<BigtableFilter> {
 
   @Override
-  public RowFilter adapt(FilterAdapterContext context, BigtableFilter filter) throws IOException {
-    return filter.getRowFilter();
+  public Filter adapt(FilterAdapterContext context, BigtableFilter filter) throws IOException {
+    return filter.getFilter();
   }
 
   @Override

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/ColumnCountGetFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/ColumnCountGetFilterAdapter.java
@@ -16,7 +16,7 @@
 package com.google.cloud.bigtable.hbase.adapters.filters;
 
 import static com.google.cloud.bigtable.data.v2.models.Filters.FILTERS;
-import com.google.bigtable.v2.RowFilter;
+import com.google.cloud.bigtable.data.v2.models.Filters.Filter;
 
 import org.apache.hadoop.hbase.filter.ColumnCountGetFilter;
 
@@ -33,14 +33,13 @@ public class ColumnCountGetFilterAdapter extends TypedFilterAdapterBase<ColumnCo
 
   /** {@inheritDoc} */
   @Override
-  public RowFilter adapt(FilterAdapterContext context, ColumnCountGetFilter filter)
+  public Filter adapt(FilterAdapterContext context, ColumnCountGetFilter filter)
       throws IOException {
     // This is fairly broken for all scans, but I'm simply going for bug-for-bug
     // compatible with string reader expressions.
     return FILTERS.chain()
         .filter(FILTERS.limit().cellsPerColumn(1))
-        .filter(FILTERS.limit().cellsPerRow(filter.getLimit()))
-        .toProto();
+        .filter(FILTERS.limit().cellsPerRow(filter.getLimit()));
   }
 
   /** {@inheritDoc} */

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/ColumnPaginationFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/ColumnPaginationFilterAdapter.java
@@ -16,7 +16,6 @@
 package com.google.cloud.bigtable.hbase.adapters.filters;
 
 import static com.google.cloud.bigtable.data.v2.models.Filters.FILTERS;
-import com.google.bigtable.v2.RowFilter;
 import com.google.cloud.bigtable.data.v2.models.Filters.ChainFilter;
 import com.google.cloud.bigtable.data.v2.models.Filters.Filter;
 import com.google.protobuf.ByteString;
@@ -41,8 +40,9 @@ public class ColumnPaginationFilterAdapter extends TypedFilterAdapterBase<Column
 
   /** {@inheritDoc} */
   @Override
-  public RowFilter adapt(FilterAdapterContext context, ColumnPaginationFilter filter)
+  public Filter adapt(FilterAdapterContext context, ColumnPaginationFilter filter)
       throws IOException {
+    //REVISIT:
     if (filter.getColumnOffset() != null) {
       byte[] family = context.getScan().getFamilies()[0];
       ByteString startQualifier = ByteString.copyFrom(filter.getColumnOffset());
@@ -68,7 +68,7 @@ public class ColumnPaginationFilterAdapter extends TypedFilterAdapterBase<Column
    * qualifier, those cells that pass an option intermediate filter
    * and are less than the limit per row.
    */
-  private RowFilter createChain(
+  private Filter createChain(
       ColumnPaginationFilter filter, Filter intermediate) {
     ChainFilter chain = FILTERS.chain();
     chain.filter(FILTERS.limit().cellsPerColumn(1));
@@ -76,7 +76,7 @@ public class ColumnPaginationFilterAdapter extends TypedFilterAdapterBase<Column
       chain.filter(intermediate);
     }
     chain.filter(FILTERS.limit().cellsPerRow(filter.getLimit()));
-    return chain.toProto();
+    return chain;
   }
 
   /** {@inheritDoc} */

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/ColumnPrefixFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/ColumnPrefixFilterAdapter.java
@@ -15,13 +15,14 @@
  */
 package com.google.cloud.bigtable.hbase.adapters.filters;
 
-import com.google.bigtable.v2.RowFilter;
+import com.google.cloud.bigtable.data.v2.models.Filters.Filter;
 import com.google.cloud.bigtable.hbase.adapters.read.ReaderExpressionHelper;
 import com.google.protobuf.ByteString;
 
 import org.apache.hadoop.hbase.filter.ColumnPrefixFilter;
 
-import java.io.ByteArrayOutputStream;
+import static com.google.cloud.bigtable.data.v2.models.Filters.FILTERS;
+
 import java.io.IOException;
 
 /**
@@ -35,21 +36,18 @@ public class ColumnPrefixFilterAdapter extends TypedFilterAdapterBase<ColumnPref
 
   /** {@inheritDoc} */
   @Override
-  public RowFilter adapt(FilterAdapterContext context, ColumnPrefixFilter filter)
+  public Filter adapt(FilterAdapterContext context, ColumnPrefixFilter filter)
       throws IOException {
     byte[] prefix = filter.getPrefix();
 
     // Quoting for RE2 can result in at most length * 2 characters written. Pre-allocate
-    // that much space in the ByteArrayOutputStream to prevent reallocation later.
-    ByteArrayOutputStream outputStream = new ByteArrayOutputStream(prefix.length * 2);
-    ReaderExpressionHelper.writeQuotedRegularExpression(outputStream, prefix);
+    // that much space in the ByteString.Output to prevent reallocation later.
+    ByteString.Output outputStream = ByteString.newOutput(prefix.length * 2);
+    ReaderExpressionHelper.writeQuotedExpression(outputStream, prefix);
     outputStream.write(ReaderExpressionHelper.ALL_QUALIFIERS_BYTES);
+    Filter qualifierFilter = FILTERS.qualifier().regex(outputStream.toByteString());
 
-    return RowFilter.newBuilder()
-        .setColumnQualifierRegexFilter(
-            ByteString.copyFrom(
-                outputStream.toByteArray()))
-        .build();
+    return FILTERS.chain().filter(qualifierFilter);
   }
 
   /** {@inheritDoc} */

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/ColumnRangeFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/ColumnRangeFilterAdapter.java
@@ -17,7 +17,7 @@ package com.google.cloud.bigtable.hbase.adapters.filters;
 
 import static com.google.cloud.bigtable.data.v2.models.Filters.FILTERS;
 
-import com.google.bigtable.v2.RowFilter;
+import com.google.cloud.bigtable.data.v2.models.Filters.Filter;
 import com.google.cloud.bigtable.data.v2.models.Filters.QualifierRangeFilter;
 import com.google.protobuf.ByteString;
 
@@ -43,7 +43,7 @@ public class ColumnRangeFilterAdapter extends TypedFilterAdapterBase<ColumnRange
 
   /** {@inheritDoc} */
   @Override
-  public RowFilter adapt(FilterAdapterContext context, ColumnRangeFilter filter)
+  public Filter adapt(FilterAdapterContext context, ColumnRangeFilter filter)
       throws IOException {
     byte[] familyName = getSingleFamily(context.getScan());
     QualifierRangeFilter rangeBuilder = FILTERS.qualifier().rangeWithinFamily(Bytes.toString(familyName));
@@ -65,7 +65,7 @@ public class ColumnRangeFilterAdapter extends TypedFilterAdapterBase<ColumnRange
         rangeBuilder.endOpen(endQualifier);
       }
     }
-    return rangeBuilder.toProto();
+    return rangeBuilder;
   }
 
   /** {@inheritDoc} */

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/FamilyFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/FamilyFilterAdapter.java
@@ -17,7 +17,7 @@ package com.google.cloud.bigtable.hbase.adapters.filters;
 
 import static com.google.cloud.bigtable.data.v2.models.Filters.FILTERS;
 
-import com.google.bigtable.v2.RowFilter;
+import com.google.cloud.bigtable.data.v2.models.Filters.Filter;
 import com.google.cloud.bigtable.hbase.adapters.read.ReaderExpressionHelper;
 
 import com.google.protobuf.ByteString;
@@ -39,7 +39,7 @@ public class FamilyFilterAdapter extends TypedFilterAdapterBase<FamilyFilter> {
 
   /** {@inheritDoc} */
   @Override
-  public RowFilter adapt(FilterAdapterContext context, FamilyFilter filter)
+  public Filter adapt(FilterAdapterContext context, FamilyFilter filter)
       throws IOException {
     CompareOp compareOp = filter.getOperator();
     if (compareOp != CompareFilter.CompareOp.EQUAL) {
@@ -61,7 +61,7 @@ public class FamilyFilterAdapter extends TypedFilterAdapterBase<FamilyFilter> {
       throw new IllegalStateException(
           "Cannot adapt comparator " + comparator.getClass().getCanonicalName());
     }
-    return FILTERS.family().regex(family).toProto();
+    return FILTERS.family().regex(family);
   }
 
   /** {@inheritDoc} */

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/FilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/FilterAdapter.java
@@ -15,7 +15,7 @@
  */
 package com.google.cloud.bigtable.hbase.adapters.filters;
 
-import com.google.bigtable.v2.RowFilter;
+import com.google.cloud.bigtable.data.v2.models.Filters;
 import com.google.cloud.bigtable.hbase.filter.BigtableFilter;
 import com.google.cloud.bigtable.hbase.filter.TimestampRangeFilter;
 import com.google.cloud.bigtable.util.RowKeyWrapper;
@@ -165,7 +165,7 @@ public class FilterAdapter {
    * @return a {@link com.google.common.base.Optional} object.
    * @throws java.io.IOException if any.
    */
-  public Optional<RowFilter> adaptFilter(FilterAdapterContext context, Filter filter)
+  public Optional<Filters.Filter> adaptFilter(FilterAdapterContext context, Filter filter)
       throws IOException {
     SingleFilterAdapter<?> adapter = getAdapterForFilterOrThrow(filter);
     return Optional.fromNullable(adapter.adapt(context, filter));

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/FirstKeyOnlyFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/FirstKeyOnlyFilterAdapter.java
@@ -17,7 +17,7 @@ package com.google.cloud.bigtable.hbase.adapters.filters;
 
 import static com.google.cloud.bigtable.data.v2.models.Filters.FILTERS;
 
-import com.google.bigtable.v2.RowFilter;
+import com.google.cloud.bigtable.data.v2.models.Filters;
 
 import org.apache.hadoop.hbase.filter.FirstKeyOnlyFilter;
 
@@ -29,14 +29,14 @@ import org.apache.hadoop.hbase.filter.FirstKeyOnlyFilter;
  */
 public class FirstKeyOnlyFilterAdapter extends TypedFilterAdapterBase<FirstKeyOnlyFilter> {
 
-  private static RowFilter LIMIT_ONE = FILTERS.chain()
+
+  private static Filters.Filter LIMIT_ONE = FILTERS.chain()
       .filter(FILTERS.limit().cellsPerRow(1))
-      .filter(FILTERS.value().strip())
-      .toProto();
+      .filter(FILTERS.value().strip());
 
   /** {@inheritDoc} */
   @Override
-  public RowFilter adapt(FilterAdapterContext context, FirstKeyOnlyFilter filter) {
+  public Filters.Filter adapt(FilterAdapterContext context, FirstKeyOnlyFilter filter) {
     return LIMIT_ONE;
   }
 

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/FirstKeyOnlyFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/FirstKeyOnlyFilterAdapter.java
@@ -29,7 +29,10 @@ import org.apache.hadoop.hbase.filter.FirstKeyOnlyFilter;
  */
 public class FirstKeyOnlyFilterAdapter extends TypedFilterAdapterBase<FirstKeyOnlyFilter> {
 
-  private static RowFilter LIMIT_ONE = FILTERS.limit().cellsPerRow(1).toProto();
+  private static RowFilter LIMIT_ONE = FILTERS.chain()
+      .filter(FILTERS.limit().cellsPerRow(1))
+      .filter(FILTERS.value().strip())
+      .toProto();
 
   /** {@inheritDoc} */
   @Override

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/FuzzyRowFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/FuzzyRowFilterAdapter.java
@@ -27,7 +27,6 @@ import org.apache.hadoop.hbase.util.Pair;
 
 import com.google.cloud.bigtable.data.v2.models.Filters.Filter;
 
-import com.google.bigtable.v2.RowFilter;
 import com.google.cloud.bigtable.data.v2.models.Filters.InterleaveFilter;
 import com.google.cloud.bigtable.hbase.adapters.read.ReaderExpressionHelper;
 import com.google.cloud.bigtable.hbase.adapters.read.ReaderExpressionHelper.QuoteMetaOutputStream;
@@ -40,7 +39,6 @@ import com.google.common.base.Preconditions;
  * @version $Id: $Id
  */
 public class FuzzyRowFilterAdapter extends TypedFilterAdapterBase<FuzzyRowFilter> {
-  private static final RowFilter ALL_VALUES_FILTER = FILTERS.pass().toProto();
 
   private static Field FUZZY_KEY_DATA_FIELD;
   private static Exception FUZZY_KEY_DATA_FIELD_EXCEPTION;
@@ -56,10 +54,10 @@ public class FuzzyRowFilterAdapter extends TypedFilterAdapterBase<FuzzyRowFilter
 
   /** {@inheritDoc} */
   @Override
-  public RowFilter adapt(FilterAdapterContext context, FuzzyRowFilter filter) throws IOException {
+  public Filter adapt(FilterAdapterContext context, FuzzyRowFilter filter) throws IOException {
     List<Pair<byte[], byte[]>> pairs = extractFuzzyRowFilterPairs(filter);
     if (pairs.isEmpty()) {
-      return ALL_VALUES_FILTER;
+      return FILTERS.pass();
     }
     InterleaveFilter interleave = FILTERS.interleave();
     for (Pair<byte[], byte[]> pair : pairs) {
@@ -70,7 +68,7 @@ public class FuzzyRowFilterAdapter extends TypedFilterAdapterBase<FuzzyRowFilter
           createSingleRowFilter(
               pair.getFirst(), pair.getSecond()));
     }
-    return interleave.toProto();
+    return interleave;
   }
 
   private static Filter createSingleRowFilter(byte[] key, byte[] mask) throws IOException {

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/KeyOnlyFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/KeyOnlyFilterAdapter.java
@@ -17,7 +17,8 @@ package com.google.cloud.bigtable.hbase.adapters.filters;
 
 import static com.google.cloud.bigtable.data.v2.models.Filters.FILTERS;
 
-import com.google.bigtable.v2.RowFilter;
+import com.google.cloud.bigtable.data.v2.models.Filters;
+
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.filter.KeyOnlyFilter;
@@ -40,15 +41,15 @@ public class KeyOnlyFilterAdapter extends TypedFilterAdapterBase<KeyOnlyFilter> 
       1L,
       Bytes.toBytes('v'));
 
-  private static RowFilter KEY_ONLY_FILTER =
+
+  private static Filters.Filter KEY_ONLY_FILTER =
       FILTERS.chain()
           .filter(FILTERS.limit().cellsPerColumn(1))
-          .filter(FILTERS.value().strip())
-          .toProto();
+          .filter(FILTERS.value().strip());
 
   /** {@inheritDoc} */
   @Override
-  public RowFilter adapt(FilterAdapterContext context, KeyOnlyFilter filter) throws IOException {
+  public Filters.Filter adapt(FilterAdapterContext context, KeyOnlyFilter filter) throws IOException {
     return KEY_ONLY_FILTER;
   }
 

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/KeyOnlyFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/KeyOnlyFilterAdapter.java
@@ -42,7 +42,7 @@ public class KeyOnlyFilterAdapter extends TypedFilterAdapterBase<KeyOnlyFilter> 
 
   private static RowFilter KEY_ONLY_FILTER =
       FILTERS.chain()
-          .filter(FILTERS.limit().cellsPerRow(1))
+          .filter(FILTERS.limit().cellsPerColumn(1))
           .filter(FILTERS.value().strip())
           .toProto();
 

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/MultiRowRangeFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/MultiRowRangeFilterAdapter.java
@@ -17,7 +17,7 @@ package com.google.cloud.bigtable.hbase.adapters.filters;
 
 import static com.google.cloud.bigtable.data.v2.models.Filters.FILTERS;
 
-import com.google.bigtable.v2.RowFilter;
+import com.google.cloud.bigtable.data.v2.models.Filters.Filter;
 import com.google.cloud.bigtable.util.RowKeyWrapper;
 import com.google.common.collect.BoundType;
 import com.google.common.collect.ImmutableRangeSet;
@@ -41,10 +41,10 @@ public class MultiRowRangeFilterAdapter extends TypedFilterAdapterBase<MultiRowR
           "MultiRowRange filters can not be contained in MUST_PASS_ONE FilterLists");
 
   @Override
-  public RowFilter adapt(FilterAdapterContext context, MultiRowRangeFilter filter)
+  public Filter adapt(FilterAdapterContext context, MultiRowRangeFilter filter)
       throws IOException {
 
-    return FILTERS.pass().toProto();
+    return FILTERS.pass();
   }
 
   @Override

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/MultipleColumnPrefixFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/MultipleColumnPrefixFilterAdapter.java
@@ -17,7 +17,7 @@ package com.google.cloud.bigtable.hbase.adapters.filters;
 
 import static com.google.cloud.bigtable.data.v2.models.Filters.FILTERS;
 
-import com.google.bigtable.v2.RowFilter;
+import com.google.cloud.bigtable.data.v2.models.Filters.Filter;
 import com.google.cloud.bigtable.data.v2.models.Filters.InterleaveFilter;
 import com.google.cloud.bigtable.hbase.adapters.read.ReaderExpressionHelper;
 
@@ -38,7 +38,7 @@ public class MultipleColumnPrefixFilterAdapter
 
   /** {@inheritDoc} */
   @Override
-  public RowFilter adapt(
+  public Filter adapt(
       FilterAdapterContext context,
       MultipleColumnPrefixFilter filter) throws IOException {
     InterleaveFilter interleave = FILTERS.interleave();
@@ -55,7 +55,7 @@ public class MultipleColumnPrefixFilterAdapter
 
       interleave.filter(FILTERS.qualifier().regex(outputStream.toByteString()));
     }
-    return interleave.toProto();
+    return interleave;
   }
 
   /** {@inheritDoc} */

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/PageFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/PageFilterAdapter.java
@@ -16,7 +16,7 @@
 package com.google.cloud.bigtable.hbase.adapters.filters;
 
 import com.google.bigtable.v2.ReadRowsRequest;
-import com.google.bigtable.v2.RowFilter;
+import com.google.cloud.bigtable.data.v2.models.Filters.Filter;
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
 
@@ -41,7 +41,7 @@ public class PageFilterAdapter extends TypedFilterAdapterBase<PageFilter> {
 
   /** {@inheritDoc} */
   @Override
-  public RowFilter adapt(FilterAdapterContext context, PageFilter filter) throws IOException {
+  public Filter adapt(FilterAdapterContext context, PageFilter filter) throws IOException {
     final long pageSize = filter.getPageSize();
     context.getReadHooks().composePreSendHook(new Function<ReadRowsRequest, ReadRowsRequest>() {
       @Override

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/PrefixFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/PrefixFilterAdapter.java
@@ -17,7 +17,7 @@ package com.google.cloud.bigtable.hbase.adapters.filters;
 
 import static com.google.cloud.bigtable.data.v2.models.Filters.FILTERS;
 
-import com.google.bigtable.v2.RowFilter;
+import com.google.cloud.bigtable.data.v2.models.Filters.Filter;
 import com.google.cloud.bigtable.hbase.adapters.read.ReaderExpressionHelper;
 import com.google.cloud.bigtable.util.RowKeyUtil;
 import com.google.cloud.bigtable.util.RowKeyWrapper;
@@ -40,13 +40,13 @@ public class PrefixFilterAdapter extends TypedFilterAdapterBase<PrefixFilter> {
    * {@inheritDoc}
    */
   @Override
-  public RowFilter adapt(FilterAdapterContext context, PrefixFilter filter)
+  public Filter adapt(FilterAdapterContext context, PrefixFilter filter)
       throws IOException {
     ByteString.Output output = ByteString.newOutput(filter.getPrefix().length * 2);
     ReaderExpressionHelper.writeQuotedRegularExpression(output, filter.getPrefix());
     // Unquoted all bytes:
     output.write(ReaderExpressionHelper.ALL_QUALIFIERS_BYTES);
-    return FILTERS.key().regex(output.toByteString()).toProto();
+    return FILTERS.key().regex(output.toByteString());
   }
 
   /**

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/QualifierFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/QualifierFilterAdapter.java
@@ -17,7 +17,6 @@ package com.google.cloud.bigtable.hbase.adapters.filters;
 
 import static com.google.cloud.bigtable.data.v2.models.Filters.FILTERS;
 
-import com.google.bigtable.v2.RowFilter;
 import com.google.cloud.bigtable.data.v2.models.Filters.Filter;
 import com.google.cloud.bigtable.data.v2.models.Filters.QualifierRangeFilter;
 import com.google.cloud.bigtable.hbase.adapters.read.ReaderExpressionHelper;
@@ -50,16 +49,14 @@ public class QualifierFilterAdapter extends TypedFilterAdapterBase<QualifierFilt
 
   /** {@inheritDoc} */
   @Override
-  public RowFilter adapt(FilterAdapterContext context, QualifierFilter filter)
+  public Filter adapt(FilterAdapterContext context, QualifierFilter filter)
       throws IOException {
     if (filter.getComparator() instanceof RegexStringComparator) {
       return adaptRegexStringComparator(
-          filter.getOperator(), (RegexStringComparator) filter.getComparator())
-          .toProto();
+          filter.getOperator(), (RegexStringComparator) filter.getComparator());
     } else if (filter.getComparator() instanceof BinaryComparator) {
       return adaptBinaryComparator(
-          context, filter.getOperator(), (BinaryComparator) filter.getComparator())
-          .toProto();
+          context, filter.getOperator(), (BinaryComparator) filter.getComparator());
     }
     throw new IllegalStateException(
         String.format(

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/RandomRowFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/RandomRowFilterAdapter.java
@@ -17,7 +17,7 @@ package com.google.cloud.bigtable.hbase.adapters.filters;
 
 import static com.google.cloud.bigtable.data.v2.models.Filters.FILTERS;
 
-import com.google.bigtable.v2.RowFilter;
+import com.google.cloud.bigtable.data.v2.models.Filters.Filter;
 
 import org.apache.hadoop.hbase.filter.RandomRowFilter;
 
@@ -32,9 +32,9 @@ import java.io.IOException;
 public class RandomRowFilterAdapter extends TypedFilterAdapterBase<RandomRowFilter> {
   /** {@inheritDoc} */
   @Override
-  public RowFilter adapt(FilterAdapterContext context, RandomRowFilter filter)
+  public Filter adapt(FilterAdapterContext context, RandomRowFilter filter)
       throws IOException {
-    return FILTERS.key().sample(filter.getChance()).toProto();
+    return FILTERS.key().sample(filter.getChance());
   }
 
   /** {@inheritDoc} */

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/RowFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/RowFilterAdapter.java
@@ -25,7 +25,7 @@ import org.apache.hadoop.hbase.filter.CompareFilter;
 import org.apache.hadoop.hbase.filter.CompareFilter.CompareOp;
 import org.apache.hadoop.hbase.filter.RegexStringComparator;
 
-import com.google.bigtable.v2.RowFilter;
+import com.google.cloud.bigtable.data.v2.models.Filters.Filter;
 import com.google.cloud.bigtable.hbase.adapters.read.ReaderExpressionHelper;
 import com.google.protobuf.ByteString;
 
@@ -46,7 +46,7 @@ public class RowFilterAdapter
 
   /** {@inheritDoc} */
   @Override
-  public RowFilter adapt(FilterAdapterContext context,
+  public Filter adapt(FilterAdapterContext context,
       org.apache.hadoop.hbase.filter.RowFilter filter) throws IOException {
     CompareOp compareOp = filter.getOperator();
     if (compareOp != CompareFilter.CompareOp.EQUAL) {
@@ -66,7 +66,7 @@ public class RowFilterAdapter
       throw new IllegalStateException(String.format("Cannot adapt comparator %s", comparator
           .getClass().getCanonicalName()));
     }
-    return FILTERS.key().regex(regexValue).toProto();
+    return FILTERS.key().regex(regexValue);
   }
   
   /** {@inheritDoc} */

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/SingleColumnValueExcludeFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/SingleColumnValueExcludeFilterAdapter.java
@@ -17,7 +17,7 @@ package com.google.cloud.bigtable.hbase.adapters.filters;
 
 import static com.google.cloud.bigtable.data.v2.models.Filters.FILTERS;
 
-import com.google.bigtable.v2.RowFilter;
+import com.google.cloud.bigtable.data.v2.models.Filters.Filter;
 import com.google.cloud.bigtable.data.v2.models.Filters.QualifierRangeFilter;
 import com.google.protobuf.ByteString;
 
@@ -54,7 +54,7 @@ public class SingleColumnValueExcludeFilterAdapter
 
   /** {@inheritDoc} */
   @Override
-  public RowFilter adapt(FilterAdapterContext context, SingleColumnValueExcludeFilter filter)
+  public Filter adapt(FilterAdapterContext context, SingleColumnValueExcludeFilter filter)
       throws IOException {
     String family = Bytes.toString(context.getScan().getFamilies()[0]);
     ByteString qualifier = ByteString.copyFrom(filter.getQualifier());
@@ -62,8 +62,8 @@ public class SingleColumnValueExcludeFilterAdapter
         .filter(delegateAdapter.toFilter(context, filter))
         .filter(FILTERS.interleave()
             .filter(range(family).endOpen(qualifier))
-            .filter(range(family).startOpen(qualifier)))
-        .toProto();
+            .filter(range(family).startOpen(qualifier)));
+        
   }
 
   private static QualifierRangeFilter range(String family) {

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/SingleColumnValueFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/SingleColumnValueFilterAdapter.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 import org.apache.hadoop.hbase.filter.SingleColumnValueFilter;
 import org.apache.hadoop.hbase.filter.ValueFilter;
 
-import com.google.bigtable.v2.RowFilter;
 import com.google.cloud.bigtable.data.v2.models.Filters.Filter;
 import com.google.cloud.bigtable.data.v2.models.Filters.ChainFilter;
 import com.google.common.annotations.VisibleForTesting;
@@ -144,9 +143,9 @@ public class SingleColumnValueFilterAdapter
    * <p>
    */
   @Override
-  public RowFilter adapt(FilterAdapterContext context, SingleColumnValueFilter filter)
+  public Filter adapt(FilterAdapterContext context, SingleColumnValueFilter filter)
       throws IOException {
-    return toFilter(context, filter).toProto();
+    return toFilter(context, filter);
   }
 
   Filter toFilter(FilterAdapterContext context, SingleColumnValueFilter filter)

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/SingleFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/SingleFilterAdapter.java
@@ -15,10 +15,9 @@
  */
 package com.google.cloud.bigtable.hbase.adapters.filters;
 
+import com.google.cloud.bigtable.data.v2.models.Filters;
 import com.google.cloud.bigtable.util.RowKeyWrapper;
 import com.google.common.base.Preconditions;
-import com.google.bigtable.v2.RowFilter;
-
 import com.google.common.collect.RangeSet;
 import org.apache.hadoop.hbase.filter.Filter;
 
@@ -73,7 +72,7 @@ public class SingleFilterAdapter<T extends Filter> {
    * @return a {@link com.google.bigtable.v2.RowFilter} object.
    * @throws java.io.IOException if any.
    */
-  public RowFilter adapt(FilterAdapterContext context, Filter hbaseFilter)
+  public Filters.Filter adapt(FilterAdapterContext context, Filter hbaseFilter)
       throws IOException {
     T typedFilter = getTypedFilter(hbaseFilter);
     return adapter.adapt(context, typedFilter);

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/TimestampRangeFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/TimestampRangeFilterAdapter.java
@@ -15,7 +15,8 @@
  */
 package com.google.cloud.bigtable.hbase.adapters.filters;
 
-import com.google.bigtable.v2.RowFilter;
+
+import com.google.cloud.bigtable.data.v2.models.Filters.Filter;
 import com.google.cloud.bigtable.hbase.filter.TimestampRangeFilter;
 
 /**
@@ -24,11 +25,10 @@ import com.google.cloud.bigtable.hbase.filter.TimestampRangeFilter;
 public class TimestampRangeFilterAdapter extends TypedFilterAdapterBase<TimestampRangeFilter> {
 
   @Override
-  public RowFilter adapt(FilterAdapterContext context, TimestampRangeFilter filter) {
+  public Filter adapt(FilterAdapterContext context, TimestampRangeFilter filter) {
     return TimestampFilterUtil.hbaseToTimestampRangeFilter(
         filter.getStartTimestampInclusive(),
-        filter.getEndTimestampExclusive())
-        .toProto();
+        filter.getEndTimestampExclusive());
   }
 
   @Override

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/TimestampsFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/TimestampsFilterAdapter.java
@@ -17,7 +17,7 @@ package com.google.cloud.bigtable.hbase.adapters.filters;
 
 import static com.google.cloud.bigtable.data.v2.models.Filters.FILTERS;
 
-import com.google.bigtable.v2.RowFilter;
+import com.google.cloud.bigtable.data.v2.models.Filters.Filter;
 import com.google.cloud.bigtable.data.v2.models.Filters.InterleaveFilter;
 
 import org.apache.hadoop.hbase.filter.TimestampsFilter;
@@ -34,12 +34,12 @@ public class TimestampsFilterAdapter
 
   /** {@inheritDoc} */
   @Override
-  public RowFilter adapt(FilterAdapterContext context, TimestampsFilter filter) {
+  public Filter adapt(FilterAdapterContext context, TimestampsFilter filter) {
     InterleaveFilter interleave = FILTERS.interleave();
     for (long timestamp : filter.getTimestamps()) {
       interleave.filter(TimestampFilterUtil.hbaseToTimestampRangeFilter(timestamp, timestamp + 1));
     }
-    return interleave.toProto();
+    return interleave;
   }
 
   /** {@inheritDoc} */

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/TypedFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/TypedFilterAdapter.java
@@ -15,7 +15,7 @@
  */
 package com.google.cloud.bigtable.hbase.adapters.filters;
 
-import com.google.bigtable.v2.RowFilter;
+import com.google.cloud.bigtable.data.v2.models.Filters;
 import com.google.cloud.bigtable.util.RowKeyWrapper;
 import com.google.common.collect.RangeSet;
 import java.io.IOException;
@@ -36,10 +36,10 @@ public interface TypedFilterAdapter<S extends Filter> {
    *
    * @param context a {@link com.google.cloud.bigtable.hbase.adapters.filters.FilterAdapterContext} object.
    * @param filter a S object.
-   * @return a {@link com.google.bigtable.v2.RowFilter} object.
+   * @return a {@link com.google.cloud.bigtable.data.v2.models.Filters.Filter} object.
    * @throws java.io.IOException if any.
    */
-  RowFilter adapt(FilterAdapterContext context, S filter) throws IOException;
+  Filters.Filter adapt(FilterAdapterContext context, S filter) throws IOException;
 
   /**
    * Determine if the given filter can be adapted to a Bigtable RowFilter.

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/ValueFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/ValueFilterAdapter.java
@@ -17,7 +17,6 @@ package com.google.cloud.bigtable.hbase.adapters.filters;
 
 import static com.google.cloud.bigtable.data.v2.models.Filters.FILTERS;
 
-import com.google.bigtable.v2.RowFilter;
 import com.google.cloud.bigtable.data.v2.models.Filters.Filter;
 import com.google.cloud.bigtable.data.v2.models.Filters.ValueRangeFilter;
 import com.google.cloud.bigtable.hbase.adapters.read.ReaderExpressionHelper;
@@ -40,8 +39,8 @@ public class ValueFilterAdapter extends TypedFilterAdapterBase<ValueFilter> {
 
   /** {@inheritDoc} */
   @Override
-  public RowFilter adapt(FilterAdapterContext context, ValueFilter filter) throws IOException {
-    return toFilter(context, filter).toProto();
+  public Filter adapt(FilterAdapterContext context, ValueFilter filter) throws IOException {
+    return toFilter(context, filter);
   }
 
   public Filter toFilter(FilterAdapterContext context, ValueFilter filter) throws IOException {

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/WhileMatchFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/WhileMatchFilterAdapter.java
@@ -15,14 +15,12 @@
  */
 package com.google.cloud.bigtable.hbase.adapters.filters;
 
+import static com.google.cloud.bigtable.data.v2.models.Filters.FILTERS;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.bigtable.v2.RowFilter;
-import com.google.bigtable.v2.RowFilter.Chain;
-import com.google.bigtable.v2.RowFilter.Interleave;
+import com.google.cloud.bigtable.data.v2.models.Filters;
 import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableList;
 
 import org.apache.hadoop.hbase.filter.Filter;
 import org.apache.hadoop.hbase.filter.FilterList;
@@ -87,56 +85,33 @@ public class WhileMatchFilterAdapter extends TypedFilterAdapterBase<WhileMatchFi
    * WhileMatchFilter} instance with a "block all" filter and rescan from the next row.
    */
   @Override
-  public RowFilter adapt(FilterAdapterContext context, WhileMatchFilter filter) throws IOException {
+  public Filters.Filter adapt(FilterAdapterContext context, WhileMatchFilter filter) throws IOException {
     // We need to eventually support more than one {@link WhileMatchFilter}s soon. Checking the size
     // of a list of {@link WhileMatchFilter}s makes more sense than verifying a single boolean flag.
     checkArgument(
         context.getNumberOfWhileMatchFilters() == 0,
         "More than one WhileMatchFilter is not supported.");
     checkNotNull(filter.getFilter(), "The wrapped filter for a WhileMatchFilter cannot be null.");
-    Optional<RowFilter> wrappedFilter = subFilterAdapter.adaptFilter(context, filter.getFilter());
+    Optional<Filters.Filter> wrappedFilter = subFilterAdapter.adaptFilter(context, filter.getFilter());
     checkArgument(
         wrappedFilter.isPresent(), "Unable to adapted the wrapped filter: " + filter.getFilter());
 
     String whileMatchFileterId = context.getNextUniqueId();
-    RowFilter sink = RowFilter.newBuilder().setSink(true).build();
-    RowFilter inLabel =
-        RowFilter.newBuilder()
-            .setApplyLabelTransformer(whileMatchFileterId + IN_LABEL_SUFFIX)
-            .build();
-    RowFilter inLabelAndSink =
-        RowFilter.newBuilder()
-            .setChain(Chain.newBuilder().addAllFilters(ImmutableList.of(inLabel, sink)))
-            .build();
-    RowFilter outLabel =
-        RowFilter.newBuilder()
-            .setApplyLabelTransformer(whileMatchFileterId + OUT_LABEL_SUFFIX)
-            .build();
-    RowFilter outLabelAndSink =
-        RowFilter.newBuilder()
-            .setChain(Chain.newBuilder().addAllFilters(ImmutableList.of(outLabel, sink)))
-            .build();
 
-    RowFilter all = RowFilter.newBuilder().setPassAllFilter(true).build();
-    RowFilter outInterleave =
-        RowFilter.newBuilder()
-            .setInterleave(
-                Interleave.newBuilder().addAllFilters(ImmutableList.of(outLabelAndSink, all)))
-            .build();
-    RowFilter outChain =
-        RowFilter.newBuilder()
-            .setChain(Chain.newBuilder().addAllFilters(
-                ImmutableList.of(wrappedFilter.get(), outInterleave)))
-            .build();
-    RowFilter rowFilter =
-        RowFilter.newBuilder()
-            .setInterleave(
-                Interleave.newBuilder().addAllFilters(ImmutableList.of(inLabelAndSink, outChain)))
-            .build();
+    Filters.Filter inLabel = FILTERS.label(whileMatchFileterId + IN_LABEL_SUFFIX);
+    Filters.Filter inLabelAndSink = FILTERS.chain().filter(inLabel).filter(FILTERS.sink());
+
+    Filters.Filter outLabel = FILTERS.label(whileMatchFileterId + OUT_LABEL_SUFFIX);
+    Filters.Filter outLabelAndSink = FILTERS.chain().filter(outLabel).filter(FILTERS.sink());
+
+    Filters.Filter outInterleave = FILTERS.interleave().filter(outLabelAndSink).filter(FILTERS.pass());
+    Filters.Filter outChain = FILTERS.chain().filter(wrappedFilter.get()).filter(outInterleave);
+
+    Filters.Filter finalFilter = FILTERS.interleave().filter(inLabelAndSink).filter(outChain);
 
     context.addWhileMatchFilter(filter);
 
-    return rowFilter;
+    return finalFilter;
   }
 
   /** {@inheritDoc} */
@@ -192,7 +167,7 @@ public class WhileMatchFilterAdapter extends TypedFilterAdapterBase<WhileMatchFi
     if (filter == whileMatchFilter) {
       return true;
     }
- 
+
     if (filter instanceof FilterList) {
       FilterList list = (FilterList) filter;
       for (Filter subFilter : list.getFilters()) {

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/GetAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/GetAdapter.java
@@ -59,7 +59,7 @@ public class GetAdapter implements ReadOperationAdapter<Get> {
     Scan operationAsScan = new Scan(addKeyOnlyFilter(operation));
     scanAdapter.throwIfUnsupportedScan(operationAsScan);
     return ReadRowsRequest.newBuilder()
-        .setFilter(scanAdapter.buildFilter(operationAsScan, readHooks))
+        .setFilter(scanAdapter.buildFilter(operationAsScan, readHooks).toProto())
         .setRows(RowSet.newBuilder().addRowKeys(ByteString.copyFrom(operation.getRow())));
   }
 

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/filter/BigtableFilter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/filter/BigtableFilter.java
@@ -15,6 +15,8 @@
  */
 package com.google.cloud.bigtable.hbase.filter;
 
+import static com.google.cloud.bigtable.data.v2.models.Filters.FILTERS;
+
 import java.io.IOException;
 import java.io.Serializable;
 
@@ -39,28 +41,24 @@ public class BigtableFilter extends FilterBase implements Serializable {
 
   private static final long serialVersionUID = 1L;
 
-  private final RowFilter rowFilter;
+  private final Filters.Filter filter;
 
   public BigtableFilter(Filters.Filter filter) {
-    this.rowFilter = filter.toProto();
-  }
-  
-  @Deprecated
-  public BigtableFilter(com.google.cloud.bigtable.data.v2.wrappers.Filters.Filter filter) {
-    this.rowFilter = filter.toProto();
+    this.filter = filter;
   }
 
-  private BigtableFilter(RowFilter rowFilter) {
-    this.rowFilter = rowFilter;
+  @Deprecated
+  public BigtableFilter(com.google.cloud.bigtable.data.v2.wrappers.Filters.Filter filter) {
+    this(FILTERS.fromProto(filter.toProto()));
   }
 
   @Override
-  public ReturnCode filterKeyValue(Cell arg0) throws IOException {
+  public ReturnCode filterKeyValue(Cell cell) throws IOException {
     return ReturnCode.SKIP;
   }
 
-  public RowFilter getRowFilter() {
-    return rowFilter;
+  public Filters.Filter getFilter() {
+    return filter;
   }
 
   @Override
@@ -69,17 +67,17 @@ public class BigtableFilter extends FilterBase implements Serializable {
       return false;
     }
     BigtableFilter other = (BigtableFilter) obj;
-    return rowFilter.equals(other.rowFilter);
+    return filter.toProto().equals(other.filter.toProto());
   }
 
   @Override
   public byte[] toByteArray() throws IOException {
-    return rowFilter.toByteArray();
+    return filter.toProto().toByteArray();
   }
 
   public static BigtableFilter parseFrom(final byte[] bytes) throws DeserializationException {
     try {
-      return new BigtableFilter(RowFilter.parseFrom(bytes));
+      return new BigtableFilter(FILTERS.fromProto(RowFilter.parseFrom(bytes)));
     } catch (InvalidProtocolBufferException e) {
       throw new DeserializationException(e);
     }

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/util/ModifyTableBuilder.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/util/ModifyTableBuilder.java
@@ -15,29 +15,20 @@
  */
 package com.google.cloud.bigtable.hbase.util;
 
-import com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest;
-import com.google.cloud.bigtable.grpc.BigtableTableName;
-import com.google.cloud.bigtable.hbase.adapters.admin.ColumnDescriptorAdapter;
+import com.google.cloud.bigtable.admin.v2.models.ModifyColumnFamiliesRequest;
 import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.util.Bytes;
 
-import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
+import static com.google.cloud.bigtable.hbase.adapters.admin.ColumnDescriptorAdapter.buildGarbageCollectionRule;
 /**
  * Utilitiy to create {@link ModifyColumnFamiliesRequest} from HBase {@link HColumnDescriptor}s.
  */
 public class ModifyTableBuilder {
-
-  private static final ColumnDescriptorAdapter ADAPTER = new ColumnDescriptorAdapter();
-
-  public static ModifyTableBuilder create() {
-    return new ModifyTableBuilder();
-  }
 
   private static Set<String> getColumnNames(HTableDescriptor tableDescriptor) {
     Set<String> names = new HashSet<>();
@@ -48,22 +39,25 @@ public class ModifyTableBuilder {
   }
 
   /**
-   * This method will build list of of protobuf {@link ModifyColumnFamiliesRequest.Modification} objects based on a diff of the
+   * This method will build {@link ModifyColumnFamiliesRequest} objects based on a diff of the
    * new and existing set of column descriptors.  This is for use in
    * {@link org.apache.hadoop.hbase.client.Admin#modifyTable(TableName, HTableDescriptor)}.
    */
-  public static ModifyTableBuilder buildModifications(
-      HTableDescriptor newTableDescriptor,
-      HTableDescriptor currentTableDescriptors) {
-    ModifyTableBuilder builder = new ModifyTableBuilder();
+  public static ModifyColumnFamiliesRequest buildModifications(
+          HTableDescriptor newTableDescriptor,
+          HTableDescriptor currentTableDescriptors,
+          ModifyColumnFamiliesRequest modifyColumnRequest) {
     Set<String> currentColumnNames = getColumnNames(currentTableDescriptors);
     Set<String> newColumnNames = getColumnNames(newTableDescriptor);
 
     for (HColumnDescriptor hColumnDescriptor : newTableDescriptor.getFamilies()) {
-      if (currentColumnNames.contains(hColumnDescriptor.getNameAsString())) {
-        builder.modify(hColumnDescriptor);
+      String columnName = hColumnDescriptor.getNameAsString();
+      if (currentColumnNames.contains(columnName)) {
+        modifyColumnRequest.updateFamily(columnName,
+                buildGarbageCollectionRule(hColumnDescriptor));
       } else {
-        builder.add(hColumnDescriptor);
+        modifyColumnRequest.addFamily(columnName,
+                buildGarbageCollectionRule(hColumnDescriptor));
       }
     }
 
@@ -71,47 +65,8 @@ public class ModifyTableBuilder {
     columnsToRemove.removeAll(newColumnNames);
 
     for (String column : columnsToRemove) {
-      builder.delete(column);
+      modifyColumnRequest.dropFamily(column);
     }
-    return builder;
-  }
-
-  private final List<ModifyColumnFamiliesRequest.Modification> modifications = new ArrayList<>();
-
-  public ModifyTableBuilder add(HColumnDescriptor descriptor) {
-    String columnName = descriptor.getNameAsString();
-    modifications.add(ModifyColumnFamiliesRequest.Modification
-        .newBuilder()
-        .setId(columnName)
-        .setCreate(ADAPTER.adapt(descriptor))
-        .build());
-    return this;
-  }
-
-  public ModifyTableBuilder modify(HColumnDescriptor descriptor) {
-    String columnName = descriptor.getNameAsString();
-    modifications.add(ModifyColumnFamiliesRequest.Modification
-        .newBuilder()
-        .setId(columnName)
-        .setUpdate(ADAPTER.adapt(descriptor))
-        .build());
-    return this;
-  }
-
-  public ModifyTableBuilder delete(String name) {
-    modifications.add(ModifyColumnFamiliesRequest.Modification
-        .newBuilder()
-        .setId(name)
-        .setDrop(true)
-        .build());
-    return this;
-  }
-
-  public ModifyColumnFamiliesRequest toProto(String name) {
-    return ModifyColumnFamiliesRequest
-        .newBuilder()
-        .setName(name)
-        .addAllModifications(modifications)
-        .build();
+    return modifyColumnRequest;
   }
 }

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableAdmin.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableAdmin.java
@@ -354,13 +354,14 @@ public abstract class AbstractBigtableAdmin implements Admin {
   /** {@inheritDoc} */
   @Override
   public void createTable(HTableDescriptor desc, byte[][] splitKeys) throws IOException {
-    createTable(desc.getTableName(), TableAdapter.adapt(desc, splitKeys));
+    createTable(desc.getTableName(), TableAdapter.adapt(desc, splitKeys)
+            .toProto(bigtableInstanceName.toAdminInstanceName()));
   }
 
-  protected void createTable(TableName tableName, CreateTableRequest.Builder builder) throws IOException {
-    builder.setParent(bigtableInstanceName.toString());
+  //TODO(rahulkql):update methods to adapt to v2.models.CreateTableRequest
+  protected void createTable(TableName tableName, CreateTableRequest request) throws IOException {
     try {
-      bigtableTableAdminClient.createTable(builder.build());
+      bigtableTableAdminClient.createTable(request);
     } catch (Throwable throwable) {
       throw convertToTableExistsException(tableName, throwable);
     }
@@ -370,14 +371,15 @@ public abstract class AbstractBigtableAdmin implements Admin {
   @Override
   public void createTableAsync(final HTableDescriptor desc, byte[][] splitKeys) throws IOException {
     LOG.warn("Creating the table synchronously");
-    CreateTableRequest.Builder builder = TableAdapter.adapt(desc, splitKeys);
-    createTableAsync(builder, desc.getTableName());
+    CreateTableRequest request = TableAdapter.adapt(desc, splitKeys)
+            .toProto(bigtableInstanceName.toAdminInstanceName());
+    createTableAsync(request, desc.getTableName());
   }
 
-  protected ListenableFuture<Table> createTableAsync(CreateTableRequest.Builder builder,
+  //TODO(rahulkql):update methods to adapt to v2.models.CreateTableRequest
+  protected ListenableFuture<Table> createTableAsync(CreateTableRequest request,
       final TableName tableName) throws IOException {
-    builder.setParent(bigtableInstanceName.toString());
-    ListenableFuture<Table> future = bigtableTableAdminClient.createTableAsync(builder.build());
+    ListenableFuture<Table> future = bigtableTableAdminClient.createTableAsync(request);
     final SettableFuture<Table> settableFuture = SettableFuture.create();
     Futures.addCallback(future, new FutureCallback<Table>() {
       @Override public void onSuccess(@Nullable Table result) {

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableAdmin.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableAdmin.java
@@ -126,7 +126,7 @@ public abstract class AbstractBigtableAdmin implements Admin {
     disabledTables = connection.getDisabledTables();
     bigtableInstanceName = options.getInstanceName();
     tableAdapter = new TableAdapter(bigtableInstanceName);
-    instanceName =
+    instanceName = 
         InstanceName.of(bigtableInstanceName.getProjectId(), bigtableInstanceName.getInstanceId());
 
     String clusterId = configuration.get(BigtableOptionsFactory.BIGTABLE_SNAPSHOT_CLUSTER_ID_KEY, null);

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/PutAdapterPerf.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/PutAdapterPerf.java
@@ -18,6 +18,8 @@ package com.google.cloud.bigtable.hbase;
 import com.google.bigtable.v2.BigtableGrpc;
 import com.google.bigtable.v2.MutateRowRequest;
 import com.google.cloud.bigtable.config.BigtableOptions;
+import com.google.cloud.bigtable.data.v2.internal.RequestContext;
+import com.google.cloud.bigtable.data.v2.models.RowMutation;
 import com.google.cloud.bigtable.hbase.adapters.HBaseRequestAdapter;
 import com.google.cloud.bigtable.hbase.adapters.PutAdapter;
 
@@ -31,6 +33,7 @@ import org.apache.hadoop.hbase.util.Bytes;
  * Simple microbenchmark for {@link PutAdapter}
  */
 public class PutAdapterPerf {
+  private static RequestContext requestContext;
   public static void main(String[] args) {
     String rowKey = String.format("rowKey0");
     Put put = new Put(Bytes.toBytes(rowKey));
@@ -44,6 +47,7 @@ public class PutAdapterPerf {
     HBaseRequestAdapter adapter =
         new HBaseRequestAdapter(options,
             TableName.valueOf("tableName"), new Configuration());
+    requestContext = RequestContext.create(options.getInstanceName().toGcbInstanceName(), "");
     for (int i = 0; i < 10; i++) {
       putAdapterPerf(adapter, put);
     }
@@ -52,7 +56,7 @@ public class PutAdapterPerf {
   static int count = 1_000_000;
 
   private static void putAdapterPerf(HBaseRequestAdapter adapter, Put put) {
-    System.out.println("Size: " + adapter.adapt(put).getSerializedSize());
+    System.out.println("Size: " + adapter.adapt(put).toProto(requestContext).getSerializedSize());
     System.gc();
     { 
       long start = System.nanoTime();
@@ -68,8 +72,8 @@ public class PutAdapterPerf {
     { 
       long start = System.nanoTime();
       for (int i = 0; i < count; i++) {
-        MutateRowRequest adapted = adapter.adapt(put);
-        BigtableGrpc.getMutateRowMethod().streamRequest(adapted);
+        RowMutation adapted = adapter.adapt(put);
+        BigtableGrpc.getMutateRowMethod().streamRequest(adapted.toProto(requestContext));
       }
       long time = System.nanoTime() - start;
       System.out.println(
@@ -80,7 +84,7 @@ public class PutAdapterPerf {
     { 
       long start = System.nanoTime();
       for (int i = 0; i < count; i++) {
-        MutateRowRequest adapted = adapter.adapt(put);
+        MutateRowRequest adapted = adapter.adapt(put).toProto(requestContext);
         adapted.getSerializedSize();
         BigtableGrpc.getMutateRowMethod().streamRequest(adapted);
       }

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/TestAppendAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/TestAppendAdapter.java
@@ -17,6 +17,9 @@ package com.google.cloud.bigtable.hbase.adapters;
 
 import com.google.bigtable.v2.ReadModifyWriteRowRequest;
 import com.google.bigtable.v2.ReadModifyWriteRule;
+import com.google.cloud.bigtable.data.v2.internal.RequestContext;
+import com.google.cloud.bigtable.data.v2.models.InstanceName;
+import com.google.cloud.bigtable.data.v2.models.ReadModifyWriteRow;
 import com.google.cloud.bigtable.hbase.DataGenerationHelper;
 import com.google.protobuf.ByteString;
 
@@ -31,6 +34,11 @@ import java.util.List;
 
 @RunWith(JUnit4.class)
 public class TestAppendAdapter {
+  private static final String PROJECT_ID = "test-project-id";
+  private static final String INSTANCE_ID = "test-instance-id";
+  private static final String TABLE_ID = "test-table-id";
+  private static final String APP_PROFILE_ID = "test-app-profile-id";
+  private RequestContext requestContext = RequestContext.create(InstanceName.of(PROJECT_ID, INSTANCE_ID), APP_PROFILE_ID);
   protected AppendAdapter appendAdapter = new AppendAdapter();
   protected DataGenerationHelper dataHelper = new DataGenerationHelper();
 
@@ -38,9 +46,10 @@ public class TestAppendAdapter {
   public void testBasicRowKeyAppend() {
     byte[] rowKey = dataHelper.randomData("rk1-");
     Append append = new Append(rowKey);
-    ReadModifyWriteRowRequest.Builder requestBuilder = ReadModifyWriteRowRequest.newBuilder();
-    appendAdapter.adapt(append, requestBuilder);
-    ReadModifyWriteRowRequest request = requestBuilder.build();
+    ReadModifyWriteRow readModifyWriteRow = ReadModifyWriteRow
+        .create(TABLE_ID, ByteString.copyFrom(rowKey));
+    appendAdapter.adapt(append, readModifyWriteRow);
+    ReadModifyWriteRowRequest request = readModifyWriteRow.toProto(requestContext);
     ByteString adaptedRowKey = request.getRowKey();
     Assert.assertArrayEquals(rowKey, adaptedRowKey.toByteArray());
   }
@@ -61,9 +70,10 @@ public class TestAppendAdapter {
     append.add(family1, qualifier1, value1);
     append.add(family2, qualifier2, value2);
 
-    ReadModifyWriteRowRequest.Builder requestBuilder = ReadModifyWriteRowRequest.newBuilder();
-    appendAdapter.adapt(append, requestBuilder);
-    ReadModifyWriteRowRequest request = requestBuilder.build();
+    ReadModifyWriteRow readModifyWriteRow = ReadModifyWriteRow
+        .create(TABLE_ID, ByteString.copyFrom(rowKey));
+    appendAdapter.adapt(append, readModifyWriteRow);
+    ReadModifyWriteRowRequest request = readModifyWriteRow.toProto(requestContext);
     List<ReadModifyWriteRule> rules = request.getRulesList();
     Assert.assertEquals(2, rules.size());
 
@@ -95,9 +105,10 @@ public class TestAppendAdapter {
     append.add(family2, qualifier2, value2);
     append.add(family2, qualifier2, value3);
 
-    ReadModifyWriteRowRequest.Builder requestBuilder = ReadModifyWriteRowRequest.newBuilder();
-    appendAdapter.adapt(append, requestBuilder);
-    ReadModifyWriteRowRequest request = requestBuilder.build();
+    ReadModifyWriteRow readModifyWriteRow = ReadModifyWriteRow
+        .create(TABLE_ID, ByteString.copyFrom(rowKey));
+    appendAdapter.adapt(append, readModifyWriteRow);
+    ReadModifyWriteRowRequest request = readModifyWriteRow.toProto(requestContext);
     List<ReadModifyWriteRule> rules = request.getRulesList();
     Assert.assertEquals(2, rules.size());
 
@@ -126,9 +137,10 @@ public class TestAppendAdapter {
     append.add(family1, qualifier1, value1);
     append.add(family2, qualifier1, value2);
 
-    ReadModifyWriteRowRequest.Builder requestBuilder = ReadModifyWriteRowRequest.newBuilder();
-    appendAdapter.adapt(append, requestBuilder);
-    ReadModifyWriteRowRequest request = requestBuilder.build();
+    ReadModifyWriteRow readModifyWriteRow = ReadModifyWriteRow
+        .create(TABLE_ID, ByteString.copyFrom(rowKey));
+    appendAdapter.adapt(append, readModifyWriteRow);
+    ReadModifyWriteRowRequest request = readModifyWriteRow.toProto(requestContext);
     List<ReadModifyWriteRule> rules = request.getRulesList();
     Assert.assertEquals(2, rules.size());
 

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/TestCheckAndMutateUtil.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/TestCheckAndMutateUtil.java
@@ -20,6 +20,7 @@ import com.google.bigtable.v2.CheckAndMutateRowRequest;
 import com.google.bigtable.v2.Mutation;
 import com.google.bigtable.v2.RowFilter;
 import com.google.cloud.bigtable.data.v2.internal.RequestContext;
+import com.google.cloud.bigtable.data.v2.models.ConditionalRowMutation;
 import com.google.cloud.bigtable.data.v2.models.Filters;
 import com.google.cloud.bigtable.data.v2.models.InstanceName;
 import com.google.cloud.bigtable.grpc.BigtableInstanceName;
@@ -30,7 +31,6 @@ import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Delete;
 import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.RowMutations;
-import org.apache.hadoop.hbase.filter.CompareFilter;
 import org.apache.hadoop.hbase.filter.CompareFilter.CompareOp;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.Assert;
@@ -52,7 +52,9 @@ public class TestCheckAndMutateUtil {
   private static final BigtableTableName BT_TABLE_NAME =
       new BigtableInstanceName("project", "instance")
           .toTableName(TABLE_NAME.getNameAsString());
-
+  private static final RequestContext REQUEST_CONTEXT =
+      RequestContext
+          .create(InstanceName.of(BT_TABLE_NAME.getProjectId(), BT_TABLE_NAME.getInstanceId()), "SomeAppProfileId");
   private static final byte[] rowKey = Bytes.toBytes("rowKey");
   private static final byte[] family = Bytes.toBytes("family");
   private static final byte[] qual = Bytes.toBytes("qual");
@@ -111,12 +113,13 @@ public class TestCheckAndMutateUtil {
   public void testPut() throws DoNotRetryIOException {
     CheckAndMutateUtil.RequestBuilder underTest = createRequestBuilder();
 
-    CheckAndMutateRowRequest result = underTest
+    ConditionalRowMutation conditionalRowMutation = underTest
         .qualifier(qual)
         .ifMatches(CompareOp.EQUAL, checkValue)
         .withPut(PUT)
         .build();
 
+    CheckAndMutateRowRequest result = conditionalRowMutation.toProto(REQUEST_CONTEXT);
     Assert.assertEquals(1, result.getTrueMutationsCount());
 
     checkPutMutation(result.getTrueMutations(0));
@@ -128,12 +131,13 @@ public class TestCheckAndMutateUtil {
   public void testDelete() throws DoNotRetryIOException {
     CheckAndMutateUtil.RequestBuilder underTest = createRequestBuilder();
 
-    CheckAndMutateRowRequest result = underTest
+    ConditionalRowMutation conditionalRowMutation = underTest
         .qualifier(qual)
         .ifMatches(CompareOp.EQUAL, checkValue)
         .withDelete(new Delete(rowKey).addColumns(family, qual))
         .build();
 
+    CheckAndMutateRowRequest result = conditionalRowMutation.toProto(REQUEST_CONTEXT);
     Assert.assertEquals(1, result.getTrueMutationsCount());
 
     Mutation.DeleteFromColumn delete = result.getTrueMutations(0).getDeleteFromColumn();
@@ -150,12 +154,14 @@ public class TestCheckAndMutateUtil {
 
     RowMutations rowMutations = new RowMutations(rowKey);
     rowMutations.add(PUT);
-    CheckAndMutateRowRequest result = underTest
+
+    ConditionalRowMutation conditionalRowMutation = underTest
         .qualifier(qual)
         .ifMatches(CompareOp.EQUAL, checkValue)
         .withMutations(rowMutations)
         .build();
 
+    CheckAndMutateRowRequest result = conditionalRowMutation.toProto(REQUEST_CONTEXT);
     Assert.assertEquals(1, result.getTrueMutationsCount());
     checkPutMutation(result.getTrueMutations(0));
     checkPredicate(result);
@@ -164,17 +170,19 @@ public class TestCheckAndMutateUtil {
   @Test
   /**
    * Tests that a CheckAndMutate with a {@link Put} which ensures that the conversion to a
-   * {@link CheckAndMutateRowRequest} sets a server-side timeatamp (-1) on the {@link Mutation}
+   * {@link ConditionalRowMutation} sets a server-side timeatamp (-1) on the
+   * {@link com.google.cloud.bigtable.data.v2.models.Mutation}
    */
   public void testPutServerSideTimestamps() throws DoNotRetryIOException {
     CheckAndMutateUtil.RequestBuilder underTest = createRequestBuilder();
 
-    CheckAndMutateRowRequest result = underTest
+    ConditionalRowMutation conditionalRowMutation = underTest
         .qualifier(qual)
         .ifMatches(CompareOp.EQUAL, checkValue)
         .withPut(PUT)
         .build();
 
+    CheckAndMutateRowRequest result = conditionalRowMutation.toProto(REQUEST_CONTEXT);
     Assert.assertEquals(1, result.getTrueMutationsCount());
 
     Mutation.SetCell setCell = result.getTrueMutations(0).getSetCell();
@@ -184,19 +192,21 @@ public class TestCheckAndMutateUtil {
   @Test
   /**
    * Tests that a CheckAndMutate with a {@link Put} which ensures that the conversion to a
-   * {@link CheckAndMutateRowRequest} sets a clientr-side timeatamp on the {@link Mutation}
+   * {@link ConditionalRowMutation} sets a clientr-side timeatamp on the
+   * {@link com.google.cloud.bigtable.data.v2.models.Mutation}
    * if a user explicitly sets a timestamp on the Put
    */
   public void testPutServerClientTimestamps() throws DoNotRetryIOException {
     CheckAndMutateUtil.RequestBuilder underTest = createRequestBuilder();
 
     long timestamp = (long) (Math.random() * 10000000000L);
-    CheckAndMutateRowRequest result = underTest
+    ConditionalRowMutation conditionalRowMutation = underTest
         .qualifier(qual)
         .ifMatches(CompareOp.EQUAL, checkValue)
         .withPut(new Put(rowKey).addColumn(family, qual, timestamp, newValue))
         .build();
 
+    CheckAndMutateRowRequest result = conditionalRowMutation.toProto(REQUEST_CONTEXT);
     Assert.assertEquals(1, result.getTrueMutationsCount());
 
     Mutation.SetCell setCell = result.getTrueMutations(0).getSetCell();
@@ -206,20 +216,21 @@ public class TestCheckAndMutateUtil {
   @Test
   /**
    * Tests that a CheckAndMutate with a {@link RowMutations} with a {@link Put} which ensures that
-   * the conversion to a {@link CheckAndMutateRowRequest} sets a server-side timeatamp (-1) on the
-   * {@link Mutation}.
+   * the conversion to a {@link ConditionalRowMutation} sets a server-side timeatamp (-1) on the
+   * {@link com.google.cloud.bigtable.data.v2.models.Mutation}.
    */
   public void testRowMutationServerSideTimestamps() throws IOException {
     CheckAndMutateUtil.RequestBuilder underTest = createRequestBuilder();
 
     RowMutations rowMutations = new RowMutations(rowKey);
     rowMutations.add(PUT);
-    CheckAndMutateRowRequest result = underTest
+    ConditionalRowMutation conditionalRowMutation = underTest
         .qualifier(qual)
         .ifMatches(CompareOp.EQUAL, checkValue)
         .withMutations(rowMutations)
         .build();
 
+    CheckAndMutateRowRequest result = conditionalRowMutation.toProto(REQUEST_CONTEXT);
     Assert.assertEquals(1, result.getTrueMutationsCount());
 
     Mutation.SetCell setCell = result.getTrueMutations(0).getSetCell();
@@ -233,12 +244,13 @@ public class TestCheckAndMutateUtil {
   public void testIfNotExists() throws DoNotRetryIOException {
     CheckAndMutateUtil.RequestBuilder underTest = createRequestBuilder();
 
-    CheckAndMutateRowRequest result = underTest
+    ConditionalRowMutation conditionalRowMutation = underTest
         .qualifier(qual)
         .ifNotExists()
         .withPut(PUT)
         .build();
 
+    CheckAndMutateRowRequest result = conditionalRowMutation.toProto(REQUEST_CONTEXT);
     Assert.assertEquals(1, result.getFalseMutationsCount());
     checkPutMutation(result.getFalseMutations(0));
 
@@ -258,12 +270,13 @@ public class TestCheckAndMutateUtil {
   public void testNotEqualsNull() throws DoNotRetryIOException {
     CheckAndMutateUtil.RequestBuilder underTest = createRequestBuilder();
 
-    CheckAndMutateRowRequest result = underTest
+    ConditionalRowMutation conditionalRowMutation = underTest
         .qualifier(qual)
         .ifMatches(CompareOp.NOT_EQUAL, null)
         .withPut(PUT)
         .build();
 
+    CheckAndMutateRowRequest result = conditionalRowMutation.toProto(REQUEST_CONTEXT);
     Assert.assertEquals(1, result.getTrueMutationsCount());
 
     RowFilter expected = FILTERS.chain()
@@ -288,12 +301,13 @@ public class TestCheckAndMutateUtil {
 
     otherOps.remove(CompareOp.NOT_EQUAL);
     int index = (int) (Math.random() * otherOps.size());
-    CheckAndMutateRowRequest result = underTest
+    ConditionalRowMutation conditionalRowMutation = underTest
         .qualifier(qual)
         .ifMatches(otherOps.get(index), null)
         .withPut(PUT)
         .build();
 
+    CheckAndMutateRowRequest result = conditionalRowMutation.toProto(REQUEST_CONTEXT);
     Assert.assertEquals(1, result.getFalseMutationsCount());
 
     RowFilter expected = FILTERS.chain()

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/TestCheckAndMutateUtil.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/TestCheckAndMutateUtil.java
@@ -113,13 +113,13 @@ public class TestCheckAndMutateUtil {
   public void testPut() throws DoNotRetryIOException {
     CheckAndMutateUtil.RequestBuilder underTest = createRequestBuilder();
 
-    ConditionalRowMutation conditionalRowMutation = underTest
+    CheckAndMutateRowRequest result = underTest
         .qualifier(qual)
         .ifMatches(CompareOp.EQUAL, checkValue)
         .withPut(PUT)
-        .build();
+        .build()
+        .toProto(REQUEST_CONTEXT);
 
-    CheckAndMutateRowRequest result = conditionalRowMutation.toProto(REQUEST_CONTEXT);
     Assert.assertEquals(1, result.getTrueMutationsCount());
 
     checkPutMutation(result.getTrueMutations(0));
@@ -131,13 +131,13 @@ public class TestCheckAndMutateUtil {
   public void testDelete() throws DoNotRetryIOException {
     CheckAndMutateUtil.RequestBuilder underTest = createRequestBuilder();
 
-    ConditionalRowMutation conditionalRowMutation = underTest
+    CheckAndMutateRowRequest result = underTest
         .qualifier(qual)
         .ifMatches(CompareOp.EQUAL, checkValue)
         .withDelete(new Delete(rowKey).addColumns(family, qual))
-        .build();
+        .build()
+        .toProto(REQUEST_CONTEXT);
 
-    CheckAndMutateRowRequest result = conditionalRowMutation.toProto(REQUEST_CONTEXT);
     Assert.assertEquals(1, result.getTrueMutationsCount());
 
     Mutation.DeleteFromColumn delete = result.getTrueMutations(0).getDeleteFromColumn();
@@ -155,13 +155,13 @@ public class TestCheckAndMutateUtil {
     RowMutations rowMutations = new RowMutations(rowKey);
     rowMutations.add(PUT);
 
-    ConditionalRowMutation conditionalRowMutation = underTest
+    CheckAndMutateRowRequest result = underTest
         .qualifier(qual)
         .ifMatches(CompareOp.EQUAL, checkValue)
         .withMutations(rowMutations)
-        .build();
+        .build()
+        .toProto(REQUEST_CONTEXT);
 
-    CheckAndMutateRowRequest result = conditionalRowMutation.toProto(REQUEST_CONTEXT);
     Assert.assertEquals(1, result.getTrueMutationsCount());
     checkPutMutation(result.getTrueMutations(0));
     checkPredicate(result);
@@ -176,13 +176,13 @@ public class TestCheckAndMutateUtil {
   public void testPutServerSideTimestamps() throws DoNotRetryIOException {
     CheckAndMutateUtil.RequestBuilder underTest = createRequestBuilder();
 
-    ConditionalRowMutation conditionalRowMutation = underTest
+    CheckAndMutateRowRequest result = underTest
         .qualifier(qual)
         .ifMatches(CompareOp.EQUAL, checkValue)
         .withPut(PUT)
-        .build();
+        .build()
+        .toProto(REQUEST_CONTEXT);
 
-    CheckAndMutateRowRequest result = conditionalRowMutation.toProto(REQUEST_CONTEXT);
     Assert.assertEquals(1, result.getTrueMutationsCount());
 
     Mutation.SetCell setCell = result.getTrueMutations(0).getSetCell();
@@ -200,13 +200,13 @@ public class TestCheckAndMutateUtil {
     CheckAndMutateUtil.RequestBuilder underTest = createRequestBuilder();
 
     long timestamp = (long) (Math.random() * 10000000000L);
-    ConditionalRowMutation conditionalRowMutation = underTest
+    CheckAndMutateRowRequest result = underTest
         .qualifier(qual)
         .ifMatches(CompareOp.EQUAL, checkValue)
         .withPut(new Put(rowKey).addColumn(family, qual, timestamp, newValue))
-        .build();
+        .build()
+        .toProto(REQUEST_CONTEXT);
 
-    CheckAndMutateRowRequest result = conditionalRowMutation.toProto(REQUEST_CONTEXT);
     Assert.assertEquals(1, result.getTrueMutationsCount());
 
     Mutation.SetCell setCell = result.getTrueMutations(0).getSetCell();
@@ -224,13 +224,13 @@ public class TestCheckAndMutateUtil {
 
     RowMutations rowMutations = new RowMutations(rowKey);
     rowMutations.add(PUT);
-    ConditionalRowMutation conditionalRowMutation = underTest
+    CheckAndMutateRowRequest result = underTest
         .qualifier(qual)
         .ifMatches(CompareOp.EQUAL, checkValue)
         .withMutations(rowMutations)
-        .build();
+        .build()
+        .toProto(REQUEST_CONTEXT);
 
-    CheckAndMutateRowRequest result = conditionalRowMutation.toProto(REQUEST_CONTEXT);
     Assert.assertEquals(1, result.getTrueMutationsCount());
 
     Mutation.SetCell setCell = result.getTrueMutations(0).getSetCell();
@@ -244,13 +244,13 @@ public class TestCheckAndMutateUtil {
   public void testIfNotExists() throws DoNotRetryIOException {
     CheckAndMutateUtil.RequestBuilder underTest = createRequestBuilder();
 
-    ConditionalRowMutation conditionalRowMutation = underTest
+    CheckAndMutateRowRequest result = underTest
         .qualifier(qual)
         .ifNotExists()
         .withPut(PUT)
-        .build();
+        .build()
+        .toProto(REQUEST_CONTEXT);
 
-    CheckAndMutateRowRequest result = conditionalRowMutation.toProto(REQUEST_CONTEXT);
     Assert.assertEquals(1, result.getFalseMutationsCount());
     checkPutMutation(result.getFalseMutations(0));
 
@@ -270,13 +270,13 @@ public class TestCheckAndMutateUtil {
   public void testNotEqualsNull() throws DoNotRetryIOException {
     CheckAndMutateUtil.RequestBuilder underTest = createRequestBuilder();
 
-    ConditionalRowMutation conditionalRowMutation = underTest
+    CheckAndMutateRowRequest result = underTest
         .qualifier(qual)
         .ifMatches(CompareOp.NOT_EQUAL, null)
         .withPut(PUT)
-        .build();
+        .build()
+        .toProto(REQUEST_CONTEXT);
 
-    CheckAndMutateRowRequest result = conditionalRowMutation.toProto(REQUEST_CONTEXT);
     Assert.assertEquals(1, result.getTrueMutationsCount());
 
     RowFilter expected = FILTERS.chain()
@@ -301,13 +301,13 @@ public class TestCheckAndMutateUtil {
 
     otherOps.remove(CompareOp.NOT_EQUAL);
     int index = (int) (Math.random() * otherOps.size());
-    ConditionalRowMutation conditionalRowMutation = underTest
+    CheckAndMutateRowRequest result = underTest
         .qualifier(qual)
         .ifMatches(otherOps.get(index), null)
         .withPut(PUT)
-        .build();
+        .build()
+        .toProto(REQUEST_CONTEXT);
 
-    CheckAndMutateRowRequest result = conditionalRowMutation.toProto(REQUEST_CONTEXT);
     Assert.assertEquals(1, result.getFalseMutationsCount());
 
     RowFilter expected = FILTERS.chain()

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/TestIncrementAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/TestIncrementAdapter.java
@@ -17,6 +17,9 @@ package com.google.cloud.bigtable.hbase.adapters;
 
 import com.google.bigtable.v2.ReadModifyWriteRowRequest;
 import com.google.bigtable.v2.ReadModifyWriteRule;
+import com.google.cloud.bigtable.data.v2.internal.RequestContext;
+import com.google.cloud.bigtable.data.v2.models.InstanceName;
+import com.google.cloud.bigtable.data.v2.models.ReadModifyWriteRow;
 import com.google.cloud.bigtable.hbase.DataGenerationHelper;
 import com.google.protobuf.ByteString;
 
@@ -36,6 +39,11 @@ public class TestIncrementAdapter {
   @Rule
   public ExpectedException expectedException = ExpectedException.none();
 
+  private static final String PROJECT_ID = "test-project-id";
+  private static final String INSTANCE_ID = "test-instance-id";
+  private static final String TABLE_ID = "test-table-id";
+  private static final String APP_PROFILE_ID = "test-app-profile-id";
+  private RequestContext requestContext = RequestContext.create(InstanceName.of(PROJECT_ID, INSTANCE_ID), APP_PROFILE_ID);
   protected IncrementAdapter incrementAdapter = new IncrementAdapter();
   protected DataGenerationHelper dataHelper = new DataGenerationHelper();
 
@@ -43,8 +51,10 @@ public class TestIncrementAdapter {
   public void testBasicRowKeyIncrement() {
     byte[] rowKey = dataHelper.randomData("rk1-");
     Increment incr = new Increment(rowKey);
-    ReadModifyWriteRowRequest.Builder requestBuilder = ReadModifyWriteRowRequest.newBuilder();
-    incrementAdapter.adapt(incr, requestBuilder);
+    ReadModifyWriteRow readModifyWriteRow = ReadModifyWriteRow
+        .create(TABLE_ID, ByteString.copyFrom(rowKey));
+    incrementAdapter.adapt(incr, readModifyWriteRow);
+    ReadModifyWriteRowRequest requestBuilder = readModifyWriteRow.toProto(requestContext);
     ByteString adaptedRowKey = requestBuilder.getRowKey();
     Assert.assertArrayEquals(rowKey, adaptedRowKey.toByteArray());
   }
@@ -59,8 +69,10 @@ public class TestIncrementAdapter {
     Increment incr = new Increment(rowKey);
     incr.addColumn(family, qualifier, amount);
 
-    ReadModifyWriteRowRequest.Builder requestBuilder = ReadModifyWriteRowRequest.newBuilder();
-    incrementAdapter.adapt(incr, requestBuilder);
+    ReadModifyWriteRow readModifyWriteRow = ReadModifyWriteRow
+        .create(TABLE_ID, ByteString.copyFrom(rowKey));
+    incrementAdapter.adapt(incr, readModifyWriteRow);
+    ReadModifyWriteRowRequest requestBuilder = readModifyWriteRow.toProto(requestContext);
 
     Assert.assertEquals(1, requestBuilder.getRulesCount());
     ReadModifyWriteRule rule = requestBuilder.getRules(0);
@@ -86,8 +98,10 @@ public class TestIncrementAdapter {
     incr.addColumn(family1, qualifier1, amount1);
     incr.addColumn(family2, qualifier2, amount2);
 
-    ReadModifyWriteRowRequest.Builder requestBuilder = ReadModifyWriteRowRequest.newBuilder();
-    incrementAdapter.adapt(incr, requestBuilder);
+    ReadModifyWriteRow readModifyWriteRow = ReadModifyWriteRow
+        .create(TABLE_ID, ByteString.copyFrom(rowKey));
+    incrementAdapter.adapt(incr, readModifyWriteRow);
+    ReadModifyWriteRowRequest requestBuilder = readModifyWriteRow.toProto(requestContext);
     Assert.assertEquals(2, requestBuilder.getRulesCount());
 
     ReadModifyWriteRule rule = requestBuilder.getRules(0);
@@ -121,8 +135,10 @@ public class TestIncrementAdapter {
     incr.addColumn(family2, qualifier2, amount2);
     incr.addColumn(family2, qualifier2, amount3);
 
-    ReadModifyWriteRowRequest.Builder requestBuilder = ReadModifyWriteRowRequest.newBuilder();
-    incrementAdapter.adapt(incr, requestBuilder);
+    ReadModifyWriteRow readModifyWriteRow = ReadModifyWriteRow
+        .create(TABLE_ID, ByteString.copyFrom(rowKey));
+    incrementAdapter.adapt(incr, readModifyWriteRow);
+    ReadModifyWriteRowRequest requestBuilder = readModifyWriteRow.toProto(requestContext);
     Assert.assertEquals(2, requestBuilder.getRulesCount());
 
     ReadModifyWriteRule rule = requestBuilder.getRules(0);
@@ -146,6 +162,8 @@ public class TestIncrementAdapter {
     expectedException.expect(UnsupportedOperationException.class);
     expectedException.expectMessage("Setting the time range in an Increment is not implemented");
 
-    incrementAdapter.adapt(incr, ReadModifyWriteRowRequest.newBuilder());
+    ReadModifyWriteRow readModifyWriteRow = ReadModifyWriteRow
+        .create(TABLE_ID, ByteString.copyFrom(rowKey));
+    incrementAdapter.adapt(incr, readModifyWriteRow);
   }
 }

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/admin/TestTableAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/admin/TestTableAdapter.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.adapters.admin;
+
+import static com.google.cloud.bigtable.admin.v2.models.GCRules.GCRULES;
+import com.google.bigtable.admin.v2.ColumnFamily;
+import com.google.bigtable.admin.v2.InstanceName;
+import com.google.bigtable.admin.v2.Table;
+import com.google.cloud.bigtable.admin.v2.models.CreateTableRequest;
+import com.google.cloud.bigtable.admin.v2.models.GCRules.GCRule;
+import com.google.cloud.bigtable.grpc.BigtableInstanceName;
+import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class TestTableAdapter {
+
+  private static final String PROJECT_ID = "fakeProject";
+  private static final String INSTANCE_ID = "fakeInstance";
+  private static final String TABLE_ID = "myTable";
+  private static final String INSTANCE_NAME = "projects/" + PROJECT_ID + "/instances/" + INSTANCE_ID;
+  private static final String TABLE_NAME = INSTANCE_NAME + "/tables/" + TABLE_ID;
+  private static final String COLUMN_FAMILY = "myColumnFamily";
+
+  private TableAdapter tableAdapter;
+  private InstanceName instanceName;
+
+  @Before
+  public void setUp(){
+    BigtableInstanceName bigtableInstanceName = new BigtableInstanceName(PROJECT_ID, INSTANCE_ID);
+    tableAdapter = new TableAdapter(bigtableInstanceName);
+    instanceName = InstanceName.of(PROJECT_ID, INSTANCE_ID);
+  }
+
+  @Test
+  public void testAdaptWithHTableDescriptor(){
+    byte[][] splits = new byte[][] {
+            Bytes.toBytes("AAA"),
+            Bytes.toBytes("BBB"),
+            Bytes.toBytes("CCC"),
+    };
+    CreateTableRequest actualRequest =
+            TableAdapter.adapt(new HTableDescriptor(TableName.valueOf(TABLE_ID)), splits);
+
+    CreateTableRequest expectedRequest = CreateTableRequest.of(TABLE_ID);
+    TableAdapter.addSplitKeys(splits, expectedRequest);
+    Assert.assertEquals(
+            expectedRequest.toProto(instanceName),
+            actualRequest.toProto(instanceName));
+  }
+
+
+  @Test
+  public void testAdaptWithHTableDescriptorWhenSplitIsEmpty(){
+    byte[][] splits = new byte[0][0];
+    CreateTableRequest actualRequest =
+            TableAdapter.adapt(new HTableDescriptor(TableName.valueOf(TABLE_ID)), splits);
+
+    CreateTableRequest expectedRequest = CreateTableRequest.of(TABLE_ID);
+    Assert.assertEquals(
+            expectedRequest.toProto(instanceName),
+            actualRequest.toProto(instanceName));
+  }
+
+  @Test
+  public void testAdaptWithColumnDesc(){
+    HColumnDescriptor columnDesc = new HColumnDescriptor(COLUMN_FAMILY);
+    HTableDescriptor desc = new HTableDescriptor(TableName.valueOf(TABLE_ID));
+    CreateTableRequest request = CreateTableRequest.of(TABLE_ID);
+    desc.addFamily(columnDesc);
+
+    TableAdapter.adapt(desc, request);
+
+    GCRule gcRule = ColumnDescriptorAdapter.buildGarbageCollectionRule(columnDesc);
+    CreateTableRequest expected =
+            CreateTableRequest.of(TABLE_ID).addFamily(COLUMN_FAMILY, gcRule);
+    Assert.assertEquals(request.toProto(instanceName), expected.toProto(instanceName));
+  }
+
+
+  @Test
+  public void testAdaptForTable(){
+    //If no GcRule passed to ColumnFamily, then ColumnDescriptorAdapter#buildGarbageCollectionRule
+    //updates maxVersion to Integer.MAX_VALUE
+    GCRule gcRule = GCRULES.maxVersions(1);
+    ColumnFamily columnFamily = ColumnFamily.newBuilder()
+            .setGcRule(gcRule.toProto()).build();
+    Table table = Table.newBuilder()
+            .setName(TABLE_NAME)
+            .putColumnFamilies(COLUMN_FAMILY, columnFamily).build();
+    HTableDescriptor actualTableDesc = tableAdapter.adapt(table);
+
+    HTableDescriptor expected = new HTableDescriptor(TableName.valueOf(TABLE_ID));
+    expected.addFamily(new HColumnDescriptor(COLUMN_FAMILY));
+    Assert.assertEquals(expected, actualTableDesc);
+  }
+}

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestColumnCountGetFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestColumnCountGetFilterAdapter.java
@@ -17,7 +17,7 @@ package com.google.cloud.bigtable.hbase.adapters.filters;
 
 import static com.google.cloud.bigtable.data.v2.models.Filters.FILTERS;
 
-import com.google.bigtable.v2.RowFilter;
+import com.google.cloud.bigtable.data.v2.models.Filters;
 
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.filter.ColumnCountGetFilter;
@@ -35,15 +35,14 @@ public class TestColumnCountGetFilterAdapter {
 
   @Test
   public void testSimpleColumnCount() throws IOException {
-    RowFilter adaptedFilter =
+    Filters.Filter adaptedFilter =
         adapter.adapt(
             new FilterAdapterContext(new Scan(), null),
             new ColumnCountGetFilter(2));
     Assert.assertEquals(
         FILTERS.chain()
             .filter(FILTERS.limit().cellsPerColumn(1))
-            .filter(FILTERS.limit().cellsPerRow(2))
-            .toProto(),
-        adaptedFilter);
+            .filter(FILTERS.limit().cellsPerRow(2)).toProto(),
+        adaptedFilter.toProto());
   }
 }

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestColumnPaginationFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestColumnPaginationFilterAdapter.java
@@ -17,7 +17,7 @@ package com.google.cloud.bigtable.hbase.adapters.filters;
 
 import static com.google.cloud.bigtable.data.v2.models.Filters.FILTERS;
 
-import com.google.bigtable.v2.RowFilter;
+import com.google.cloud.bigtable.data.v2.models.Filters;
 import com.google.protobuf.ByteString;
 
 import org.apache.hadoop.hbase.client.Scan;
@@ -38,40 +38,37 @@ public class TestColumnPaginationFilterAdapter {
   @Test
   public void integerLimitsAreApplied() throws IOException {
     ColumnPaginationFilter filter = new ColumnPaginationFilter(10, 20);
-    RowFilter adaptedFilter = adapter.adapt(
+    Filters.Filter adaptedFilter = adapter.adapt(
         new FilterAdapterContext(new Scan(), null), filter);
-    RowFilter expected = FILTERS.chain()
+    Filters.Filter expected = FILTERS.chain()
           .filter(FILTERS.limit().cellsPerColumn(1))
           .filter(FILTERS.offset().cellsPerRow(20))
-          .filter(FILTERS.limit().cellsPerRow(10))
-          .toProto();
-    Assert.assertEquals(expected, adaptedFilter);
+          .filter(FILTERS.limit().cellsPerRow(10));
+    Assert.assertEquals(expected.toProto(), adaptedFilter.toProto());
   }
 
   @Test
   public void zeroOffsetLimitIsSupported() throws IOException {
     ColumnPaginationFilter filter = new ColumnPaginationFilter(10, 0);
-    RowFilter adaptedFilter = adapter.adapt(
+    Filters.Filter adaptedFilter = adapter.adapt(
         new FilterAdapterContext(new Scan(), null), filter);
-    RowFilter expected = FILTERS.chain()
+    Filters.Filter expected = FILTERS.chain()
         .filter(FILTERS.limit().cellsPerColumn(1))
-        .filter(FILTERS.limit().cellsPerRow(10))
-        .toProto();
-    Assert.assertEquals(expected, adaptedFilter);
+        .filter(FILTERS.limit().cellsPerRow(10));
+    Assert.assertEquals(expected.toProto(), adaptedFilter.toProto());
   }
 
   @Test
   public void qualifierOffsetIsPartiallySupported() throws IOException {
     Scan scan = new Scan().addFamily(Bytes.toBytes("f1"));
-    RowFilter adaptedFilter = adapter.adapt(
+    Filters.Filter adaptedFilter = adapter.adapt(
         new FilterAdapterContext(scan, null),
         new ColumnPaginationFilter(10, Bytes.toBytes("q1")));
-    RowFilter expected = FILTERS.chain()
+    Filters.Filter expected = FILTERS.chain()
         .filter(FILTERS.limit().cellsPerColumn(1))
         .filter(FILTERS.qualifier().rangeWithinFamily("f1")
             .startClosed(ByteString.copyFromUtf8("q1")))
-        .filter(FILTERS.limit().cellsPerRow(10))
-        .toProto();
-    Assert.assertEquals(expected, adaptedFilter);
+        .filter(FILTERS.limit().cellsPerRow(10));
+    Assert.assertEquals(expected.toProto(), adaptedFilter.toProto());
   }
 }

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestColumnPrefixFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestColumnPrefixFilterAdapter.java
@@ -15,7 +15,7 @@
  */
 package com.google.cloud.bigtable.hbase.adapters.filters;
 
-import com.google.bigtable.v2.RowFilter;
+import com.google.cloud.bigtable.data.v2.models.Filters;
 
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.filter.ColumnPrefixFilter;
@@ -37,9 +37,9 @@ public class TestColumnPrefixFilterAdapter {
   @Test
   public void columnPrefixFiltersAreAdapted() throws IOException {
     ColumnPrefixFilter filter = new ColumnPrefixFilter(Bytes.toBytes("prefix"));
-    RowFilter rowFilter = adapter.adapt(emptyScanContext, filter);
+    Filters.Filter expected = adapter.adapt(emptyScanContext, filter);
     Assert.assertEquals(
         "prefix\\C*",
-        Bytes.toString(rowFilter.getColumnQualifierRegexFilter().toByteArray()));
+        Bytes.toString(expected.toProto().getColumnQualifierRegexFilter().toByteArray()));
   }
 }

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestColumnRangeFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestColumnRangeFilterAdapter.java
@@ -25,7 +25,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import com.google.bigtable.v2.ColumnRange;
-import com.google.bigtable.v2.RowFilter;
+import com.google.cloud.bigtable.data.v2.models.Filters;
 import com.google.protobuf.ByteString;
 
 @RunWith(JUnit4.class)
@@ -47,10 +47,10 @@ public class TestColumnRangeFilterAdapter {
     ColumnRangeFilter filter = new ColumnRangeFilter(
         Bytes.toBytes("a"), true, Bytes.toBytes("b"), false);
     Scan familyScan = new Scan().addFamily(Bytes.toBytes("foo"));
-    RowFilter rowFilter = filterAdapter.adapt(
+    Filters.Filter expected = filterAdapter.adapt(
         new FilterAdapterContext(familyScan, null), filter);
 
-    ColumnRange columnRange = rowFilter.getColumnRangeFilter();
+    ColumnRange columnRange = expected.toProto().getColumnRangeFilter();
     Assert.assertEquals(0, columnRange.getStartQualifierOpen().size());
     Assert.assertEquals("a", toString(columnRange.getStartQualifierClosed()));
     Assert.assertEquals("b", toString(columnRange.getEndQualifierOpen()));
@@ -62,10 +62,10 @@ public class TestColumnRangeFilterAdapter {
     ColumnRangeFilter filter = new ColumnRangeFilter(
         null, true, Bytes.toBytes("b"), false);
     Scan familyScan = new Scan().addFamily(Bytes.toBytes("foo"));
-    RowFilter rowFilter = filterAdapter.adapt(
+    Filters.Filter expectedFilter = filterAdapter.adapt(
         new FilterAdapterContext(familyScan, null), filter);
 
-    ColumnRange columnRange = rowFilter.getColumnRangeFilter();
+    ColumnRange columnRange = expectedFilter.toProto().getColumnRangeFilter();
     Assert.assertEquals(0, columnRange.getStartQualifierClosed().size());
     Assert.assertEquals(0, columnRange.getStartQualifierOpen().size());
     Assert.assertEquals("b", toString(columnRange.getEndQualifierOpen()));
@@ -77,10 +77,10 @@ public class TestColumnRangeFilterAdapter {
     ColumnRangeFilter filter = new ColumnRangeFilter(
         Bytes.toBytes("a"), true, null, false);
     Scan familyScan = new Scan().addFamily(Bytes.toBytes("foo"));
-    RowFilter rowFilter = filterAdapter.adapt(
+    Filters.Filter expectedFilter = filterAdapter.adapt(
         new FilterAdapterContext(familyScan, null), filter);
 
-    ColumnRange columnRange = rowFilter.getColumnRangeFilter();
+    ColumnRange columnRange = expectedFilter.toProto().getColumnRangeFilter();
     Assert.assertEquals("a", toString(columnRange.getStartQualifierClosed()));
     Assert.assertEquals(0, columnRange.getStartQualifierOpen().size());
     Assert.assertEquals(0, columnRange.getEndQualifierOpen().size());

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestFamilyFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestFamilyFilterAdapter.java
@@ -57,7 +57,7 @@ public class TestFamilyFilterAdapter {
             .setRowKeyRegexFilter(
                 ByteString.copyFrom(regexp.getBytes()))
             .build(),
-        adapter.adapt(context, filter));
+        adapter.adapt(context, filter).toProto());
   }
 
   @Test
@@ -71,7 +71,7 @@ public class TestFamilyFilterAdapter {
         RowFilter.newBuilder()
             .setRowKeyRegexFilter(ReaderExpressionHelper.quoteRegularExpression(bytes))
             .build(),
-        adapter.adapt(context, filter));
+        adapter.adapt(context, filter).toProto());
   }
 
   @Test
@@ -87,7 +87,7 @@ public class TestFamilyFilterAdapter {
             .setRowKeyRegexFilter(
                 ByteString.copyFrom(regexp.getBytes()))
             .build(),
-        adapter.adapt(context, filter));
+        adapter.adapt(context, filter).toProto());
   }
 
 
@@ -103,7 +103,7 @@ public class TestFamilyFilterAdapter {
             .setRowKeyRegexFilter(
                 ByteString.copyFrom(new byte[0]))
             .build(),
-        adapter.adapt(context, filter));
+        adapter.adapt(context, filter).toProto());
   }
 
   @Test

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestFilterListAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestFilterListAdapter.java
@@ -15,7 +15,7 @@
  */
 package com.google.cloud.bigtable.hbase.adapters.filters;
 
-import com.google.bigtable.v2.RowFilter;
+import com.google.cloud.bigtable.data.v2.models.Filters;
 import com.google.cloud.bigtable.hbase.adapters.read.DefaultReadHooks;
 import com.google.cloud.bigtable.util.RowKeyWrapper;
 import com.google.common.base.Optional;
@@ -67,10 +67,10 @@ public class TestFilterListAdapter {
   public void interleavedFiltersAreAdapted() throws IOException {
     FilterList filterList = makeFilterList(Operator.MUST_PASS_ONE);
     List<Filter> filters = filterList.getFilters();
-    RowFilter rowFilter = adapt(filterList);
-    Assert.assertEquals(filters.size(), rowFilter.getInterleave().getFiltersCount());
+    Filters.Filter expectedFilter = adapt(filterList);
+    Assert.assertEquals(filters.size(), expectedFilter.toProto().getInterleave().getFiltersCount());
     for (int i = 0; i < filters.size(); i++) {
-      Assert.assertEquals(adapt(filters.get(i)), rowFilter.getInterleave().getFilters(i));
+      Assert.assertEquals(adapt(filters.get(i)).toProto(), expectedFilter.toProto().getInterleave().getFilters(i));
     }
   }
 
@@ -78,10 +78,10 @@ public class TestFilterListAdapter {
   public void chainedFiltersAreAdapted() throws IOException {
     FilterList filterList = makeFilterList(Operator.MUST_PASS_ALL);
     List<Filter> filters = filterList.getFilters();
-    RowFilter rowFilter = adapt(filterList);
-    Assert.assertEquals(filters.size(), rowFilter.getChain().getFiltersCount());
+    Filters.Filter expectedFilter = adapt(filterList);
+    Assert.assertEquals(filters.size(), expectedFilter.toProto().getChain().getFiltersCount());
     for (int i = 0; i < filters.size(); i++) {
-      Assert.assertEquals(adapt(filters.get(i)), rowFilter.getChain().getFilters(i));
+      Assert.assertEquals(adapt(filters.get(i)).toProto(), expectedFilter.toProto().getChain().getFilters(i));
     }
   }
 
@@ -140,14 +140,14 @@ public class TestFilterListAdapter {
         new QualifierFilter(CompareOp.EQUAL, new BinaryComparator(qualA)),
         pageFilter);
     FilterAdapter adapter = FilterAdapter.buildAdapter();
-    Optional<RowFilter> adapted =
+    Optional<Filters.Filter> adapted =
         adapter.adaptFilter(new FilterAdapterContext(new Scan(), new DefaultReadHooks()),
             filterList);
     Assert.assertTrue(adapted.isPresent());
-    Optional<RowFilter> qualifierAdapted =
+    Optional<Filters.Filter> qualifierAdapted =
         adapter.adaptFilter(new FilterAdapterContext(new Scan(), new DefaultReadHooks()),
             filterList.getFilters().get(0));
-    Assert.assertEquals(qualifierAdapted.get(), adapted.get());
+    Assert.assertEquals(qualifierAdapted.get().toProto(), adapted.get().toProto());
   }
 
   @Test
@@ -227,7 +227,7 @@ public class TestFilterListAdapter {
     Assert.assertEquals(expected, actual);
   }
 
-  protected RowFilter adapt(Filter filter) throws IOException {
+  protected Filters.Filter adapt(Filter filter) throws IOException {
     return filterAdapter.adaptFilter(emptyScanContext, filter).get();
   }
 

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestFirstKeyOnlyFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestFirstKeyOnlyFilterAdapter.java
@@ -15,6 +15,8 @@
  */
 package com.google.cloud.bigtable.hbase.adapters.filters;
 
+import static com.google.cloud.bigtable.data.v2.models.Filters.FILTERS;
+
 import com.google.bigtable.v2.RowFilter;
 
 import org.apache.hadoop.hbase.client.Scan;
@@ -24,21 +26,20 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-import java.io.IOException;
-
 @RunWith(JUnit4.class)
 public class TestFirstKeyOnlyFilterAdapter {
 
-  FirstKeyOnlyFilterAdapter adapter = new FirstKeyOnlyFilterAdapter();
+  private final static FirstKeyOnlyFilterAdapter adapter = new FirstKeyOnlyFilterAdapter();
 
   @Test
-  public void onlyTheFirstKeyFromEachRowIsEmitted() throws IOException {
+  public void onlyTheFirstKeyFromEachRowIsEmitted() {
     RowFilter adaptedFilter = adapter.adapt(
         new FilterAdapterContext(new Scan(), null), new FirstKeyOnlyFilter());
     Assert.assertEquals(
-        RowFilter.newBuilder()
-            .setCellsPerRowLimitFilter(1)
-            .build(),
+        FILTERS.chain()
+            .filter(FILTERS.limit().cellsPerRow(1))
+            .filter(FILTERS.value().strip())
+            .toProto(),
         adaptedFilter);
   }
 }

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestFirstKeyOnlyFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestFirstKeyOnlyFilterAdapter.java
@@ -15,9 +15,7 @@
  */
 package com.google.cloud.bigtable.hbase.adapters.filters;
 
-import static com.google.cloud.bigtable.data.v2.models.Filters.FILTERS;
-
-import com.google.bigtable.v2.RowFilter;
+import com.google.cloud.bigtable.data.v2.models.Filters;
 
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.filter.FirstKeyOnlyFilter;
@@ -26,20 +24,24 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import static com.google.cloud.bigtable.data.v2.models.Filters.FILTERS;
+
+import java.io.IOException;
+
 @RunWith(JUnit4.class)
 public class TestFirstKeyOnlyFilterAdapter {
 
   private final static FirstKeyOnlyFilterAdapter adapter = new FirstKeyOnlyFilterAdapter();
 
   @Test
-  public void onlyTheFirstKeyFromEachRowIsEmitted() {
-    RowFilter adaptedFilter = adapter.adapt(
+  public void onlyTheFirstKeyFromEachRowIsEmitted() throws IOException {
+    Filters.Filter adaptedFilter = adapter.adapt(
         new FilterAdapterContext(new Scan(), null), new FirstKeyOnlyFilter());
     Assert.assertEquals(
-        FILTERS.chain()
+      FILTERS.chain()
             .filter(FILTERS.limit().cellsPerRow(1))
             .filter(FILTERS.value().strip())
             .toProto(),
-        adaptedFilter);
+        adaptedFilter.toProto());
   }
 }

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestFuzzyRowFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestFuzzyRowFilterAdapter.java
@@ -17,11 +17,8 @@ package com.google.cloud.bigtable.hbase.adapters.filters;
 
 import static com.google.cloud.bigtable.data.v2.models.Filters.FILTERS;
 
-import com.google.bigtable.v2.RowFilter;
-import com.google.bigtable.v2.RowFilter.Interleave;
 import com.google.cloud.bigtable.data.v2.models.Filters;
 import com.google.common.collect.ImmutableList;
-import com.google.protobuf.ByteString;
 
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.filter.FuzzyRowFilter;
@@ -48,14 +45,13 @@ import java.util.List;
         .build();
 
     FuzzyRowFilter filter = new FuzzyRowFilter(testPairs);
-    RowFilter adaptedFilter = adapter.adapt(context, filter);
-    RowFilter expected = FILTERS.interleave()
+    Filters.Filter adaptedFilter = adapter.adapt(context, filter);
+    Filters.Filter expected = FILTERS.interleave()
         .filter(FILTERS.key().regex("abcd\\C*"))
         .filter(FILTERS.key().regex("\\.f\\Ch\\C*"))
-        .filter(FILTERS.key().regex("\\C\\C\\C\\C\\C*"))
-        .toProto();
+        .filter(FILTERS.key().regex("\\C\\C\\C\\C\\C*"));
 
 
-    Assert.assertEquals(expected, adaptedFilter);
+    Assert.assertEquals(expected.toProto(), adaptedFilter.toProto());
   }
 }

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestKeyOnlyFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestKeyOnlyFilterAdapter.java
@@ -17,7 +17,6 @@ package com.google.cloud.bigtable.hbase.adapters.filters;
 
 import java.io.IOException;
 
-import com.google.cloud.bigtable.data.v2.models.Filters;
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.filter.KeyOnlyFilter;
 import org.junit.Assert;
@@ -25,10 +24,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-import com.google.bigtable.v2.RowFilter;
 import com.google.bigtable.v2.RowFilter.Chain;
-
-import static com.google.cloud.bigtable.data.v2.models.Filters.FILTERS;
+import com.google.cloud.bigtable.data.v2.models.Filters;
 
 @RunWith(JUnit4.class)
 public class TestKeyOnlyFilterAdapter {
@@ -40,13 +37,17 @@ public class TestKeyOnlyFilterAdapter {
   @Test
   public void stripValuesIsApplied() throws IOException {
     KeyOnlyFilter filter = new KeyOnlyFilter();
-    RowFilter rowFilter = filterAdapter.adapt(emptyScanContext, filter);
+    Filters.Filter expectedFilter = filterAdapter.adapt(emptyScanContext, filter);
+    Chain chain = expectedFilter.toProto().getChain();
+    Assert.assertTrue(
+        chain.getFilters(0).getStripValueTransformer()
+            || chain.getFilters(1).getStripValueTransformer());
+    Filters.Filter filters = filterAdapter.adapt(emptyScanContext, filter);
     Filters f = Filters.FILTERS;
-    Assert.assertEquals(rowFilter,
+    Assert.assertEquals(filters.toProto(),
         f.chain()
             .filter(f.limit().cellsPerColumn(1))
-            .filter(f.value().strip())
-            .toProto());
+            .filter(f.value().strip()).toProto());
   }
 
   @Test

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestKeyOnlyFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestKeyOnlyFilterAdapter.java
@@ -17,6 +17,7 @@ package com.google.cloud.bigtable.hbase.adapters.filters;
 
 import java.io.IOException;
 
+import com.google.cloud.bigtable.data.v2.models.Filters;
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.filter.KeyOnlyFilter;
 import org.junit.Assert;
@@ -26,6 +27,8 @@ import org.junit.runners.JUnit4;
 
 import com.google.bigtable.v2.RowFilter;
 import com.google.bigtable.v2.RowFilter.Chain;
+
+import static com.google.cloud.bigtable.data.v2.models.Filters.FILTERS;
 
 @RunWith(JUnit4.class)
 public class TestKeyOnlyFilterAdapter {
@@ -38,10 +41,12 @@ public class TestKeyOnlyFilterAdapter {
   public void stripValuesIsApplied() throws IOException {
     KeyOnlyFilter filter = new KeyOnlyFilter();
     RowFilter rowFilter = filterAdapter.adapt(emptyScanContext, filter);
-    Chain chain = rowFilter.getChain();
-    Assert.assertTrue(
-        chain.getFilters(0).getStripValueTransformer()
-            || chain.getFilters(1).getStripValueTransformer());
+    Filters f = Filters.FILTERS;
+    Assert.assertEquals(rowFilter,
+        f.chain()
+            .filter(f.limit().cellsPerColumn(1))
+            .filter(f.value().strip())
+            .toProto());
   }
 
   @Test

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestMultiRowRangeAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestMultiRowRangeAdapter.java
@@ -15,7 +15,7 @@
  */
 package com.google.cloud.bigtable.hbase.adapters.filters;
 
-import com.google.bigtable.v2.RowFilter;
+import com.google.cloud.bigtable.data.v2.models.Filters;
 import com.google.cloud.bigtable.hbase.adapters.filters.FilterAdapterContext.ContextCloseable;
 import com.google.cloud.bigtable.util.RowKeyWrapper;
 import com.google.common.collect.ImmutableRangeSet;
@@ -41,16 +41,14 @@ public class TestMultiRowRangeAdapter {
   private MultiRowRangeFilterAdapter adapter;
   private Scan scan;
   private FilterAdapterContext context;
-  private RowFilter unaffectedRowFilter;
+  private Filters.Filter unaffectedRowFilter;
 
   @Before
   public void setup() {
     scan = new Scan();
     context = new FilterAdapterContext(scan, null);
     adapter = new MultiRowRangeFilterAdapter();
-    unaffectedRowFilter = RowFilter.newBuilder()
-        .setPassAllFilter(true)
-        .build();
+    unaffectedRowFilter = Filters.FILTERS.pass();
   }
 
   @Test
@@ -59,7 +57,7 @@ public class TestMultiRowRangeAdapter {
         new RowRange("cc", true, "ee", true)
     ));
 
-    RowFilter adaptedFilter = adapter.adapt(context, filter);
+    Filters.Filter adaptedFilter = adapter.adapt(context, filter);
     Assert.assertEquals(unaffectedRowFilter, adaptedFilter);
 
     RangeSet<RowKeyWrapper> indexScanHint = adapter.getIndexScanHint(filter);
@@ -78,7 +76,7 @@ public class TestMultiRowRangeAdapter {
         new RowRange("cc", false, "ee", false)
     ));
 
-    RowFilter adaptedFilter = adapter.adapt(context, filter);
+    Filters.Filter adaptedFilter = adapter.adapt(context, filter);
     Assert.assertEquals(unaffectedRowFilter, adaptedFilter);
 
     RangeSet<RowKeyWrapper> indexScanHint = adapter.getIndexScanHint(filter);
@@ -97,7 +95,7 @@ public class TestMultiRowRangeAdapter {
         new RowRange("cc", false, "ee", true)
     ));
 
-    RowFilter adaptedFilter = adapter.adapt(context, filter);
+    Filters.Filter adaptedFilter = adapter.adapt(context, filter);
     Assert.assertEquals(unaffectedRowFilter, adaptedFilter);
 
     RangeSet<RowKeyWrapper> indexScanHint = adapter.getIndexScanHint(filter);
@@ -116,7 +114,7 @@ public class TestMultiRowRangeAdapter {
         new RowRange("cc", true, "ee", false)
     ));
 
-    RowFilter adaptedFilter = adapter.adapt(context, filter);
+    Filters.Filter adaptedFilter = adapter.adapt(context, filter);
     Assert.assertEquals(unaffectedRowFilter, adaptedFilter);
 
     RangeSet<RowKeyWrapper> indexScanHint = adapter.getIndexScanHint(filter);
@@ -135,7 +133,7 @@ public class TestMultiRowRangeAdapter {
         new RowRange(HConstants.EMPTY_START_ROW, true, "ee".getBytes(), true)
     ));
 
-    RowFilter adaptedFilter = adapter.adapt(context, filter);
+    Filters.Filter adaptedFilter = adapter.adapt(context, filter);
     Assert.assertEquals(unaffectedRowFilter, adaptedFilter);
 
     RangeSet<RowKeyWrapper> indexScanHint = adapter.getIndexScanHint(filter);
@@ -153,7 +151,7 @@ public class TestMultiRowRangeAdapter {
         new RowRange("cc".getBytes(), true, HConstants.EMPTY_END_ROW, true)
     ));
 
-    RowFilter adaptedFilter = adapter.adapt(context, filter);
+    Filters.Filter adaptedFilter = adapter.adapt(context, filter);
     Assert.assertEquals(unaffectedRowFilter, adaptedFilter);
 
     RangeSet<RowKeyWrapper> indexScanHint = adapter.getIndexScanHint(filter);
@@ -171,7 +169,7 @@ public class TestMultiRowRangeAdapter {
         new RowRange(HConstants.EMPTY_START_ROW, true, HConstants.EMPTY_END_ROW, true)
     ));
 
-    RowFilter adaptedFilter = adapter.adapt(context, filter);
+    Filters.Filter adaptedFilter = adapter.adapt(context, filter);
     Assert.assertEquals(unaffectedRowFilter, adaptedFilter);
 
     RangeSet<RowKeyWrapper> indexScanHint = adapter.getIndexScanHint(filter);
@@ -186,7 +184,7 @@ public class TestMultiRowRangeAdapter {
         new RowRange("ss", true, "yy", true)
     ));
 
-    RowFilter adaptedFilter = adapter.adapt(context, filter);
+    Filters.Filter adaptedFilter = adapter.adapt(context, filter);
     Assert.assertEquals(unaffectedRowFilter, adaptedFilter);
 
     RangeSet<RowKeyWrapper> indexScanHint = adapter.getIndexScanHint(filter);
@@ -211,7 +209,7 @@ public class TestMultiRowRangeAdapter {
         new RowRange("ca", true, "yy", true)
     ));
 
-    RowFilter adaptedFilter = adapter.adapt(context, filter);
+    Filters.Filter adaptedFilter = adapter.adapt(context, filter);
     Assert.assertEquals(unaffectedRowFilter, adaptedFilter);
 
     RangeSet<RowKeyWrapper> indexScanHint = adapter.getIndexScanHint(filter);

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestMultipleColumnPrefxiFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestMultipleColumnPrefxiFilterAdapter.java
@@ -15,8 +15,8 @@
  */
 package com.google.cloud.bigtable.hbase.adapters.filters;
 
-import com.google.bigtable.v2.RowFilter;
 import com.google.bigtable.v2.RowFilter.Interleave;
+import com.google.cloud.bigtable.data.v2.models.Filters;
 
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.filter.MultipleColumnPrefixFilter;
@@ -42,8 +42,8 @@ public class TestMultipleColumnPrefxiFilterAdapter {
         new MultipleColumnPrefixFilter(
             new byte[][]{Bytes.toBytes("prefix"), Bytes.toBytes("prefix2")});
 
-    RowFilter rowFilter = filterAdapter.adapt(emptyScanContext, filter);
-    Interleave interleave = rowFilter.getInterleave();
+    Filters.Filter expectedFilter = filterAdapter.adapt(emptyScanContext, filter);
+    Interleave interleave = expectedFilter.toProto().getInterleave();
     Assert.assertEquals(2, interleave.getFiltersCount());
     Assert.assertEquals(
         "prefix\\C*",

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestPageFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestPageFilterAdapter.java
@@ -16,7 +16,7 @@
 package com.google.cloud.bigtable.hbase.adapters.filters;
 
 import com.google.bigtable.v2.ReadRowsRequest;
-import com.google.bigtable.v2.RowFilter;
+import com.google.cloud.bigtable.data.v2.models.Filters;
 import com.google.cloud.bigtable.hbase.adapters.filters.FilterAdapterContext.ContextCloseable;
 import com.google.cloud.bigtable.hbase.adapters.read.DefaultReadHooks;
 import com.google.cloud.bigtable.hbase.adapters.read.ReadHooks;
@@ -113,8 +113,8 @@ public class TestPageFilterAdapter {
     ReadHooks hooks = new DefaultReadHooks();
     FilterAdapterContext context = new FilterAdapterContext(new Scan(), hooks);
     PageFilter pageFilter = new PageFilter(20);
-    RowFilter adaptedFilter = pageFilterAdapter.adapt(context, pageFilter);
-    Assert.assertNull("PageFilterAdapter should not return a RowFilter.", adaptedFilter);
+    Filters.Filter adaptedFilter = pageFilterAdapter.adapt(context, pageFilter);
+    Assert.assertNull("PageFilterAdapter should not return a Filters.Filter.", adaptedFilter);
 
     ReadRowsRequest request = ReadRowsRequest.newBuilder().setRowsLimit(100).build();
     ReadRowsRequest postHookRequest = hooks.applyPreSendHook(request);

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestPrefixFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestPrefixFilterAdapter.java
@@ -16,12 +16,14 @@
 package com.google.cloud.bigtable.hbase.adapters.filters;
 
 
-import com.google.bigtable.v2.RowFilter;
 import com.google.cloud.bigtable.util.RowKeyWrapper;
 import com.google.common.collect.ImmutableRangeSet;
 import com.google.common.collect.Range;
 import com.google.common.collect.RangeSet;
 import com.google.protobuf.ByteString;
+
+import static com.google.cloud.bigtable.data.v2.models.Filters.FILTERS;
+
 import java.io.IOException;
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.filter.PrefixFilter;
@@ -47,11 +49,9 @@ public class TestPrefixFilterAdapter {
 
     byte[] prefixRegex = Bytes.toBytes(prefix + "\\C*");
     Assert.assertEquals(
-        RowFilter.newBuilder()
-            .setRowKeyRegexFilter(
-                ByteString.copyFrom(prefixRegex))
-            .build(),
-        adapter.adapt(context, filter));
+      FILTERS.key()
+        .regex(ByteString.copyFrom(prefixRegex)).toProto(),
+        adapter.adapt(context, filter).toProto());
   }
 
   @Test

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestRowFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestRowFilterAdapter.java
@@ -15,6 +15,8 @@
  */
 package com.google.cloud.bigtable.hbase.adapters.filters;
 
+import static com.google.cloud.bigtable.data.v2.models.Filters.FILTERS;
+
 import java.io.IOException;
 
 import org.apache.hadoop.hbase.client.Scan;
@@ -29,7 +31,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-import com.google.bigtable.v2.RowFilter;
 import com.google.cloud.bigtable.hbase.adapters.read.ReaderExpressionHelper;
 import com.google.protobuf.ByteString;
 
@@ -53,11 +54,8 @@ public class TestRowFilterAdapter {
         new org.apache.hadoop.hbase.filter.RowFilter(
             CompareFilter.CompareOp.EQUAL, comparator);
     Assert.assertEquals(
-        RowFilter.newBuilder()
-            .setRowKeyRegexFilter(
-                ByteString.copyFrom(regexp.getBytes()))
-            .build(),
-        adapter.adapt(context, filter));
+        FILTERS.key().regex(regexp).toProto(),  
+        adapter.adapt(context, filter).toProto());
   }
 
   @Test
@@ -68,10 +66,9 @@ public class TestRowFilterAdapter {
         new org.apache.hadoop.hbase.filter.RowFilter(
             CompareFilter.CompareOp.EQUAL, comparator);
     Assert.assertEquals(
-        RowFilter.newBuilder()
-            .setRowKeyRegexFilter(ReaderExpressionHelper.quoteRegularExpression(bytes))
-            .build(),
-        adapter.adapt(context, filter));
+        FILTERS.key()
+          .regex(ReaderExpressionHelper.quoteRegularExpression(bytes)).toProto(),
+        adapter.adapt(context, filter).toProto());
   }
 
   @Test
@@ -83,11 +80,8 @@ public class TestRowFilterAdapter {
         new org.apache.hadoop.hbase.filter.RowFilter(
             CompareFilter.CompareOp.EQUAL, comparator);
     Assert.assertEquals(
-        RowFilter.newBuilder()
-            .setRowKeyRegexFilter(
-                ByteString.copyFrom(regexp.getBytes()))
-            .build(),
-        adapter.adapt(context, filter));
+        FILTERS.key().regex(regexp).toProto(),
+        adapter.adapt(context, filter).toProto());
   }
 
 
@@ -99,11 +93,8 @@ public class TestRowFilterAdapter {
         new org.apache.hadoop.hbase.filter.RowFilter(
             CompareFilter.CompareOp.EQUAL, comparator);
     Assert.assertEquals(
-        RowFilter.newBuilder()
-            .setRowKeyRegexFilter(
-                ByteString.copyFrom(new byte[0]))
-            .build(),
-        adapter.adapt(context, filter));
+        FILTERS.key().regex(ByteString.copyFrom(new byte[0])).toProto(),
+        adapter.adapt(context, filter).toProto());
   }
 
   @Test

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestSingleColumnValueFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestSingleColumnValueFilterAdapter.java
@@ -20,6 +20,8 @@ import static com.google.cloud.bigtable.data.v2.models.Filters.FILTERS;
 import com.google.bigtable.v2.RowFilter;
 import com.google.bigtable.v2.RowFilter.Chain;
 import com.google.bigtable.v2.RowFilter.Condition;
+import com.google.bigtable.v2.RowFilter.Interleave;
+import com.google.cloud.bigtable.data.v2.models.Filters;
 import com.google.protobuf.ByteString;
 
 import org.apache.hadoop.hbase.client.Scan;
@@ -55,7 +57,7 @@ public class TestSingleColumnValueFilterAdapter  {
     filter.setFilterIfMissing(false);
     filter.setLatestVersionOnly(true);
 
-    RowFilter adaptedFilter = UNDER_TEST.adapt(
+    Filters.Filter adaptedFilter = UNDER_TEST.adapt(
         new FilterAdapterContext(new Scan(), null),
         filter);
 
@@ -82,7 +84,7 @@ public class TestSingleColumnValueFilterAdapter  {
     filter.setFilterIfMissing(false);
     filter.setLatestVersionOnly(false);
 
-    RowFilter adaptedFilter = UNDER_TEST.adapt(
+    Filters.Filter adaptedFilter = UNDER_TEST.adapt(
         new FilterAdapterContext(new Scan(), null),
         filter);
 
@@ -110,7 +112,7 @@ public class TestSingleColumnValueFilterAdapter  {
     filter.setFilterIfMissing(true);
     filter.setLatestVersionOnly(false);
 
-    RowFilter adaptedFilter = UNDER_TEST.adapt(
+    Filters.Filter adaptedFilter = UNDER_TEST.adapt(
         new FilterAdapterContext(new Scan(), null),
         filter);
 
@@ -118,21 +120,21 @@ public class TestSingleColumnValueFilterAdapter  {
         family,
         qualifier,
         false,
-        adaptedFilter
+        adaptedFilter.toProto()
             .getCondition()
             .getPredicateFilter());
 
     Assert.assertEquals(
         createValueRangeFilter(valueStr),
         getValueRangeFilter(
-            adaptedFilter
+            adaptedFilter.toProto()
             .getCondition()
             .getPredicateFilter()
             .getChain()));
 
     Assert.assertEquals(
         FILTERS.pass().toProto(),
-        adaptedFilter.getCondition().getTrueFilter());
+        adaptedFilter.toProto().getCondition().getTrueFilter());
   }
 
   private static RowFilter createValueRangeFilter(String valueStr) {
@@ -164,9 +166,10 @@ public class TestSingleColumnValueFilterAdapter  {
       byte[] qualifier,
       byte[] value,
       boolean latestOnly,
-      RowFilter adaptedFilter) throws IOException {
-    Condition cellSetCondition = adaptedFilter.getInterleave().getFilters(0).getCondition();
-    Condition cellUnsetCondition = adaptedFilter.getInterleave().getFilters(1).getCondition();
+      Filters.Filter adaptedFilter) throws IOException {
+    Interleave interleaveFilter = adaptedFilter.toProto().getInterleave();
+    Condition cellSetCondition = interleaveFilter.getFilters(0).getCondition();
+    Condition cellUnsetCondition = interleaveFilter.getFilters(1).getCondition();
 
     // ---------------  Check the conditions -------------------/
 

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestTimestampRangeFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestTimestampRangeFilterAdapter.java
@@ -21,7 +21,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-import com.google.bigtable.v2.RowFilter;
+import com.google.bigtable.v2.TimestampRange;
+import com.google.cloud.bigtable.data.v2.models.Filters;
 import com.google.cloud.bigtable.hbase.filter.TimestampRangeFilter;
 
 @RunWith(JUnit4.class)
@@ -34,8 +35,9 @@ public class TestTimestampRangeFilterAdapter {
   @Test
   public void timestampFiltersAreAdapted() {
     TimestampRangeFilter filter = new TimestampRangeFilter(10L, 20L);
-    RowFilter rowFilter = filterAdapter.adapt(emptyScanContext, filter);
-    Assert.assertEquals(10000L, rowFilter.getTimestampRangeFilter().getStartTimestampMicros());
-    Assert.assertEquals(20000L, rowFilter.getTimestampRangeFilter().getEndTimestampMicros());
+    Filters.Filter expectedFilter = filterAdapter.adapt(emptyScanContext, filter);
+    TimestampRange expectedTimestampFilter = expectedFilter.toProto().getTimestampRangeFilter();
+    Assert.assertEquals(10000L, expectedTimestampFilter.getStartTimestampMicros());
+    Assert.assertEquals(20000L, expectedTimestampFilter.getEndTimestampMicros());
   }
 }

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestTimestampsFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestTimestampsFilterAdapter.java
@@ -15,7 +15,8 @@
  */
 package com.google.cloud.bigtable.hbase.adapters.filters;
 
-import com.google.bigtable.v2.RowFilter;
+import com.google.bigtable.v2.RowFilter.Interleave;
+import com.google.cloud.bigtable.data.v2.models.Filters;
 import com.google.common.collect.ImmutableList;
 
 import org.apache.hadoop.hbase.client.Scan;
@@ -36,19 +37,18 @@ public class TestTimestampsFilterAdapter {
   public void timestampFiltersAreAdapted() {
     // Timestamps are sorted by the filter min -> max
     TimestampsFilter filter = new TimestampsFilter(ImmutableList.of(1L, 10L, 20L));
-    RowFilter rowFilter = filterAdapter.adapt(emptyScanContext, filter);
-    Assert.assertEquals(3, rowFilter.getInterleave().getFiltersCount());
+    Filters.Filter expected = filterAdapter.adapt(emptyScanContext, filter);
+    Interleave expectedInterleaveFilter = expected.toProto().getInterleave();
+    Assert.assertEquals(3, expectedInterleaveFilter.getFiltersCount());
     Assert.assertEquals(
         10000L,
-        rowFilter
-            .getInterleave()
+        expectedInterleaveFilter
             .getFilters(1)
             .getTimestampRangeFilter()
             .getStartTimestampMicros());
     Assert.assertEquals(
         11000L,
-        rowFilter
-            .getInterleave()
+        expectedInterleaveFilter
             .getFilters(1)
             .getTimestampRangeFilter()
             .getEndTimestampMicros());

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestValueFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestValueFilterAdapter.java
@@ -15,6 +15,8 @@
  */
 package com.google.cloud.bigtable.hbase.adapters.filters;
 
+import static com.google.cloud.bigtable.data.v2.models.Filters.FILTERS;
+
 import java.io.IOException;
 
 import org.apache.hadoop.hbase.client.Scan;
@@ -30,11 +32,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import com.google.cloud.bigtable.data.v2.models.Filters;
 import com.google.cloud.bigtable.hbase.adapters.read.ReaderExpressionHelper;
-import com.google.bigtable.v2.RowFilter;
-import com.google.bigtable.v2.RowFilter.Interleave;
-import com.google.bigtable.v2.ValueRange;
-import com.google.bigtable.v2.ValueRange.Builder;
 import com.google.protobuf.ByteString;
 
 @RunWith(JUnit4.class)
@@ -48,10 +47,6 @@ public class TestValueFilterAdapter {
   Scan emptyScan = new Scan();
   FilterAdapterContext emptyScanContext = new FilterAdapterContext(emptyScan, null);
 
-  protected static RowFilter toRowFilter(Builder valueRange) {
-    return RowFilter.newBuilder().setValueRangeFilter(valueRange).build();
-  }
-
   @Test
   public void testValueFilterFiltersOnValue() {
 
@@ -60,50 +55,46 @@ public class TestValueFilterAdapter {
   @Test
   public void testLessThanValueFilter() throws IOException {
     assertAdaptedForm(FOO_BINARY_COMPARATOR, CompareOp.LESS,
-      toRowFilter(ValueRange.newBuilder().setEndValueOpen(ByteString.copyFrom(FOO_BYTES))));
+      FILTERS.value().range().endOpen(ByteString.copyFrom(FOO_BYTES)));
   }
 
   @Test
   public void testLessThanEqualValueFilter() throws IOException {
     assertAdaptedForm(FOO_BINARY_COMPARATOR, CompareOp.LESS_OR_EQUAL,
-      toRowFilter(ValueRange.newBuilder().setEndValueClosed(FOO_BYTESTRING)));
+      FILTERS.value().range().endClosed(FOO_BYTESTRING));
   }
 
   @Test
   public void testEqualValueFilter() throws IOException {
-    Builder valueRange = ValueRange.newBuilder()
-        .setStartValueClosed(FOO_BYTESTRING)
-        .setEndValueClosed(FOO_BYTESTRING);
-    assertAdaptedForm(FOO_BINARY_COMPARATOR, CompareOp.EQUAL, toRowFilter(valueRange));
+    assertAdaptedForm(FOO_BINARY_COMPARATOR, CompareOp.EQUAL, 
+      FILTERS.value().range().startClosed(FOO_BYTESTRING).endClosed(FOO_BYTESTRING));
   }
 
   @Test
   public void testGreaterThanValueFilter() throws IOException {
     assertAdaptedForm(FOO_BINARY_COMPARATOR, CompareOp.GREATER,
-      toRowFilter(ValueRange.newBuilder().setStartValueOpen(FOO_BYTESTRING)));
+      FILTERS.value().range().startOpen(FOO_BYTESTRING));
   }
 
   @Test
   public void testGreaterThanEqualValueFilter() throws IOException {
     assertAdaptedForm(FOO_BINARY_COMPARATOR, CompareOp.GREATER_OR_EQUAL,
-      toRowFilter(ValueRange.newBuilder().setStartValueClosed(FOO_BYTESTRING)));
+      FILTERS.value().range().startClosed(FOO_BYTESTRING));
   }
 
   @Test
   public void testNotEqualEmptyStringValueFilter() throws IOException {
     assertAdaptedForm(new BinaryComparator("".getBytes()), CompareOp.NOT_EQUAL,
-        RowFilter.newBuilder().setValueRegexFilter(ByteString.copyFrom(ReaderExpressionHelper.ANY_BYTES.getBytes())).build());
+      FILTERS.value().regex(ReaderExpressionHelper.ANY_BYTES));
   }
 
   @Test
   public void testNotEqualValueFilter() throws IOException {
     assertAdaptedForm(FOO_BINARY_COMPARATOR, CompareOp.NOT_EQUAL,
-      RowFilter.newBuilder()
-          .setInterleave(Interleave.newBuilder()
-              .addFilters(toRowFilter(ValueRange.newBuilder().setEndValueOpen(FOO_BYTESTRING)))
-              .addFilters(toRowFilter(ValueRange.newBuilder().setStartValueOpen(FOO_BYTESTRING))))
-          .build());
- }
+      FILTERS.interleave()
+          .filter(FILTERS.value().range().endOpen(FOO_BYTESTRING))
+          .filter(FILTERS.value().range().startOpen(FOO_BYTESTRING)));
+  }
 
   @Test
   public void testRegexValueFilter() throws IOException {
@@ -111,16 +102,14 @@ public class TestValueFilterAdapter {
     assertAdaptedForm(
         new RegexStringComparator(pattern),
         CompareOp.EQUAL,
-        RowFilter.newBuilder()
-            .setValueRegexFilter(ByteString.copyFromUtf8(pattern))
-            .build());
+        FILTERS.value().regex(pattern));
   }
 
   private void assertAdaptedForm(
-      ByteArrayComparable comparable, CompareFilter.CompareOp op, RowFilter expectedFilter)
+      ByteArrayComparable comparable, CompareFilter.CompareOp op, Filters.Filter expectedFilter)
       throws IOException {
     ValueFilter filter = new ValueFilter(op, comparable);
-    RowFilter actualFilter = adapter.adapt(emptyScanContext, filter);
-    Assert.assertEquals(expectedFilter, actualFilter);
+    Filters.Filter actualFilter = adapter.adapt(emptyScanContext, filter);
+    Assert.assertEquals(expectedFilter.toProto(), actualFilter.toProto());
   }
 }

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/read/TestScanAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/read/TestScanAdapter.java
@@ -21,9 +21,9 @@ import static org.mockito.Matchers.eq;
 
 import com.google.bigtable.v2.ReadRowsRequest;
 import com.google.bigtable.v2.ReadRowsRequest.Builder;
-import com.google.bigtable.v2.RowFilter;
 import com.google.bigtable.v2.RowRange;
 import com.google.bigtable.v2.RowSet;
+import com.google.cloud.bigtable.data.v2.models.Filters;
 import com.google.cloud.bigtable.hbase.BigtableExtendedScan;
 import com.google.cloud.bigtable.hbase.adapters.filters.FilterAdapter;
 import com.google.cloud.bigtable.hbase.adapters.filters.FilterAdapterContext;
@@ -245,7 +245,7 @@ public class TestScanAdapter {
     );
     Mockito.when(filterAdapter.getIndexScanHint(any(Filter.class))).thenReturn(rangeSet);
     Mockito.when(filterAdapter.adaptFilter(any(FilterAdapterContext.class), eq(fakeFilter)))
-        .thenReturn(Optional.of(RowFilter.getDefaultInstance()));
+        .thenReturn(Optional.of(Filters.FILTERS.pass()));
 
     Scan scan = new Scan()
         .withStartRow("a".getBytes())

--- a/bigtable-dataflow-parent/bigtable-beam-import/src/main/java/com/google/cloud/bigtable/beam/sequencefiles/CreateTableHelper.java
+++ b/bigtable-dataflow-parent/bigtable-beam-import/src/main/java/com/google/cloud/bigtable/beam/sequencefiles/CreateTableHelper.java
@@ -16,9 +16,11 @@
 package com.google.cloud.bigtable.beam.sequencefiles;
 
 import com.google.cloud.bigtable.hbase.BigtableConfiguration;
-import com.google.common.base.Throwables;
+import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ForkJoinPool;
 import org.apache.beam.sdk.io.BoundedSource.BoundedReader;
 import org.apache.beam.sdk.extensions.gcp.options.GcpOptions;
 import org.apache.beam.sdk.io.FileBasedSource;
@@ -26,6 +28,7 @@ import org.apache.beam.sdk.io.FileSystems;
 import org.apache.beam.sdk.options.Default;
 import org.apache.beam.sdk.options.Description;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.options.Validation;
 import org.apache.beam.sdk.options.ValueProvider.StaticValueProvider;
 import org.apache.beam.sdk.values.KV;
 import org.apache.commons.logging.Log;
@@ -59,29 +62,39 @@ class CreateTableHelper {
   interface CreateTableOpts extends GcpOptions {
     @Description("The project that contains the table to export. Defaults to --project.")
     @Default.InstanceFactory(Utils.DefaultBigtableProjectFactory.class)
+    @Validation.Required
     String getBigtableProject();
     @SuppressWarnings("unused")
     void setBigtableProject(String projectId);
 
     @Description("The Bigtable instance id that contains the table to export.")
+    @Validation.Required
     String getBigtableInstanceId();
     @SuppressWarnings("unused")
     void setBigtableInstanceId(String instanceId);
 
     @Description("The Bigtable table id to export.")
+    @Validation.Required
     String getBigtableTableId();
     @SuppressWarnings("unused")
     void setBigtableTableId(String tableId);
 
     @Description(
         "The fully qualified file pattern to import. Should of the form '[destinationPath]/part-*'")
+    @Validation.Required
     String getSourcePattern();
     @SuppressWarnings("unused")
     void setSourcePattern(String sourcePath);
 
     @Description("The families to add to the new table")
+    @Validation.Required
     List<String> getFamilies();
     void setFamilies(List<String> families);
+
+    @Description("Number of threads to use when probing files for splits")
+    @Default.Integer(100)
+    int getSplitConcurrency();
+    void setSplitConcurrency(int threads);
   }
 
   public static void main(String[] args) throws Exception {
@@ -109,23 +122,27 @@ class CreateTableHelper {
         .split(ImportJob.BUNDLE_SIZE, opts);
 
     // Read the start key of each split
-    byte[][] splits = splitSources.stream()
-        .parallel()
-        .map(splitSource -> {
-          try (BoundedReader<KV<ImmutableBytesWritable, Result>> reader = splitSource
-              .createReader(opts)) {
-            if (reader.start()) {
-              return reader.getCurrent().getKey();
-            }
-          } catch (Exception e) {
-            Throwables.propagate(e);
-          }
-          return null;
-        })
-        .filter(Objects::nonNull)
-        .sorted()
-        .map(ImmutableBytesWritable::copyBytes)
-        .toArray(byte[][]::new);
+    ForkJoinPool forkJoinPool = new ForkJoinPool(opts.getSplitConcurrency());
+
+    byte[][] splits = forkJoinPool.submit(() ->
+        splitSources.stream()
+            .parallel()
+            .map(splitSource -> {
+              try (BoundedReader<KV<ImmutableBytesWritable, Result>> reader = splitSource
+                  .createReader(opts)) {
+                if (reader.start()) {
+                  return reader.getCurrent().getKey();
+                }
+              } catch (IOException e) {
+                throw new RuntimeException(e);
+              }
+              return null;
+            })
+            .filter(Objects::nonNull)
+            .sorted()
+            .map(ImmutableBytesWritable::copyBytes)
+            .toArray(byte[][]::new)
+    ).get();
 
     LOG.info(String.format("Creating a new table with %d splits and the families: %s",
         splits.length, opts.getFamilies()));

--- a/bigtable-dataflow-parent/bigtable-beam-import/src/main/resources/log4j.properties
+++ b/bigtable-dataflow-parent/bigtable-beam-import/src/main/resources/log4j.properties
@@ -21,3 +21,4 @@ log4j.appender.stdout.Target=System.out
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
 
+log4j.category.org.apache.hadoop.io.compress.CodecPool=WARN

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/pom.xml
@@ -70,6 +70,8 @@ limitations under the License.
                                     <forkedProcessTimeoutInSeconds>${test.timeout}</forkedProcessTimeoutInSeconds>
                                     <parallel>classesAndMethods</parallel>
                                     <threadCount>${thread.count}</threadCount>
+                                    <!-- Make sure to fail the build when the suite fails to initialize -->
+                                    <failIfNoTests>true</failIfNoTests>
                                 </configuration>
                             </execution>
                         </executions>
@@ -114,6 +116,8 @@ limitations under the License.
                                     <trimStackTrace>false</trimStackTrace>
                                     <parallel>classesAndMethods</parallel>
                                     <threadCount>${thread.count}</threadCount>
+                                    <!-- Make sure to fail the build when the suite fails to initialize -->
+                                    <failIfNoTests>true</failIfNoTests>
                                 </configuration>
                             </execution>
                         </executions>
@@ -152,6 +156,8 @@ limitations under the License.
                                     <trimStackTrace>false</trimStackTrace>
                                     <parallel>classesAndMethods</parallel>
                                     <threadCount>${thread.count}</threadCount>
+                                    <!-- Make sure to fail the build when the suite fails to initialize -->
+                                    <failIfNoTests>true</failIfNoTests>
                                 </configuration>
                             </execution>
                         </executions>
@@ -193,6 +199,8 @@ limitations under the License.
                                         <google.bigtable.connection.impl>${google.bigtable.connection.impl}</google.bigtable.connection.impl>
                                     </systemPropertyVariables>
                                     <trimStackTrace>false</trimStackTrace>
+                                    <!-- Make sure to fail the build when the suite fails to initialize -->
+                                    <failIfNoTests>true</failIfNoTests>
                                 </configuration>
                             </execution>
                         </executions>
@@ -247,6 +255,8 @@ limitations under the License.
                                     <trimStackTrace>false</trimStackTrace>
                                     <parallel>classesAndMethods</parallel>
                                     <threadCount>${thread.count}</threadCount>
+                                    <!-- Make sure to fail the build when the suite fails to initialize -->
+                                    <failIfNoTests>true</failIfNoTests>
                                 </configuration>
                             </execution>
                         </executions>

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/IntegrationTests.java
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/IntegrationTests.java
@@ -17,13 +17,8 @@ package com.google.cloud.bigtable.hbase;
 
 import com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule;
 
-import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.hadoop.hbase.HColumnDescriptor;
-import org.apache.hadoop.hbase.HTableDescriptor;
-import org.apache.hadoop.hbase.TableName;
-import org.apache.hadoop.hbase.client.Admin;
 import org.junit.ClassRule;
 import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestFilters.java
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestFilters.java
@@ -67,7 +67,7 @@ public class TestFilters extends AbstractTestFilters {
 
     table.close();
   }
-  
+
   @Test
   public void testBigtableFilter() throws IOException {
     if (!sharedTestEnv.isBigtable()) {
@@ -94,7 +94,7 @@ public class TestFilters extends AbstractTestFilters {
       Assert.assertTrue(CellUtil.matchingValue(result.rawCells()[0], valA));
     }
   }
-  
+
   /**
    * This test case is used to validate TimestampRangeFilter with Integer.MAX_VALUE #1552
    * 
@@ -102,31 +102,31 @@ public class TestFilters extends AbstractTestFilters {
    */
   @Test
   public void testTimestampRangeFilterWithMaxVal() throws IOException {
-	    // Initialize
-	    long numCols = Integer.MAX_VALUE;
-	    long start = Integer.MAX_VALUE - 2;
-	    String goodValue = "includeThisValue";
-	    Table table = getDefaultTable();
-	    byte[] rowKey = dataHelper.randomData("testRow-TimestampRange-");
-	    Put put = new Put(rowKey);
-	    for (long i = start; i < numCols; ++i) {
-	      put.addColumn(COLUMN_FAMILY, dataHelper.randomData(""), i, Bytes.toBytes(goodValue));
-	    }
-	    table.put(put);
+    // Initialize
+    long numCols = Integer.MAX_VALUE;
+    long start = Integer.MAX_VALUE - 2;
+    String goodValue = "includeThisValue";
+    Table table = getDefaultTable();
+    byte[] rowKey = dataHelper.randomData("testRow-TimestampRange-");
+    Put put = new Put(rowKey);
+    for (long i = start; i < numCols; ++i) {
+      put.addColumn(COLUMN_FAMILY, dataHelper.randomData(""), i, Bytes.toBytes(goodValue));
+    }
+    table.put(put);
 
-	    Filter filter = new TimestampRangeFilter(start, Integer.MAX_VALUE);
-	    
-	    Get get = new Get(rowKey).setFilter(filter);
-	    Result result = table.get(get);
-	    Cell[] cells = result.rawCells();
-	    Assert.assertEquals("Should have all cells.", 2, cells.length);
+    Filter filter = new TimestampRangeFilter(start, Integer.MAX_VALUE);
 
-	    long[] timestamps =
-	        new long[] { cells[0].getTimestamp(), cells[1].getTimestamp() };
-	    Arrays.sort(timestamps);
-	    Assert.assertArrayEquals(new long[] { start, Integer.MAX_VALUE-1 }, timestamps);
+    Get get = new Get(rowKey).setFilter(filter);
+    Result result = table.get(get);
+    Cell[] cells = result.rawCells();
+    Assert.assertEquals("Should have all cells.", 2, cells.length);
 
-	    table.close();
+    long[] timestamps =
+        new long[] { cells[0].getTimestamp(), cells[1].getTimestamp() };
+    Arrays.sort(timestamps);
+    Assert.assertArrayEquals(new long[] { start, Integer.MAX_VALUE-1 }, timestamps);
+
+    table.close();
   }
 
   @Override

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/pom.xml
@@ -75,6 +75,8 @@ limitations under the License.
                                     <forkedProcessTimeoutInSeconds>${test.timeout}</forkedProcessTimeoutInSeconds>
                                     <parallel>classesAndMethods</parallel>
                                     <threadCount>${thread.count}</threadCount>
+                                    <!-- Make sure to fail the build when the suite fails to initialize -->
+                                    <failIfNoTests>true</failIfNoTests>
                                 </configuration>
                             </execution>
                         </executions>
@@ -117,6 +119,8 @@ limitations under the License.
                                     <forkedProcessTimeoutInSeconds>${test.timeout}</forkedProcessTimeoutInSeconds>
                                     <parallel>classesAndMethods</parallel>
                                     <threadCount>${thread.count}</threadCount>
+                                    <!-- Make sure to fail the build when the suite fails to initialize -->
+                                    <failIfNoTests>true</failIfNoTests>
                                 </configuration>
                             </execution>
                         </executions>
@@ -168,6 +172,8 @@ limitations under the License.
                                     <forkedProcessTimeoutInSeconds>${test.timeout}</forkedProcessTimeoutInSeconds>
                                     <parallel>classesAndMethods</parallel>
                                     <threadCount>${thread.count}</threadCount>
+                                    <!-- Make sure to fail the build when the suite fails to initialize -->
+                                    <failIfNoTests>true</failIfNoTests>
                                 </configuration>
                             </execution>
                         </executions>
@@ -209,6 +215,8 @@ limitations under the License.
                                         <google.bigtable.connection.impl>${google.bigtable.connection.impl}</google.bigtable.connection.impl>
                                         <compileSource>1.8</compileSource>
                                     </systemPropertyVariables>
+                                    <!-- Make sure to fail the build when the suite fails to initialize -->
+                                    <failIfNoTests>true</failIfNoTests>
                                 </configuration>
                             </execution>
                         </executions>
@@ -233,6 +241,8 @@ limitations under the License.
                                 </goals>
                                 <configuration>
                                     <propertyName>bigtable.emulator.endpoint</propertyName>
+                                    <!-- Make sure to fail the build when the suite fails to initialize -->
+                                    <failIfNoTests>true</failIfNoTests>
                                 </configuration>
                             </execution>
                         </executions>

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestFilters.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestFilters.java
@@ -102,31 +102,31 @@ public class TestFilters extends AbstractTestFilters {
    */
   @Test
   public void testTimestampRangeFilterWithMaxVal() throws IOException {
-	    // Initialize
-	    long numCols = Integer.MAX_VALUE;
-	    long start = Integer.MAX_VALUE - 2;
-	    String goodValue = "includeThisValue";
-	    Table table = getDefaultTable();
-	    byte[] rowKey = dataHelper.randomData("testRow-TimestampRange-");
-	    Put put = new Put(rowKey);
-	    for (long i = start; i < numCols; ++i) {
-	      put.addColumn(COLUMN_FAMILY, dataHelper.randomData(""), i, Bytes.toBytes(goodValue));
-	    }
-	    table.put(put);
+    // Initialize
+    long numCols = Integer.MAX_VALUE;
+    long start = Integer.MAX_VALUE - 2;
+    String goodValue = "includeThisValue";
+    Table table = getDefaultTable();
+    byte[] rowKey = dataHelper.randomData("testRow-TimestampRange-");
+    Put put = new Put(rowKey);
+    for (long i = start; i < numCols; ++i) {
+      put.addColumn(COLUMN_FAMILY, dataHelper.randomData(""), i, Bytes.toBytes(goodValue));
+    }
+    table.put(put);
 
-	    Filter filter = new TimestampRangeFilter(start, Integer.MAX_VALUE);
-	    
-	    Get get = new Get(rowKey).setFilter(filter);
-	    Result result = table.get(get);
-	    Cell[] cells = result.rawCells();
-	    Assert.assertEquals("Should have all cells.", 2, cells.length);
+    Filter filter = new TimestampRangeFilter(start, Integer.MAX_VALUE);
 
-	    long[] timestamps =
-	        new long[] { cells[0].getTimestamp(), cells[1].getTimestamp() };
-	    Arrays.sort(timestamps);
-	    Assert.assertArrayEquals(new long[] { start, Integer.MAX_VALUE-1 }, timestamps);
+    Get get = new Get(rowKey).setFilter(filter);
+    Result result = table.get(get);
+    Cell[] cells = result.rawCells();
+    Assert.assertEquals("Should have all cells.", 2, cells.length);
 
-	    table.close();
+    long[] timestamps =
+        new long[] { cells[0].getTimestamp(), cells[1].getTimestamp() };
+    Arrays.sort(timestamps);
+    Assert.assertArrayEquals(new long[] { start, Integer.MAX_VALUE-1 }, timestamps);
+
+    table.close();
   }
   
   @Override

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAdmin.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAdmin.java
@@ -72,7 +72,6 @@ import com.google.cloud.bigtable.hbase.util.ModifyTableBuilder;
 import com.google.cloud.bigtable.hbase2_x.adapters.admin.TableAdapter2x;
 import com.google.common.util.concurrent.Futures;
 
-
 /**
  * HBase 2.x specific implementation of {@link AbstractBigtableAdmin}.
  * @author spollapally
@@ -100,11 +99,11 @@ public class BigtableAdmin extends AbstractBigtableAdmin {
     createTable(desc, createSplitKeys(startKey, endKey, numRegions));
   }
 
-
   /** {@inheritDoc} */
   @Override
   public void createTable(TableDescriptor desc, byte[][] splitKeys) throws IOException {
-    createTable(desc.getTableName(), TableAdapter2x.adapt(desc, splitKeys));
+    createTable(desc.getTableName(), TableAdapter2x.adapt(desc, splitKeys)
+            .toProto(bigtableInstanceName.toAdminInstanceName()));
   }
 
   /** {@inheritDoc} */
@@ -357,7 +356,6 @@ public class BigtableAdmin extends AbstractBigtableAdmin {
           }
         });
   }
-
 
   /* (non-Javadoc)
    * @see org.apache.hadoop.hbase.client.Admin#truncateTableAsync(org.apache.hadoop.hbase.TableName, boolean)

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAdmin.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAdmin.java
@@ -63,11 +63,15 @@ import org.apache.hadoop.hbase.util.Bytes;
 
 import com.google.bigtable.admin.v2.DeleteTableRequest;
 import com.google.bigtable.admin.v2.DropRowRangeRequest;
+import com.google.bigtable.admin.v2.GcRule;
 import com.google.bigtable.admin.v2.ListSnapshotsRequest;
 import com.google.bigtable.admin.v2.ListSnapshotsResponse;
 import com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest;
 import com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest.Modification;
 import com.google.bigtable.admin.v2.Snapshot;
+import com.google.cloud.bigtable.admin.v2.models.CreateTableRequest;
+import com.google.cloud.bigtable.admin.v2.models.GCRules;
+import com.google.cloud.bigtable.hbase.adapters.admin.ColumnDescriptorAdapter;
 import com.google.cloud.bigtable.hbase.util.ModifyTableBuilder;
 import com.google.cloud.bigtable.hbase2_x.adapters.admin.TableAdapter2x;
 import com.google.common.util.concurrent.Futures;
@@ -99,11 +103,11 @@ public class BigtableAdmin extends AbstractBigtableAdmin {
     createTable(desc, createSplitKeys(startKey, endKey, numRegions));
   }
 
+
   /** {@inheritDoc} */
   @Override
   public void createTable(TableDescriptor desc, byte[][] splitKeys) throws IOException {
-    createTable(desc.getTableName(), TableAdapter2x.adapt(desc, splitKeys)
-            .toProto(bigtableInstanceName.toAdminInstanceName()));
+    createTable(desc.getTableName(), TableAdapter2x.adapt(desc, splitKeys));
   }
 
   /** {@inheritDoc} */
@@ -356,6 +360,7 @@ public class BigtableAdmin extends AbstractBigtableAdmin {
           }
         });
   }
+
 
   /* (non-Javadoc)
    * @see org.apache.hadoop.hbase.client.Admin#truncateTableAsync(org.apache.hadoop.hbase.TableName, boolean)

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncAdmin.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncAdmin.java
@@ -15,6 +15,8 @@
  */
 package com.google.cloud.bigtable.hbase2_x;
 
+import static com.google.cloud.bigtable.hbase2_x.FutureUtils.failedFuture;
+
 import com.google.bigtable.admin.v2.CreateTableFromSnapshotRequest;
 import com.google.bigtable.admin.v2.CreateTableRequest;
 import com.google.bigtable.admin.v2.DeleteSnapshotRequest;
@@ -83,8 +85,6 @@ import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import static com.google.cloud.bigtable.hbase2_x.FutureUtils.failedFuture;
-
 /**
  * Bigtable implementation of {@link AsyncAdmin}
  *
@@ -127,9 +127,9 @@ public class BigtableAsyncAdmin implements AsyncAdmin {
       return failedFuture(new IllegalArgumentException("TableName cannot be null"));
     }
 
-    CreateTableRequest.Builder builder = TableAdapter2x.adapt(desc, splitKeys);
-    builder.setParent(bigtableInstanceName.toString());
-    return bigtableTableAdminClient.createTableAsync(builder.build())
+    CreateTableRequest request = TableAdapter2x.adapt(desc, splitKeys)
+            .toProto(bigtableInstanceName.toAdminInstanceName());
+    return bigtableTableAdminClient.createTableAsync(request)
         .handle((resp, ex) -> {
           if (ex != null) {
             throw new CompletionException(
@@ -616,7 +616,6 @@ public class BigtableAsyncAdmin implements AsyncAdmin {
       }
     });
   }
-
 
   private BigtableClusterName getSnapshotClusterName() throws IOException {
     if (bigtableSnapshotClusterName == null) {

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncAdmin.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncAdmin.java
@@ -15,10 +15,7 @@
  */
 package com.google.cloud.bigtable.hbase2_x;
 
-import static com.google.cloud.bigtable.hbase2_x.FutureUtils.failedFuture;
-
 import com.google.bigtable.admin.v2.CreateTableFromSnapshotRequest;
-import com.google.bigtable.admin.v2.CreateTableRequest;
 import com.google.bigtable.admin.v2.DeleteSnapshotRequest;
 import com.google.bigtable.admin.v2.DeleteTableRequest;
 import com.google.bigtable.admin.v2.DropRowRangeRequest;
@@ -27,7 +24,10 @@ import com.google.bigtable.admin.v2.ListSnapshotsRequest;
 import com.google.bigtable.admin.v2.ListTablesRequest;
 import com.google.bigtable.admin.v2.Snapshot;
 import com.google.bigtable.admin.v2.SnapshotTableRequest;
+import com.google.bigtable.admin.v2.InstanceName;
 import com.google.bigtable.admin.v2.Table;
+import com.google.cloud.bigtable.admin.v2.models.CreateTableRequest;
+import com.google.cloud.bigtable.admin.v2.models.ModifyColumnFamiliesRequest;
 import com.google.cloud.bigtable.config.BigtableOptions;
 import com.google.cloud.bigtable.config.Logger;
 import com.google.cloud.bigtable.grpc.BigtableClusterName;
@@ -85,6 +85,9 @@ import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import static com.google.cloud.bigtable.hbase.adapters.admin.ColumnDescriptorAdapter.buildGarbageCollectionRule;
+import static com.google.cloud.bigtable.hbase2_x.FutureUtils.failedFuture;
+
 /**
  * Bigtable implementation of {@link AsyncAdmin}
  *
@@ -101,6 +104,7 @@ public class BigtableAsyncAdmin implements AsyncAdmin {
   private final CommonConnection asyncConnection;
   private BigtableClusterName bigtableSnapshotClusterName;
   private final Configuration configuration;
+  private InstanceName instanceName;
 
   public BigtableAsyncAdmin(CommonConnection asyncConnection) throws IOException {
     LOG.debug("Creating BigtableAsyncAdmin");
@@ -112,6 +116,8 @@ public class BigtableAsyncAdmin implements AsyncAdmin {
     this.tableAdapter2x = new TableAdapter2x(options);
     this.asyncConnection = asyncConnection;
     this.configuration = asyncConnection.getConfiguration();
+    instanceName =
+            InstanceName.of(bigtableInstanceName.getProjectId(), bigtableInstanceName.getInstanceId());
 
     String clusterId = configuration.get(BigtableOptionsFactory.BIGTABLE_SNAPSHOT_CLUSTER_ID_KEY, null);
     if (clusterId != null) {
@@ -127,9 +133,8 @@ public class BigtableAsyncAdmin implements AsyncAdmin {
       return failedFuture(new IllegalArgumentException("TableName cannot be null"));
     }
 
-    CreateTableRequest request = TableAdapter2x.adapt(desc, splitKeys)
-            .toProto(bigtableInstanceName.toAdminInstanceName());
-    return bigtableTableAdminClient.createTableAsync(request)
+    CreateTableRequest createTableRequest = TableAdapter2x.adapt(desc, splitKeys);
+    return bigtableTableAdminClient.createTableAsync(createTableRequest.toProto(instanceName))
         .handle((resp, ex) -> {
           if (ex != null) {
             throw new CompletionException(
@@ -201,19 +206,8 @@ public class BigtableAsyncAdmin implements AsyncAdmin {
   /** {@inheritDoc} */
   @Override
   public CompletableFuture<Boolean> tableExists(TableName tableName) {
-    GetTableRequest request = GetTableRequest.newBuilder()
-        .setName(options.getInstanceName().toTableNameStr(tableName.getNameAsString()))
-        .setView(Table.View.NAME_ONLY)
-        .build();
-    return bigtableTableAdminClient.getTableAsync(request)
-        .thenApply(r -> true)
-        .exceptionally(e -> {
-            if(Status.fromThrowable(e).getCode() == Status.Code.NOT_FOUND) {
-              return false;
-            } else {
-              throw new CompletionException("Could not get the table", e);
-            }
-        });
+    return listTableNames(Optional.of(Pattern.compile(tableName.getNameAsString())))
+        .thenApply(r -> r.stream().anyMatch(e -> e.equals(tableName)));
   }
 
   private CompletableFuture<List<TableName>> listTableNames(Optional<Pattern> tableNamePattern) {
@@ -260,7 +254,7 @@ public class BigtableAsyncAdmin implements AsyncAdmin {
   }
 
   private CompletableFuture<List<Table>> requestTableList() {
-    ListTablesRequest  request = ListTablesRequest.newBuilder().setParent(bigtableInstanceName.toString()).build();
+    ListTablesRequest request = ListTablesRequest.newBuilder().setParent(bigtableInstanceName.toString()).build();
     return bigtableTableAdminClient.listTablesAsync(request)
         .thenApply(r -> r.getTablesList());
   }
@@ -331,34 +325,46 @@ public class BigtableAsyncAdmin implements AsyncAdmin {
   @Override
   public CompletableFuture<Void> addColumnFamily(TableName tableName,
       ColumnFamilyDescriptor columnFamilyDesc) {
-    return modifyColumns(tableName,
-        ModifyTableBuilder.create().add(TableAdapter2x.toHColumnDescriptor(columnFamilyDesc)));
+    ModifyColumnFamiliesRequest modifyColumnRequest = ModifyColumnFamiliesRequest.of(tableName.getNameAsString());
+    modifyColumnRequest.addFamily(columnFamilyDesc.getNameAsString(),
+            buildGarbageCollectionRule(TableAdapter2x.toHColumnDescriptor(columnFamilyDesc)));
+
+    return modifyColumns(tableName, modifyColumnRequest);
   }
 
 
   @Override
   public CompletableFuture<Void> deleteColumnFamily(TableName tableName,
       byte[] columnName) {
-    return modifyColumns(tableName, ModifyTableBuilder.create().delete(Bytes.toString(columnName)));
+    ModifyColumnFamiliesRequest modifyColumnRequest = ModifyColumnFamiliesRequest.of(tableName.getNameAsString());
+    modifyColumnRequest.dropFamily(Bytes.toString(columnName));
+
+    return modifyColumns(tableName, modifyColumnRequest);
+
   }
 
   @Override
   public CompletableFuture<Void> modifyColumnFamily(TableName tableName,
       ColumnFamilyDescriptor columnFamilyDesc) {
-    return modifyColumns(tableName,
-        ModifyTableBuilder.create().modify(TableAdapter2x.toHColumnDescriptor(columnFamilyDesc)));
+    ModifyColumnFamiliesRequest modifyColumnRequest = ModifyColumnFamiliesRequest.of(tableName.getNameAsString());
+    modifyColumnRequest.updateFamily(columnFamilyDesc.getNameAsString(),
+            buildGarbageCollectionRule(TableAdapter2x.toHColumnDescriptor(columnFamilyDesc)));
+
+    return modifyColumns(tableName, modifyColumnRequest);
   }
 
   @Override
   public CompletableFuture<Void> modifyTable(TableDescriptor newDescriptor) {
+    ModifyColumnFamiliesRequest modifyColumnRequest =
+            ModifyColumnFamiliesRequest.of(newDescriptor.getTableName().getNameAsString());
     return getDescriptor(newDescriptor.getTableName())
         .thenApply(descriptor -> ModifyTableBuilder
             .buildModifications(
                 new HTableDescriptor(newDescriptor),
-                new HTableDescriptor(descriptor)))
-        .thenApply(modifications -> {
+                new HTableDescriptor(descriptor) , modifyColumnRequest))
+        .thenApply(modifyRequest -> {
           try {
-            modifyColumns(newDescriptor.getTableName(), modifications).get();
+            modifyColumns(newDescriptor.getTableName(), modifyRequest).get();
           } catch (InterruptedException | ExecutionException e) {
             throw new CompletionException(e);
           }
@@ -370,12 +376,12 @@ public class BigtableAsyncAdmin implements AsyncAdmin {
    * <p>modifyColumns.</p>
    *
    * @param tableName a {@link org.apache.hadoop.hbase.TableName} object.
-   * @param modifications a {@link ModifyTableBuilder} object.
+   * @param modifyColumnRequest a {@link ModifyColumnFamiliesRequest} object.
    */
   private CompletableFuture<Void> modifyColumns(TableName tableName,
-      ModifyTableBuilder modifications) {
+            ModifyColumnFamiliesRequest modifyColumnRequest) {
     return bigtableTableAdminClient
-        .modifyColumnFamilyAsync(modifications.toProto(toBigtableName(tableName)))
+        .modifyColumnFamilyAsync(modifyColumnRequest.toProto(instanceName))
         .thenApply(r -> null);
   }
 
@@ -616,6 +622,7 @@ public class BigtableAsyncAdmin implements AsyncAdmin {
       }
     });
   }
+
 
   private BigtableClusterName getSnapshotClusterName() throws IOException {
     if (bigtableSnapshotClusterName == null) {

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncTable.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncTable.java
@@ -88,6 +88,8 @@ public class BigtableAsyncTable implements AsyncTable<ScanResultConsumer> {
   private final HBaseRequestAdapter hbaseAdapter;
   private final TableName tableName;
   private BatchExecutor batchExecutor;
+  // Once the IBigtableDataClient interface is implemented this will be removed
+  private RequestContext requestContext;
 
   public BigtableAsyncTable(BigtableAsyncConnection asyncConnection,
       HBaseRequestAdapter hbaseAdapter) {
@@ -96,6 +98,9 @@ public class BigtableAsyncTable implements AsyncTable<ScanResultConsumer> {
     this.client = new BigtableDataClient(session.getDataClient());
     this.hbaseAdapter = hbaseAdapter;
     this.tableName = hbaseAdapter.getTableName();
+    // Once the IBigtableDataClient interface is implemented this will be removed
+    this.requestContext =
+        RequestContext.create(hbaseAdapter.getBigtableTableName().toGcbInstanceName(), "");
   }
 
   protected synchronized BatchExecutor getBatchExecutor() {
@@ -244,7 +249,7 @@ public class BigtableAsyncTable implements AsyncTable<ScanResultConsumer> {
   @Override
   public CompletableFuture<Void> delete(Delete delete) {
     // figure out how to time this with Opencensus
-    return client.mutateRowAsync(hbaseAdapter.adapt(delete))
+    return client.mutateRowAsync(hbaseAdapter.adapt(delete).toProto(requestContext))
         .thenApply(r -> null);
   }
 
@@ -366,7 +371,7 @@ public class BigtableAsyncTable implements AsyncTable<ScanResultConsumer> {
    */
   @Override
   public CompletableFuture<Void> mutateRow(RowMutations rowMutations) {
-    return client.mutateRowAsync(hbaseAdapter.adapt(rowMutations))
+    return client.mutateRowAsync(hbaseAdapter.adapt(rowMutations).toProto(requestContext))
         .thenApply(r -> null);
   }
 
@@ -376,7 +381,7 @@ public class BigtableAsyncTable implements AsyncTable<ScanResultConsumer> {
   @Override
   public CompletableFuture<Void> put(Put put) {
     // figure out how to time this with Opencensus
-    return client.mutateRowAsync(hbaseAdapter.adapt(put))
+    return client.mutateRowAsync(hbaseAdapter.adapt(put).toProto(requestContext))
         .thenApply(r -> null);
   }
 

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncTable.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncTable.java
@@ -17,6 +17,9 @@ package com.google.cloud.bigtable.hbase2_x;
 
 import static java.util.stream.Collectors.toList;
 
+import com.google.cloud.bigtable.data.v2.internal.RequestContext;
+import com.google.cloud.bigtable.data.v2.models.ConditionalRowMutation;
+import com.google.cloud.bigtable.data.v2.models.InstanceName;
 import io.opencensus.common.Scope;
 import io.opencensus.trace.Status;
 import java.io.IOException;
@@ -137,11 +140,14 @@ public class BigtableAsyncTable implements AsyncTable<ScanResultConsumer> {
 
     private final CheckAndMutateUtil.RequestBuilder builder;
     private final BigtableDataClient client;
+    // Once the IBigtableDataClient interface is implemented this will be removed
+    protected final RequestContext requestContext;
 
     public CheckAndMutateBuilderImpl(BigtableDataClient client, HBaseRequestAdapter hbaseAdapter,
         byte[] row, byte[] family) {
       this.client = client;
       this.builder = new CheckAndMutateUtil.RequestBuilder(hbaseAdapter, row, family);
+      this.requestContext = RequestContext.create(InstanceName.of("projectId", "instanceId"), "appProfileId");
     }
 
     /**
@@ -224,7 +230,8 @@ public class BigtableAsyncTable implements AsyncTable<ScanResultConsumer> {
 
     private CompletableFuture<Boolean> call()
         throws IOException {
-      CheckAndMutateRowRequest request = builder.build();
+      ConditionalRowMutation conditionalRowMutation = builder.build();
+      CheckAndMutateRowRequest request = conditionalRowMutation.toProto(requestContext);
       return client.checkAndMutateRowAsync(request).thenApply(
         response -> CheckAndMutateUtil.wasMutationApplied(request, response));
     }

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/adapters/admin/TableAdapter2x.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/adapters/admin/TableAdapter2x.java
@@ -15,13 +15,9 @@
  */
 package com.google.cloud.bigtable.hbase2_x.adapters.admin;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import com.google.api.core.InternalApi;
 
-import com.google.bigtable.admin.v2.CreateTableRequest;
+import com.google.cloud.bigtable.admin.v2.models.CreateTableRequest;
 import com.google.cloud.bigtable.grpc.BigtableInstanceName;
 import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HTableDescriptor;
@@ -29,35 +25,26 @@ import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.ColumnFamilyDescriptor;
 import org.apache.hadoop.hbase.client.TableDescriptor;
 import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
-import org.apache.hadoop.hbase.util.Bytes;
-import com.google.bigtable.admin.v2.ColumnFamily;
 import com.google.bigtable.admin.v2.Table;
 import com.google.cloud.bigtable.config.BigtableOptions;
 import com.google.cloud.bigtable.hbase.adapters.admin.ColumnDescriptorAdapter;
 import com.google.cloud.bigtable.hbase.adapters.admin.TableAdapter;
 
 /**
- * Need this extended class as {@link TableAdapter#adapt(org.apache.hadoop.hbase.HTableDescriptor)}
- * is not binary compatible with {@link TableAdapter2x#adapt(TableDescriptor)}
+ * Need this extended class as {@link TableAdapter#adapt(HTableDescriptor, CreateTableRequest)}
+ * is not binary compatible with {@link TableAdapter2x#adapt(TableDescriptor, byte[][])}
  * 
  * Similarly, {@link ColumnDescriptorAdapter#adapt(HColumnDescriptor)} is not binary compatible with
  * {@link ColumnFamilyDescriptor}.
  * 
  * @author spollapally
  */
+@InternalApi
 public class TableAdapter2x {
   protected static final ColumnDescriptorAdapter columnDescriptorAdapter = new ColumnDescriptorAdapter();
 
-  public static CreateTableRequest.Builder adapt(TableDescriptor desc, byte[][] splitKeys) {
+  public static CreateTableRequest adapt(TableDescriptor desc, byte[][] splitKeys) {
     return TableAdapter.adapt(new HTableDescriptor(desc), splitKeys);
-  }
-
-  public static Table adapt(TableDescriptor desc) {
-    return adapt(new HTableDescriptor(desc), null).getTable();
-  }
-
-  public static ColumnFamily toColumnFamily(ColumnFamilyDescriptor column) {
-    return columnDescriptorAdapter.adapt(toHColumnDescriptor(column));
   }
 
   public static HColumnDescriptor toHColumnDescriptor(ColumnFamilyDescriptor column) {

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/adapters/admin/TableAdapter2x.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/adapters/admin/TableAdapter2x.java
@@ -15,8 +15,6 @@
  */
 package com.google.cloud.bigtable.hbase2_x.adapters.admin;
 
-import com.google.api.core.InternalApi;
-
 import com.google.cloud.bigtable.admin.v2.models.CreateTableRequest;
 import com.google.cloud.bigtable.grpc.BigtableInstanceName;
 import org.apache.hadoop.hbase.HColumnDescriptor;
@@ -25,26 +23,30 @@ import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.ColumnFamilyDescriptor;
 import org.apache.hadoop.hbase.client.TableDescriptor;
 import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
+import com.google.bigtable.admin.v2.ColumnFamily;
 import com.google.bigtable.admin.v2.Table;
 import com.google.cloud.bigtable.config.BigtableOptions;
 import com.google.cloud.bigtable.hbase.adapters.admin.ColumnDescriptorAdapter;
 import com.google.cloud.bigtable.hbase.adapters.admin.TableAdapter;
 
 /**
- * Need this extended class as {@link TableAdapter#adapt(HTableDescriptor, CreateTableRequest)}
- * is not binary compatible with {@link TableAdapter2x#adapt(TableDescriptor, byte[][])}
+ * Need this extended class as {@link TableAdapter#adapt(CreateTableRequest , org.apache.hadoop.hbase.HTableDescriptor)}
+ * is not binary compatible with {@link TableAdapter2x#adapt(TableDescriptor)}
  * 
  * Similarly, {@link ColumnDescriptorAdapter#adapt(HColumnDescriptor)} is not binary compatible with
  * {@link ColumnFamilyDescriptor}.
  * 
  * @author spollapally
  */
-@InternalApi
 public class TableAdapter2x {
   protected static final ColumnDescriptorAdapter columnDescriptorAdapter = new ColumnDescriptorAdapter();
 
   public static CreateTableRequest adapt(TableDescriptor desc, byte[][] splitKeys) {
     return TableAdapter.adapt(new HTableDescriptor(desc), splitKeys);
+  }
+
+  public static CreateTableRequest adapt(TableDescriptor desc) {
+    return adapt(new HTableDescriptor(desc), null);
   }
 
   public static HColumnDescriptor toHColumnDescriptor(ColumnFamilyDescriptor column) {

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/test/java/com/google/cloud/bigtable/hbase/com/google/cloud/bigtable/hbase2_x/adapters/admin/TestTableAdapter2x.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/test/java/com/google/cloud/bigtable/hbase/com/google/cloud/bigtable/hbase2_x/adapters/admin/TestTableAdapter2x.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.com.google.cloud.bigtable.hbase2_x.adapters.admin;
+
+import static com.google.cloud.bigtable.admin.v2.models.GCRules.GCRULES;
+
+import com.google.bigtable.admin.v2.ColumnFamily;
+import com.google.bigtable.admin.v2.InstanceName;
+import com.google.bigtable.admin.v2.Table;
+import com.google.cloud.bigtable.admin.v2.models.CreateTableRequest;
+import com.google.cloud.bigtable.admin.v2.models.GCRules;
+import com.google.cloud.bigtable.config.BigtableOptions;
+import com.google.cloud.bigtable.hbase.adapters.admin.TableAdapter;
+import com.google.cloud.bigtable.hbase2_x.adapters.admin.TableAdapter2x;
+import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.*;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class TestTableAdapter2x {
+
+  private static final String PROJECT_ID = "fakeProject";
+  private static final String INSTANCE_ID = "fakeInstance";
+  private static final String TABLE_ID = "myTable";
+  private static final String INSTANCE_NAME = "projects/" + PROJECT_ID + "/instances/" + INSTANCE_ID;
+  private static final String TABLE_NAME = INSTANCE_NAME + "/tables/" + TABLE_ID;
+  private static final String COLUMN_FAMILY = "myColumnFamily";
+
+  private TableAdapter2x tableAdapter2x;
+  private InstanceName instanceName;
+
+  @Before
+  public void setUp(){
+    BigtableOptions bigtableOptions = BigtableOptions.builder().setProjectId(PROJECT_ID)
+            .setInstanceId(INSTANCE_ID).build();
+    tableAdapter2x = new TableAdapter2x(bigtableOptions);
+    instanceName = InstanceName.of(PROJECT_ID, INSTANCE_ID);
+  }
+
+  @Test
+  public void testAdaptWithSplitKeys(){
+    byte[][] splits = new byte[][] {
+            Bytes.toBytes("AAA"),
+            Bytes.toBytes("BBB"),
+            Bytes.toBytes("CCC"),
+    };
+    TableDescriptor desc = TableDescriptorBuilder.newBuilder(TableName.valueOf(TABLE_ID)).build();
+    CreateTableRequest actualRequest = TableAdapter2x.adapt(desc, splits);
+
+    CreateTableRequest expectedRequest = CreateTableRequest.of(TABLE_ID);
+    TableAdapter.addSplitKeys(splits, expectedRequest);
+    Assert.assertEquals(
+            expectedRequest.toProto(instanceName),
+            actualRequest.toProto(instanceName));
+  }
+
+  @Test
+  public void testAdaptWithTable(){
+    //If no GcRule passed to ColumnFamily, then ColumnDescriptorAdapter#buildGarbageCollectionRule
+    //updates maxVersion to Integer.MAX_VALUE
+    int maxVersion = 1;
+    GCRules.GCRule gcRule = GCRULES.maxVersions(maxVersion);
+    ColumnFamily columnFamily = ColumnFamily.newBuilder()
+            .setGcRule(gcRule.toProto()).build();
+    Table table = Table.newBuilder()
+            .setName(TABLE_NAME)
+            .putColumnFamilies(COLUMN_FAMILY, columnFamily).build();
+    TableDescriptor actualTableDesc = tableAdapter2x.adapt(table);
+
+    TableDescriptor expected = new HTableDescriptor(TableName.valueOf(TABLE_ID))
+            .addFamily(new HColumnDescriptor(COLUMN_FAMILY));
+
+    Assert.assertEquals(expected, actualTableDesc);
+  }
+
+  @Test
+  public void testHColumnDescriptorAdapter(){
+    ColumnFamilyDescriptor columnFamilyDesc = ColumnFamilyDescriptorBuilder.of(COLUMN_FAMILY);
+    HColumnDescriptor actualDesc = TableAdapter2x.toHColumnDescriptor(columnFamilyDesc);
+    HColumnDescriptor columnDes = new HColumnDescriptor(COLUMN_FAMILY);
+
+    Assert.assertEquals(columnDes, actualDesc);
+  }
+}


### PR DESCRIPTION
### Commit Contains: 
Veneer client related changes for `AbstractBigtableAdmin` which is tracked under #1974 

Adding updates for following methods:
- [x] createTableAsync
- [x] addColumn
- [x]  modifyColumn
- [x]  deleteColumn
- [x] createTable
- [x]  modifyColumns
- [x] deleteColumn

Also Added `ColumnDescriptorAdapter#buildGarbageCollectionRule` for `com.google.cloud.bigtable.admin.v2.models.GCRules.GCRule` creation.
