### PR TITLE
Fail build when suite fails to initialize.

### DIFF
--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/pom.xml
@@ -70,6 +70,8 @@ limitations under the License.
                                     <forkedProcessTimeoutInSeconds>${test.timeout}</forkedProcessTimeoutInSeconds>
                                     <parallel>classesAndMethods</parallel>
                                     <threadCount>${thread.count}</threadCount>
+                                    <!-- Make sure to fail the build when the suite fails to initialize -->
+                                    <failIfNoTests>true</failIfNoTests>
                                 </configuration>
                             </execution>
                         </executions>
@@ -114,6 +116,8 @@ limitations under the License.
                                     <trimStackTrace>false</trimStackTrace>
                                     <parallel>classesAndMethods</parallel>
                                     <threadCount>${thread.count}</threadCount>
+                                    <!-- Make sure to fail the build when the suite fails to initialize -->
+                                    <failIfNoTests>true</failIfNoTests>
                                 </configuration>
                             </execution>
                         </executions>
@@ -152,6 +156,8 @@ limitations under the License.
                                     <trimStackTrace>false</trimStackTrace>
                                     <parallel>classesAndMethods</parallel>
                                     <threadCount>${thread.count}</threadCount>
+                                    <!-- Make sure to fail the build when the suite fails to initialize -->
+                                    <failIfNoTests>true</failIfNoTests>
                                 </configuration>
                             </execution>
                         </executions>
@@ -193,6 +199,8 @@ limitations under the License.
                                         <google.bigtable.connection.impl>${google.bigtable.connection.impl}</google.bigtable.connection.impl>
                                     </systemPropertyVariables>
                                     <trimStackTrace>false</trimStackTrace>
+                                    <!-- Make sure to fail the build when the suite fails to initialize -->
+                                    <failIfNoTests>true</failIfNoTests>
                                 </configuration>
                             </execution>
                         </executions>
@@ -247,6 +255,8 @@ limitations under the License.
                                     <trimStackTrace>false</trimStackTrace>
                                     <parallel>classesAndMethods</parallel>
                                     <threadCount>${thread.count}</threadCount>
+                                    <!-- Make sure to fail the build when the suite fails to initialize -->
+                                    <failIfNoTests>true</failIfNoTests>
                                 </configuration>
                             </execution>
                         </executions>

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/pom.xml
@@ -75,6 +75,8 @@ limitations under the License.
                                     <forkedProcessTimeoutInSeconds>${test.timeout}</forkedProcessTimeoutInSeconds>
                                     <parallel>classesAndMethods</parallel>
                                     <threadCount>${thread.count}</threadCount>
+                                    <!-- Make sure to fail the build when the suite fails to initialize -->
+                                    <failIfNoTests>true</failIfNoTests>
                                 </configuration>
                             </execution>
                         </executions>
@@ -117,6 +119,8 @@ limitations under the License.
                                     <forkedProcessTimeoutInSeconds>${test.timeout}</forkedProcessTimeoutInSeconds>
                                     <parallel>classesAndMethods</parallel>
                                     <threadCount>${thread.count}</threadCount>
+                                    <!-- Make sure to fail the build when the suite fails to initialize -->
+                                    <failIfNoTests>true</failIfNoTests>
                                 </configuration>
                             </execution>
                         </executions>
@@ -168,6 +172,8 @@ limitations under the License.
                                     <forkedProcessTimeoutInSeconds>${test.timeout}</forkedProcessTimeoutInSeconds>
                                     <parallel>classesAndMethods</parallel>
                                     <threadCount>${thread.count}</threadCount>
+                                    <!-- Make sure to fail the build when the suite fails to initialize -->
+                                    <failIfNoTests>true</failIfNoTests>
                                 </configuration>
                             </execution>
                         </executions>
@@ -209,6 +215,8 @@ limitations under the License.
                                         <google.bigtable.connection.impl>${google.bigtable.connection.impl}</google.bigtable.connection.impl>
                                         <compileSource>1.8</compileSource>
                                     </systemPropertyVariables>
+                                    <!-- Make sure to fail the build when the suite fails to initialize -->
+                                    <failIfNoTests>true</failIfNoTests>
                                 </configuration>
                             </execution>
                         </executions>
@@ -233,6 +241,8 @@ limitations under the License.
                                 </goals>
                                 <configuration>
                                     <propertyName>bigtable.emulator.endpoint</propertyName>
+                                    <!-- Make sure to fail the build when the suite fails to initialize -->
+                                    <failIfNoTests>true</failIfNoTests>
                                 </configuration>
                             </execution>
                         </executions>


### PR DESCRIPTION
If the environment setup fails in a junit suite, no tests are loaded and maven assumes that the build succeeded because no tests failed. This PR fails the integration tests if no tests are run