### PR TITLE
Fix `KeyOnlyFilterAdapter` and `KeyOnlyFilterAdapter`

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestFilters.java
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestFilters.java
@@ -1370,9 +1370,6 @@ public abstract class AbstractTestFilters extends AbstractTest {
     Get get = new Get(rowKey).setFilter(filter);
     Result result = table.get(get);
     Assert.assertEquals("Should only return 1 keyvalue", 1, result.size());
-    // The following is true for Bigtable, but not HBase.
-//    Assert.assertEquals("Should only have 0 bytes", 0,
-//        result.rawCells()[0].getValueLength());
 
     table.close();
   }
@@ -1386,8 +1383,9 @@ public abstract class AbstractTestFilters extends AbstractTest {
     byte[] rowKey = dataHelper.randomData("testRow-");
     Put put = new Put(rowKey);
     for (int i = 0; i < numCols; ++i) {
-      put.addColumn(COLUMN_FAMILY, dataHelper.randomData(""), 100L, Bytes.toBytes(goodValue));
-      put.addColumn(COLUMN_FAMILY, dataHelper.randomData(""), 5000L, Bytes.toBytes(goodValue));
+      byte[] qual = dataHelper.randomData("");
+      put.addColumn(COLUMN_FAMILY, qual, 100L, Bytes.toBytes(goodValue));
+      put.addColumn(COLUMN_FAMILY, qual, 5000L, Bytes.toBytes(goodValue));
     }
     table.put(put);
 

--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestFilters.java
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestFilters.java
@@ -1370,6 +1370,9 @@ public abstract class AbstractTestFilters extends AbstractTest {
     Get get = new Get(rowKey).setFilter(filter);
     Result result = table.get(get);
     Assert.assertEquals("Should only return 1 keyvalue", 1, result.size());
+    // The following is true for Bigtable, but not HBase.
+//    Assert.assertEquals("Should only have 0 bytes", 0,
+//        result.rawCells()[0].getValueLength());
 
     table.close();
   }
@@ -1383,7 +1386,8 @@ public abstract class AbstractTestFilters extends AbstractTest {
     byte[] rowKey = dataHelper.randomData("testRow-");
     Put put = new Put(rowKey);
     for (int i = 0; i < numCols; ++i) {
-      put.addColumn(COLUMN_FAMILY, dataHelper.randomData(""), Bytes.toBytes(goodValue));
+      put.addColumn(COLUMN_FAMILY, dataHelper.randomData(""), 100L, Bytes.toBytes(goodValue));
+      put.addColumn(COLUMN_FAMILY, dataHelper.randomData(""), 5000L, Bytes.toBytes(goodValue));
     }
     table.put(put);
 
@@ -1393,6 +1397,7 @@ public abstract class AbstractTestFilters extends AbstractTest {
     Get get = new Get(rowKey).setFilter(filter);
     Result result = table.get(get);
     Cell[] cells = result.rawCells();
+    Assert.assertEquals("Should return " + numCols + " cells", numCols, cells.length);
     for (Cell cell : cells) {
       Assert.assertEquals(
           "Should NOT have a length.",

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/FirstKeyOnlyFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/FirstKeyOnlyFilterAdapter.java
@@ -30,8 +30,8 @@ import org.apache.hadoop.hbase.filter.FirstKeyOnlyFilter;
 public class FirstKeyOnlyFilterAdapter extends TypedFilterAdapterBase<FirstKeyOnlyFilter> {
 
   private static RowFilter LIMIT_ONE = FILTERS.chain()
-      .filter(FILTERS.value().strip())
       .filter(FILTERS.limit().cellsPerRow(1))
+      .filter(FILTERS.value().strip())
       .toProto();
 
   /** {@inheritDoc} */

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/FirstKeyOnlyFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/FirstKeyOnlyFilterAdapter.java
@@ -29,7 +29,10 @@ import org.apache.hadoop.hbase.filter.FirstKeyOnlyFilter;
  */
 public class FirstKeyOnlyFilterAdapter extends TypedFilterAdapterBase<FirstKeyOnlyFilter> {
 
-  private static RowFilter LIMIT_ONE = FILTERS.limit().cellsPerRow(1).toProto();
+  private static RowFilter LIMIT_ONE = FILTERS.chain()
+      .filter(FILTERS.value().strip())
+      .filter(FILTERS.limit().cellsPerRow(1))
+      .toProto();
 
   /** {@inheritDoc} */
   @Override

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/KeyOnlyFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/KeyOnlyFilterAdapter.java
@@ -42,7 +42,7 @@ public class KeyOnlyFilterAdapter extends TypedFilterAdapterBase<KeyOnlyFilter> 
 
   private static RowFilter KEY_ONLY_FILTER =
       FILTERS.chain()
-          .filter(FILTERS.limit().cellsPerRow(1))
+          .filter(FILTERS.limit().cellsPerColumn(1))
           .filter(FILTERS.value().strip())
           .toProto();
 

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestFirstKeyOnlyFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestFirstKeyOnlyFilterAdapter.java
@@ -15,6 +15,8 @@
  */
 package com.google.cloud.bigtable.hbase.adapters.filters;
 
+import static com.google.cloud.bigtable.data.v2.models.Filters.FILTERS;
+
 import com.google.bigtable.v2.RowFilter;
 
 import org.apache.hadoop.hbase.client.Scan;
@@ -36,9 +38,10 @@ public class TestFirstKeyOnlyFilterAdapter {
     RowFilter adaptedFilter = adapter.adapt(
         new FilterAdapterContext(new Scan(), null), new FirstKeyOnlyFilter());
     Assert.assertEquals(
-        RowFilter.newBuilder()
-            .setCellsPerRowLimitFilter(1)
-            .build(),
+        FILTERS.chain()
+            .filter(FILTERS.value().strip())
+            .filter(FILTERS.limit().cellsPerRow(1))
+            .toProto(),
         adaptedFilter);
   }
 }

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestFirstKeyOnlyFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestFirstKeyOnlyFilterAdapter.java
@@ -26,21 +26,19 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-import java.io.IOException;
-
 @RunWith(JUnit4.class)
 public class TestFirstKeyOnlyFilterAdapter {
 
-  FirstKeyOnlyFilterAdapter adapter = new FirstKeyOnlyFilterAdapter();
+  private final static FirstKeyOnlyFilterAdapter adapter = new FirstKeyOnlyFilterAdapter();
 
   @Test
-  public void onlyTheFirstKeyFromEachRowIsEmitted() throws IOException {
+  public void onlyTheFirstKeyFromEachRowIsEmitted() {
     RowFilter adaptedFilter = adapter.adapt(
         new FilterAdapterContext(new Scan(), null), new FirstKeyOnlyFilter());
     Assert.assertEquals(
         FILTERS.chain()
-            .filter(FILTERS.value().strip())
             .filter(FILTERS.limit().cellsPerRow(1))
+            .filter(FILTERS.value().strip())
             .toProto(),
         adaptedFilter);
   }

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestKeyOnlyFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestKeyOnlyFilterAdapter.java
@@ -17,6 +17,7 @@ package com.google.cloud.bigtable.hbase.adapters.filters;
 
 import java.io.IOException;
 
+import com.google.cloud.bigtable.data.v2.models.Filters;
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.filter.KeyOnlyFilter;
 import org.junit.Assert;
@@ -26,6 +27,8 @@ import org.junit.runners.JUnit4;
 
 import com.google.bigtable.v2.RowFilter;
 import com.google.bigtable.v2.RowFilter.Chain;
+
+import static com.google.cloud.bigtable.data.v2.models.Filters.FILTERS;
 
 @RunWith(JUnit4.class)
 public class TestKeyOnlyFilterAdapter {
@@ -38,10 +41,12 @@ public class TestKeyOnlyFilterAdapter {
   public void stripValuesIsApplied() throws IOException {
     KeyOnlyFilter filter = new KeyOnlyFilter();
     RowFilter rowFilter = filterAdapter.adapt(emptyScanContext, filter);
-    Chain chain = rowFilter.getChain();
-    Assert.assertTrue(
-        chain.getFilters(0).getStripValueTransformer()
-            || chain.getFilters(1).getStripValueTransformer());
+    Filters f = Filters.FILTERS;
+    Assert.assertEquals(rowFilter,
+        f.chain()
+            .filter(f.limit().cellsPerColumn(1))
+            .filter(f.value().strip())
+            .toProto());
   }
 
   @Test


### PR DESCRIPTION
- `FirstKeyOnlyFilterAdapter` now strips value (Fixes #1989)
- `KeyOnlyFilter` returns all key/family/qualifier combinations (Fixes #1987)