### PR TITLE
TableAdapter  & TableAdapter2x Vaneer adaption

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/admin/ColumnDescriptorAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/admin/ColumnDescriptorAdapter.java
@@ -20,6 +20,7 @@ import com.google.bigtable.admin.v2.GcRule;
 import com.google.bigtable.admin.v2.GcRule.Intersection;
 import com.google.bigtable.admin.v2.GcRule.RuleCase;
 import com.google.bigtable.admin.v2.GcRule.Union;
+import com.google.cloud.bigtable.admin.v2.models.GCRules.GCRule;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
@@ -36,6 +37,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import static com.google.cloud.bigtable.admin.v2.models.GCRules.GCRULES;
 
 /**
  * Adapt a single instance of an HBase {@link org.apache.hadoop.hbase.HColumnDescriptor} to
@@ -164,12 +167,12 @@ public class ColumnDescriptorAdapter {
   }
 
   /**
-   * Construct an Bigtable {@link com.google.bigtable.admin.v2.GcRule} from the given column descriptor.
+   * Construct an Bigtable {@link GCRule} from the given column descriptor.
    *
    * @param columnDescriptor a {@link org.apache.hadoop.hbase.HColumnDescriptor} object.
-   * @return a {@link com.google.bigtable.admin.v2.GcRule} object.
+   * @return a {@link GCRule} object.
    */
-  public static GcRule buildGarbageCollectionRule(HColumnDescriptor columnDescriptor) {
+  public static GCRule buildGarbageCollectionRule(HColumnDescriptor columnDescriptor) {
     int maxVersions = columnDescriptor.getMaxVersions();
     int minVersions = columnDescriptor.getMinVersions();
     int ttlSeconds = columnDescriptor.getTimeToLive();
@@ -181,12 +184,12 @@ public class ColumnDescriptorAdapter {
       if (maxVersions == Integer.MAX_VALUE) {
         return null;
       } else {
-        return maxVersions(maxVersions);
+        return GCRULES.maxVersions(maxVersions);
       }
     }
 
     // minVersions only comes into play with a TTL:
-    GcRule ageRule = maxAge(ttlSeconds);
+    GCRule ageRule = GCRULES.maxAge(org.threeten.bp.Duration.ofSeconds(ttlSeconds));
     if (minVersions != HColumnDescriptor.DEFAULT_MIN_VERSIONS) {
       // The logic here is: only delete a cell if:
       //  1) the age is older than :ttlSeconds AND
@@ -196,12 +199,12 @@ public class ColumnDescriptorAdapter {
       // Intersection (AND)
       //    - maxAge = :HBase_ttlSeconds
       //    - maxVersions = :HBase_minVersion
-      ageRule = intersection(ageRule, maxVersions(minVersions));
+      ageRule = GCRULES.intersection().rule(ageRule).rule(GCRULES.maxVersions(minVersions));
     }
     if (maxVersions == Integer.MAX_VALUE) {
       return ageRule;
     } else {
-      return union(ageRule, maxVersions(maxVersions));
+      return GCRULES.union().rule(ageRule).rule(GCRULES.maxVersions(maxVersions));
     }
   }
 
@@ -338,9 +341,9 @@ public class ColumnDescriptorAdapter {
     throwIfRequestingUnsupportedFeatures(columnDescriptor);
 
     ColumnFamily.Builder resultBuilder = ColumnFamily.newBuilder();
-    GcRule gcRule = buildGarbageCollectionRule(columnDescriptor);
+    GCRule gcRule = buildGarbageCollectionRule(columnDescriptor);
     if (gcRule != null) {
-      resultBuilder.setGcRule(gcRule);
+      resultBuilder.setGcRule(gcRule.toProto());
     }
     return resultBuilder.build();
   }

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/admin/TableAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/admin/TableAdapter.java
@@ -16,7 +16,7 @@
 package com.google.cloud.bigtable.hbase.adapters.admin;
 
 import com.google.bigtable.admin.v2.ColumnFamily;
-import com.google.bigtable.admin.v2.CreateTableRequest;
+import com.google.cloud.bigtable.admin.v2.models.CreateTableRequest;
 import com.google.bigtable.admin.v2.Table;
 import com.google.cloud.bigtable.grpc.BigtableInstanceName;
 
@@ -29,6 +29,8 @@ import org.apache.hadoop.hbase.TableName;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+
+import static com.google.cloud.bigtable.hbase.adapters.admin.ColumnDescriptorAdapter.buildGarbageCollectionRule;
 
 /**
  * <p>TableAdapter class.</p>
@@ -49,29 +51,24 @@ public class TableAdapter {
    * @param desc a {@link org.apache.hadoop.hbase.HTableDescriptor} object.
    * @return a {@link com.google.bigtable.admin.v2.Table} object.
    */
-  protected static Table adapt(HTableDescriptor desc) {
-    Map<String, ColumnFamily> columnFamilies = new HashMap<>();
+  protected static void adapt(CreateTableRequest createTableRequest, HTableDescriptor desc) {
     for (HColumnDescriptor column : desc.getColumnFamilies()) {
       String columnName = column.getNameAsString();
-      ColumnFamily columnFamily = columnDescriptorAdapter.adapt(column);
-      columnFamilies.put(columnName, columnFamily);
+      createTableRequest.addFamily(columnName, buildGarbageCollectionRule(column));
     }
-    return Table.newBuilder().putAllColumnFamilies(columnFamilies).build();
   }
 
-  public static CreateTableRequest.Builder adapt(HTableDescriptor desc, byte[][] splitKeys) {
-    CreateTableRequest.Builder builder = CreateTableRequest.newBuilder();
-    builder.setTableId(desc.getTableName().getQualifierAsString());
-    builder.setTable(adapt(desc));
-    addSplitKeys(builder, splitKeys);
-    return builder;
+  public static CreateTableRequest adapt(HTableDescriptor desc, byte[][] splitKeys) {
+    CreateTableRequest createTableRequest = CreateTableRequest.of(desc.getTableName().getNameAsString());
+    adapt(createTableRequest, desc);
+    addSplitKeys(createTableRequest, splitKeys);
+    return createTableRequest;
   }
 
-  public static void addSplitKeys(CreateTableRequest.Builder builder, byte[][] splitKeys) {
+  public static void addSplitKeys(CreateTableRequest createTableRequest, byte[][] splitKeys) {
     if (splitKeys != null) {
       for (byte[] splitKey : splitKeys) {
-        builder.addInitialSplits(
-            CreateTableRequest.Split.newBuilder().setKey(ByteString.copyFrom(splitKey)).build());
+        createTableRequest.addSplit(ByteString.copyFrom(splitKey));
       }
     }
   }

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableAdmin.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableAdmin.java
@@ -123,7 +123,7 @@ public abstract class AbstractBigtableAdmin implements Admin {
     disabledTables = connection.getDisabledTables();
     bigtableInstanceName = options.getInstanceName();
     tableAdapter = new TableAdapter(bigtableInstanceName);
-    this.instanceName = InstanceName.of(bigtableInstanceName.getProjectId(), bigtableInstanceName.getInstanceName());
+    this.instanceName = InstanceName.of(bigtableInstanceName.getProjectId(), bigtableInstanceName.getInstanceId());
 
     String clusterId = configuration.get(BigtableOptionsFactory.BIGTABLE_SNAPSHOT_CLUSTER_ID_KEY, null);
     if (clusterId != null) {

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAdmin.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAdmin.java
@@ -104,7 +104,7 @@ public class BigtableAdmin extends AbstractBigtableAdmin {
   /** {@inheritDoc} */
   @Override
   public void createTable(TableDescriptor desc, byte[][] splitKeys) throws IOException {
-    createTable(desc.getTableName(), TableAdapter2x.adapt(desc, splitKeys));
+    createTable(desc.getTableName(), TableAdapter2x.adapt(desc, splitKeys).toProto(instanceName));
   }
 
   /** {@inheritDoc} */

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncAdmin.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncAdmin.java
@@ -114,7 +114,7 @@ public class BigtableAsyncAdmin implements AsyncAdmin {
     this.tableAdapter2x = new TableAdapter2x(options);
     this.asyncConnection = asyncConnection;
     this.configuration = asyncConnection.getConfiguration();
-    this.instanceName = InstanceName.of(bigtableInstanceName.getProjectId(), bigtableInstanceName.getInstanceName());
+    this.instanceName = InstanceName.of(bigtableInstanceName.getProjectId(), bigtableInstanceName.getInstanceId());
     String clusterId = configuration.get(BigtableOptionsFactory.BIGTABLE_SNAPSHOT_CLUSTER_ID_KEY, null);
     if (clusterId != null) {
       bigtableSnapshotClusterName = bigtableInstanceName.toClusterName(clusterId);

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableTableAdminClient.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableTableAdminClient.java
@@ -60,7 +60,6 @@ public class BigtableTableAdminClient {
    *
    * @param request a {@link CreateTableRequest} object.
    */
-  //TODO(rahulkql):update methods to adapt to v2.models.CreateTableRequest
   public CompletableFuture<Table> createTableAsync(CreateTableRequest request) {
     return toCompletableFuture(adminClient.createTableAsync(request));
   }

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableTableAdminClient.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableTableAdminClient.java
@@ -60,6 +60,7 @@ public class BigtableTableAdminClient {
    *
    * @param request a {@link CreateTableRequest} object.
    */
+  //TODO(rahulkql):update methods to adapt to v2.models.CreateTableRequest
   public CompletableFuture<Table> createTableAsync(CreateTableRequest request) {
     return toCompletableFuture(adminClient.createTableAsync(request));
   }

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/adapters/admin/TableAdapter2x.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/adapters/admin/TableAdapter2x.java
@@ -56,6 +56,10 @@ public class TableAdapter2x {
     return adapt(new HTableDescriptor(desc), null);
   }
 
+  public static ColumnFamily toColumnFamily(ColumnFamilyDescriptor column) {
+    return columnDescriptorAdapter.adapt(toHColumnDescriptor(column));
+  }
+
   public static HColumnDescriptor toHColumnDescriptor(ColumnFamilyDescriptor column) {
     TableDescriptor desc =
         TableDescriptorBuilder.newBuilder(TableName.valueOf("N_A")).setColumnFamily(column)

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/adapters/admin/TableAdapter2x.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/adapters/admin/TableAdapter2x.java
@@ -21,7 +21,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.google.bigtable.admin.v2.CreateTableRequest;
+import com.google.cloud.bigtable.admin.v2.models.CreateTableRequest;
 import com.google.cloud.bigtable.grpc.BigtableInstanceName;
 import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HTableDescriptor;
@@ -37,7 +37,7 @@ import com.google.cloud.bigtable.hbase.adapters.admin.ColumnDescriptorAdapter;
 import com.google.cloud.bigtable.hbase.adapters.admin.TableAdapter;
 
 /**
- * Need this extended class as {@link TableAdapter#adapt(org.apache.hadoop.hbase.HTableDescriptor)}
+ * Need this extended class as {@link TableAdapter#adapt(CreateTableRequest, HTableDescriptor)}
  * is not binary compatible with {@link TableAdapter2x#adapt(TableDescriptor)}
  * 
  * Similarly, {@link ColumnDescriptorAdapter#adapt(HColumnDescriptor)} is not binary compatible with
@@ -48,16 +48,12 @@ import com.google.cloud.bigtable.hbase.adapters.admin.TableAdapter;
 public class TableAdapter2x {
   protected static final ColumnDescriptorAdapter columnDescriptorAdapter = new ColumnDescriptorAdapter();
 
-  public static CreateTableRequest.Builder adapt(TableDescriptor desc, byte[][] splitKeys) {
+  public static CreateTableRequest adapt(TableDescriptor desc, byte[][] splitKeys) {
     return TableAdapter.adapt(new HTableDescriptor(desc), splitKeys);
   }
 
-  public static Table adapt(TableDescriptor desc) {
-    return adapt(new HTableDescriptor(desc), null).getTable();
-  }
-
-  public static ColumnFamily toColumnFamily(ColumnFamilyDescriptor column) {
-    return columnDescriptorAdapter.adapt(toHColumnDescriptor(column));
+  public static CreateTableRequest adapt(TableDescriptor desc) {
+    return adapt(new HTableDescriptor(desc), null);
   }
 
   public static HColumnDescriptor toHColumnDescriptor(ColumnFamilyDescriptor column) {


### PR DESCRIPTION
This PR containes changes related to:
- Updated `TableAdapter` & `TableAdapter2x` to adapt to `v2.models.CreateTableRequest`.
- updated `ColumnDescriptorAdapter#buildGarbageCollectionRule` to adapt to  `v2.models.GCRules.GCRule`.
- `hbase1_x.BigtableAdmin`,  `hbase2_x.BigtableAdmin` & `AbstractBigtableAdmin` contains `toProto()` & **TOODs**, which will be removed with #1985.