### PR TITLE
garbage collect stale tables 15 mins after they are created

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestListTables.java
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestListTables.java
@@ -77,8 +77,8 @@ public abstract class AbstractTestListTables extends AbstractTest {
     String tablePrefix = sharedTestEnv.newTestTableName().toString() + "-";
 
     try (Admin admin = getConnection().getAdmin()) {
-      TableName tableName1 = TableName.valueOf(tablePrefix + "-1");
-      TableName tableName2 = TableName.valueOf(tablePrefix + "-2");
+      TableName tableName1 = TableName.valueOf(tablePrefix + "1");
+      TableName tableName2 = TableName.valueOf(tablePrefix + "2");
       addTable(tableName1);
       addTable(tableName2);
 
@@ -108,14 +108,14 @@ public abstract class AbstractTestListTables extends AbstractTest {
       }
 
       {
-        List<TableName> tableList = listTableNames(admin, Pattern.compile(tablePrefix + ".*"));
+        List<TableName> tableList = listTableNames(admin, Pattern.compile(tableName1 + ".*"));
         Assert.assertTrue(tableList.contains(tableName1));
         Assert.assertFalse(tableList.contains(tableName2));
       }
       
       {
         List<TableName> tableList = 
-            listTableNamesUsingDescriptors(admin, Pattern.compile(tablePrefix + ".*"));
+            listTableNamesUsingDescriptors(admin, Pattern.compile(tableName1 + ".*"));
         Assert.assertTrue(tableList.contains(tableName1));
         Assert.assertFalse(tableList.contains(tableName2));
         Assert.assertEquals(1, tableList.size());

--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestListTables.java
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestListTables.java
@@ -74,13 +74,11 @@ public abstract class AbstractTestListTables extends AbstractTest {
    */
   @Test
   public void testTableNames() throws Exception {
+    String tablePrefix = sharedTestEnv.newTestTableName().toString() + "-";
+
     try (Admin admin = getConnection().getAdmin()) {
-      // This prefix is required because there are regex checks on list_table1 and list_table2.
-      // In HBase 2.* tests, there are multiple subclasses to AbstractTestListTables, and each subclass
-      // needs a unique namespace on which to run the regex checks, since they might run in paralle.
-      String prefix = randomAlphanumeric(8);
-      TableName tableName1 = TableName.valueOf("list_table1-" + prefix + randomAlphanumeric(8));
-      TableName tableName2 = TableName.valueOf("list_table2-" + prefix + randomAlphanumeric(8));
+      TableName tableName1 = TableName.valueOf(tablePrefix + "-1");
+      TableName tableName2 = TableName.valueOf(tablePrefix + "-2");
       addTable(tableName1);
       addTable(tableName2);
 
@@ -110,14 +108,14 @@ public abstract class AbstractTestListTables extends AbstractTest {
       }
 
       {
-        List<TableName> tableList = listTableNames(admin, Pattern.compile("list_table1-" + prefix + ".*"));
+        List<TableName> tableList = listTableNames(admin, Pattern.compile(tablePrefix + ".*"));
         Assert.assertTrue(tableList.contains(tableName1));
         Assert.assertFalse(tableList.contains(tableName2));
       }
       
       {
         List<TableName> tableList = 
-            listTableNamesUsingDescriptors(admin, Pattern.compile("list_table1-" + prefix + ".*"));
+            listTableNamesUsingDescriptors(admin, Pattern.compile(tablePrefix + ".*"));
         Assert.assertTrue(tableList.contains(tableName1));
         Assert.assertFalse(tableList.contains(tableName2));
         Assert.assertEquals(1, tableList.size());
@@ -136,8 +134,8 @@ public abstract class AbstractTestListTables extends AbstractTest {
   @Test
   public void testDeleteTable() throws Exception {
     try (Admin admin = getConnection().getAdmin()) {
-      TableName tableName1 = TableName.valueOf("del_table1-" + UUID.randomUUID().toString());
-      TableName tableName2 = TableName.valueOf("del_table2-" + UUID.randomUUID().toString());
+      TableName tableName1 = sharedTestEnv.newTestTableName();
+      TableName tableName2 = sharedTestEnv.newTestTableName();
 
       addTable(tableName1);
       addTable(tableName2);

--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/test_env/BigtableEnv.java
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/test_env/BigtableEnv.java
@@ -23,6 +23,7 @@ import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.apache.hadoop.hbase.HBaseConfiguration;
@@ -81,12 +82,31 @@ class BigtableEnv extends SharedTestEnv {
       }
     }
 
+    // Garbage collect tables that previous runs failed to clean up
     ListeningExecutorService executor = MoreExecutors.listeningDecorator(getExecutor());
     try (Connection connection = ConnectionFactory.createConnection(configuration);
         Admin admin = connection.getAdmin()) {
       List<ListenableFuture<?>> futures = new ArrayList<>();
+
+      // Limit clean up to specific prefixes. In 12/2018, the table name pattern was modified to
+      // always start with test_table2 and to include a timestamp. In the transition, the old
+      // patterns are retained.
       for (final TableName tableName : admin
           .listTableNames(Pattern.compile("(test_table|list_table[12]|TestTable).*"))) {
+
+        // If this is a new style table name, only clean it up if it been lingering for more than 30
+        // minutes. This avoids concurrent tests deleting each other's tables.
+        // The name is created in SharedTestEnvRule.newTestTableName()
+        Pattern timestampPattern = Pattern.compile("test_table2-([0-9a-f]{16})-.*");
+        Matcher matcher = timestampPattern.matcher(tableName.getNameAsString());
+        if (matcher.matches()) {
+          String timestampStr = matcher.group(1);
+          long timestamp = Long.parseLong(timestampStr, 16);
+          if (System.currentTimeMillis() - timestamp < TimeUnit.MINUTES.toMillis(30)) {
+            continue;
+          }
+        }
+
         futures.add(executor.submit(new Runnable() {
           @Override
           public void run() {
@@ -98,8 +118,9 @@ class BigtableEnv extends SharedTestEnv {
             }
           }
         }));
-        Futures.allAsList(futures).get(2, TimeUnit.MINUTES);
       }
+
+      Futures.allAsList(futures).get(2, TimeUnit.MINUTES);
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       throw new IOException("Interrupted while deleting tables", e);

--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/test_env/BigtableEnv.java
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/test_env/BigtableEnv.java
@@ -102,7 +102,8 @@ class BigtableEnv extends SharedTestEnv {
         if (matcher.matches()) {
           String timestampStr = matcher.group(1);
           long timestamp = Long.parseLong(timestampStr, 16);
-          if (System.currentTimeMillis() - timestamp < TimeUnit.MINUTES.toMillis(30)) {
+          if (System.currentTimeMillis() - timestamp < TimeUnit.MINUTES.toMillis(15)) {
+            LOG.info("Found fresh table, ignoring: " + tableName);
             continue;
           }
         }

--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/test_env/SharedTestEnvRule.java
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/test_env/SharedTestEnvRule.java
@@ -19,6 +19,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
@@ -141,7 +142,10 @@ public class SharedTestEnvRule extends ExternalResource {
   }
 
   public TableName newTestTableName() {
-    return TableName.valueOf("test_table-" + UUID.randomUUID().toString());
+    String suffix = String.format(
+        "%016x-%016x", System.currentTimeMillis(), new Random().nextLong()
+    );
+    return TableName.valueOf("test_table2-" + suffix);
   }
 
   public ExecutorService getExecutor() {

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestIncrement.java
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestIncrement.java
@@ -301,9 +301,8 @@ public class TestIncrement extends AbstractTest {
   public void testIncrementWithMaxVersions() throws IOException {
     // Initialize data
     byte[] incrementFamily = Bytes.toBytes("i");
-    byte[] incrementTable = Bytes.toBytes("increment_table");
 
-    TableName incrementTableName = TableName.valueOf(incrementTable);
+    TableName incrementTableName = sharedTestEnv.newTestTableName();
     Admin admin = getConnection().getAdmin();
     HTableDescriptor tableDescriptor = new HTableDescriptor(incrementTableName);
     tableDescriptor.addFamily(new HColumnDescriptor(incrementFamily).setMaxVersions(1));

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestIncrement.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestIncrement.java
@@ -301,9 +301,8 @@ public class TestIncrement extends AbstractTest {
   public void testIncrementWithMaxVersions() throws IOException {
     // Initialize data
     byte[] incrementFamily = Bytes.toBytes("i");
-    byte[] incrementTable = Bytes.toBytes("increment_table");
 
-    TableName incrementTableName = TableName.valueOf(incrementTable);
+    TableName incrementTableName = sharedTestEnv.newTestTableName();
     Admin admin = getConnection().getAdmin();
     HTableDescriptor tableDescriptor = new HTableDescriptor(incrementTableName);
     tableDescriptor.addFamily(new HColumnDescriptor(incrementFamily).setMaxVersions(1));


### PR DESCRIPTION
The benefit is that this prevents concurrent test runs from interfering with each other.
It accomplishes this by encoding the current timestamp into the table name and only deleting tables whose timestamps are old than 15 minutes
