### PR TITLE
fix large row splitting on import

### DIFF
--- a/bigtable-dataflow-parent/bigtable-beam-import/src/main/java/com/google/cloud/bigtable/beam/sequencefiles/HBaseResultToMutationFn.java
+++ b/bigtable-dataflow-parent/bigtable-beam-import/src/main/java/com/google/cloud/bigtable/beam/sequencefiles/HBaseResultToMutationFn.java
@@ -49,7 +49,7 @@ class HBaseResultToMutationFn
 
   private static final long serialVersionUID = 1L;
 
-  private static final int MAX_CELLS = 100_000;
+  private static final int MAX_CELLS = 100_000 - 1;
 
   private static final Predicate<Cell> IS_DELETE_MARKER_FILTER =  new Predicate<Cell>() {
     @Override


### PR DESCRIPTION
Looks like the limit on mutation sizes is less than 100K not 100K.