### PR TITLE
Refactored value provider

### DIFF
--- a/bigtable-dataflow-parent/bigtable-beam-import/src/main/java/com/google/cloud/bigtable/beam/TemplateUtils.java
+++ b/bigtable-dataflow-parent/bigtable-beam-import/src/main/java/com/google/cloud/bigtable/beam/TemplateUtils.java
@@ -15,12 +15,8 @@
  */
 package com.google.cloud.bigtable.beam;
 
-import com.google.bigtable.repackaged.com.google.bigtable.v2.ReadRowsRequest;
 import com.google.cloud.bigtable.beam.sequencefiles.ExportJob.ExportOptions;
 import com.google.cloud.bigtable.beam.sequencefiles.ImportJob.ImportOptions;
-import com.google.cloud.bigtable.hbase.adapters.Adapters;
-import com.google.cloud.bigtable.hbase.adapters.read.DefaultReadHooks;
-import com.google.cloud.bigtable.hbase.adapters.read.ReadHooks;
 import java.io.Serializable;
 import java.nio.charset.CharacterCodingException;
 import org.apache.beam.sdk.options.ValueProvider;
@@ -57,77 +53,18 @@ public class TemplateUtils {
     return builder.build();
   }
 
-  /** Provides a request that is constructed with some attributes. */
-  private static class RequestValueProvider
-      implements ValueProvider<ReadRowsRequest>, Serializable {
-    private final ValueProvider<String> start;
-    private final ValueProvider<String> stop;
-    private final ValueProvider<Integer> maxVersion;
-    private final ValueProvider<String> filter;
-    private ReadRowsRequest cachedRequest;
-
-    RequestValueProvider(ExportOptions options) {
-      this.start = options.getBigtableStartRow();
-      this.stop = options.getBigtableStopRow();
-      this.maxVersion = options.getBigtableMaxVersions();
-      this.filter = options.getBigtableFilter();
-    }
-
-    @Override
-    public ReadRowsRequest get() {
-      if (cachedRequest == null) {
-        Scan scan = new Scan();
-        if (start.get() != null && !start.get().isEmpty()) {
-          scan.setStartRow(start.get().getBytes());
-        }
-        if (stop.get() != null && !stop.get().isEmpty()) {
-          scan.setStopRow(stop.get().getBytes());
-        }
-        if (maxVersion.get() != null) {
-          scan.setMaxVersions(maxVersion.get());
-        }
-        if (filter.get() != null && !filter.get().isEmpty()) {
-          try {
-            scan.setFilter(new ParseFilter().parseFilterString(filter.get()));
-          } catch (CharacterCodingException e) {
-            throw new RuntimeException(e);
-          }
-        }
-
-        ReadHooks readHooks = new DefaultReadHooks();
-        ReadRowsRequest.Builder builder = Adapters.SCAN_ADAPTER.adapt(scan, readHooks);
-        cachedRequest = readHooks.applyPreSendHook(builder.build());
-      }
-      return cachedRequest;
-    }
-
-    @Override
-    public boolean isAccessible() {
-      return start.isAccessible()
-          && stop.isAccessible()
-          && maxVersion.isAccessible()
-          && filter.isAccessible();
-    }
-
-    @Override
-    public String toString() {
-      if (isAccessible()) {
-        return String.valueOf(get());
-      }
-      return CloudBigtableConfiguration.VALUE_UNAVAILABLE;
-    }
-  }
-
   /** Builds CloudBigtableScanConfiguration from input runtime parameters for export job. */
   public static CloudBigtableScanConfiguration BuildExportConfig(ExportOptions options) {
-    ValueProvider<ReadRowsRequest> request = new RequestValueProvider(options);
     CloudBigtableScanConfiguration.Builder configBuilder =
         new CloudBigtableScanConfiguration.Builder()
             .withProjectId(options.getBigtableProject())
             .withInstanceId(options.getBigtableInstanceId())
             .withTableId(options.getBigtableTableId())
             .withAppProfileId(options.getBigtableAppProfileId())
-            .withRequest(request);
+            .withConfiguration("startRow", options.getBigtableStartRow())
+            .withConfiguration("stopRow", options.getBigtableStopRow())
+            .withMaxVersion(options.getBigtableMaxVersions())
+            .withConfiguration("filter", options.getBigtableFilter());
 
     return configBuilder.build();
   }

--- a/bigtable-dataflow-parent/bigtable-beam-import/src/main/java/com/google/cloud/bigtable/beam/TemplateUtils.java
+++ b/bigtable-dataflow-parent/bigtable-beam-import/src/main/java/com/google/cloud/bigtable/beam/TemplateUtils.java
@@ -15,8 +15,12 @@
  */
 package com.google.cloud.bigtable.beam;
 
+import com.google.bigtable.repackaged.com.google.bigtable.v2.ReadRowsRequest;
 import com.google.cloud.bigtable.beam.sequencefiles.ExportJob.ExportOptions;
 import com.google.cloud.bigtable.beam.sequencefiles.ImportJob.ImportOptions;
+import com.google.cloud.bigtable.hbase.adapters.Adapters;
+import com.google.cloud.bigtable.hbase.adapters.read.DefaultReadHooks;
+import com.google.cloud.bigtable.hbase.adapters.read.ReadHooks;
 import java.io.Serializable;
 import java.nio.charset.CharacterCodingException;
 import org.apache.beam.sdk.options.ValueProvider;
@@ -53,18 +57,77 @@ public class TemplateUtils {
     return builder.build();
   }
 
+  /** Provides a request that is constructed with some attributes. */
+  private static class RequestValueProvider
+      implements ValueProvider<ReadRowsRequest>, Serializable {
+    private final ValueProvider<String> start;
+    private final ValueProvider<String> stop;
+    private final ValueProvider<Integer> maxVersion;
+    private final ValueProvider<String> filter;
+    private ReadRowsRequest cachedRequest;
+
+    RequestValueProvider(ExportOptions options) {
+      this.start = options.getBigtableStartRow();
+      this.stop = options.getBigtableStopRow();
+      this.maxVersion = options.getBigtableMaxVersions();
+      this.filter = options.getBigtableFilter();
+    }
+
+    @Override
+    public ReadRowsRequest get() {
+      if (cachedRequest == null) {
+        Scan scan = new Scan();
+        if (start.get() != null && !start.get().isEmpty()) {
+          scan.setStartRow(start.get().getBytes());
+        }
+        if (stop.get() != null && !stop.get().isEmpty()) {
+          scan.setStopRow(stop.get().getBytes());
+        }
+        if (maxVersion.get() != null) {
+          scan.setMaxVersions(maxVersion.get());
+        }
+        if (filter.get() != null && !filter.get().isEmpty()) {
+          try {
+            scan.setFilter(new ParseFilter().parseFilterString(filter.get()));
+          } catch (CharacterCodingException e) {
+            throw new RuntimeException(e);
+          }
+        }
+
+        ReadHooks readHooks = new DefaultReadHooks();
+        ReadRowsRequest.Builder builder = Adapters.SCAN_ADAPTER.adapt(scan, readHooks);
+        cachedRequest = readHooks.applyPreSendHook(builder.build());
+      }
+      return cachedRequest;
+    }
+
+    @Override
+    public boolean isAccessible() {
+      return start.isAccessible()
+          && stop.isAccessible()
+          && maxVersion.isAccessible()
+          && filter.isAccessible();
+    }
+
+    @Override
+    public String toString() {
+      if (isAccessible()) {
+        return String.valueOf(get());
+      }
+      return CloudBigtableConfiguration.VALUE_UNAVAILABLE;
+    }
+  }
+
   /** Builds CloudBigtableScanConfiguration from input runtime parameters for export job. */
   public static CloudBigtableScanConfiguration BuildExportConfig(ExportOptions options) {
+    ValueProvider<ReadRowsRequest> request = new RequestValueProvider(options);
     CloudBigtableScanConfiguration.Builder configBuilder =
         new CloudBigtableScanConfiguration.Builder()
             .withProjectId(options.getBigtableProject())
             .withInstanceId(options.getBigtableInstanceId())
             .withTableId(options.getBigtableTableId())
             .withAppProfileId(options.getBigtableAppProfileId())
-            .withConfiguration("startRow", options.getBigtableStartRow())
-            .withConfiguration("stopRow", options.getBigtableStopRow())
-            .withMaxVersion(options.getBigtableMaxVersions())
-            .withConfiguration("filter", options.getBigtableFilter());
+            .withRequest(request);
 
     return configBuilder.build();
   }

--- a/bigtable-dataflow-parent/bigtable-hbase-beam/src/test/java/com/google/cloud/bigtable/beam/CloudBigtableScanConfigurationTest.java
+++ b/bigtable-dataflow-parent/bigtable-hbase-beam/src/test/java/com/google/cloud/bigtable/beam/CloudBigtableScanConfigurationTest.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.bigtable.beam;
 
+import java.util.Arrays;
 import org.apache.beam.sdk.options.ValueProvider.StaticValueProvider;
 import org.apache.beam.sdk.util.SerializableUtils;
 import org.apache.hadoop.hbase.client.Scan;
@@ -137,5 +138,24 @@ public class CloudBigtableScanConfigurationTest {
             .withRequest(StaticValueProvider.of(updatedRequest))
             .build();
     Assert.assertEquals(withRegularParameters, withRuntimeParameters);
+  }
+
+  @Test
+  public void testRowKeys(){
+    byte[] PREFIX = "PRE".getBytes();
+    Scan scan = new Scan()
+        .setStartRow(START_ROW)
+        .setStopRow(STOP_ROW)
+        .setRowPrefixFilter(PREFIX);
+    CloudBigtableScanConfiguration scanConfiguration =
+        new CloudBigtableScanConfiguration.Builder()
+            .withTableId(StaticValueProvider.of(TABLE))
+            .withProjectId(StaticValueProvider.of(PROJECT))
+            .withInstanceId(StaticValueProvider.of(INSTANCE))
+            .withScan(scan)
+            .withConfiguration("somekey", StaticValueProvider.of("somevalue"))
+            .build();
+    Assert.assertTrue(Arrays.equals(PREFIX, scanConfiguration.getStartRow()));
+    Assert.assertFalse(Arrays.equals(PREFIX, scanConfiguration.getStopRow()));
   }
 }

--- a/bigtable-dataflow-parent/bigtable-hbase-beam/src/test/java/com/google/cloud/bigtable/beam/CloudBigtableScanConfigurationTest.java
+++ b/bigtable-dataflow-parent/bigtable-hbase-beam/src/test/java/com/google/cloud/bigtable/beam/CloudBigtableScanConfigurationTest.java
@@ -126,10 +126,7 @@ public class CloudBigtableScanConfigurationTest {
             .withKeys(START_ROW, STOP_ROW)
             .withConfiguration("somekey", StaticValueProvider.of("somevalue"))
             .build();
-    Assert.assertEquals(withRegularParameters.getProjectId(), withRuntimeParameters.getProjectId());
-    Assert.assertEquals(withRegularParameters.getInstanceId(), withRuntimeParameters.getInstanceId());
-    Assert.assertEquals(withRegularParameters.getRequest(), withRuntimeParameters.getRequest());
-    Assert.assertEquals(withRegularParameters.getRowRange(), withRuntimeParameters.getRowRange());
+    Assert.assertEquals(withRegularParameters, withRuntimeParameters);
 
     // Verify with requests.
     ReadRowsRequest updatedRequest = withRegularParameters.getRequest();
@@ -139,6 +136,6 @@ public class CloudBigtableScanConfigurationTest {
             .toBuilder()
             .withRequest(StaticValueProvider.of(updatedRequest))
             .build();
-    Assert.assertEquals(withRegularParameters.getRequest(), withRuntimeParameters.getRequest());
+    Assert.assertEquals(withRegularParameters, withRuntimeParameters);
   }
 }

--- a/bigtable-dataflow-parent/bigtable-hbase-beam/src/test/java/com/google/cloud/bigtable/beam/CloudBigtableScanConfigurationTest.java
+++ b/bigtable-dataflow-parent/bigtable-hbase-beam/src/test/java/com/google/cloud/bigtable/beam/CloudBigtableScanConfigurationTest.java
@@ -126,7 +126,10 @@ public class CloudBigtableScanConfigurationTest {
             .withKeys(START_ROW, STOP_ROW)
             .withConfiguration("somekey", StaticValueProvider.of("somevalue"))
             .build();
-    Assert.assertEquals(withRegularParameters, withRuntimeParameters);
+    Assert.assertEquals(withRegularParameters.getProjectId(), withRuntimeParameters.getProjectId());
+    Assert.assertEquals(withRegularParameters.getInstanceId(), withRuntimeParameters.getInstanceId());
+    Assert.assertEquals(withRegularParameters.getRequest(), withRuntimeParameters.getRequest());
+    Assert.assertEquals(withRegularParameters.getRowRange(), withRuntimeParameters.getRowRange());
 
     // Verify with requests.
     ReadRowsRequest updatedRequest = withRegularParameters.getRequest();
@@ -136,6 +139,6 @@ public class CloudBigtableScanConfigurationTest {
             .toBuilder()
             .withRequest(StaticValueProvider.of(updatedRequest))
             .build();
-    Assert.assertEquals(withRegularParameters, withRuntimeParameters);
+    Assert.assertEquals(withRegularParameters.getRequest(), withRuntimeParameters.getRequest());
   }
 }


### PR DESCRIPTION
Refactoring `ReadRowsRequest` creation into a new `RequestWithScanValueProvider`. Now request.get() would have two different get()
-  Inside TemplateUtil's  [RequestValueProvider#get](https://github.com/GoogleCloudPlatform/cloud-bigtable-client/blob/a7c42302ad53d8361f541be02c56db598795ae41/bigtable-dataflow-parent/bigtable-beam-import/src/main/java/com/google/cloud/bigtable/beam/TemplateUtils.java#L77).
- Inside beam/CloudBigtableScanConfiguration's [RequestWithScanValueProvide#get](https://github.com/GoogleCloudPlatform/cloud-bigtable-client/compare/master...rahulKQL:refactored_valueProvider#diff-5836fc24866e6a80ee2b663eb55592d4R446).
 