### PR TITLE
Upgraing Jackson Binding

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/pom.xml
+++ b/bigtable-client-core-parent/bigtable-client-core/pom.xml
@@ -211,7 +211,7 @@ limitations under the License.
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.7</version>
+            <version>2.9.8</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Github is complaining about 2.9.7, saying that it's a security risk.  It's only used in some tests, but upgrading anyway.