### PR TITLE
upgrade google-cloud-java client version 

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableInstanceName.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableInstanceName.java
@@ -126,11 +126,6 @@ public class BigtableInstanceName implements Serializable {
     return InstanceName.of(projectId, instanceId);
   }
 
-  //TODO(rahulkql): Refactor once google-cloud-java/issues/4091 is resolved.
-  public com.google.bigtable.admin.v2.InstanceName toAdminInstanceName() {
-    return com.google.bigtable.admin.v2.InstanceName.of(projectId, instanceId);
-  }
-
   public BigtableClusterName toClusterName(String clusterId) {
     return new BigtableClusterName(instanceName + "/clusters/" + clusterId);
   }

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestBigtableInstanceName.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestBigtableInstanceName.java
@@ -103,10 +103,4 @@ public class TestBigtableInstanceName {
   public void testGcbInstanceName(){
     Assert.assertTrue(bigtableInstanceName.toGcbInstanceName() instanceof InstanceName);
   }
-
-  @Test
-  public void testAdminInstanceName(){
-    Assert.assertTrue(bigtableInstanceName.toAdminInstanceName() instanceof
-            com.google.bigtable.admin.v2.InstanceName);
-  }
 }

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableAdmin.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableAdmin.java
@@ -363,7 +363,7 @@ public abstract class AbstractBigtableAdmin implements Admin {
           throws IOException {
     try {
       bigtableTableAdminClient.createTable(
-              request.toProto(bigtableInstanceName.toAdminInstanceName()));
+              request.toProto(options.getProjectId(), options.getInstanceId()));
     } catch (Throwable throwable) {
       throw convertToTableExistsException(tableName, throwable);
     }
@@ -385,7 +385,7 @@ public abstract class AbstractBigtableAdmin implements Admin {
             CreateTableRequest request) throws IOException {
     ListenableFuture<Table> future =
             bigtableTableAdminClient.createTableAsync(
-                    request.toProto(bigtableInstanceName.toAdminInstanceName()));
+                    request.toProto(options.getProjectId(), options.getInstanceId()));
     final SettableFuture<Table> settableFuture = SettableFuture.create();
     Futures.addCallback(future, new FutureCallback<Table>() {
       @Override public void onSuccess(@Nullable Table result) {
@@ -612,7 +612,7 @@ public abstract class AbstractBigtableAdmin implements Admin {
         ModifyColumnFamiliesRequest request =
             buildModifications(newDecriptor, getTableDescriptor(tableName)).build();
         bigtableTableAdminClient.modifyColumnFamily(
-                request.toProto(bigtableInstanceName.toAdminInstanceName()));
+                request.toProto(options.getProjectId(), options.getInstanceId()));
       } catch (Throwable throwable) {
         throw new IOException(
             String.format("Failed to modify table '%s'", tableName.getNameAsString()), throwable);
@@ -636,7 +636,7 @@ public abstract class AbstractBigtableAdmin implements Admin {
     ModifyColumnFamiliesRequest request = builder.build();
     try {
       bigtableTableAdminClient.modifyColumnFamily(
-              request.toProto(bigtableInstanceName.toAdminInstanceName()));
+              request.toProto(options.getProjectId(), options.getInstanceId()));
       return null;
     } catch (Throwable throwable) {
       throw new IOException(

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/admin/TestTableAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/admin/TestTableAdapter.java
@@ -17,7 +17,6 @@ package com.google.cloud.bigtable.hbase.adapters.admin;
 
 import static com.google.cloud.bigtable.admin.v2.models.GCRules.GCRULES;
 import com.google.bigtable.admin.v2.ColumnFamily;
-import com.google.bigtable.admin.v2.InstanceName;
 import com.google.bigtable.admin.v2.Table;
 import com.google.cloud.bigtable.admin.v2.models.CreateTableRequest;
 import com.google.cloud.bigtable.admin.v2.models.GCRules.GCRule;
@@ -43,13 +42,11 @@ public class TestTableAdapter {
   private static final String COLUMN_FAMILY = "myColumnFamily";
 
   private TableAdapter tableAdapter;
-  private InstanceName instanceName;
 
   @Before
   public void setUp(){
     BigtableInstanceName bigtableInstanceName = new BigtableInstanceName(PROJECT_ID, INSTANCE_ID);
     tableAdapter = new TableAdapter(bigtableInstanceName);
-    instanceName = InstanceName.of(PROJECT_ID, INSTANCE_ID);
   }
 
   @Test
@@ -65,8 +62,8 @@ public class TestTableAdapter {
     CreateTableRequest expectedRequest = CreateTableRequest.of(TABLE_ID);
     TableAdapter.addSplitKeys(splits, expectedRequest);
     Assert.assertEquals(
-            expectedRequest.toProto(instanceName),
-            actualRequest.toProto(instanceName));
+            expectedRequest.toProto(PROJECT_ID, INSTANCE_ID),
+            actualRequest.toProto(PROJECT_ID, INSTANCE_ID));
   }
 
 
@@ -78,8 +75,8 @@ public class TestTableAdapter {
 
     CreateTableRequest expectedRequest = CreateTableRequest.of(TABLE_ID);
     Assert.assertEquals(
-            expectedRequest.toProto(instanceName),
-            actualRequest.toProto(instanceName));
+            expectedRequest.toProto(PROJECT_ID, INSTANCE_ID),
+            actualRequest.toProto(PROJECT_ID, INSTANCE_ID));
   }
 
   @Test
@@ -94,7 +91,7 @@ public class TestTableAdapter {
     GCRule gcRule = ColumnDescriptorAdapter.buildGarbageCollectionRule(columnDesc);
     CreateTableRequest expected =
             CreateTableRequest.of(TABLE_ID).addFamily(COLUMN_FAMILY, gcRule);
-    Assert.assertEquals(request.toProto(instanceName), expected.toProto(instanceName));
+    Assert.assertEquals(request.toProto(PROJECT_ID, INSTANCE_ID), expected.toProto(PROJECT_ID, INSTANCE_ID));
   }
 
 

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/util/TestModifyTableBuilder.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/util/TestModifyTableBuilder.java
@@ -17,13 +17,11 @@ package com.google.cloud.bigtable.hbase.util;
 
 import static com.google.cloud.bigtable.hbase.adapters.admin.ColumnDescriptorAdapter.buildGarbageCollectionRule;
 
-import com.google.bigtable.admin.v2.InstanceName;
 import com.google.cloud.bigtable.admin.v2.models.ModifyColumnFamiliesRequest;
 import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.TableName;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -36,12 +34,6 @@ public class TestModifyTableBuilder {
   private static final String TABLE_ID = "myTable";
   private static final String COLUMN_FAMILY = "myColumnFamily";
 
-  private InstanceName instanceName;
-  @Before
-  public void setUp() {
-    instanceName = InstanceName.of(PROJECT_ID, INSTANCE_ID);
-  }
-
   @Test
   public void testBuildModificationForAddFamily(){
     HTableDescriptor tableDescriptor = new HTableDescriptor(TableName.valueOf(TABLE_ID));
@@ -53,8 +45,8 @@ public class TestModifyTableBuilder {
     ModifyColumnFamiliesRequest expectedRequest = ModifyColumnFamiliesRequest.of(TABLE_ID)
         .addFamily(COLUMN_FAMILY, buildGarbageCollectionRule(addColumn));
 
-    Assert.assertEquals(expectedRequest.toProto(instanceName),
-        actualRequest.build().toProto(instanceName));
+    Assert.assertEquals(expectedRequest.toProto(PROJECT_ID, INSTANCE_ID),
+        actualRequest.build().toProto(PROJECT_ID, INSTANCE_ID));
   }
 
   @Test
@@ -68,8 +60,8 @@ public class TestModifyTableBuilder {
     ModifyColumnFamiliesRequest expectedRequest = ModifyColumnFamiliesRequest.of(TABLE_ID)
         .updateFamily(COLUMN_FAMILY, buildGarbageCollectionRule(addColumn));
 
-    Assert.assertEquals(expectedRequest.toProto(instanceName),
-        actualRequest.build().toProto(instanceName));
+    Assert.assertEquals(expectedRequest.toProto(PROJECT_ID, INSTANCE_ID),
+        actualRequest.build().toProto(PROJECT_ID, INSTANCE_ID));
   }
 
   @Test
@@ -89,7 +81,7 @@ public class TestModifyTableBuilder {
         .addFamily(COLUMN_FAMILY, buildGarbageCollectionRule(addColumn))
         .dropFamily(NEW_COLUMN_FAMILY);
 
-    Assert.assertEquals(expectedRequest.toProto(instanceName),
-        actualRequest.build().toProto(instanceName));
+    Assert.assertEquals(expectedRequest.toProto(PROJECT_ID, INSTANCE_ID),
+        actualRequest.build().toProto(PROJECT_ID, INSTANCE_ID));
   }
 }

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncAdmin.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncAdmin.java
@@ -132,7 +132,7 @@ public class BigtableAsyncAdmin implements AsyncAdmin {
 
     CreateTableRequest request = TableAdapter2x.adapt(desc, splitKeys);
     return bigtableTableAdminClient.createTableAsync(
-            request.toProto(bigtableInstanceName.toAdminInstanceName()))
+            request.toProto(options.getProjectId(), options.getInstanceId()))
         .handle((resp, ex) -> {
           if (ex != null) {
             throw new CompletionException(
@@ -368,7 +368,7 @@ public class BigtableAsyncAdmin implements AsyncAdmin {
       ModifyTableBuilder modifications) {
     ModifyColumnFamiliesRequest request = modifications.build();
     return bigtableTableAdminClient
-        .modifyColumnFamilyAsync(request.toProto(bigtableInstanceName.toAdminInstanceName()))
+        .modifyColumnFamilyAsync(request.toProto(options.getProjectId(), options.getInstanceId()))
         .thenApply(r -> null);
   }
 

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/test/java/com/google/cloud/bigtable/hbase/com/google/cloud/bigtable/hbase2_x/adapters/admin/TestTableAdapter2x.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/test/java/com/google/cloud/bigtable/hbase/com/google/cloud/bigtable/hbase2_x/adapters/admin/TestTableAdapter2x.java
@@ -18,7 +18,6 @@ package com.google.cloud.bigtable.hbase.com.google.cloud.bigtable.hbase2_x.adapt
 import static com.google.cloud.bigtable.admin.v2.models.GCRules.GCRULES;
 
 import com.google.bigtable.admin.v2.ColumnFamily;
-import com.google.bigtable.admin.v2.InstanceName;
 import com.google.bigtable.admin.v2.Table;
 import com.google.cloud.bigtable.admin.v2.models.CreateTableRequest;
 import com.google.cloud.bigtable.admin.v2.models.GCRules;
@@ -47,14 +46,12 @@ public class TestTableAdapter2x {
   private static final String COLUMN_FAMILY = "myColumnFamily";
 
   private TableAdapter2x tableAdapter2x;
-  private InstanceName instanceName;
 
   @Before
   public void setUp(){
     BigtableOptions bigtableOptions = BigtableOptions.builder().setProjectId(PROJECT_ID)
             .setInstanceId(INSTANCE_ID).build();
     tableAdapter2x = new TableAdapter2x(bigtableOptions);
-    instanceName = InstanceName.of(PROJECT_ID, INSTANCE_ID);
   }
 
   @Test
@@ -70,8 +67,8 @@ public class TestTableAdapter2x {
     CreateTableRequest expectedRequest = CreateTableRequest.of(TABLE_ID);
     TableAdapter.addSplitKeys(splits, expectedRequest);
     Assert.assertEquals(
-            expectedRequest.toProto(instanceName),
-            actualRequest.toProto(instanceName));
+            expectedRequest.toProto(PROJECT_ID, INSTANCE_ID),
+            actualRequest.toProto(PROJECT_ID, INSTANCE_ID));
   }
 
   @Test

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@ limitations under the License.
         <hamcrest.version>1.3</hamcrest.version>
 
         <!-- google-cloud-java related dependency versions -->
-        <google-cloud.version>0.73.0-alpha</google-cloud.version>
+        <google-cloud.version>0.76.0-alpha</google-cloud.version>
         <opencensus.version>0.15.0</opencensus.version>
         <guava.version>26.0-android</guava.version>
 


### PR DESCRIPTION
## What Changes it contains:

 - Upgraded google-cloud-java to it's latest build i.e. `0.76.0`.
 - Removed usage of typesafe as it is deprecated from #4257.
 - Have only removed [`com.google.bigtable.admin.v2.InstanceName`](https://github.com/googleapis/google-cloud-java/blob/master/google-api-grpc/proto-google-cloud-bigtable-admin-v2/src/main/java/com/google/bigtable/admin/v2/InstanceName.java).
 - Would raise another PR to change deprecated [`com.google.cloud.bigtable.data.v2.models.InstanceName`](https://github.com/googleapis/google-cloud-java/blob/master/google-cloud-clients/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/models/InstanceName.java#L29) usages.


### Tests performed on local
 - Performed simple build
 - Performed build with `hbaseLocalMiniClusterTest` profile for both H1 & H2.
 - Performed build with `bigtableIntegrationTest ` profile for both H1 & H2 with actual bigtable.