### PR TITLE
Upgrading google-cloud-clients to 0.77

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,8 +59,8 @@ limitations under the License.
         <hamcrest.version>1.3</hamcrest.version>
 
         <!-- google-cloud-java related dependency versions -->
-        <google-cloud.version>0.76.0-alpha</google-cloud.version>
-        <opencensus.version>0.15.0</opencensus.version>
+        <google-cloud.version>0.78.0-alpha</google-cloud.version>
+        <opencensus.version>0.17.0</opencensus.version>
         <guava.version>26.0-android</guava.version>
 
         <!-- hbase dependency versions -->


### PR DESCRIPTION
This upgrades grpc to 0.17.1, and opencensus to 0.17.0