### PR TITLE
Allow skipping session warmup

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
@@ -98,7 +98,10 @@ public class BigtableSession implements Closeable {
   static final String USER_AGENT_EMPTY_OR_NULL = "UserAgent must not be empty or null";
 
   static {
-    performWarmup();
+    if (!System.getProperty("BIGTABLE_SESSION_SKIP_WARMUP", "")
+        .equalsIgnoreCase("true")) {
+      performWarmup();
+    }
   }
 
   private static void performWarmup() {


### PR DESCRIPTION
I'm starting to use the emulator for tests that run during our CI process, but we have hooks in place that block DNS requests to non-localhost domains (in JUnit).  This change simply allows one to disable the warmup that's done when BigtableSession is first accessed.