### PR TITLE
Removed google-cloud-bigtable-admin artifact from pom.xml declaration

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/pom.xml
+++ b/bigtable-client-core-parent/bigtable-client-core/pom.xml
@@ -48,10 +48,6 @@ limitations under the License.
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-bigtable</artifactId>
         </dependency>
-        <dependency>
-            <groupId>com.google.cloud</groupId>
-            <artifactId>google-cloud-bigtable-admin</artifactId>
-        </dependency>
 
         <!-- Protos -->
         <dependency>

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableVersionInfo.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableVersionInfo.java
@@ -11,7 +11,7 @@ public class BigtableVersionInfo {
   public static final String CLIENT_VERSION = getVersion();
   public static final String JDK_VERSION = getJavaVersion();
 
-  public static final String CORE_UESR_AGENT = "bigtable-" + CLIENT_VERSION +",jdk-" + JDK_VERSION;
+  public static final String CORE_USER_AGENT = "bigtable-" + CLIENT_VERSION +",jdk-" + JDK_VERSION;
 
   /**
    * Gets user agent from bigtable-version.properties. Returns a default dev user agent with current

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
@@ -544,7 +544,7 @@ public class BigtableSession implements Closeable {
     return builder
         .idleTimeout(Long.MAX_VALUE, TimeUnit.SECONDS)
         .maxInboundMessageSize(MAX_MESSAGE_SIZE)
-        .userAgent(BigtableVersionInfo.CORE_UESR_AGENT + "," + options.getUserAgent())
+        .userAgent(BigtableVersionInfo.CORE_USER_AGENT + "," + options.getUserAgent())
         .intercept(interceptors)
         .build();
   }


### PR DESCRIPTION
 ## What changes it contains
- Removed `google-cloud-bigtable-admin` form `Bigtable-client-core`'s pom.xml.
- Fixed typo in for `BigtableVersionInfo`.

