### PR TITLE
Removing deprecated uses of gcp InstanceName

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableOptions.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableOptions.java
@@ -301,6 +301,8 @@ public class BigtableOptions implements Serializable, Cloneable {
   private boolean useCachedDataPool;
 
   private BigtableInstanceName instanceName;
+
+  // TODO: remove the `transient` modifier once RequestContext is Serializable.
   private transient RequestContext requestContext;
 
   private BulkOptions bulkOptions;

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableOptions.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableOptions.java
@@ -19,6 +19,7 @@ import java.io.Serializable;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
+import com.google.cloud.bigtable.data.v2.internal.RequestContext;
 import com.google.cloud.bigtable.grpc.BigtableInstanceName;
 import com.google.cloud.bigtable.grpc.BigtableSession;
 import com.google.common.annotations.VisibleForTesting;
@@ -300,6 +301,7 @@ public class BigtableOptions implements Serializable, Cloneable {
   private boolean useCachedDataPool;
 
   private BigtableInstanceName instanceName;
+  private transient RequestContext requestContext;
 
   private BulkOptions bulkOptions;
   private CallOptionsConfig callOptionsConfig;
@@ -405,10 +407,25 @@ public class BigtableOptions implements Serializable, Cloneable {
   /**
    * <p>Getter for the field <code>instanceName</code>.</p>
    *
-   * @return a {@link com.google.cloud.bigtable.grpc.BigtableInstanceName} object.
+   * @return a {@link BigtableInstanceName} object.
    */
   public BigtableInstanceName getInstanceName() {
     return instanceName;
+  }
+
+  /**
+   * <p>Getter for the field <code>instanceName</code>.</p>
+   *
+   * @return a {@link RequestContext} object.
+   */
+  public RequestContext getRequestContext() {
+    if (requestContext == null && instanceName != null) {
+      // RequestContext is not Serializable, so it is declared transient
+      // and is built as needed.
+      requestContext =
+          RequestContext.create(projectId, instanceId, appProfileId);
+    }
+    return requestContext;
   }
 
   /**

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableOptions.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableOptions.java
@@ -19,7 +19,6 @@ import java.io.Serializable;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
-import com.google.cloud.bigtable.data.v2.internal.RequestContext;
 import com.google.cloud.bigtable.grpc.BigtableInstanceName;
 import com.google.cloud.bigtable.grpc.BigtableSession;
 import com.google.common.annotations.VisibleForTesting;
@@ -302,9 +301,6 @@ public class BigtableOptions implements Serializable, Cloneable {
 
   private BigtableInstanceName instanceName;
 
-  // TODO: remove the `transient` modifier once RequestContext is Serializable.
-  private transient RequestContext requestContext;
-
   private BulkOptions bulkOptions;
   private CallOptionsConfig callOptionsConfig;
   private CredentialOptions credentialOptions;
@@ -413,21 +409,6 @@ public class BigtableOptions implements Serializable, Cloneable {
    */
   public BigtableInstanceName getInstanceName() {
     return instanceName;
-  }
-
-  /**
-   * <p>Getter for the field <code>instanceName</code>.</p>
-   *
-   * @return a {@link RequestContext} object.
-   */
-  public RequestContext getRequestContext() {
-    if (requestContext == null && instanceName != null) {
-      // RequestContext is not Serializable, so it is declared transient
-      // and is built as needed.
-      requestContext =
-          RequestContext.create(projectId, instanceId, appProfileId);
-    }
-    return requestContext;
   }
 
   /**

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableInstanceName.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableInstanceName.java
@@ -15,7 +15,6 @@
  */
 package com.google.cloud.bigtable.grpc;
 
-import com.google.cloud.bigtable.data.v2.models.InstanceName;
 import java.io.Serializable;
 
 import com.google.api.client.util.Strings;
@@ -120,10 +119,6 @@ public class BigtableInstanceName implements Serializable {
    */
   public String getInstanceName() {
     return instanceName;
-  }
-
-  public InstanceName toGcbInstanceName() {
-    return InstanceName.of(projectId, instanceId);
   }
 
   public BigtableClusterName toClusterName(String clusterId) {

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
@@ -28,6 +28,7 @@ import com.google.cloud.bigtable.config.Logger;
 import com.google.cloud.bigtable.config.RetryOptions;
 import com.google.cloud.bigtable.core.IBigtableDataClient;
 import com.google.cloud.bigtable.core.IBigtableTableAdminClient;
+import com.google.cloud.bigtable.data.v2.internal.RequestContext;
 import com.google.cloud.bigtable.grpc.async.AsyncExecutor;
 import com.google.cloud.bigtable.grpc.async.BulkMutation;
 import com.google.cloud.bigtable.grpc.async.BulkRead;
@@ -307,6 +308,14 @@ public class BigtableSession implements Closeable {
    */
   public BigtableDataClient getDataClient() {
     return dataClient;
+  }
+
+  /**
+   * @return a {@link RequestContext} object for use with {@link #getDataClient()} during the
+   * transition to {@link #getClientWrapper()}.
+   */
+  public RequestContext getDataRequestContext() {
+    return RequestContext.create(options.getProjectId(), options.getInstanceId(), options.getAppProfileId());
   }
 
   /**

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestBigtableInstanceName.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestBigtableInstanceName.java
@@ -15,7 +15,6 @@
  */
 package com.google.cloud.bigtable.grpc;
 
-import com.google.cloud.bigtable.data.v2.models.InstanceName;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -25,7 +24,6 @@ import org.junit.runners.JUnit4;
 
 import com.google.bigtable.admin.v2.CreateTableRequest;
 import com.google.bigtable.admin.v2.ListTablesRequest;
-import com.google.cloud.bigtable.grpc.BigtableInstanceName;
 
 @RunWith(JUnit4.class)
 public class TestBigtableInstanceName {
@@ -97,10 +95,5 @@ public class TestBigtableInstanceName {
   public void testNoInstanceName() {
     expectedException.expect(IllegalArgumentException.class);
     new BigtableInstanceName("project", "");
-  }
-
-  @Test
-  public void testGcbInstanceName(){
-    Assert.assertTrue(bigtableInstanceName.toGcbInstanceName() instanceof InstanceName);
   }
 }

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/AbstractBigtableTable.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/AbstractBigtableTable.java
@@ -138,7 +138,7 @@ public abstract class AbstractBigtableTable implements Table {
     this.clientWrapper = session.getClientWrapper();
     this.hbaseAdapter = hbaseAdapter;
     this.tableName = hbaseAdapter.getTableName();
-    this.requestContext = options.getRequestContext();
+    this.requestContext = session.getDataRequestContext();
   }
 
   /** {@inheritDoc} */

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/AbstractBigtableTable.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/AbstractBigtableTable.java
@@ -139,8 +139,7 @@ public abstract class AbstractBigtableTable implements Table {
     this.clientWrapper = session.getClientWrapper();
     this.hbaseAdapter = hbaseAdapter;
     this.tableName = hbaseAdapter.getTableName();
-    this.requestContext = RequestContext
-        .create(options.getProjectId(), options.getInstanceId(), options.getAppProfileId());
+    this.requestContext = options.getRequestContext();
   }
 
   /** {@inheritDoc} */

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BatchExecutor.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BatchExecutor.java
@@ -173,7 +173,7 @@ public class BatchExecutor {
     this.asyncExecutor = session.createAsyncExecutor();
     this.options = session.getOptions();
     this.requestAdapter = requestAdapter;
-    this.requestContext = options.getRequestContext();
+    this.requestContext = session.getDataRequestContext();
   }
 
   /**

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BatchExecutor.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BatchExecutor.java
@@ -173,8 +173,7 @@ public class BatchExecutor {
     this.asyncExecutor = session.createAsyncExecutor();
     this.options = session.getOptions();
     this.requestAdapter = requestAdapter;
-    this.requestContext = RequestContext
-        .create(options.getProjectId(), options.getInstanceId(), options.getAppProfileId());
+    this.requestContext = options.getRequestContext();
   }
 
   /**

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutatorHelper.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutatorHelper.java
@@ -94,7 +94,7 @@ public class BigtableBufferedMutatorHelper {
     this.asyncExecutor = session.createAsyncExecutor();
     BigtableTableName tableName = this.adapter.getBigtableTableName();
     this.bulkMutation = session.createBulkMutation(tableName);
-    this.requestContext = options.getRequestContext();
+    this.requestContext = session.getDataRequestContext();
   }
 
   public void close() throws IOException {

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutatorHelper.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutatorHelper.java
@@ -94,8 +94,7 @@ public class BigtableBufferedMutatorHelper {
     this.asyncExecutor = session.createAsyncExecutor();
     BigtableTableName tableName = this.adapter.getBigtableTableName();
     this.bulkMutation = session.createBulkMutation(tableName);
-    this.requestContext = RequestContext
-        .create(options.getProjectId(), options.getInstanceId(), options.getAppProfileId());
+    this.requestContext = options.getRequestContext();
   }
 
   public void close() throws IOException {

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/HBaseRequestAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/HBaseRequestAdapter.java
@@ -100,10 +100,9 @@ public class HBaseRequestAdapter {
     this(tableName,
         options.getInstanceName().toTableName(tableName.getQualifierAsString()),
         mutationAdapters,
-        options.getRequestContext()
-    );
+        RequestContext
+            .create(options.getProjectId(), options.getInstanceId(), options.getAppProfileId()));
   }
-
 
   /**
    * <p>Constructor for HBaseRequestAdapter.</p>

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/HBaseRequestAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/HBaseRequestAdapter.java
@@ -100,8 +100,8 @@ public class HBaseRequestAdapter {
     this(tableName,
         options.getInstanceName().toTableName(tableName.getQualifierAsString()),
         mutationAdapters,
-        RequestContext
-            .create(options.getProjectId(), options.getInstanceId(), options.getAppProfileId()));
+        options.getRequestContext()
+    );
   }
 
 

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/PutAdapterPerf.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/PutAdapterPerf.java
@@ -47,7 +47,7 @@ public class PutAdapterPerf {
     HBaseRequestAdapter adapter =
         new HBaseRequestAdapter(options,
             TableName.valueOf("tableName"), new Configuration());
-    requestContext = RequestContext.create(options.getInstanceName().toGcbInstanceName(), "");
+    requestContext = options.getRequestContext();
     for (int i = 0; i < 10; i++) {
       putAdapterPerf(adapter, put);
     }

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/PutAdapterPerf.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/PutAdapterPerf.java
@@ -47,7 +47,8 @@ public class PutAdapterPerf {
     HBaseRequestAdapter adapter =
         new HBaseRequestAdapter(options,
             TableName.valueOf("tableName"), new Configuration());
-    requestContext = options.getRequestContext();
+    requestContext = RequestContext
+        .create(options.getProjectId(), options.getInstanceId(), options.getAppProfileId());
     for (int i = 0; i < 10; i++) {
       putAdapterPerf(adapter, put);
     }

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/PutMicroBenchmark.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/PutMicroBenchmark.java
@@ -67,7 +67,8 @@ public class PutMicroBenchmark {
     int putCount = useRealConnection ? REAL_CHANNEL_PUT_COUNT : FAKE_CHANNEL_PUT_COUNT;
     HBaseRequestAdapter hbaseAdapter =
         new HBaseRequestAdapter(options, TableName.valueOf(tableId), new Configuration(false));
-    requestContext = options.getRequestContext();
+    requestContext = RequestContext
+        .create(options.getProjectId(), options.getInstanceId(), options.getAppProfileId());
 
     testCreatePuts(10_000);
 

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/PutMicroBenchmark.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/PutMicroBenchmark.java
@@ -67,7 +67,7 @@ public class PutMicroBenchmark {
     int putCount = useRealConnection ? REAL_CHANNEL_PUT_COUNT : FAKE_CHANNEL_PUT_COUNT;
     HBaseRequestAdapter hbaseAdapter =
         new HBaseRequestAdapter(options, TableName.valueOf(tableId), new Configuration(false));
-    requestContext = RequestContext.create(options.getInstanceName().toGcbInstanceName(), "");
+    requestContext = options.getRequestContext();
 
     testCreatePuts(10_000);
 

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBatchExecutor.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBatchExecutor.java
@@ -28,6 +28,7 @@ import com.google.bigtable.v2.MutateRowsRequest;
 import com.google.bigtable.v2.ReadModifyWriteRowRequest;
 import com.google.bigtable.v2.ReadRowsRequest;
 import com.google.cloud.bigtable.config.BigtableOptions;
+import com.google.cloud.bigtable.data.v2.internal.RequestContext;
 import com.google.cloud.bigtable.grpc.BigtableSession;
 import com.google.cloud.bigtable.grpc.BigtableTableName;
 import com.google.cloud.bigtable.grpc.async.AsyncExecutor;
@@ -141,11 +142,14 @@ public class TestBatchExecutor {
         .build();
     requestAdapter =
         new HBaseRequestAdapter(options, TableName.valueOf("table"), new Configuration(false));
+    RequestContext requetsContext = RequestContext
+        .create(options.getProjectId(), options.getInstanceId(), options.getAppProfileId());
 
     MockitoAnnotations.initMocks(this);
     when(mockBulkMutation.add(any(MutateRowsRequest.Entry.class))).thenReturn(mockFuture);
     when(mockAsyncExecutor.readModifyWriteRowAsync(any(ReadModifyWriteRowRequest.class))).thenReturn(mockFuture);
     when(mockBigtableSession.createAsyncExecutor()).thenReturn(mockAsyncExecutor);
+    when(mockBigtableSession.getDataRequestContext()).thenReturn(requetsContext);
     when(mockBigtableSession.createBulkMutation(any(BigtableTableName.class))).thenReturn(mockBulkMutation);
     when(mockBigtableSession.createBulkRead(any(BigtableTableName.class))).thenReturn(mockBulkRead);
     doAnswer(new Answer<Void>() {

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableBufferedMutator.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableBufferedMutator.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import com.google.cloud.bigtable.data.v2.internal.RequestContext;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Append;
@@ -87,6 +88,8 @@ public class TestBigtableBufferedMutator {
     MockitoAnnotations.initMocks(this);
     when(mockSession.createAsyncExecutor()).thenReturn(mockAsyncExecutor);
     when(mockSession.createBulkMutation(any(BigtableTableName.class))).thenReturn(mockBulkMutation);
+    when(mockSession.getDataRequestContext())
+        .thenReturn(RequestContext.create("project", "instance", ""));
   }
 
   @After
@@ -145,6 +148,7 @@ public class TestBigtableBufferedMutator {
     verify(mockAsyncExecutor, times(1))
         .readModifyWriteRowAsync(any(ReadModifyWriteRowRequest.class));
   }
+
   @Test
   public void testInvalidPut() throws Exception {
     when(mockBulkMutation.add(any(MutateRowsRequest.Entry.class)))

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableTable.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableTable.java
@@ -29,7 +29,6 @@ import com.google.bigtable.v2.RowFilter.Chain;
 import com.google.cloud.bigtable.config.BigtableOptions;
 import com.google.cloud.bigtable.config.RetryOptions;
 import com.google.cloud.bigtable.data.v2.internal.RequestContext;
-import com.google.cloud.bigtable.data.v2.models.InstanceName;
 import com.google.cloud.bigtable.data.v2.models.RowMutation;
 import com.google.cloud.bigtable.grpc.BigtableDataClient;
 import com.google.cloud.bigtable.grpc.BigtableDataClientWrapper;
@@ -39,7 +38,6 @@ import com.google.cloud.bigtable.grpc.scanner.ResultScanner;
 import com.google.cloud.bigtable.hbase.adapters.HBaseRequestAdapter;
 import com.google.protobuf.ByteString;
 
-import java.util.concurrent.ExecutionException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.CellUtil;
 import org.apache.hadoop.hbase.TableName;
@@ -123,14 +121,12 @@ public class TestBigtableTable {
   }
 
   @Test
-  public void projectIsPopulatedInMutationRequests()
-      throws IOException, ExecutionException, InterruptedException {
+  public void projectIsPopulatedInMutationRequests() throws IOException {
     table.delete(new Delete(Bytes.toBytes("rowKey1")));
 
     ArgumentCaptor<RowMutation> argument = ArgumentCaptor.forClass(RowMutation.class);
     verify(mockBigtableDataClient).mutateRow(argument.capture());
-    RequestContext requestContext =
-        RequestContext.create(InstanceName.of(TEST_PROJECT, TEST_INSTANCE), "");
+    RequestContext requestContext = mockSession.getOptions().getRequestContext();
 
     Assert.assertEquals(
         "projects/testproject/instances/testinstance/tables/testtable",

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncTable.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncTable.java
@@ -99,8 +99,7 @@ public class BigtableAsyncTable implements AsyncTable<ScanResultConsumer> {
     this.hbaseAdapter = hbaseAdapter;
     this.tableName = hbaseAdapter.getTableName();
     // Once the IBigtableDataClient interface is implemented this will be removed
-    BigtableOptions options = asyncConnection.getOptions();
-    this.requestContext = options.getRequestContext();
+    this.requestContext = session.getDataRequestContext();
   }
 
   protected synchronized BatchExecutor getBatchExecutor() {

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncTable.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncTable.java
@@ -99,8 +99,7 @@ public class BigtableAsyncTable implements AsyncTable<ScanResultConsumer> {
     this.tableName = hbaseAdapter.getTableName();
     // Once the IBigtableDataClient interface is implemented this will be removed
     BigtableOptions options = asyncConnection.getOptions();
-    this.requestContext = RequestContext
-        .create(options.getProjectId(), options.getInstanceId(), options.getAppProfileId());
+    this.requestContext = options.getRequestContext();
   }
 
   protected synchronized BatchExecutor getBatchExecutor() {


### PR DESCRIPTION
Also, adding a `BigtableOptions.getRequestContext()` for convenience