### PR TITLE
Fix links to Guava API docs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -181,7 +181,7 @@ limitations under the License.
 
                         <offlineLinks>
                             <offlineLink>
-                                <url>https://google.github.io/guava/releases/20.0/api/docs/</url>
+                                <url>https://google.github.io/guava/releases/27.0-jre/api/docs/</url>
                                 <location>${basedir}/javadoc/guava-docs</location>
                             </offlineLink>
                             <offlineLink>


### PR DESCRIPTION
In #2060, I pointed to an old version of Guava that doesn't include classes that we expose. As a result, our Javadoc output contained broken links.

Guava v27.0-jre contains these classes, so pointing to that version prevents broken links.