### PR TITLE
 Removed RequestContext  references from HBaseRequestAdapter

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutatorHelper.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutatorHelper.java
@@ -15,7 +15,9 @@
  */
 package com.google.cloud.bigtable.hbase;
 
+import com.google.bigtable.v2.MutateRowsRequest;
 import com.google.cloud.bigtable.data.v2.internal.RequestContext;
+import com.google.cloud.bigtable.data.v2.models.RowMutation;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -189,7 +191,7 @@ public class BigtableBufferedMutatorHelper {
         return Futures.immediateFailedFuture(
             new IllegalArgumentException("Cannot perform a mutation on a null object."));
       } else {
-        return bulkMutation.add(adapter.adaptEntry(mutation));
+        return bulkMutation.add(toEntry(adapter.adaptEntry(mutation)));
       }
     } finally {
       closedReadLock.unlock();
@@ -208,9 +210,9 @@ public class BigtableBufferedMutatorHelper {
         future = Futures.immediateFailedFuture(
           new IllegalArgumentException("Cannot perform a mutation on a null object."));
       } else if (mutation instanceof Put) {
-        future = bulkMutation.add(adapter.adaptEntry((Put) mutation));
+        future = bulkMutation.add(toEntry(adapter.adaptEntry((Put) mutation)));
       } else if (mutation instanceof Delete) {
-        future = bulkMutation.add(adapter.adaptEntry((Delete) mutation));
+        future = bulkMutation.add(toEntry(adapter.adaptEntry((Delete) mutation)));
       } else if (mutation instanceof Increment) {
         future =
             asyncExecutor.readModifyWriteRowAsync(
@@ -230,6 +232,9 @@ public class BigtableBufferedMutatorHelper {
     return future;
   }
 
+  private MutateRowsRequest.Entry toEntry(RowMutation rowMutation) {
+    return rowMutation.toBulkProto(requestContext).getEntries(0);
+  }
 
   /**
    * <p>hasInflightRequests.</p>

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/HBaseRequestAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/HBaseRequestAdapter.java
@@ -16,7 +16,6 @@
 package com.google.cloud.bigtable.hbase.adapters;
 
 import com.google.api.core.InternalApi;
-import com.google.cloud.bigtable.data.v2.internal.RequestContext;
 import com.google.cloud.bigtable.data.v2.models.Mutation;
 import com.google.cloud.bigtable.data.v2.models.MutationApi;
 import com.google.cloud.bigtable.data.v2.models.Query;
@@ -34,8 +33,6 @@ import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.RowMutations;
 import org.apache.hadoop.hbase.client.Scan;
 
-import com.google.bigtable.v2.MutateRowRequest;
-import com.google.bigtable.v2.MutateRowsRequest;
 import com.google.cloud.bigtable.config.BigtableOptions;
 import com.google.cloud.bigtable.grpc.BigtableTableName;
 import com.google.cloud.bigtable.hbase.adapters.read.DefaultReadHooks;

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/HBaseRequestAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/HBaseRequestAdapter.java
@@ -74,7 +74,6 @@ public class HBaseRequestAdapter {
   protected final MutationAdapters mutationAdapters;
   protected final TableName tableName;
   protected final BigtableTableName bigtableTableName;
-  protected final RequestContext requestContext;
 
   /**
    * <p>Constructor for HBaseRequestAdapter.</p>
@@ -99,9 +98,7 @@ public class HBaseRequestAdapter {
                              MutationAdapters mutationAdapters) {
     this(tableName,
         options.getInstanceName().toTableName(tableName.getQualifierAsString()),
-        mutationAdapters,
-        RequestContext
-            .create(options.getProjectId(), options.getInstanceId(), options.getAppProfileId()));
+        mutationAdapters);
   }
 
   /**
@@ -114,16 +111,14 @@ public class HBaseRequestAdapter {
   @VisibleForTesting
   HBaseRequestAdapter(TableName tableName,
                               BigtableTableName bigtableTableName,
-                              MutationAdapters mutationAdapters,
-                              RequestContext requestContext) {
+                              MutationAdapters mutationAdapters) {
     this.tableName = tableName;
     this.bigtableTableName = bigtableTableName;
     this.mutationAdapters = mutationAdapters;
-    this.requestContext = requestContext;
   }
 
   public HBaseRequestAdapter withServerSideTimestamps(){
-    return new HBaseRequestAdapter(tableName, bigtableTableName, mutationAdapters.withServerSideTimestamps(), requestContext);
+    return new HBaseRequestAdapter(tableName, bigtableTableName, mutationAdapters.withServerSideTimestamps());
   }
 
   /**
@@ -155,10 +150,10 @@ public class HBaseRequestAdapter {
    * @param delete a {@link org.apache.hadoop.hbase.client.Delete} object.
    * @return a {@link com.google.bigtable.v2.MutateRowsRequest.Entry} object.
    */
-  public MutateRowsRequest.Entry adaptEntry(Delete delete) {
+  public RowMutation adaptEntry(Delete delete) {
     RowMutation rowMutation = newRowMutationModel(delete.getRow());
     adapt(delete, rowMutation);
-    return toEntry(rowMutation);
+    return rowMutation;
   }
 
   /**
@@ -243,10 +238,10 @@ public class HBaseRequestAdapter {
    * @param put a {@link org.apache.hadoop.hbase.client.Put} object.
    * @return a {@link com.google.bigtable.v2.MutateRowsRequest.Entry} object.
    */
-  public MutateRowsRequest.Entry adaptEntry(Put put) {
+  public RowMutation adaptEntry(Put put) {
     RowMutation rowMutation = newRowMutationModel(put.getRow());
     adapt(put, rowMutation);
-    return toEntry(rowMutation);
+    return rowMutation;
   }
 
   /**
@@ -278,10 +273,10 @@ public class HBaseRequestAdapter {
    * @param mutations a {@link org.apache.hadoop.hbase.client.RowMutations} object.
    * @return a {@link com.google.bigtable.v2.MutateRowsRequest.Entry} object.
    */
-  public MutateRowsRequest.Entry adaptEntry(RowMutations mutations) {
+  public RowMutation adaptEntry(RowMutations mutations) {
     RowMutation rowMutation = newRowMutationModel(mutations.getRow());
     adapt(mutations, rowMutation);
-    return toEntry(rowMutation);
+    return rowMutation;
   }
 
   /**
@@ -290,10 +285,10 @@ public class HBaseRequestAdapter {
    * @param mutation a {@link org.apache.hadoop.hbase.client.Mutation} object.
    * @return a {@link com.google.bigtable.v2.MutateRowRequest} object.
    */
-  public MutateRowRequest adapt(org.apache.hadoop.hbase.client.Mutation mutation) {
+  public RowMutation adapt(org.apache.hadoop.hbase.client.Mutation mutation) {
     RowMutation rowMutation = newRowMutationModel(mutation.getRow());
     adapt(mutation, rowMutation);
-    return rowMutation.toProto(requestContext);
+    return rowMutation;
   }
 
   /**
@@ -332,10 +327,6 @@ public class HBaseRequestAdapter {
    */
   protected String getTableNameString() {
     return getBigtableTableName().toString();
-  }
-
-  private MutateRowsRequest.Entry toEntry(RowMutation rowMutation) {
-    return rowMutation.toBulkProto(requestContext).getEntries(0);
   }
 
   private RowMutation newRowMutationModel(byte [] rowKey) {

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/TestCheckAndMutateUtil.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/TestCheckAndMutateUtil.java
@@ -75,11 +75,7 @@ public class TestCheckAndMutateUtil {
     requestAdapter = new HBaseRequestAdapter(
         TABLE_NAME,
         BT_TABLE_NAME,
-        mutationAdapters,
-        RequestContext.create(
-            InstanceName.of(BT_TABLE_NAME.getProjectId(), BT_TABLE_NAME.getInstanceId()),
-            "APP_PROFILE_ID"
-        ));
+        mutationAdapters);
   }
 
   private static void checkPredicate(CheckAndMutateRowRequest result) {


### PR DESCRIPTION
Removed reference of `RequestContext` from `HBaseRequestAdapter` and moved protobuf conversion to `BigtableBufferedMutatorHelper`.