### PR TITLE
Scan.next() should return null after stream close

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ResumingStreamingResultScanner.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ResumingStreamingResultScanner.java
@@ -72,7 +72,9 @@ public class ResumingStreamingResultScanner implements ResultScanner<FlatRow> {
   /** {@inheritDoc} */
   @Override
   public FlatRow next() throws IOException {
-    Preconditions.checkState(!isConsumed, "Scanner is already closed");
+    if (isConsumed) {
+      return null;
+    }
 
     try(Timer.Context ignored = resultsTimer.time()) {
       FlatRow result = responseQueueReader.getNextMergedRow();

--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/TestScan.java
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/TestScan.java
@@ -68,6 +68,32 @@ public class TestScan extends AbstractTest {
   }
 
   @Test
+  public void testNextAfterClose() throws IOException {
+    Table table = getDefaultTable();
+    byte[] rowKey = dataHelper.randomData("testrow-");
+    byte[] qual = dataHelper.randomData("qual-");
+    byte[] value = dataHelper.randomData("value-");
+
+    table.put(new Put(rowKey).addColumn(COLUMN_FAMILY, qual, value));
+
+    Scan scan = new Scan().withStartRow(rowKey).withStopRow(rowKey, true);
+    ResultScanner resultScanner = table.getScanner(scan);
+
+    Assert.assertNotNull(resultScanner.next());
+
+    // The scanner should close here.
+    Assert.assertNull(resultScanner.next());
+
+    // This shouldn't throw an exception
+    Assert.assertNull(resultScanner.next());
+
+    resultScanner.close();
+
+    // This shouldn't throw an exception
+    Assert.assertNull(resultScanner.next());
+  }
+
+    @Test
   public void testGetScannerBeforeTimestamp() throws IOException {
     Table table = getDefaultTable();
     byte[] rowKey = dataHelper.randomData("testrow-");
@@ -77,8 +103,9 @@ public class TestScan extends AbstractTest {
     long ts1 = 100000l;
     long ts2 = 200000l;
 
-    table.put(new Put(rowKey).addColumn(COLUMN_FAMILY, qual, ts1, values[0]));
-    table.put(new Put(rowKey).addColumn(COLUMN_FAMILY, qual, ts2, values[1]));
+    table.put(new Put(rowKey)
+        .addColumn(COLUMN_FAMILY, qual, ts1, values[0])
+        .addColumn(COLUMN_FAMILY, qual, ts2, values[1]));
 
     Scan scan1 = new Scan()
             .withStartRow(rowKey)


### PR DESCRIPTION
`Scan.next()` returns null after the stream closes.  The next one (before this PR) throws an `Exception`.  Users should be able to call `Scan.next()` after the stream closes and still get null.