### PR TITLE
Upgrading to google-cloud-clients 0.80.0-alpha

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@ limitations under the License.
         <hamcrest.version>1.3</hamcrest.version>
 
         <!-- google-cloud-java related dependency versions -->
-        <google-cloud.version>0.78.0-alpha</google-cloud.version>
+        <google-cloud.version>0.80.0-alpha</google-cloud.version>
         <opencensus.version>0.17.0</opencensus.version>
         <guava.version>26.0-android</guava.version>
         <checkerframework.version>2.5.2</checkerframework.version>


### PR DESCRIPTION
This doesn't change other critical dependencies, but does bring in a useful tool for the conversion to using google-cloud-bigtable models.