### PR TITLE
Deprecating BigtableSession#getTableAdminClient

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
@@ -356,9 +356,12 @@ public class BigtableSession implements Closeable {
   /**
    * <p>Getter for the field <code>tableAdminClient</code>.</p>
    *
+   * @deprecated Please use {@link #getTableAdminClientWrapper()}.
+   *
    * @return a {@link com.google.cloud.bigtable.grpc.BigtableTableAdminClient} object.
    * @throws java.io.IOException if any.
    */
+  @Deprecated
   public synchronized BigtableTableAdminClient getTableAdminClient() throws IOException {
     if (tableAdminClient == null) {
       ManagedChannel channel = createManagedPool(options.getAdminHost(), 1);

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableConnection.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableConnection.java
@@ -19,7 +19,6 @@ package org.apache.hadoop.hbase.client;
 import com.google.cloud.bigtable.config.BigtableOptions;
 import com.google.cloud.bigtable.config.Logger;
 import com.google.cloud.bigtable.grpc.BigtableSession;
-import com.google.cloud.bigtable.grpc.BigtableTableAdminClient;
 import com.google.cloud.bigtable.hbase.BigtableBufferedMutator;
 import com.google.cloud.bigtable.hbase.BigtableOptionsFactory;
 import com.google.cloud.bigtable.hbase.BigtableRegionLocator;
@@ -332,17 +331,6 @@ public abstract class AbstractBigtableConnection implements Connection, CommonCo
   /** {@inheritDoc} */
   @Override
   public abstract Admin getAdmin() throws IOException;
-
-  /* Methods needed to construct a Bigtable Admin implementation: */
-  /**
-   * <p>getBigtableTableAdminClient.</p>
-   *
-   * @return a {@link com.google.cloud.bigtable.grpc.BigtableTableAdminClient} object.
-   * @throws java.io.IOException if any.
-   */
-  protected BigtableTableAdminClient getBigtableTableAdminClient() throws IOException {
-    return session.getTableAdminClient();
-  }
 
   /**
    * <p>Getter for the field <code>options</code>.</p>


### PR DESCRIPTION
- Marked BigtableSession#getTableAdminClient deprecated, It will be removed once GCJ's adapter are ready to be used.
- Removed reference of BigtableTableAdminClient.

Potentially fixes #1974 