### PR TITLE
Futures related touch ups

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/util/ApiFutureUtil.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/util/ApiFutureUtil.java
@@ -19,11 +19,9 @@ import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutureToListenableFuture;
 import com.google.api.core.ListenableFutureToApiFuture;
 import com.google.common.base.Function;
-import com.google.common.collect.Iterables;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
-import java.util.List;
 
 public final class ApiFutureUtil {
 
@@ -38,27 +36,5 @@ public final class ApiFutureUtil {
   public static <F, T> ApiFuture<T> transformAndAdapt(ListenableFuture<F> listenableFuture,
       Function<F, T> transform) {
     return adapt(Futures.transform(listenableFuture, transform, MoreExecutors.directExecutor()));
-  }
-
-  /**
-   * Creates a new {@code ApiFuture} whose value is a list containing the values of all its
-   * successful input futures.
-   *
-   * <p>Similar to {@link Futures#successfulAsList(Iterable)}.</p>
-   *
-   * @param futures a {@link List} containing {@link ApiFuture} tasks.
-   * @return a future that provides a list of the results of the component futures
-   */
-  public static <V> ApiFuture<List<V>> successfulAsList(
-      Iterable<? extends ApiFuture<? extends V>> futures) {
-    return new ListenableFutureToApiFuture<>(
-        Futures.successfulAsList(
-            Iterables.transform(
-                futures,
-                new Function<ApiFuture<? extends V>, ListenableFuture<? extends V>>() {
-                  public ListenableFuture<? extends V> apply(ApiFuture<? extends V> apiFuture) {
-                    return new ApiFutureToListenableFuture<>(apiFuture);
-                  }
-                })));
   }
 }

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestBigtableDataClientWrapper.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestBigtableDataClientWrapper.java
@@ -21,7 +21,6 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.google.api.core.ApiFuture;
 import com.google.bigtable.v2.Cell;
 import com.google.bigtable.v2.CheckAndMutateRowRequest;
 import com.google.bigtable.v2.CheckAndMutateRowResponse;
@@ -53,6 +52,8 @@ import com.google.protobuf.ByteString;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.Future;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -155,7 +156,7 @@ public class TestBigtableDataClientWrapper {
     ListenableFuture<CheckAndMutateRowResponse> future = Futures.immediateFuture(response);
 
     when(client.checkAndMutateRowAsync(request)).thenReturn(future);
-    ApiFuture<Boolean> actual = clientWrapper.checkAndMutateRowAsync(conditonalMutation);
+    Future<Boolean> actual = clientWrapper.checkAndMutateRowAsync(conditonalMutation);
     verify(client).checkAndMutateRowAsync(request);
     assertTrue(actual.get());
   }
@@ -172,7 +173,7 @@ public class TestBigtableDataClientWrapper {
     ListenableFuture<CheckAndMutateRowResponse> future = Futures.immediateFuture(response);
 
     when(client.checkAndMutateRowAsync(request)).thenReturn(future);
-    ApiFuture<Boolean> actual = clientWrapper.checkAndMutateRowAsync(conditonalMutation);
+    Future<Boolean> actual = clientWrapper.checkAndMutateRowAsync(conditonalMutation);
     verify(client).checkAndMutateRowAsync(request);
     assertFalse(actual.get());
   }
@@ -209,7 +210,7 @@ public class TestBigtableDataClientWrapper {
         com.google.cloud.bigtable.data.v2.models.Row.create(ROW_KEY, Collections.singletonList(rowCell));
 
     when(client.readModifyWriteRowAsync(request)).thenReturn(listenableResponse);
-    ApiFuture<com.google.cloud.bigtable.data.v2.models.Row> output =
+    Future<com.google.cloud.bigtable.data.v2.models.Row> output =
         clientWrapper.readModifyWriteRowAsync(readModify);
     assertEquals(modelRow, output.get());
     verify(client).readModifyWriteRowAsync(request);

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestBulkMutation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestBulkMutation.java
@@ -29,13 +29,10 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
-import com.google.bigtable.v2.ReadModifyWriteRowRequest;
-import com.google.bigtable.v2.ReadModifyWriteRowResponse;
-import com.google.bigtable.v2.ReadRowsResponse;
+import com.google.api.core.SettableApiFuture;
 import com.google.cloud.bigtable.core.IBigtableDataClient;
 import com.google.cloud.bigtable.data.v2.models.ReadModifyWriteRow;
 import com.google.cloud.bigtable.data.v2.models.Row;
-import com.google.cloud.bigtable.util.ApiFutureUtil;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -379,9 +376,8 @@ public class TestBulkMutation {
 
   @Test
   public void testReadWriteModify()  {
-    SettableFuture<Row> future = SettableFuture.create();
-    when(clientWrapper.readModifyWriteRowAsync(any(ReadModifyWriteRow.class))).thenReturn(
-        ApiFutureUtil.adapt(future));
+    SettableApiFuture<Row> future = SettableApiFuture.create();
+    when(clientWrapper.readModifyWriteRowAsync(any(ReadModifyWriteRow.class))).thenReturn(future);
     underTest.readModifyWrite(ReadModifyWriteRow.create("table", "key"));
     Assert.assertTrue(operationAccountant.hasInflightOperations());
     future.set(null);


### PR DESCRIPTION
- Removing `ApiFutureUtil.successfulAsList(resultFutures).get()` from `BatchExecutor`.  It is superflous.
- Replacing `ApiFuture` with `Future` in tests where possible.