### PR TITLE
Fix a couple of Throttler issues

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/ThrottlingClientInterceptor.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/ThrottlingClientInterceptor.java
@@ -22,18 +22,18 @@ import io.grpc.CallOptions;
 import io.grpc.Channel;
 import io.grpc.ClientCall;
 import io.grpc.ClientInterceptor;
-import io.grpc.ForwardingClientCall;
 import io.grpc.ForwardingClientCallListener.SimpleForwardingClientCallListener;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
+import java.util.concurrent.CancellationException;
+import javax.annotation.Nullable;
 
 /**
  * Throttles requests based on {@link ResourceLimiter}
  *
  */
 public class ThrottlingClientInterceptor implements ClientInterceptor {
-
   private final ResourceLimiter resourceLimiter;
 
   public ThrottlingClientInterceptor(ResourceLimiter resourceLimiter) {
@@ -48,7 +48,9 @@ public class ThrottlingClientInterceptor implements ClientInterceptor {
       return delegateChannel.newCall(method, callOptions);
     }
 
-    return new ForwardingClientCall<ReqT, RespT>() {
+    return new ClientCall<ReqT, RespT>() {
+      private boolean cancelledEarly;
+
       private ClientCall.Listener<RespT> delegateListener = null;
       private ClientCall<ReqT, RespT> delegateCall;
       private Metadata headers;
@@ -57,18 +59,48 @@ public class ThrottlingClientInterceptor implements ClientInterceptor {
 
       @Override
       public void start(ClientCall.Listener<RespT> listener, Metadata headers) {
-        this.delegateListener = listener;
-        this.headers = headers;
+        Preconditions.checkState(!cancelledEarly, "Call already cancelled");
+        Preconditions.checkState(
+            this.delegateListener == null && this.headers == null, "Call already started");
+
+        this.delegateListener = Preconditions.checkNotNull(listener);
+        this.headers = Preconditions.checkNotNull(headers);
       }
 
       @Override
       public void request(int numMessages) {
-        if (id == null) {
-          // request() might be called multiple times before sendMessage(), so add up all of the
-          // requested sendMessages.
-          numMessagesRequested += numMessages;
-        } else {
-          delegate().request(numMessages);
+        if (delegateCall != null) {
+          delegateCall.request(numMessages);
+          return;
+        }
+
+        Preconditions.checkState(!cancelledEarly, "Call already cancelled");
+
+        // request() might be called multiple times before sendMessage(), so add up all of the
+        // requested sendMessages.
+        numMessagesRequested += numMessages;
+      }
+
+      @Override
+      public void cancel(@Nullable String message, @Nullable Throwable cause) {
+        if (delegateCall != null) {
+          delegateCall.cancel(message, cause);
+          return;
+        }
+
+        cancelledEarly = true;
+
+        if (message == null && cause == null) {
+          cause = new CancellationException("Cancelled without a message or cause");
+        }
+
+        if (delegateListener != null) {
+          delegateListener.onClose(
+              Status.CANCELLED
+                .withDescription(message)
+                .withCause(cause),
+              new Metadata()
+          );
         }
       }
 
@@ -76,11 +108,10 @@ public class ThrottlingClientInterceptor implements ClientInterceptor {
       public void sendMessage(ReqT message) {
         Preconditions.checkState(delegateCall == null,
           "ThrottlingClientInterceptor only supports unary operations");
-        Preconditions.checkState(id == null,
-          "ThrottlingClientInterceptor only supports unary operations");
-        Preconditions.checkState(delegateListener != null,
+        Preconditions.checkState(delegateListener != null && headers != null,
           "start() has to be called before sendMessage().");
-        Preconditions.checkState(headers != null, "start() has to be called before sendMessage().");
+        Preconditions.checkState(!cancelledEarly, "Call already cancelled");
+
         try {
           id = resourceLimiter
               .registerOperationWithHeapSize(((MessageLite) message).getSerializedSize());
@@ -98,14 +129,14 @@ public class ThrottlingClientInterceptor implements ClientInterceptor {
                 delegate().onClose(status, trailers);
               }
             };
-        delegate().start(markCompletionListener, headers);
-        delegate().request(numMessagesRequested);
-        delegate().sendMessage(message);
+        delegateCall.start(markCompletionListener, headers);
+        delegateCall.request(numMessagesRequested);
+        delegateCall.sendMessage(message);
       }
 
       @Override
-      protected ClientCall<ReqT, RespT> delegate() {
-        return delegateCall;
+      public void halfClose() {
+        // Noop
       }
     };
   }

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/ThrottlingClientInterceptor.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/ThrottlingClientInterceptor.java
@@ -132,6 +132,7 @@ public class ThrottlingClientInterceptor implements ClientInterceptor {
         delegateCall.start(markCompletionListener, headers);
         delegateCall.request(numMessagesRequested);
         delegateCall.sendMessage(message);
+        delegateCall.halfClose();
       }
 
       @Override

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestThrottlingClientInterceptor.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestThrottlingClientInterceptor.java
@@ -134,6 +134,25 @@ public class TestThrottlingClientInterceptor {
     Assert.assertEquals(statusCaptor.getValue().getCode(), Code.INTERNAL);
   }
 
+
+  @Test
+  public void testCallProxy() {
+    final ThrottlingClientInterceptor underTest = new ThrottlingClientInterceptor(mockResourceLimiter);
+
+    ClientCall call = underTest
+        .interceptCall(methodDescriptor, CallOptions.DEFAULT, mockChannel);
+
+    call.start(mockListener, new Metadata());
+    call.sendMessage(request);
+    call.halfClose();
+    call.request(1);
+
+    verify(mockClientCall).start(any(ClientCall.Listener.class), any(Metadata.class));
+    verify(mockClientCall).sendMessage(request);
+    verify(mockClientCall).halfClose();
+    verify(mockClientCall).request(1);
+  }
+
   @Test
   public void testCancel() throws Exception {
     final ThrottlingClientInterceptor underTest = new ThrottlingClientInterceptor(mockResourceLimiter);
@@ -166,4 +185,5 @@ public class TestThrottlingClientInterceptor {
         .onClose(statusCaptor.capture(), any(Metadata.class));
     Assert.assertEquals(statusCaptor.getValue().getCode(), Code.CANCELLED);
   }
+
 }


### PR DESCRIPTION
The common path to invoking the ThrottlingClientInterceptor:
call = channel.newCall(...)
call.sendMessage(request)
call.halfClose()

However if the resource limiter is interrupted while the interceptor is
waiting to send a message, the delegate call will not be set, causing an
NPE.

To fix this issue, the ForwardedClientCall was remove and all forwarded
calls check for null delegates. The impl for halfClose is skipped
entirely because only UnaryCalls are supported.

The other issue addressed here is an unhandled cancellation of the call
before sending a message.