### PR TITLE
chore: fix tag to 1.25.2-sp.1, remove distributionManagement section

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,17 +87,6 @@ limitations under the License.
     <jmh.version>1.23</jmh.version>
   </properties>
 
-  <distributionManagement>
-    <snapshotRepository>
-      <id>sonatype-nexus-snapshots</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-    </snapshotRepository>
-    <repository>
-      <id>sonatype-nexus-staging</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-    </repository>
-  </distributionManagement>
-
   <scm>
     <connection>
       scm:git:git@github.com:googleapis/java-bigtable-hbase.git


### PR DESCRIPTION
Release-As: v1.25.2-sp.1

also cleanup distributionManagement section, which is defined in the shared config