### PR TITLE
chore: update java-shared-config to 1.16.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@ limitations under the License.
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-shared-config</artifactId>
-    <version>1.15.4</version>
+    <version>1.16.1</version>
   </parent>
 
   <licenses>


### PR DESCRIPTION
The latest java-shared-config has the profile to disable nexus-staging-maven-plugin. This is part of the mirgation to Central Portal.

Verified with `mvn clean deploy -V     -DaltDeploymentRepository=local::default::file:${local_staging_dir}     -DskipTests=true     -P=-release-sonatype     -P=-release-staging-repository     -P=-clirr-compatibility-check     -P=-checkstyle-tests     -P=-animal-sniffer  -Dclirr.skip=true`
```
[INFO] --- maven-deploy-plugin:3.1.4:deploy (default-deploy) @ bigtable-hbase-mirroring-client-2.x-hadoop ---
[INFO] Using alternate deployment repository local::default::file:/tmp/maven-staging-dir.gKgMXi
[WARNING] Using legacy syntax for alternative repository. Use "local::file:/tmp/maven-staging-dir.gKgMXi" instead.
Downloading from local: file:/tmp/maven-staging-dir.gKgMXi/com/google/cloud/bigtable/bigtable-hbase-mirroring-client-2.x-hadoop/0.10.3-SNAPSHOT/maven-metadata.xml
Uploading to local: file:/tmp/maven-staging-dir.gKgMXi/com/google/cloud/bigtable/bigtable-hbase-mirroring-client-2.x-hadoop/0.10.3-SNAPSHOT/bigtable-hbase-mirroring-client-2.x-hadoop-0.10.3-20250619.191451-1.pom
Uploaded to local: file:/tmp/maven-staging-dir.gKgMXi/com/google/cloud/bigtable/bigtable-hbase-mirroring-client-2.x-hadoop/0.10.3-SNAPSHOT/bigtable-hbase-mirroring-client-2.x-hadoop-0.10.3-20250619.191451-1.pom (5.6 kB at 5.6 MB/s)
Uploading to local: file:/tmp/maven-staging-dir.gKgMXi/com/google/cloud/bigtable/bigtable-hbase-mirroring-client-2.x-hadoop/0.10.3-SNAPSHOT/bigtable-hbase-mirroring-client-2.x-hadoop-0.10.3-20250619.191451-1.jar
Uploaded to local: file:/tmp/maven-staging-dir.gKgMXi/com/google/cloud/bigtable/bigtable-hbase-mirroring-client-2.x-hadoop/0.10.3-SNAPSHOT/bigtable-hbase-mirroring-client-2.x-hadoop-0.10.3-20250619.191451-1.jar (6.7 MB at 280 MB/s)
Uploading to local: file:/tmp/maven-staging-dir.gKgMXi/com/google/cloud/bigtable/bigtable-hbase-mirroring-client-2.x-hadoop/0.10.3-SNAPSHOT/bigtable-hbase-mirroring-client-2.x-hadoop-0.10.3-20250619.191451-1-tests.jar
Uploaded to local: file:/tmp/maven-staging-dir.gKgMXi/com/google/cloud/bigtable/bigtable-hbase-mirroring-client-2.x-hadoop/0.10.3-SNAPSHOT/bigtable-hbase-mirroring-client-2.x-hadoop-0.10.3-20250619.191451-1-tests.jar (4.0 kB at 4.0 MB/s)
Downloading from local: file:/tmp/maven-staging-dir.gKgMXi/com/google/cloud/bigtable/bigtable-hbase-mirroring-client-2.x-hadoop/maven-metadata.xml
Uploading to local: file:/tmp/maven-staging-dir.gKgMXi/com/google/cloud/bigtable/bigtable-hbase-mirroring-client-2.x-hadoop/0.10.3-SNAPSHOT/maven-metadata.xml
Uploaded to local: file:/tmp/maven-staging-dir.gKgMXi/com/google/cloud/bigtable/bigtable-hbase-mirroring-client-2.x-hadoop/0.10.3-SNAPSHOT/maven-metadata.xml (1.0 kB)
Uploading to local: file:/tmp/maven-staging-dir.gKgMXi/com/google/cloud/bigtable/bigtable-hbase-mirroring-client-2.x-hadoop/maven-metadata.xml
Uploaded to local: file:/tmp/maven-staging-dir.gKgMXi/com/google/cloud/bigtable/bigtable-hbase-mirroring-client-2.x-hadoop/maven-metadata.xml (328 B at 328 kB/s)
```
