### PR TITLE
chore: fix bigtable-build-helper plugin

### DIFF
--- a/bigtable-dataflow-parent/bigtable-hbase-beam/pom.xml
+++ b/bigtable-dataflow-parent/bigtable-hbase-beam/pom.xml
@@ -159,7 +159,7 @@ limitations under the License.
                   <!-- to enable netty logging, include:
                   -Djava.util.logging.config.file=src/test/resources/logging.properties
                   -->
-                  <forkCount>1</forkCount>
+<!--                  <forkCount>1</forkCount>-->
                   <includes>
                     <include>**/CloudBigtableIOIntegrationTest.java</include>
                   </includes>

--- a/bigtable-test/bigtable-build-helper/pom.xml
+++ b/bigtable-test/bigtable-build-helper/pom.xml
@@ -75,6 +75,9 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-plugin-plugin</artifactId>
           <version>3.10.2</version>
+          <configuration>
+            <goalPrefix>bigtable-build-helper</goalPrefix>
+          </configuration>
         </plugin>
 
         <!-- Start Skip publishing -->


### PR DESCRIPTION
Builds are failing with 
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-plugin-plugin:3.15.2:descriptor (default-descriptor) on project bigtable-build-helper: You need to specify a goalPrefix as it can not be correctly computed -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.apache.maven.plugins:maven-plugin-plugin:3.15.2:descriptor (default-descriptor) on project bigtable-build-helper: You need to specify a goalPrefix as it can not be correctly computed
```
