### PR TITLE
deps: upgrade java-bigtable to 2.76.0 to to enable DirectAccess by default

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/veneer/SharedDataClientWrapperFactoryTest.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/veneer/SharedDataClientWrapperFactoryTest.java
@@ -15,6 +15,8 @@
  */
 package com.google.cloud.bigtable.hbase.wrappers.veneer;
 
+import static com.google.common.truth.Truth.assertThat;
+
 import com.google.bigtable.v2.BigtableGrpc;
 import com.google.bigtable.v2.MutateRowRequest;
 import com.google.bigtable.v2.MutateRowResponse;
@@ -40,7 +42,6 @@ import java.util.List;
 import java.util.Set;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -78,6 +79,7 @@ public class SharedDataClientWrapperFactoryTest {
   @Test
   public void testChannelsAreShared() throws Exception {
     int channelCount = 2;
+    int clientCount = 10;
     Configuration configuration = new Configuration(false);
     configuration.set(BigtableOptionsFactory.PROJECT_ID_KEY, "my-project");
     configuration.set(BigtableOptionsFactory.INSTANCE_ID_KEY, "my-instance");
@@ -98,12 +100,10 @@ public class SharedDataClientWrapperFactoryTest {
     SharedDataClientWrapperFactory factory = new SharedDataClientWrapperFactory();
     List<DataClientWrapper> clients = new ArrayList<>();
 
-    for (int i = 0; i < channelCount * 5; i++) {
-      for (int j = 0; j < channelCount * 5; j++) {
-        DataClientWrapper dataClient = factory.createDataClient(settings);
-        clients.add(dataClient);
-        dataClient.mutateRowAsync(RowMutation.create("fake-table", "fake-key").deleteRow()).get();
-      }
+    for (int i = 0; i < clientCount; i++) {
+      DataClientWrapper dataClient = factory.createDataClient(settings);
+      clients.add(dataClient);
+      dataClient.mutateRowAsync(RowMutation.create("fake-table", "fake-key").deleteRow()).get();
     }
 
     // cleanup
@@ -113,7 +113,7 @@ public class SharedDataClientWrapperFactoryTest {
 
     // Despite having multiple client instances, there should only be `channelCount` remoteCallers
     Set<SocketAddress> uniqueRemoteCallers = new HashSet<>(remoteCallers);
-    Assert.assertEquals(channelCount, uniqueRemoteCallers.size());
+    assertThat(uniqueRemoteCallers.size()).isLessThan(clientCount * channelCount);
   }
 
   /**

--- a/pom.xml
+++ b/pom.xml
@@ -55,8 +55,8 @@ limitations under the License.
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!-- core dependency versions -->
-    <bigtable.version>2.75.1</bigtable.version>
-    <google-cloud-bigtable-emulator.version>0.212.1</google-cloud-bigtable-emulator.version>
+    <bigtable.version>2.76.0</bigtable.version>
+    <google-cloud-bigtable-emulator.version>0.213.0</google-cloud-bigtable-emulator.version>
     <bigtable-metrics-api.version>1.29.2</bigtable-metrics-api.version>
     <!-- Optional dep for bigtable-metrics-api used for tests -->
     <dropwizard-metrics.version>4.2.22</dropwizard-metrics.version>


### PR DESCRIPTION


Change-Id: I4e5d86e313de2a08aa8e6355c2f6c3c35f171c96

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-bigtable-hbase/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> ☕️

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
