### PR TITLE
deps: upgrade to to java-bigtable 2.77 for session support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,8 +55,8 @@ limitations under the License.
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!-- core dependency versions -->
-    <bigtable.version>2.76.0</bigtable.version>
-    <google-cloud-bigtable-emulator.version>0.213.0</google-cloud-bigtable-emulator.version>
+    <bigtable.version>2.77.0</bigtable.version>
+    <google-cloud-bigtable-emulator.version>0.214.0</google-cloud-bigtable-emulator.version>
     <bigtable-metrics-api.version>1.29.2</bigtable-metrics-api.version>
     <!-- Optional dep for bigtable-metrics-api used for tests -->
     <dropwizard-metrics.version>4.2.22</dropwizard-metrics.version>


### PR DESCRIPTION
Release-As: 2.18.0

