### PR TITLE
fix: do not split near empty ranges

### DIFF
--- a/bigtable-dataflow-parent/bigtable-hbase-beam/src/main/java/com/google/cloud/bigtable/beam/CloudBigtableIO.java
+++ b/bigtable-dataflow-parent/bigtable-hbase-beam/src/main/java/com/google/cloud/bigtable/beam/CloudBigtableIO.java
@@ -836,7 +836,7 @@ public class CloudBigtableIO {
       ByteKey splitKey;
       try {
         splitKey = rangeTracker.getRange().interpolateKey(fraction);
-      } catch (IllegalArgumentException e) {
+      } catch (IllegalArgumentException | IllegalStateException e) {
         READER_LOG.info(
             "{}: Failed to interpolate key for fraction {}.", rangeTracker.getRange(), fraction);
         return null;


### PR DESCRIPTION
Catch the exception
```
Completed work item 4231779587829057376 UNSUCCESSFULLY: UNKNOWN: java.lang.IllegalStateException: Refusing to interpolate for near-empty ByteKeyRange{startKey=[6c617267652d6b6579], endKey=[6c617267652d6b657900]} where start and end keys differ only by trailing zero bytes.
	at org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkState(Preconditions.java:601)
	at org.apache.beam.sdk.io.range.ByteKeyRange.interpolateKey(ByteKeyRange.java:238)
	at com.google.cloud.bigtable.beam.CloudBigtableIO$Reader.splitAtFraction(CloudBigtableIO.java:838)
```